### PR TITLE
RuboCop: Fix Layout/SpaceInsideHashLiteralBraces

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,14 +15,6 @@
 Layout/AlignHash:
   Enabled: false
 
-# Offense count: 1186
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: false
-
 # Offense count: 150
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@
 * RuboCop: Fix Performance/StringReplacement [leila-alderman] #3782
 * RuboCop: Fix Naming/HeredocDelimiterCase & Naming [leila-alderman] #3781
 * BlueSnap: Add address fields to contact info [naashton] #3777
+* RuboCop: Fix Layout/SpaceInsideHashLiteralBraces [leila-alderman] #3780
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/avs_result.rb
+++ b/lib/active_merchant/billing/avs_result.rb
@@ -88,7 +88,7 @@ module ActiveMerchant
         { 'code' => code,
           'message' => message,
           'street_match' => street_match,
-          'postal_match' => postal_match}
+          'postal_match' => postal_match }
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -844,7 +844,7 @@ module ActiveMerchant
         doc = Nokogiri::XML(body)
         doc.remove_namespaces!
 
-        response = {action: action}
+        response = { action: action }
 
         response[:response_code] = if (element = doc.at_xpath('//transactionResponse/responseCode'))
                                      empty?(element.content) ? nil : element.content.to_i

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -878,7 +878,7 @@ module ActiveMerchant #:nodoc:
 
       def parse_direct_response(params)
         delimiter = @options[:delimiter] || ','
-        direct_response = {'raw' => params}
+        direct_response = { 'raw' => params }
         direct_response_fields = params.split(delimiter)
         direct_response.merge(
           {

--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -74,7 +74,7 @@ module ActiveMerchant #:nodoc:
 
       def card_brand(card)
         brand = super
-        ({'master' => 'mastercard', 'american_express' => 'amex'}[brand] || brand)
+        ({ 'master' => 'mastercard', 'american_express' => 'amex' }[brand] || brand)
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -71,7 +71,7 @@ module ActiveMerchant #:nodoc:
         post[:shopperName] = options[:shopper_name] if options[:shopper_name]
 
         if options[:third_party_payout]
-          post[:recurring] = options[:recurring_contract] || {contract: 'PAYOUT'}
+          post[:recurring] = options[:recurring_contract] || { contract: 'PAYOUT' }
           MultiResponse.run do |r|
             r.process {
               commit(
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
       def store(creditcard, options = {})
         post = store_request(options)
         post[:card] = credit_card_hash(creditcard)
-        post[:recurring] = {contract: 'RECURRING'}
+        post[:recurring] = { contract: 'RECURRING' }
 
         commit('store', post)
       end

--- a/lib/active_merchant/billing/gateways/beanstream.rb
+++ b/lib/active_merchant/billing/gateways/beanstream.rb
@@ -175,7 +175,7 @@ module ActiveMerchant #:nodoc:
       # can't actually delete a secure profile with the supplicated API. This function sets the status of the profile to closed (C).
       # Closed profiles will have to removed manually.
       def delete(vault_id)
-        update(vault_id, false, {status: 'C'})
+        update(vault_id, false, { status: 'C' })
       end
 
       alias unstore delete

--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -47,9 +47,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case normalize(paysource)
         when /1$/
-          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true)
+          Response.new(true, SUCCESS_MESSAGE, { paid_amount: money }, test: true)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, { paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -61,9 +61,9 @@ module ActiveMerchant #:nodoc:
         when /1$/
           raise Error, REFUND_ERROR_MESSAGE
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, { paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
-          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true)
+          Response.new(true, SUCCESS_MESSAGE, { paid_amount: money }, test: true)
         end
       end
 
@@ -73,9 +73,9 @@ module ActiveMerchant #:nodoc:
         when /1$/
           raise Error, CAPTURE_ERROR_MESSAGE
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, { paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
-          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true)
+          Response.new(true, SUCCESS_MESSAGE, { paid_amount: money }, test: true)
         end
       end
 
@@ -84,18 +84,18 @@ module ActiveMerchant #:nodoc:
         when /1$/
           raise Error, VOID_ERROR_MESSAGE
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {authorization: reference, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, { authorization: reference, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
-          Response.new(true, SUCCESS_MESSAGE, {authorization: reference}, test: true)
+          Response.new(true, SUCCESS_MESSAGE, { authorization: reference }, test: true)
         end
       end
 
       def store(paysource, options = {})
         case normalize(paysource)
         when /1$/
-          Response.new(true, SUCCESS_MESSAGE, {billingid: '1'}, test: true, authorization: AUTHORIZATION)
+          Response.new(true, SUCCESS_MESSAGE, { billingid: '1' }, test: true, authorization: AUTHORIZATION)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {billingid: nil, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, { billingid: nil, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -106,7 +106,7 @@ module ActiveMerchant #:nodoc:
         when /1$/
           Response.new(true, SUCCESS_MESSAGE, {}, test: true)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, { error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, UNSTORE_ERROR_MESSAGE
         end
@@ -118,9 +118,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case money
         when /00$/
-          Response.new(true, SUCCESS_MESSAGE, {authorized_amount: money}, test: true, authorization: AUTHORIZATION, emv_authorization: AUTHORIZATION_EMV_SUCCESS)
+          Response.new(true, SUCCESS_MESSAGE, { authorized_amount: money }, test: true, authorization: AUTHORIZATION, emv_authorization: AUTHORIZATION_EMV_SUCCESS)
         when /05$/
-          Response.new(false, FAILURE_MESSAGE, {authorized_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error], emv_authorization: AUTHORIZATION_EMV_DECLINE)
+          Response.new(false, FAILURE_MESSAGE, { authorized_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error], emv_authorization: AUTHORIZATION_EMV_DECLINE)
         else
           raise Error, error_message(paysource)
         end
@@ -130,9 +130,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case normalize(paysource)
         when /1$/, AUTHORIZATION
-          Response.new(true, SUCCESS_MESSAGE, {authorized_amount: money}, test: true, authorization: AUTHORIZATION)
+          Response.new(true, SUCCESS_MESSAGE, { authorized_amount: money }, test: true, authorization: AUTHORIZATION)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {authorized_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, { authorized_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end
@@ -142,9 +142,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case money
         when /00$/
-          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true, authorization: AUTHORIZATION, emv_authorization: AUTHORIZATION_EMV_SUCCESS)
+          Response.new(true, SUCCESS_MESSAGE, { paid_amount: money }, test: true, authorization: AUTHORIZATION, emv_authorization: AUTHORIZATION_EMV_SUCCESS)
         when /05$/
-          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error], emv_authorization: AUTHORIZATION_EMV_DECLINE)
+          Response.new(false, FAILURE_MESSAGE, { paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error], emv_authorization: AUTHORIZATION_EMV_DECLINE)
         else
           raise Error, error_message(paysource)
         end
@@ -154,9 +154,9 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case normalize(paysource)
         when /1$/, AUTHORIZATION
-          Response.new(true, SUCCESS_MESSAGE, {paid_amount: money}, test: true, authorization: AUTHORIZATION)
+          Response.new(true, SUCCESS_MESSAGE, { paid_amount: money }, test: true, authorization: AUTHORIZATION)
         when /2$/
-          Response.new(false, FAILURE_MESSAGE, {paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+          Response.new(false, FAILURE_MESSAGE, { paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
         else
           raise Error, error_message(paysource)
         end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -203,9 +203,9 @@ module ActiveMerchant #:nodoc:
       def check_customer_exists(customer_vault_id)
         commit do
           @braintree_gateway.customer.find(customer_vault_id)
-          ActiveMerchant::Billing::Response.new(true, 'Customer found', {exists: true}, authorization: customer_vault_id)
+          ActiveMerchant::Billing::Response.new(true, 'Customer found', { exists: true }, authorization: customer_vault_id)
         rescue Braintree::NotFoundError
-          ActiveMerchant::Billing::Response.new(true, 'Customer not found', {exists: false})
+          ActiveMerchant::Billing::Response.new(true, 'Customer not found', { exists: false })
         end
       end
 

--- a/lib/active_merchant/billing/gateways/cecabank.rb
+++ b/lib/active_merchant/billing/gateways/cecabank.rb
@@ -21,7 +21,7 @@ module ActiveMerchant #:nodoc:
       CECA_UI_LESS_REFUND_PAGE = 'anulacion_xml'
       CECA_ACTION_REFUND   = 'anulaciones/anularParcial' # use partial refund's URL to avoid time frame limitations and decision logic on client side
       CECA_ACTION_PURCHASE = 'tpv/compra'
-      CECA_CURRENCIES_DICTIONARY = {'EUR' => 978, 'USD' => 840, 'GBP' => 826}
+      CECA_CURRENCIES_DICTIONARY = { 'EUR' => 978, 'USD' => 840, 'GBP' => 826 }
 
       # Creates a new CecabankGateway
       #
@@ -57,14 +57,14 @@ module ActiveMerchant #:nodoc:
       def purchase(money, creditcard, options = {})
         requires!(options, :order_id)
 
-        post = {'Descripcion' => options[:description],
+        post = { 'Descripcion' => options[:description],
                 'Num_operacion' => options[:order_id],
                 'Idioma' => CECA_UI_LESS_LANGUAGE,
                 'Pago_soportado' => CECA_MODE,
                 'URL_OK' => CECA_NOTIFICATIONS_URL,
                 'URL_NOK' => CECA_NOTIFICATIONS_URL,
                 'Importe' => amount(money),
-                'TipoMoneda' => CECA_CURRENCIES_DICTIONARY[options[:currency] || currency(money)]}
+                'TipoMoneda' => CECA_CURRENCIES_DICTIONARY[options[:currency] || currency(money)] }
 
         add_creditcard(post, creditcard)
 
@@ -84,12 +84,12 @@ module ActiveMerchant #:nodoc:
       def refund(money, identification, options = {})
         reference, order_id = split_authorization(identification)
 
-        post = {'Referencia' => reference,
+        post = { 'Referencia' => reference,
                 'Num_operacion' => order_id,
                 'Idioma' => CECA_UI_LESS_LANGUAGE_REFUND,
                 'Pagina' => CECA_UI_LESS_REFUND_PAGE,
                 'Importe' => amount(money),
-                'TipoMoneda' => CECA_CURRENCIES_DICTIONARY[options[:currency] || currency(money)]}
+                'TipoMoneda' => CECA_CURRENCIES_DICTIONARY[options[:currency] || currency(money)] }
 
         commit(CECA_ACTION_REFUND, post)
       end

--- a/lib/active_merchant/billing/gateways/commercegate.rb
+++ b/lib/active_merchant/billing/gateways/commercegate.rb
@@ -102,7 +102,7 @@ module ActiveMerchant #:nodoc:
           response,
           authorization: response['transID'],
           test: test?,
-          avs_result: {code: response['avsCode']},
+          avs_result: { code: response['avsCode'] },
           cvv_result: response['cvvCode']
         )
       end

--- a/lib/active_merchant/billing/gateways/conekta.rb
+++ b/lib/active_merchant/billing/gateways/conekta.rb
@@ -180,7 +180,7 @@ module ActiveMerchant #:nodoc:
           'Accept-Language' => 'es',
           'Authorization' => 'Basic ' + Base64.encode64("#{@options[:key]}:"),
           'RaiseHtmlError' => 'false',
-          'Conekta-Client-User-Agent' => {'agent' => "Conekta ActiveMerchantBindings/#{ActiveMerchant::VERSION}"}.to_json,
+          'Conekta-Client-User-Agent' => { 'agent' => "Conekta ActiveMerchantBindings/#{ActiveMerchant::VERSION}" }.to_json,
           'X-Conekta-Client-User-Agent' => conekta_client_user_agent(options),
           'X-Conekta-Client-User-Metadata' => options[:meta].to_json
         }
@@ -189,7 +189,7 @@ module ActiveMerchant #:nodoc:
       def conekta_client_user_agent(options)
         return user_agent unless options[:application]
 
-        JSON.dump(JSON.parse(user_agent).merge!({application: options[:application]}))
+        JSON.dump(JSON.parse(user_agent).merge!({ application: options[:application] }))
       end
 
       def commit(method, url, parameters, options = {})

--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -228,7 +228,7 @@ module ActiveMerchant #:nodoc:
             r.process {
               split_auth = split_authorization(r.authorization)
               auth = (action.include?('recur') ? split_auth[4] : split_auth[0])
-              action.include?('recur') ? commit_raw('recur/ack', {ID: auth}) : commit_raw('ack', {TransactionNumber: auth})
+              action.include?('recur') ? commit_raw('recur/ack', { ID: auth }) : commit_raw('ack', { TransactionNumber: auth })
             }
           end
         end

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -390,7 +390,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_create_subscription_request(payment_method, options)
-        default_subscription_params = {frequency: 'on-demand', amount: 0, automatic_renew: false}
+        default_subscription_params = { frequency: 'on-demand', amount: 0, automatic_renew: false }
         options[:subscription] = default_subscription_params.update(
           options[:subscription] || {}
         )
@@ -472,7 +472,7 @@ module ActiveMerchant #:nodoc:
 
       def add_line_item_data(xml, options)
         options[:line_items].each_with_index do |value, index|
-          xml.tag! 'item', {'id' => index} do
+          xml.tag! 'item', { 'id' => index } do
             xml.tag! 'unitPrice', localized_amount(value[:declared_value].to_i, options[:currency] || default_currency)
             xml.tag! 'quantity', value[:quantity]
             xml.tag! 'productCode', value[:code] || 'shipping_only'
@@ -595,7 +595,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_tax_service(xml)
-        xml.tag! 'taxService', {'run' => 'true'} do
+        xml.tag! 'taxService', { 'run' => 'true' } do
           xml.tag!('nexus', @options[:nexus]) unless @options[:nexus].blank?
           xml.tag!('sellerRegistration', @options[:vat_reg_number]) unless @options[:vat_reg_number].blank?
         end
@@ -605,7 +605,7 @@ module ActiveMerchant #:nodoc:
         if network_tokenization?(payment_method)
           add_auth_network_tokenization(xml, payment_method, options)
         else
-          xml.tag! 'ccAuthService', {'run' => 'true'} do
+          xml.tag! 'ccAuthService', { 'run' => 'true' } do
             if options[:three_d_secure]
               add_normalized_threeds_2_data(xml, payment_method, options)
             else
@@ -678,7 +678,7 @@ module ActiveMerchant #:nodoc:
 
         case brand
         when :visa
-          xml.tag! 'ccAuthService', {'run' => 'true'} do
+          xml.tag! 'ccAuthService', { 'run' => 'true' } do
             xml.tag!('cavv', payment_method.payment_cryptogram)
             xml.tag!('commerceIndicator', ECI_BRAND_MAPPING[brand])
             xml.tag!('xid', payment_method.payment_cryptogram)
@@ -689,13 +689,13 @@ module ActiveMerchant #:nodoc:
             xml.tag!('authenticationData', payment_method.payment_cryptogram)
             xml.tag!('collectionIndicator', DEFAULT_COLLECTION_INDICATOR)
           end
-          xml.tag! 'ccAuthService', {'run' => 'true'} do
+          xml.tag! 'ccAuthService', { 'run' => 'true' } do
             xml.tag!('commerceIndicator', ECI_BRAND_MAPPING[brand])
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
           end
         when :american_express
           cryptogram = Base64.decode64(payment_method.payment_cryptogram)
-          xml.tag! 'ccAuthService', {'run' => 'true'} do
+          xml.tag! 'ccAuthService', { 'run' => 'true' } do
             xml.tag!('cavv', Base64.encode64(cryptogram[0...20]))
             xml.tag!('commerceIndicator', ECI_BRAND_MAPPING[brand])
             xml.tag!('xid', Base64.encode64(cryptogram[20...40]))
@@ -711,7 +711,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_capture_service(xml, request_id, request_token)
-        xml.tag! 'ccCaptureService', {'run' => 'true'} do
+        xml.tag! 'ccCaptureService', { 'run' => 'true' } do
           xml.tag! 'authRequestID', request_id
           xml.tag! 'authRequestToken', request_token
           xml.tag! 'reconciliationID', options[:reconciliation_id] if options[:reconciliation_id]
@@ -720,56 +720,56 @@ module ActiveMerchant #:nodoc:
 
       def add_purchase_service(xml, payment_method, options)
         if options[:pinless_debit_card]
-          xml.tag! 'pinlessDebitService', {'run' => 'true'} do
+          xml.tag! 'pinlessDebitService', { 'run' => 'true' } do
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
           end
         else
           add_auth_service(xml, payment_method, options)
-          xml.tag! 'ccCaptureService', {'run' => 'true'} do
+          xml.tag! 'ccCaptureService', { 'run' => 'true' } do
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
           end
         end
       end
 
       def add_void_service(xml, request_id, request_token)
-        xml.tag! 'voidService', {'run' => 'true'} do
+        xml.tag! 'voidService', { 'run' => 'true' } do
           xml.tag! 'voidRequestID', request_id
           xml.tag! 'voidRequestToken', request_token
         end
       end
 
       def add_auth_reversal_service(xml, request_id, request_token)
-        xml.tag! 'ccAuthReversalService', {'run' => 'true'} do
+        xml.tag! 'ccAuthReversalService', { 'run' => 'true' } do
           xml.tag! 'authRequestID', request_id
           xml.tag! 'authRequestToken', request_token
         end
       end
 
       def add_credit_service(xml, request_id = nil, request_token = nil)
-        xml.tag! 'ccCreditService', {'run' => 'true'} do
+        xml.tag! 'ccCreditService', { 'run' => 'true' } do
           xml.tag! 'captureRequestID', request_id if request_id
           xml.tag! 'captureRequestToken', request_token if request_token
         end
       end
 
       def add_check_service(xml)
-        xml.tag! 'ecDebitService', {'run' => 'true'}
+        xml.tag! 'ecDebitService', { 'run' => 'true' }
       end
 
       def add_subscription_create_service(xml, options)
-        xml.tag! 'paySubscriptionCreateService', {'run' => 'true'}
+        xml.tag! 'paySubscriptionCreateService', { 'run' => 'true' }
       end
 
       def add_subscription_update_service(xml, options)
-        xml.tag! 'paySubscriptionUpdateService', {'run' => 'true'}
+        xml.tag! 'paySubscriptionUpdateService', { 'run' => 'true' }
       end
 
       def add_subscription_delete_service(xml, options)
-        xml.tag! 'paySubscriptionDeleteService', {'run' => 'true'}
+        xml.tag! 'paySubscriptionDeleteService', { 'run' => 'true' }
       end
 
       def add_subscription_retrieve_service(xml, options)
-        xml.tag! 'paySubscriptionRetrieveService', {'run' => 'true'}
+        xml.tag! 'paySubscriptionRetrieveService', { 'run' => 'true' }
       end
 
       def add_subscription(xml, options, reference = nil)
@@ -834,13 +834,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_validate_pinless_debit_service(xml)
-        xml.tag! 'pinlessDebitValidateService', {'run' => 'true'}
+        xml.tag! 'pinlessDebitValidateService', { 'run' => 'true' }
       end
 
       def add_threeds_services(xml, options)
-        xml.tag! 'payerAuthEnrollService', {'run' => 'true'} if options[:payer_auth_enroll_service]
+        xml.tag! 'payerAuthEnrollService', { 'run' => 'true' } if options[:payer_auth_enroll_service]
         if options[:payer_auth_validate_service]
-          xml.tag! 'payerAuthValidateService', {'run' => 'true'} do
+          xml.tag! 'payerAuthValidateService', { 'run' => 'true' } do
             xml.tag! 'signedPARes', options[:pares]
           end
         end
@@ -889,17 +889,17 @@ module ActiveMerchant #:nodoc:
 
         xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
-        xml.tag! 's:Envelope', {'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/'} do
+        xml.tag! 's:Envelope', { 'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/' } do
           xml.tag! 's:Header' do
-            xml.tag! 'wsse:Security', {'s:mustUnderstand' => '1', 'xmlns:wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'} do
+            xml.tag! 'wsse:Security', { 's:mustUnderstand' => '1', 'xmlns:wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' } do
               xml.tag! 'wsse:UsernameToken' do
                 xml.tag! 'wsse:Username', @options[:login]
                 xml.tag! 'wsse:Password', @options[:password], 'Type' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText'
               end
             end
           end
-          xml.tag! 's:Body', {'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema'} do
-            xml.tag! 'requestMessage', {'xmlns' => "urn:schemas-cybersource-com:transaction-data-#{xsd_version}"} do
+          xml.tag! 's:Body', { 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema' } do
+            xml.tag! 'requestMessage', { 'xmlns' => "urn:schemas-cybersource-com:transaction-data-#{xsd_version}" } do
               add_merchant_data(xml, options)
               xml << body
             end

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -295,7 +295,7 @@ module ActiveMerchant
 
       def parse_authorization_string(authorization)
         reference, auth_code, ca_reference = authorization.to_s.split(';')
-        {reference: reference, auth_code: auth_code, ca_reference: ca_reference}
+        { reference: reference, auth_code: auth_code, ca_reference: ca_reference }
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/digitzs.rb
+++ b/lib/active_merchant/billing/gateways/digitzs.rb
@@ -151,7 +151,7 @@ module ActiveMerchant #:nodoc:
         post[:data][:type] = 'payments'
         post[:data][:attributes][:merchantId] = options[:merchant_id]
         post[:data][:attributes][:paymentType] = 'cardRefund'
-        post[:data][:attributes][:originalTransaction] = {id: authorization}
+        post[:data][:attributes][:originalTransaction] = { id: authorization }
         add_transaction(post, money, options)
 
         post

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -222,7 +222,7 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, parameters)
         url = url_for((test? ? test_url : live_url), action, parameters)
-        response = parse(ssl_request(HTTP_METHOD[action], url, post_data(action, parameters), {'x-ebanx-client-user-agent': "ActiveMerchant/#{ActiveMerchant::VERSION}"}))
+        response = parse(ssl_request(HTTP_METHOD[action], url, post_data(action, parameters), { 'x-ebanx-client-user-agent': "ActiveMerchant/#{ActiveMerchant::VERSION}" }))
 
         success = success_from(action, response)
 

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -54,7 +54,7 @@ module ActiveMerchant #:nodoc:
       def void(identification, options = {})
         requires!(options, :order_id)
         original_transaction_id, = identification.split(';')
-        commit(:void_transaction, {reference_number: format_reference_number(options[:order_id]), transaction_id: original_transaction_id})
+        commit(:void_transaction, { reference_number: format_reference_number(options[:order_id]), transaction_id: original_transaction_id })
       end
 
       def voice_authorize(money, authorization_code, creditcard, options = {})

--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options = {})
         trans_id, trans_amount = split_authorization(authorization)
-        options.merge!({trans_id: trans_id, trans_amount: trans_amount, reversal_type: 'Full'})
+        options.merge!({ trans_id: trans_id, trans_amount: trans_amount, reversal_type: 'Full' })
 
         request = build_soap_request do |xml|
           xml.CreditCardReversal(xmlns: 'https://transaction.elementexpress.com') do

--- a/lib/active_merchant/billing/gateways/evo_ca.rb
+++ b/lib/active_merchant/billing/gateways/evo_ca.rb
@@ -153,7 +153,7 @@ module ActiveMerchant #:nodoc:
       # The <tt>identification</tt> parameter is the transaction ID, retrieved
       # from {Response#authorization}.
       def refund(money, identification)
-        post = {transactionid: identification}
+        post = { transactionid: identification }
         commit('refund', money, post)
       end
 
@@ -181,7 +181,7 @@ module ActiveMerchant #:nodoc:
       # The <tt>identification</tt> parameter is the transaction ID, retrieved
       # from {Response#authorization}.
       def void(identification)
-        post = {transactionid: identification}
+        post = { transactionid: identification }
         commit('void', nil, post)
       end
 
@@ -192,7 +192,7 @@ module ActiveMerchant #:nodoc:
       # The <tt>identification</tt> parameter is the transaction ID, retrieved
       # from {Response#authorization}.
       def update(identification, options)
-        post = {transactionid: identification}
+        post = { transactionid: identification }
         add_order(post, options)
         commit('update', nil, post)
       end
@@ -291,7 +291,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(action, parameters = {})
-        post = {type: action}
+        post = { type: action }
 
         if test?
           post[:username] = 'demo'

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -243,16 +243,16 @@ module ActiveMerchant #:nodoc:
 
         xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
-        xml.tag! 'soap12:Envelope', {'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema', 'xmlns:soap12' => 'http://www.w3.org/2003/05/soap-envelope'} do
+        xml.tag! 'soap12:Envelope', { 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema', 'xmlns:soap12' => 'http://www.w3.org/2003/05/soap-envelope' } do
           xml.tag! 'soap12:Header' do
-            xml.tag! 'eWAYHeader', {'xmlns' => 'https://www.eway.com.au/gateway/managedpayment'} do
+            xml.tag! 'eWAYHeader', { 'xmlns' => 'https://www.eway.com.au/gateway/managedpayment' } do
               xml.tag! 'eWAYCustomerID', @options[:login]
               xml.tag! 'Username', @options[:username]
               xml.tag! 'Password', @options[:password]
             end
           end
           xml.tag! 'soap12:Body' do |x|
-            x.tag! action, {'xmlns' => 'https://www.eway.com.au/gateway/managedpayment'} do |y|
+            x.tag! action, { 'xmlns' => 'https://www.eway.com.au/gateway/managedpayment' } do |y|
               post.each do |key, value|
                 y.tag! key, value
               end

--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -232,7 +232,7 @@ module ActiveMerchant #:nodoc:
         params[key] = {}
 
         add_name_and_email(params[key], options[:shipping_address], options[:email])
-        add_address(params[key], options[:shipping_address], {skip_company: true})
+        add_address(params[key], options[:shipping_address], { skip_company: true })
       end
 
       def add_name_and_email(params, address, email, payment_method = nil)
@@ -310,7 +310,7 @@ module ActiveMerchant #:nodoc:
           cvv_result: cvv_result_from(raw)
         )
       rescue ActiveMerchant::ResponseError => e
-        return ActiveMerchant::Billing::Response.new(false, e.response.message, {status_code: e.response.code}, test: test?)
+        return ActiveMerchant::Billing::Response.new(false, e.response.message, { status_code: e.response.code }, test: test?)
       end
 
       def parse(data)
@@ -365,7 +365,7 @@ module ActiveMerchant #:nodoc:
           else
             'I'
           end
-        {code: code}
+        { code: code }
       end
 
       def cvv_result_from(response)

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -5,8 +5,8 @@ module ActiveMerchant #:nodoc:
 
       API_VERSION = '8.5'
 
-      TEST_LOGINS = [{login: 'A00049-01', password: 'test1'},
-                     {login: 'A00427-01', password: 'testus'}]
+      TEST_LOGINS = [{ login: 'A00049-01', password: 'test1' },
+                     { login: 'A00427-01', password: 'testus' }]
 
       TRANSACTIONS = { sale: '00',
                        authorization: '01',
@@ -15,16 +15,16 @@ module ActiveMerchant #:nodoc:
 
       ENVELOPE_NAMESPACES = { 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
                               'xmlns:env' => 'http://schemas.xmlsoap.org/soap/envelope/',
-                              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'}
+                              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance' }
 
       SEND_AND_COMMIT_ATTRIBUTES = { 'xmlns:n1' => 'http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/Request',
-                                     'env:encodingStyle' => 'http://schemas.xmlsoap.org/soap/encoding/'}
+                                     'env:encodingStyle' => 'http://schemas.xmlsoap.org/soap/encoding/' }
 
       SEND_AND_COMMIT_SOURCE_ATTRIBUTES = { 'xmlns:n2' => 'http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/encodedTypes',
-                                            'xsi:type' => 'n2:Transaction'}
+                                            'xsi:type' => 'n2:Transaction' }
 
       POST_HEADERS = { 'soapAction' => 'http://secure2.e-xact.com/vplug-in/transaction/rpc-enc/SendAndCommit',
-                       'Content-Type' => 'text/xml'}
+                       'Content-Type' => 'text/xml' }
 
       SUCCESS = 'true'
 

--- a/lib/active_merchant/billing/gateways/federated_canada.rb
+++ b/lib/active_merchant/billing/gateways/federated_canada.rb
@@ -124,7 +124,7 @@ module ActiveMerchant #:nodoc:
         Response.new(success?(response), message, response,
           test: test?,
           authorization: response['transactionid'],
-          avs_result: {code: response['avsresponse']},
+          avs_result: { code: response['avsresponse'] },
           cvv_result: response['cvvresponse'])
       end
 

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
         discover: 'Discover'
       }
 
-      E4_BRANDS = BRANDS.merge({mastercard: 'Mastercard'})
+      E4_BRANDS = BRANDS.merge({ mastercard: 'Mastercard' })
 
       DEFAULT_ECI = '07'
 
@@ -357,7 +357,7 @@ module ActiveMerchant #:nodoc:
         Response.new(successful?(response), message_from(response), response,
           test: test?,
           authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
-          avs_result: {code: response[:avs]},
+          avs_result: { code: response[:avs] },
           cvv_result: response[:cvv2],
           error_code: standard_error_code(response))
       end

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -372,7 +372,7 @@ module ActiveMerchant #:nodoc:
         Response.new(successful?(response), message_from(response), response,
           test: test?,
           authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
-          avs_result: {code: response[:avs]},
+          avs_result: { code: response[:avs] },
           cvv_result: response[:cvv2],
           error_code: standard_error_code(response))
       end

--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -186,7 +186,7 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, parameters)
         response = parse(ssl_post(url(action), post_data(action, parameters),
-          { 'Content-Type' => 'application/soap+xml; charset=utf-8'}))
+          { 'Content-Type' => 'application/soap+xml; charset=utf-8' }))
 
         Response.new(
           success_from(response),

--- a/lib/active_merchant/billing/gateways/in_context_paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/in_context_paypal_express.rb
@@ -5,7 +5,7 @@ module ActiveMerchant #:nodoc:
       self.live_redirect_url = 'https://www.paypal.com/checkoutnow'
 
       def redirect_url_for(token, options = {})
-        options = {review: true}.update(options)
+        options = { review: true }.update(options)
         url  = "#{redirect_url}?token=#{token}"
         url += '&useraction=commit' unless options[:review]
         url

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -292,12 +292,12 @@ module ActiveMerchant #:nodoc:
         build_request(options) do |xml|
           if money
             currency = options[:currency] || currency(money)
-            details = {'CurrencyCode' => currency_code(currency), 'Amount' => localized_amount(money, currency)}
+            details = { 'CurrencyCode' => currency_code(currency), 'Amount' => localized_amount(money, currency) }
           else
-            details = {'CurrencyCode' => currency_code(default_currency), 'Amount' => '0'}
+            details = { 'CurrencyCode' => currency_code(default_currency), 'Amount' => '0' }
           end
           xml.tag! 'TransactionDetails', details do
-            xml.tag! 'MessageDetails', {'TransactionType' => type, 'CrossReference' => cross_reference}
+            xml.tag! 'MessageDetails', { 'TransactionType' => type, 'CrossReference' => cross_reference }
             xml.tag! 'OrderID', (options[:order_id] || order_id)
           end
         end
@@ -309,9 +309,9 @@ module ActiveMerchant #:nodoc:
         xml.instruct!(:xml, version: '1.0', encoding: 'utf-8')
         xml.tag! 'soap:Envelope', { 'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/',
                                     'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-                                    'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema'} do
+                                    'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema' } do
           xml.tag! 'soap:Body' do
-            xml.tag! options[:action], {'xmlns' => 'https://www.thepaymentgateway.net/'} do
+            xml.tag! options[:action], { 'xmlns' => 'https://www.thepaymentgateway.net/' } do
               xml.tag! 'PaymentMessage' do
                 add_merchant_data(xml, options)
                 yield(xml)
@@ -330,8 +330,8 @@ module ActiveMerchant #:nodoc:
       def add_purchase_data(xml, type, money, options)
         currency = options[:currency] || currency(money)
         requires!(options, :order_id)
-        xml.tag! 'TransactionDetails', {'Amount' => localized_amount(money, currency), 'CurrencyCode' => currency_code(currency)} do
-          xml.tag! 'MessageDetails', {'TransactionType' => type}
+        xml.tag! 'TransactionDetails', { 'Amount' => localized_amount(money, currency), 'CurrencyCode' => currency_code(currency) } do
+          xml.tag! 'MessageDetails', { 'TransactionType' => type }
           xml.tag! 'OrderID', options[:order_id]
           xml.tag! 'TransactionControl' do
             xml.tag! 'ThreeDSecureOverridePolicy', 'FALSE'
@@ -371,13 +371,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_merchant_data(xml, options)
-        xml.tag! 'MerchantAuthentication', {'MerchantID' => @options[:login], 'Password' => @options[:password]}
+        xml.tag! 'MerchantAuthentication', { 'MerchantID' => @options[:login], 'Password' => @options[:password] }
       end
 
       def commit(request, options)
         requires!(options, :action)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request,
-          {'SOAPAction' => 'https://www.thepaymentgateway.net/' + options[:action],
+          { 'SOAPAction' => 'https://www.thepaymentgateway.net/' + options[:action],
            'Content-Type' => 'text/xml; charset=utf-8' }))
 
         success = response[:transaction_result][:status_code] == '0'

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -210,8 +210,8 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'TransactionID', transaction_id.nil? ? generate_unique_id.slice(0, 18) : transaction_id
           xml.tag! 'Origin', options[:origin] || 'INTERNET'
           xml.tag! 'IndustryInfo', 'Type' => options[:industry_info] || 'ECOMMERCE'
-          xml.tag! 'Application', (options[:application] || 'n/a'), {'Version' => options[:application_version] || '1.0'}
-          xml.tag! 'Device', (options[:device] || 'n/a'), {'Version' => options[:device_version] || '1.0'}
+          xml.tag! 'Application', (options[:application] || 'n/a'), { 'Version' => options[:application_version] || '1.0' }
+          xml.tag! 'Device', (options[:device] || 'n/a'), { 'Version' => options[:device_version] || '1.0' }
           xml.tag! 'Library', 'VirtPOS SDK', 'Version' => '1.5'
           xml.tag! 'Gateway', 'JetPay'
           xml.tag! 'DeveloperID', options[:developer_id] || 'n/a'
@@ -405,7 +405,7 @@ module ActiveMerchant #:nodoc:
       def add_invoice_data(xml, options)
         xml.tag! 'OrderNumber', options[:order_id] if options[:order_id]
         if tax_amount = options[:tax_amount]
-          xml.tag! 'TaxAmount', tax_amount, {'ExemptInd' => options[:tax_exempt] || 'false'}
+          xml.tag! 'TaxAmount', tax_amount, { 'ExemptInd' => options[:tax_exempt] || 'false' }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -430,7 +430,7 @@ module ActiveMerchant #:nodoc:
         # <r_approved>APPROVED</r_approved>
         # <r_avs></r_avs>
 
-        response = {message: 'Global Error Receipt', complete: false}
+        response = { message: 'Global Error Receipt', complete: false }
 
         xml = REXML::Document.new("<response>#{xml}</response>")
         xml.root&.elements&.each do |node|

--- a/lib/active_merchant/billing/gateways/mastercard.rb
+++ b/lib/active_merchant/billing/gateways/mastercard.rb
@@ -176,7 +176,7 @@ module ActiveMerchant
       def add_3dsecure_id(post, options)
         return unless options[:threed_secure_id]
 
-        post.merge!({'3DSecureId' => options[:threed_secure_id]})
+        post.merge!({ '3DSecureId' => options[:threed_secure_id] })
       end
 
       def country_code(country)

--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -13,10 +13,10 @@ module ActiveMerchant #:nodoc:
 
       ENV_NAMESPACES = { 'xmlns:xsi'  => 'http://www.w3.org/2001/XMLSchema-instance',
                          'xmlns:xsd'  => 'http://www.w3.org/2001/XMLSchema',
-                         'xmlns:env' => 'http://schemas.xmlsoap.org/soap/envelope/'}
+                         'xmlns:env' => 'http://schemas.xmlsoap.org/soap/envelope/' }
       ENV_NAMESPACES_V4 = { 'xmlns:xsi'  => 'http://www.w3.org/2001/XMLSchema-instance',
                             'xmlns:xsd'  => 'http://www.w3.org/2001/XMLSchema',
-                            'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/'}
+                            'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/' }
 
       TX_NAMESPACE = 'http://merchantwarehouse.com/MerchantWARE/Client/TransactionRetail'
       TX_NAMESPACE_V4 = 'http://schemas.merchantwarehouse.com/merchantware/40/Credit/'

--- a/lib/active_merchant/billing/gateways/metrics_global.rb
+++ b/lib/active_merchant/billing/gateways/metrics_global.rb
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>money</tt> -- The amount to be captured as an Integer value in cents.
       # * <tt>authorization</tt> -- The authorization returned from the previous authorize request.
       def capture(money, authorization, options = {})
-        post = {trans_id: authorization}
+        post = { trans_id: authorization }
         add_customer_data(post, options)
         commit('PRIOR_AUTH_CAPTURE', money, post)
       end
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>authorization</tt> - The authorization returned from the previous authorize request.
       def void(authorization, options = {})
-        post = {trans_id: authorization}
+        post = { trans_id: authorization }
         add_duplicate_window(post)
         commit('VOID', nil, post)
       end
@@ -136,7 +136,7 @@ module ActiveMerchant #:nodoc:
         requires!(options, :card_number)
 
         post = { trans_id: identification,
-                 card_num: options[:card_number]}
+                 card_num: options[:card_number] }
 
         post[:first_name] = options[:first_name] if options[:first_name]
         post[:last_name] = options[:last_name] if options[:last_name]

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -302,7 +302,7 @@ module ActiveMerchant #:nodoc:
           message_from(response[:message]),
           response,
           test: test?,
-          avs_result: {code: response[:avs_result_code]},
+          avs_result: { code: response[:avs_result_code] },
           cvv_result: response[:cvd_result_code] && response[:cvd_result_code][-1, 1],
           authorization: authorization_from(response)
         )

--- a/lib/active_merchant/billing/gateways/money_movers.rb
+++ b/lib/active_merchant/billing/gateways/money_movers.rb
@@ -116,7 +116,7 @@ module ActiveMerchant #:nodoc:
         Response.new(success?(response), message, response,
           test: test?,
           authorization: response['transactionid'],
-          avs_result: {code: response['avsresponse']},
+          avs_result: { code: response['avsresponse'] },
           cvv_result: response['cvvresponse'])
       end
 

--- a/lib/active_merchant/billing/gateways/netaxept.rb
+++ b/lib/active_merchant/billing/gateways/netaxept.rb
@@ -146,7 +146,7 @@ module ActiveMerchant #:nodoc:
           doc = REXML::Document.new(result)
           extract_xml(doc.root).merge(container: doc.root.name)
         else
-          {result: result}
+          { result: result }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -196,12 +196,12 @@ module ActiveMerchant #:nodoc:
         Response.new(success?(response), message_from(response), response,
           test: test_response?(response),
           authorization: response[:trans_id],
-          avs_result: { code: response[:avs_code]},
+          avs_result: { code: response[:avs_code] },
           cvv_result: response[:cvv2_code])
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code =~ /^[67]\d\d$/
 
-        return Response.new(false, e.response.message, {status_code: e.response.code}, test: test?)
+        return Response.new(false, e.response.message, { status_code: e.response.code }, test: test?)
       end
 
       def test_response?(response)

--- a/lib/active_merchant/billing/gateways/network_merchants.rb
+++ b/lib/active_merchant/billing/gateways/network_merchants.rb
@@ -203,7 +203,7 @@ module ActiveMerchant #:nodoc:
         Response.new(success, raw['responsetext'], raw,
           test: test?,
           authorization: authorization,
-          avs_result: { code: raw['avsresponse']},
+          avs_result: { code: raw['avsresponse'] },
           cvv_result: raw['cvvresponse'])
       end
 

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -116,7 +116,7 @@ module ActiveMerchant #:nodoc:
         post[:device_session_id] = options[:device_session_id]
         post[:currency] = (options[:currency] || currency(money)).upcase
         post[:use_card_points] = options[:use_card_points] if options[:use_card_points]
-        post[:payment_plan] = {payments: options[:payments]} if options[:payments]
+        post[:payment_plan] = { payments: options[:payments] } if options[:payments]
         add_creditcard(post, creditcard, options)
         post
       end

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -349,7 +349,7 @@ module ActiveMerchant #:nodoc:
 
       def json_error(body)
         message = "Invalid response received #{body.inspect}"
-        { 'result' => {'description' => message, 'code' => 'unknown' } }
+        { 'result' => { 'description' => message, 'code' => 'unknown' } }
       end
 
       def success_from(response)

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -256,7 +256,7 @@ module ActiveMerchant #:nodoc:
       def schema
         { 'xmlns' => 'http://www.optimalpayments.com/creditcard/xmlschema/v1',
           'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-          'xsi:schemaLocation' => 'http://www.optimalpayments.com/creditcard/xmlschema/v1'}
+          'xsi:schemaLocation' => 'http://www.optimalpayments.com/creditcard/xmlschema/v1' }
       end
 
       def build_merchant_account(xml)

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -286,13 +286,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def retrieve_customer_profile(customer_ref_num)
-        options = {customer_profile_action: RETRIEVE, customer_ref_num: customer_ref_num}
+        options = { customer_profile_action: RETRIEVE, customer_ref_num: customer_ref_num }
         order = build_customer_request_xml(nil, options)
         commit(order, :retrieve_customer_profile)
       end
 
       def delete_customer_profile(customer_ref_num)
-        options = {customer_profile_action: DELETE, customer_ref_num: customer_ref_num}
+        options = { customer_profile_action: DELETE, customer_ref_num: customer_ref_num }
         order = build_customer_request_xml(nil, options)
         commit(order, :delete_customer_profile)
       end

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -172,7 +172,7 @@ module ActiveMerchant #:nodoc:
         success = false
 
         begin
-          raw_response = ssl_post(live_url, post.to_json, {'Content-Type' => 'application/json'})
+          raw_response = ssl_post(live_url, post.to_json, { 'Content-Type' => 'application/json' })
           response = parse(raw_response)
           success = (response['RESPONSE_CODE'] == '00')
         rescue ResponseError => e
@@ -186,7 +186,7 @@ module ActiveMerchant #:nodoc:
           response_message(response),
           response,
           test: test?,
-          avs_result: {code: response['AVS_RESULT_CODE']},
+          avs_result: { code: response['AVS_RESULT_CODE'] },
           cvv_result: response['VERIFICATION_RESULT_CODE'],
           error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['RESPONSE_CODE']]),
           authorization: response['TRANSACTION_ID'])

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -45,7 +45,7 @@ module ActiveMerchant
       end
 
       def authorize(amount, payment_method, options = {})
-        params = {transaction_type: 'authorize'}
+        params = { transaction_type: 'authorize' }
 
         add_invoice(params, options)
         add_reversal_id(params, options)
@@ -59,7 +59,7 @@ module ActiveMerchant
       end
 
       def capture(amount, authorization, options = {})
-        params = {transaction_type: 'capture'}
+        params = { transaction_type: 'capture' }
 
         add_authorization_info(params, authorization)
         add_amount(params, amount, options)
@@ -69,7 +69,7 @@ module ActiveMerchant
       end
 
       def refund(amount, authorization, options = {})
-        params = {transaction_type: 'refund'}
+        params = { transaction_type: 'refund' }
 
         add_authorization_info(params, authorization)
         add_amount(params, (amount || amount_from_authorization(authorization)), options)
@@ -78,7 +78,7 @@ module ActiveMerchant
       end
 
       def store(payment_method, options = {})
-        params = {transaction_type: 'store'}
+        params = { transaction_type: 'store' }
 
         add_creditcard_for_tokenization(params, payment_method, options)
 
@@ -86,7 +86,7 @@ module ActiveMerchant
       end
 
       def void(authorization, options = {})
-        params = {transaction_type: 'void'}
+        params = { transaction_type: 'void' }
 
         add_authorization_info(params, authorization, options)
         add_amount(params, amount_from_authorization(authorization), options)
@@ -278,7 +278,7 @@ module ActiveMerchant
           response,
           test: test?,
           authorization: authorization_from(params, response),
-          avs_result: {code: response['avs']},
+          avs_result: { code: response['avs'] },
           cvv_result: response['cvv2'],
           error_code: error_code(response, success_from(response))
         )
@@ -405,7 +405,7 @@ module ActiveMerchant
       end
 
       def json_error(raw_response)
-        {'error' => "Unable to parse response: #{raw_response.inspect}"}
+        { 'error' => "Unable to parse response: #{raw_response.inspect}" }
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -30,7 +30,7 @@ module ActiveMerchant #:nodoc:
 
       SOAP_ACTIONS = {
         initialize: { name: 'Initialize8', url: 'pxorder/pxorder.asmx', xmlns: 'http://external.payex.com/PxOrder/' },
-        purchasecc: { name: 'PurchaseCC', url: 'pxconfined/pxorder.asmx', xmlns: 'http://confined.payex.com/PxOrder/', confined: true},
+        purchasecc: { name: 'PurchaseCC', url: 'pxconfined/pxorder.asmx', xmlns: 'http://confined.payex.com/PxOrder/', confined: true },
         cancel: { name: 'Cancel2', url: 'pxorder/pxorder.asmx', xmlns: 'http://external.payex.com/PxOrder/' },
         capture: { name: 'Capture5', url: 'pxorder/pxorder.asmx', xmlns: 'http://external.payex.com/PxOrder/' },
         credit: { name: 'Credit5', url: 'pxorder/pxorder.asmx', xmlns: 'http://external.payex.com/PxOrder/' },
@@ -155,7 +155,7 @@ module ActiveMerchant #:nodoc:
         amount = amount(1) # 1 cent for authorization
         MultiResponse.run(:first) do |r|
           r.process { send_create_agreement(options) }
-          r.process { send_initialize(amount, true, options.merge({agreement_ref: r.authorization})) }
+          r.process { send_initialize(amount, true, options.merge({ agreement_ref: r.authorization })) }
           order_ref = r.params['orderref']
           r.process { send_purchasecc(creditcard, order_ref) }
         end
@@ -341,9 +341,9 @@ module ActiveMerchant #:nodoc:
 
       def build_xml_request(soap_action, properties)
         builder = Nokogiri::XML::Builder.new
-        builder.__send__('soap12:Envelope', {'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+        builder.__send__('soap12:Envelope', { 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
                                              'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
-                                             'xmlns:soap12' => 'http://www.w3.org/2003/05/soap-envelope'}) do |root|
+                                             'xmlns:soap12' => 'http://www.w3.org/2003/05/soap-envelope' }) do |root|
           root.__send__('soap12:Body') do |body|
             body.__send__(soap_action[:name], xmlns: soap_action[:xmlns]) do |doc|
               properties.each do |key, val|

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -74,14 +74,14 @@ module ActiveMerchant #:nodoc:
         post = {
           transaction: { id: authorization }
         }
-        post[:order] = {amount: amount(money).to_f} if money
+        post[:order] = { amount: amount(money).to_f } if money
 
         commit_transaction('capture', post)
       end
 
       def refund(money, authorization, options = {})
-        post = {transaction: {id: authorization}}
-        post[:order] = {amount: amount(money).to_f} if money
+        post = { transaction: { id: authorization } }
+        post[:order] = { amount: amount(money).to_f } if money
 
         commit_transaction('refund', post)
       end
@@ -113,7 +113,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def unstore(identification, options = {})
-        post = { card: { token: identification }, user: { id: options[:user_id] }}
+        post = { card: { token: identification }, user: { id: options[:user_id] } }
         commit_card('delete', post)
       end
 
@@ -194,7 +194,7 @@ module ActiveMerchant #:nodoc:
         begin
           parse(raw_response)
         rescue JSON::ParserError
-          {'status' => 'Internal server error'}
+          { 'status' => 'Internal server error' }
         end
       end
 

--- a/lib/active_merchant/billing/gateways/paypal_express_common.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express_common.rb
@@ -17,7 +17,7 @@ module ActiveMerchant
       end
 
       def redirect_url_for(token, options = {})
-        options = {review: true, mobile: false}.update(options)
+        options = { review: true, mobile: false }.update(options)
 
         cmd  = options[:mobile] ? '_express-checkout-mobile' : '_express-checkout'
         url  = "#{redirect_url}?cmd=#{cmd}&token=#{token}"

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -118,7 +118,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(xml)
-        response = {message: 'Global Error Receipt', complete: false}
+        response = { message: 'Global Error Receipt', complete: false }
 
         xml = REXML::Document.new(xml)
         xml.elements.each('//Result/*') do |node|

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -322,7 +322,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_threeds(data, options)
-        data[:threeds] = {threeDSInfo: 'CardData'} if options[:execute_threed] == true
+        data[:threeds] = { threeDSInfo: 'CardData' } if options[:execute_threed] == true
       end
 
       def determine_3ds_action(threeds_hash)

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -43,7 +43,7 @@ module ActiveMerchant #:nodoc:
       def capture(money, authorization, options = {})
         post = {}
         auth, transaction_id, token, exp_month, exp_year, _, original_currency = authorization.split('|')
-        add_transaction_data('Settle', post, money, options.merge!({currency: original_currency}))
+        add_transaction_data('Settle', post, money, options.merge!({ currency: original_currency }))
         post[:sg_AuthCode] = auth
         post[:sg_TransactionID] = transaction_id
         post[:sg_CCToken] = token
@@ -56,7 +56,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options = {})
         post = {}
         auth, transaction_id, token, exp_month, exp_year, _, original_currency = authorization.split('|')
-        add_transaction_data('Credit', post, money, options.merge!({currency: original_currency}))
+        add_transaction_data('Credit', post, money, options.merge!({ currency: original_currency }))
         post[:sg_CreditType] = 2
         post[:sg_AuthCode] = auth
         post[:sg_TransactionID] = transaction_id
@@ -79,7 +79,7 @@ module ActiveMerchant #:nodoc:
       def void(authorization, options = {})
         post = {}
         auth, transaction_id, token, exp_month, exp_year, original_amount, original_currency = authorization.split('|')
-        add_transaction_data('Void', post, (original_amount.to_f * 100), options.merge!({currency: original_currency}))
+        add_transaction_data('Void', post, (original_amount.to_f * 100), options.merge!({ currency: original_currency }))
         post[:sg_CreditType] = 2
         post[:sg_AuthCode] = auth
         post[:sg_TransactionID] = transaction_id

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -213,7 +213,7 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>:force_settlement</tt> -- Force the settlement to occur as soon as possible. This option is not supported by other gateways. See the SkipJack API reference for more details
       def capture(money, authorization, options = {})
-        post = { }
+        post = {}
         add_status_action(post, 'SETTLE')
         add_forced_settlement(post, options)
         add_transaction_id(post, authorization)

--- a/lib/active_merchant/billing/gateways/so_easy_pay.rb
+++ b/lib/active_merchant/billing/gateways/so_easy_pay.rb
@@ -157,8 +157,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(soap_action, soap, options)
-        headers = {'SOAPAction' => "\"urn:Interface##{soap_action}\"",
-                   'Content-Type' => 'text/xml; charset=utf-8'}
+        headers = { 'SOAPAction' => "\"urn:Interface##{soap_action}\"",
+                   'Content-Type' => 'text/xml; charset=utf-8' }
         response_string = ssl_post(test? ? self.test_url : self.live_url, soap, headers)
         response = parse(response_string, soap_action)
         return Response.new(response['errorcode'] == '000',
@@ -179,9 +179,9 @@ module ActiveMerchant #:nodoc:
           'xmlns:types' => 'urn:Interface/encodedTypes',
           'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/'
         }) do
-          retval.tag!('soap:Body', {'soap:encodingStyle' => 'http://schemas.xmlsoap.org/soap/encoding/'}) do
+          retval.tag!('soap:Body', { 'soap:encodingStyle' => 'http://schemas.xmlsoap.org/soap/encoding/' }) do
             retval.tag!("tns:#{request}") do
-              retval.tag!("#{request}Request", {'xsi:type' => "tns:#{request}Request"}) do
+              retval.tag!("#{request}Request", { 'xsi:type' => "tns:#{request}Request" }) do
                 yield retval
               end
             end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -309,8 +309,8 @@ module ActiveMerchant #:nodoc:
           add_creditcard(post, payment, options, true)
           add_source_owner(post, payment, options)
         elsif type == 'three_d_secure'
-          post[:three_d_secure] = {card: payment}
-          post[:redirect] = {return_url: options[:redirect_url]}
+          post[:three_d_secure] = { card: payment }
+          post[:redirect] = { return_url: options[:redirect_url] }
         end
         commit(:post, 'sources', post, options)
       end
@@ -618,7 +618,7 @@ module ActiveMerchant #:nodoc:
           'User-Agent' => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           'Stripe-Version' => api_version(options),
           'X-Stripe-Client-User-Agent' => stripe_client_user_agent(options),
-          'X-Stripe-Client-User-Metadata' => {ip: options[:ip]}.to_json
+          'X-Stripe-Client-User-Metadata' => { ip: options[:ip] }.to_json
         }
         headers['Idempotency-Key'] = idempotency_key if idempotency_key
         headers['Stripe-Account'] = options[:stripe_account] if options[:stripe_account]
@@ -628,7 +628,7 @@ module ActiveMerchant #:nodoc:
       def stripe_client_user_agent(options)
         return user_agent unless options[:application]
 
-        JSON.dump(JSON.parse(user_agent).merge!({application: options[:application]}))
+        JSON.dump(JSON.parse(user_agent).merge!({ application: options[:application] }))
       end
 
       def api_version(options)
@@ -683,7 +683,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(success, response)
-        success ? 'Transaction approved' : response.fetch('error', {'message' => 'No error details'})['message']
+        success ? 'Transaction approved' : response.fetch('error', { 'message' => 'No error details' })['message']
       end
 
       def success_from(response, options)

--- a/lib/active_merchant/billing/gateways/webpay.rb
+++ b/lib/active_merchant/billing/gateways/webpay.rb
@@ -89,7 +89,7 @@ module ActiveMerchant #:nodoc:
           'Authorization' => 'Basic ' + Base64.encode64(@api_key.to_s + ':').strip,
           'User-Agent' => "Webpay/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           'X-Webpay-Client-User-Agent' => user_agent,
-          'X-Webpay-Client-User-Metadata' => {ip: options[:ip]}.to_json
+          'X-Webpay-Client-User-Metadata' => { ip: options[:ip] }.to_json
         }
       end
     end

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -510,7 +510,7 @@ module ActiveMerchant #:nodoc:
       def add_hcg_additional_data(xml, options)
         xml.hcgAdditionalData do
           options[:hcg_additional_data].each do |k, v|
-            xml.param({name: k.to_s}, v)
+            xml.param({ name: k.to_s }, v)
           end
         end
       end
@@ -546,7 +546,7 @@ module ActiveMerchant #:nodoc:
         xml = xml.strip.gsub(/\&/, '&amp;')
         doc = Nokogiri::XML(xml, &:strict)
         doc.remove_namespaces!
-        resp_params = {action: action}
+        resp_params = { action: action }
 
         parse_elements(doc.root, resp_params)
         resp_params
@@ -731,7 +731,7 @@ module ActiveMerchant #:nodoc:
       def credit_fund_transfer_attribute(options)
         return unless options[:credit]
 
-        {'action' => 'REFUND'}
+        { 'action' => 'REFUND' }
       end
 
       def encoded_credentials

--- a/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options = {})
         if authorization
-          commit(:post, "orders/#{CGI.escape(authorization)}/capture", {'captureAmount' => money}, options, 'capture')
+          commit(:post, "orders/#{CGI.escape(authorization)}/capture", { 'captureAmount' => money }, options, 'capture')
         else
           Response.new(false,
             'FAILED',
@@ -55,7 +55,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, orderCode, options = {})
-        obj = money ? {'refundAmount' => money} : {}
+        obj = money ? { 'refundAmount' => money } : {}
         commit(:post, "orders/#{CGI.escape(orderCode)}/refund", obj, options, 'refund')
       end
 
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
           },
           'clientKey' => @client_key
         }
-        token_response = commit(:post, 'tokens', obj, {'Authorization' => @service_key}, 'token')
+        token_response = commit(:post, 'tokens', obj, { 'Authorization' => @service_key }, 'token')
         token_response
       end
 
@@ -120,7 +120,7 @@ module ActiveMerchant #:nodoc:
           'Content-Type' => 'application/json',
           'User-Agent' => "Worldpay/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           'X-Worldpay-Client-User-Agent' => user_agent,
-          'X-Worldpay-Client-User-Metadata' => {ip: options[:ip]}.to_json
+          'X-Worldpay-Client-User-Metadata' => { ip: options[:ip] }.to_json
         }
         headers['Authorization'] = options['Authorization'] if options['Authorization']
         headers

--- a/lib/support/ssl_verify.rb
+++ b/lib/support/ssl_verify.rb
@@ -27,10 +27,10 @@ class SSLVerify
         success << g
       when :fail
         print 'F'
-        failed << {gateway: g, message: message}
+        failed << { gateway: g, message: message }
       when :error
         print 'E'
-        errored << {gateway: g, message: message}
+        errored << { gateway: g, message: message }
       end
     end
 

--- a/lib/support/ssl_version.rb
+++ b/lib/support/ssl_version.rb
@@ -29,10 +29,10 @@ class SSLVersion
         success << g
       when :fail
         print 'F'
-        failed << {gateway: g, message: message}
+        failed << { gateway: g, message: message }
       when :error
         print 'E'
-        errored << {gateway: g, message: message}
+        errored << { gateway: g, message: message }
       end
     end
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -101,7 +101,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       billing_address: address(),
       order_id: '123',
-      stored_credential: {reason_type: 'unscheduled'}
+      stored_credential: { reason_type: 'unscheduled' }
     }
 
     @normalized_3ds_2_options = {
@@ -111,7 +111,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       billing_address: address(),
       order_id: '123',
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
         channel: 'browser',
         notification_url: 'https://example.com/notification',
@@ -253,7 +253,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       billing_address: address(),
       order_id: '123',
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
         channel: 'app'
       }
@@ -434,13 +434,13 @@ class RemoteAdyenTest < Test::Unit::TestCase
   end
 
   def test_succesful_purchase_with_brand_override
-    response = @gateway.purchase(@amount, @improperly_branded_maestro, @options.merge({overwrite_brand: true, selected_brand: 'maestro'}))
+    response = @gateway.purchase(@amount, @improperly_branded_maestro, @options.merge({ overwrite_brand: true, selected_brand: 'maestro' }))
     assert_success response
     assert_equal '[capture-received]', response.message
   end
 
   def test_succesful_purchase_with_brand_override_with_execute_threed_false
-    response = @gateway.purchase(@amount, @improperly_branded_maestro, @options.merge({execute_threed: false, overwrite_brand: true, selected_brand: 'maestro'}))
+    response = @gateway.purchase(@amount, @improperly_branded_maestro, @options.merge({ execute_threed: false, overwrite_brand: true, selected_brand: 'maestro' }))
     assert_success response
     assert_equal '[capture-received]', response.message
   end
@@ -771,7 +771,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
   end
 
   def test_successful_tokenize_only_store
-    assert response = @gateway.store(@credit_card, @options.merge({tokenize_only: true}))
+    assert response = @gateway.store(@credit_card, @options.merge({ tokenize_only: true }))
 
     assert_success response
     assert !response.authorization.split('#')[2].nil?

--- a/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
+++ b/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
@@ -47,14 +47,14 @@ class RemoteAuthorizeNetApplePayTest < Test::Unit::TestCase
   end
 
   def test_failed_apple_pay_authorization
-    response = @gateway.authorize(@amount, apple_pay_payment_token(payment_data: {data: 'garbage'}), @options)
+    response = @gateway.authorize(@amount, apple_pay_payment_token(payment_data: { data: 'garbage' }), @options)
     assert_failure response
     assert_equal 'There was an error processing the payment data', response.message
     assert_equal 'processing_error', response.error_code
   end
 
   def test_failed_apple_pay_purchase
-    response = @gateway.purchase(@amount, apple_pay_payment_token(payment_data: {data: 'garbage'}), @options)
+    response = @gateway.purchase(@amount, apple_pay_payment_token(payment_data: { data: 'garbage' }), @options)
     assert_failure response
     assert_equal 'There was an error processing the payment data', response.message
     assert_equal 'processing_error', response.error_code

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -68,7 +68,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_equal @profile[:ship_to_list][:phone_number], response.params['profile']['ship_to_list']['phone_number']
     assert_equal @profile[:ship_to_list][:company], response.params['profile']['ship_to_list']['company']
 
-    assert response = @gateway.update_customer_profile(profile: {customer_profile_id: @customer_profile_id, email: 'new email address'})
+    assert response = @gateway.update_customer_profile(profile: { customer_profile_id: @customer_profile_id, email: 'new email address' })
     assert response.test?
     assert_success response
     assert_nil response.authorization

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -212,7 +212,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_email_and_ip
-    options = @options.merge({email: 'hello@example.com', ip: '127.0.0.1'})
+    options = @options.merge({ email: 'hello@example.com', ip: '127.0.0.1' })
     auth = @gateway.authorize(@amount, @credit_card, options)
     assert_success auth
 

--- a/test/remote/gateways/remote_axcessms_test.rb
+++ b/test/remote/gateways/remote_axcessms_test.rb
@@ -30,7 +30,7 @@ class RemoteAxcessmsTest < Test::Unit::TestCase
     assert_success auth, 'Authorize failed'
     assert_match %r{Successful Processing - Request successfully processed}, auth.message
 
-    assert capture = @gateway.capture(@amount, auth.authorization, {mode: @mode})
+    assert capture = @gateway.capture(@amount, auth.authorization, { mode: @mode })
     assert_success capture, 'Capture failed'
     assert_match %r{Successful Processing - Request successfully processed}, capture.message
   end
@@ -40,7 +40,7 @@ class RemoteAxcessmsTest < Test::Unit::TestCase
     assert_success auth, 'Authorize failed'
     assert_match %r{Successful Processing - Request successfully processed}, auth.message
 
-    assert capture = @gateway.capture(@amount - 30, auth.authorization, {mode: @mode})
+    assert capture = @gateway.capture(@amount - 30, auth.authorization, { mode: @mode })
     assert_success capture, 'Capture failed'
     assert_match %r{Successful Processing - Request successfully processed}, capture.message
   end
@@ -50,7 +50,7 @@ class RemoteAxcessmsTest < Test::Unit::TestCase
     assert_success auth, 'Authorize failed'
     assert_match %r{Successful Processing - Request successfully processed}, auth.message
 
-    assert void = @gateway.void(auth.authorization, {mode: @mode})
+    assert void = @gateway.void(auth.authorization, { mode: @mode })
     assert_success void, 'Void failed'
     assert_match %r{Successful Processing - Request successfully processed}, void.message
   end
@@ -82,7 +82,7 @@ class RemoteAxcessmsTest < Test::Unit::TestCase
     assert_success purchase, 'Purchase failed'
     assert_match %r{Successful Processing - Request successfully processed}, purchase.message
 
-    assert refund = @gateway.refund(@amount, purchase.authorization, {mode: @mode})
+    assert refund = @gateway.refund(@amount, purchase.authorization, { mode: @mode })
     assert_success refund, 'Refund failed'
     assert_match %r{Successful Processing - Request successfully processed}, refund.message
   end
@@ -92,7 +92,7 @@ class RemoteAxcessmsTest < Test::Unit::TestCase
     assert_success purchase, 'Purchase failed'
     assert_match %r{Successful Processing - Request successfully processed}, purchase.message
 
-    assert refund = @gateway.refund(@amount - 50, purchase.authorization, {mode: @mode})
+    assert refund = @gateway.refund(@amount - 50, purchase.authorization, { mode: @mode })
     assert_success refund, 'Refund failed'
     assert_match %r{Successful Processing - Request successfully processed}, refund.message
   end
@@ -115,7 +115,7 @@ class RemoteAxcessmsTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth, 'Authorize failed'
 
-    assert capture = @gateway.capture(@amount + 30, auth.authorization, {mode: @mode})
+    assert capture = @gateway.capture(@amount + 30, auth.authorization, { mode: @mode })
     assert_failure capture, 'Capture failed'
     assert_match %r{PA value exceeded}, capture.message
   end
@@ -127,13 +127,13 @@ class RemoteAxcessmsTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    assert refund = @gateway.refund(@amount, 'invalid authorization', {mode: @mode})
+    assert refund = @gateway.refund(@amount, 'invalid authorization', { mode: @mode })
     assert_failure refund
     assert_match %r{Configuration Validation - Invalid payment data}, refund.message
   end
 
   def test_failed_void
-    void = @gateway.void('invalid authorization', {mode: @mode})
+    void = @gateway.void('invalid authorization', { mode: @mode })
     assert_failure void
     assert_match %r{Reference Error - reversal}, void.message
   end

--- a/test/remote/gateways/remote_bank_frick_test.rb
+++ b/test/remote/gateways/remote_bank_frick_test.rb
@@ -24,7 +24,7 @@ class RemoteBankFrickTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_minimal_options
-    assert response = @gateway.purchase(@amount, @credit_card, {address: address})
+    assert response = @gateway.purchase(@amount, @credit_card, { address: address })
     assert_success response
     assert response.test?
     assert_match %r{Transaction succeeded}, response.message

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -123,7 +123,7 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       billing_address: address(),
       order_id: '123',
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
         channel: 'browser',
         browser_info: {
@@ -254,7 +254,7 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       billing_address: address(),
       order_id: '123',
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
         channel: 'app'
       }
@@ -342,7 +342,7 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
   end
 
   def test_successful_third_party_payout
-    response = @gateway.credit(@amount, @credit_card, @options_with_credit_fields.merge({third_party_payout: true}))
+    response = @gateway.credit(@amount, @credit_card, @options_with_credit_fields.merge({ third_party_payout: true }))
     assert_success response
   end
 

--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -17,8 +17,8 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     @mastercard          = credit_card('5100000010001004')
     @declined_mastercard = credit_card('5100000020002000')
 
-    @amex                = credit_card('371100001000131', {verification_value: 1234})
-    @declined_amex       = credit_card('342400001000180', {verification_value: 1234})
+    @amex                = credit_card('371100001000131', { verification_value: 1234 })
+    @declined_amex       = credit_card('342400001000180', { verification_value: 1234 })
 
     # Canadian EFT
     @check = check(

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -357,7 +357,7 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
   end
 
   def test_failed_unauthorized_echeck_purchase
-    response = @gateway.purchase(@amount, @check, @options.merge({authorized_by_shopper: false}))
+    response = @gateway.purchase(@amount, @check, @options.merge({ authorized_by_shopper: false }))
     assert_failure response
     assert_match(/The payment was not authorized by shopper/, response.message)
     assert_equal '16004', response.error_code
@@ -510,7 +510,7 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert_success store_response
     assert_match(/check/, store_response.authorization)
 
-    response = @gateway.purchase(@amount, store_response.authorization, @options.merge({authorized_by_shopper: true}))
+    response = @gateway.purchase(@amount, store_response.authorization, @options.merge({ authorized_by_shopper: true }))
     assert_success response
     assert_equal 'Success', response.message
   end

--- a/test/remote/gateways/remote_bpoint_test.rb
+++ b/test/remote/gateways/remote_bpoint_test.rb
@@ -41,7 +41,7 @@ class RemoteBpointTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_more_options
-    response = @gateway.purchase(@amount, @credit_card, @options.merge({ crn1: 'ref'}))
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ crn1: 'ref' }))
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -75,7 +75,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_hold_in_escrow
-    @options.merge({merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id], hold_in_escrow: true})
+    @options.merge({ merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id], hold_in_escrow: true })
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_equal '1000 Approved', response.message
@@ -181,7 +181,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_verify_with_device_data
     # Requires Advanced Fraud Tools to be enabled
-    assert response = @gateway.verify(@credit_card, @options.merge({device_data: 'device data for verify'}))
+    assert response = @gateway.verify(@credit_card, @options.merge({ device_data: 'device data for verify' }))
     assert_success response
     assert_equal '1000 Approved', response.message
 
@@ -379,13 +379,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   def test_cvv_match
     assert response = @gateway.purchase(@amount, credit_card('5105105105105100', verification_value: '400'))
     assert_success response
-    assert_equal({'code' => 'M', 'message' => ''}, response.cvv_result)
+    assert_equal({ 'code' => 'M', 'message' => '' }, response.cvv_result)
   end
 
   def test_cvv_no_match
     assert response = @gateway.purchase(@amount, credit_card('5105105105105100', verification_value: '200'))
     assert_success response
-    assert_equal({'code' => 'N', 'message' => ''}, response.cvv_result)
+    assert_equal({ 'code' => 'N', 'message' => '' }, response.cvv_result)
   end
 
   def test_successful_purchase_with_email
@@ -560,7 +560,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, credit_card('51051051051051000'))
     assert_failure response
     assert_match %r{Credit card number is invalid\. \(81715\)}, response.message
-    assert_equal({'processor_response_code' => '91577'}, response.params['braintree_transaction'])
+    assert_equal({ 'processor_response_code' => '91577' }, response.params['braintree_transaction'])
   end
 
   def test_authorize_and_capture
@@ -661,7 +661,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert failed_void = @gateway.void(auth.authorization)
     assert_failure failed_void
     assert_match('Transaction can only be voided if status is authorized', failed_void.message)
-    assert_equal({'processor_response_code' => '91504'}, failed_void.params['braintree_transaction'])
+    assert_equal({ 'processor_response_code' => '91504' }, failed_void.params['braintree_transaction'])
   end
 
   def test_failed_capture_with_invalid_transaction_id
@@ -804,7 +804,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.update(
       customer_vault_id,
       credit_card('4000111111111115'),
-      {verify_card: true}
+      { verify_card: true }
     )
     assert_failure response
     assert_equal 'Processor declined: Do Not Honor (2000)', response.message
@@ -954,7 +954,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def assert_avs(address1, zip, expected_avs_code)
-    response = @gateway.purchase(@amount, @credit_card, billing_address: {address1: address1, zip: zip})
+    response = @gateway.purchase(@amount, @credit_card, billing_address: { address1: address1, zip: zip })
 
     assert_success response
     assert_equal expected_avs_code, response.avs_result['code']

--- a/test/remote/gateways/remote_braintree_orange_test.rb
+++ b/test/remote/gateways/remote_braintree_orange_test.rb
@@ -9,7 +9,7 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
     @check = check()
     @declined_amount = rand(99)
     @options = {  order_id: generate_unique_id,
-                  billing_address: address}
+                  billing_address: address }
   end
 
   def test_successful_purchase

--- a/test/remote/gateways/remote_card_connect_test.rb
+++ b/test/remote/gateways/remote_card_connect_test.rb
@@ -123,9 +123,9 @@ class RemoteCardConnectTest < Test::Unit::TestCase
       order_date: '20170507',
       ship_from_date: '20877',
       user_fields: [
-        {'udf0': 'value0'},
-        {'udf1': 'value1'},
-        {'udf2': 'value2'}
+        { 'udf0': 'value0' },
+        { 'udf1': 'value1' },
+        { 'udf2': 'value2' }
       ]
     }
 

--- a/test/remote/gateways/remote_card_save_test.rb
+++ b/test/remote/gateways/remote_card_save_test.rb
@@ -7,8 +7,8 @@ class RemoteCardSaveTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4976000000003436', verification_value: '452')
     @declined_card = credit_card('4221690000004963', verification_value: '125')
-    @addresses = {'4976000000003436' => { name: 'John Watson', address1: '32 Edward Street', city: 'Camborne,', state: 'Cornwall', country: 'GB', zip: 'TR14 8PA' },
-                  '4221690000004963' => { name: 'Ian Lee', address1: '274 Lymington Avenue', city: 'London', state: 'London', country: 'GB', zip: 'N22 6JN' }}
+    @addresses = { '4976000000003436' => { name: 'John Watson', address1: '32 Edward Street', city: 'Camborne,', state: 'Cornwall', country: 'GB', zip: 'TR14 8PA' },
+                  '4221690000004963' => { name: 'Ian Lee', address1: '274 Lymington Avenue', city: 'London', state: 'London', country: 'GB', zip: 'N22 6JN' } }
 
     @options = {
       order_id: '1',

--- a/test/remote/gateways/remote_card_stream_test.rb
+++ b/test/remote/gateways/remote_card_stream_test.rb
@@ -308,7 +308,7 @@ class RemoteCardStreamTest < Test::Unit::TestCase
   end
 
   def test_successful_visacreditcard_purchase_via_reference
-    assert response = @gateway.purchase(142, @visacreditcard, @visacredit_options.merge({type: '9'}))
+    assert response = @gateway.purchase(142, @visacreditcard, @visacredit_options.merge({ type: '9' }))
     assert_equal 'APPROVED', response.message
     assert_success response
     assert response.test?

--- a/test/remote/gateways/remote_cardprocess_test.rb
+++ b/test/remote/gateways/remote_cardprocess_test.rb
@@ -50,7 +50,7 @@ class RemoteCardprocessTest < Test::Unit::TestCase
   end
 
   def test_failed_authorize
-    @gateway.instance_variable_set(:@test_options, {'customParameters[forceResultCode]' => '800.100.151'})
+    @gateway.instance_variable_set(:@test_options, { 'customParameters[forceResultCode]' => '800.100.151' })
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal 'transaction declined (invalid card)', response.message
@@ -121,7 +121,7 @@ class RemoteCardprocessTest < Test::Unit::TestCase
   end
 
   def test_failed_verify
-    @gateway.instance_variable_set(:@test_options, {'customParameters[forceResultCode]' => '600.200.100'})
+    @gateway.instance_variable_set(:@test_options, { 'customParameters[forceResultCode]' => '600.200.100' })
     response = @gateway.verify(@credit_card, @options)
     assert_failure response
     assert_match %r{invalid Payment Method}, response.message

--- a/test/remote/gateways/remote_cecabank_test.rb
+++ b/test/remote/gateways/remote_cecabank_test.rb
@@ -5,8 +5,8 @@ class RemoteCecabankTest < Test::Unit::TestCase
     @gateway = CecabankGateway.new(fixtures(:cecabank))
 
     @amount = 100
-    @credit_card = credit_card('5540500001000004', {month: 12, year: Time.now.year, verification_value: 989})
-    @declined_card = credit_card('5540500001000004', {month: 11, year: Time.now.year + 1, verification_value: 001})
+    @credit_card = credit_card('5540500001000004', { month: 12, year: Time.now.year, verification_value: 989 })
+    @declined_card = credit_card('5540500001000004', { month: 11, year: Time.now.year + 1, verification_value: 001 })
 
     @options = {
       order_id: generate_unique_id,

--- a/test/remote/gateways/remote_checkout_test.rb
+++ b/test/remote/gateways/remote_checkout_test.rb
@@ -61,7 +61,7 @@ class RemoteCheckoutTest < Test::Unit::TestCase
     auth = @gateway.authorize(100, @credit_card, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(100, auth.authorization, {currency: 'CAD'})
+    assert capture = @gateway.capture(100, auth.authorization, { currency: 'CAD' })
     assert_success capture
     assert_equal 'Successful', capture.message
   end
@@ -102,7 +102,7 @@ class RemoteCheckoutTest < Test::Unit::TestCase
     assert response = @gateway.purchase(100, @credit_card, @options)
     assert_success response
 
-    assert refund = @gateway.refund(100, response.authorization, {currency: 'CAD'})
+    assert refund = @gateway.refund(100, response.authorization, { currency: 'CAD' })
     assert_success refund
     assert_equal 'Successful', refund.message
   end
@@ -111,7 +111,7 @@ class RemoteCheckoutTest < Test::Unit::TestCase
     assert response = @gateway.purchase(100, @credit_card, @options)
     assert_success response
 
-    assert refund = @gateway.refund(100, '||||', {currency: 'CAD'})
+    assert refund = @gateway.refund(100, '||||', { currency: 'CAD' })
     assert_failure refund
   end
 

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -86,7 +86,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_manual_entry_flag
-    response = @gateway.authorize(@amount, @credit_card, @options.merge(metadata: { manual_entry: true}))
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(metadata: { manual_entry: true }))
 
     assert_success response
     assert_equal 'Succeeded', response.message

--- a/test/remote/gateways/remote_conekta_test.rb
+++ b/test/remote/gateways/remote_conekta_test.rb
@@ -56,7 +56,7 @@ class RemoteConektaTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_installments
-    assert response = @gateway.purchase(@amount * 300, @credit_card, @options.merge({monthly_installments: 3}))
+    assert response = @gateway.purchase(@amount * 300, @credit_card, @options.merge({ monthly_installments: 3 }))
     assert_success response
     assert_equal nil, response.message
   end

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -26,7 +26,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
       execute_threed: true,
       three_ds_version: '2',
       three_ds_challenge_window_size: '01',
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
         channel: 'browser',
         notification_url: 'www.example.com',
@@ -190,7 +190,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_authorization_details
-    options_with_auth_details = @options.merge({authorization_type: '2', multiple_capture_count: '5' })
+    options_with_auth_details = @options.merge({ authorization_type: '2', multiple_capture_count: '5' })
     response = @gateway.authorize(@amount, @credit_card, options_with_auth_details)
     assert_success response
     assert_equal 'Succeeded', response.message

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -5,7 +5,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   def setup
     Base.mode = :test
 
-    @gateway = CyberSourceGateway.new({nexus: 'NC'}.merge(fixtures(:cyber_source)))
+    @gateway = CyberSourceGateway.new({ nexus: 'NC' }.merge(fixtures(:cyber_source)))
 
     @credit_card = credit_card('4111111111111111', verification_value: '987')
     @declined_card = credit_card('801111111111111')
@@ -677,7 +677,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_create_subscription_with_monthly_options
-    response = @gateway.store(@credit_card, @subscription_options.merge(setup_fee: 99.0, subscription: {amount: 49.0, automatic_renew: false, frequency: 'monthly'}))
+    response = @gateway.store(@credit_card, @subscription_options.merge(setup_fee: 99.0, subscription: { amount: 49.0, automatic_renew: false, frequency: 'monthly' }))
     assert_equal 'Successful transaction', response.message
     response = @gateway.retrieve(response.authorization, order_id: @subscription_options[:order_id])
     assert_equal '0.49', response.params['recurringAmount']
@@ -688,7 +688,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_successful_response(response)
 
-    assert response = @gateway.update(response.authorization, @credit_card, {order_id: generate_unique_id, setup_fee: 100})
+    assert response = @gateway.update(response.authorization, @credit_card, { order_id: generate_unique_id, setup_fee: 100 })
     assert_successful_response(response)
   end
 
@@ -697,7 +697,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
 
     assert response = @gateway.update(response.authorization, nil,
-      {order_id: generate_unique_id, setup_fee: 100, billing_address: address, email: 'someguy1232@fakeemail.net'})
+      { order_id: generate_unique_id, setup_fee: 100, billing_address: address, email: 'someguy1232@fakeemail.net' })
 
     assert_successful_response(response)
   end

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -94,7 +94,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
     assert_equal 'approved', response.message
     assert_equal 'Heavenly Buffaloes', response.params['establishment_name']
     assert_equal '99999999', response.params['site_id']
-    assert_equal({'status' => nil}, response.params['fraud_detection'])
+    assert_equal({ 'status' => nil }, response.params['fraud_detection'])
     assert response.authorization
   end
 

--- a/test/remote/gateways/remote_digitzs_test.rb
+++ b/test/remote/gateways/remote_digitzs_test.rb
@@ -99,17 +99,17 @@ class RemoteDigitzsTest < Test::Unit::TestCase
   end
 
   def test_successful_store_without_billing_address
-    assert response = @gateway.store(@credit_card, {merchant_id: 'spreedly-susanswidg-32268973-2091076-148408385'})
+    assert response = @gateway.store(@credit_card, { merchant_id: 'spreedly-susanswidg-32268973-2091076-148408385' })
     assert_success response
   end
 
   def test_store_adds_card_to_existing_customer
-    assert response = @gateway.store(@credit_card, @options.merge({customer_id: 'spreedly-susanswidg-32268973-2091076-148408385-5980208887457495-148700575'}))
+    assert response = @gateway.store(@credit_card, @options.merge({ customer_id: 'spreedly-susanswidg-32268973-2091076-148408385-5980208887457495-148700575' }))
     assert_success response
   end
 
   def test_store_creates_new_customer_and_adds_card
-    assert response = @gateway.store(@credit_card, @options.merge({customer_id: 'nonexistant'}))
+    assert response = @gateway.store(@credit_card, @options.merge({ customer_id: 'nonexistant' }))
     assert_success response
   end
 

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -131,7 +131,7 @@ class RemoteEbanxTest < Test::Unit::TestCase
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
-    refund_options = @options.merge({description: 'full refund'})
+    refund_options = @options.merge({ description: 'full refund' })
     assert refund = @gateway.refund(@amount, purchase.authorization, refund_options)
     assert_success refund
     assert_equal 'Accepted', refund.message

--- a/test/remote/gateways/remote_efsnet_test.rb
+++ b/test/remote/gateways/remote_efsnet_test.rb
@@ -12,7 +12,7 @@ class RemoteEfsnetTest < Test::Unit::TestCase
     @declined_amount = 156
 
     @options = { order_id: generate_unique_id,
-                 billing_address: address}
+                 billing_address: address }
   end
 
   def test_successful_purchase

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -198,7 +198,7 @@ class RemoteElavonTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_custom_fields
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(custom_fields: {a_key: 'a value'}))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(custom_fields: { a_key: 'a value' }))
 
     assert_success response
     assert response.test?

--- a/test/remote/gateways/remote_epay_test.rb
+++ b/test/remote/gateways/remote_epay_test.rb
@@ -8,8 +8,8 @@ class RemoteEpayTest < Test::Unit::TestCase
     @credit_card = credit_card('3333333333333000')
     @credit_card_declined = credit_card('3333333333333102')
     @amount = 100
-    @options_xid = {order_id: generate_unique_id, three_d_secure: { eci: '7', xid: '123', cavv: '456', version: '2', ds_transaction_id: nil }}
-    @options_ds_transaction_id = {order_id: generate_unique_id, three_d_secure: { eci: '7', xid: nil, cavv: '456', version: '2', ds_transaction_id: '798' }}
+    @options_xid = { order_id: generate_unique_id, three_d_secure: { eci: '7', xid: '123', cavv: '456', version: '2', ds_transaction_id: nil } }
+    @options_ds_transaction_id = { order_id: generate_unique_id, three_d_secure: { eci: '7', xid: nil, cavv: '456', version: '2', ds_transaction_id: '798' } }
   end
 
   def test_successful_purchase_xid

--- a/test/remote/gateways/remote_evo_ca_test.rb
+++ b/test/remote/gateways/remote_evo_ca_test.rb
@@ -102,7 +102,7 @@ class RemoteEvoCaTest < Test::Unit::TestCase
 
   def test_avs_match
     # To simulate an AVS Match, pass 888 in the address1 field, 77777 for zip.
-    opts = @options.merge(billing_address: address({address1: '888', zip: '77777'}))
+    opts = @options.merge(billing_address: address({ address1: '888', zip: '77777' }))
     assert response = @gateway.purchase(@amount, @credit_card, opts)
     assert_success response
     assert_equal 'Y', response.avs_result['code']

--- a/test/remote/gateways/remote_eway_test.rb
+++ b/test/remote/gateways/remote_eway_test.rb
@@ -15,7 +15,7 @@ class EwayTest < Test::Unit::TestCase
                             city: 'Bobville',
                             state: 'WA',
                             country: 'AU',
-                            zip: '2000'},
+                            zip: '2000' },
       description: 'purchased items'
     }
   end

--- a/test/remote/gateways/remote_first_pay_test.rb
+++ b/test/remote/gateways/remote_first_pay_test.rb
@@ -112,7 +112,7 @@ class RemoteFirstPayTest < Test::Unit::TestCase
   end
 
   def test_recurring_payment
-    @options.merge!({recurring: 1, recurring_start_date: DateTime.now.strftime('%m/%d/%Y'), recurring_end_date: DateTime.now.strftime('%m/%d/%Y'), recurring_type: 'monthly'})
+    @options.merge!({ recurring: 1, recurring_start_date: DateTime.now.strftime('%m/%d/%Y'), recurring_end_date: DateTime.now.strftime('%m/%d/%Y'), recurring_type: 'monthly' })
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -36,7 +36,7 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_specified_currency
-    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    options_with_specified_currency = @options.merge({ currency: 'GBP' })
     assert response = @gateway.purchase(@amount, @credit_card, options_with_specified_currency)
     assert_match(/Transaction Normal/, response.message)
     assert_success response
@@ -118,7 +118,7 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_purchase_and_credit_with_specified_currency
-    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    options_with_specified_currency = @options.merge({ currency: 'GBP' })
     assert purchase = @gateway.purchase(@amount, @credit_card, options_with_specified_currency)
     assert_success purchase
     assert purchase.authorization
@@ -203,7 +203,7 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_refund_with_specified_currency
-    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    options_with_specified_currency = @options.merge({ currency: 'GBP' })
     assert purchase = @gateway.purchase(@amount, @credit_card, options_with_specified_currency)
     assert_match(/Transaction Normal/, purchase.message)
     assert_success purchase

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -97,13 +97,13 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
             date: '20190810',
             carrier_code: 'SA',
             number: 596,
-            airline_class: 'ZZ'},
+            airline_class: 'ZZ' },
           { arrival_airport: 'RDU',
             origin_airport: 'BDL',
             date: '20190817',
             carrier_code: 'SA',
             number: 597,
-            airline_class: 'ZZ'}
+            airline_class: 'ZZ' }
         ]
       }
     )
@@ -130,7 +130,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_very_long_name
-    credit_card = credit_card('4567350000427977', { first_name: 'thisisaverylongfirstname'})
+    credit_card = credit_card('4567350000427977', { first_name: 'thisisaverylongfirstname' })
 
     response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
@@ -138,7 +138,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_blank_name
-    credit_card = credit_card('4567350000427977', { first_name: nil, last_name: nil})
+    credit_card = credit_card('4567350000427977', { first_name: nil, last_name: nil })
 
     response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response

--- a/test/remote/gateways/remote_inspire_test.rb
+++ b/test/remote/gateways/remote_inspire_test.rb
@@ -8,7 +8,7 @@ class RemoteBraintreeTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111', brand: 'visa')
     @declined_amount = rand(99)
     @options = {  order_id: generate_unique_id,
-                  billing_address: address}
+                  billing_address: address }
   end
 
   def test_successful_purchase

--- a/test/remote/gateways/remote_iridium_test.rb
+++ b/test/remote/gateways/remote_iridium_test.rb
@@ -7,10 +7,10 @@ class RemoteIridiumTest < Test::Unit::TestCase
     @gateway = IridiumGateway.new(fixtures(:iridium))
 
     @amount = 100
-    @avs_card = credit_card('4921810000005462', {verification_value: '441'})
-    @cv2_card = credit_card('4976000000003436', {verification_value: '777'})
-    @avs_cv2_card = credit_card('4921810000005462', {verification_value: '777'})
-    @credit_card = credit_card('4976000000003436', {verification_value: '452'})
+    @avs_card = credit_card('4921810000005462', { verification_value: '441' })
+    @cv2_card = credit_card('4976000000003436', { verification_value: '777' })
+    @avs_cv2_card = credit_card('4921810000005462', { verification_value: '777' })
+    @credit_card = credit_card('4976000000003436', { verification_value: '452' })
     @declined_card = credit_card('4221690000004963')
 
     our_address = address(address1: '32 Edward Street',
@@ -111,7 +111,7 @@ class RemoteIridiumTest < Test::Unit::TestCase
     assert_success response
     assert(reference = response.authorization)
 
-    assert response = @gateway.purchase(@amount, reference, {order_id: generate_unique_id})
+    assert response = @gateway.purchase(@amount, reference, { order_id: generate_unique_id })
     assert_success response
   end
 
@@ -120,7 +120,7 @@ class RemoteIridiumTest < Test::Unit::TestCase
     assert_success response
     assert response.authorization
 
-    assert response = @gateway.purchase(@amount, 'bogusref', {order_id: generate_unique_id})
+    assert response = @gateway.purchase(@amount, 'bogusref', { order_id: generate_unique_id })
     assert_failure response
   end
 
@@ -129,7 +129,7 @@ class RemoteIridiumTest < Test::Unit::TestCase
     assert_success response
     assert(reference = response.authorization)
 
-    assert response = @gateway.authorize(@amount, reference, {order_id: generate_unique_id})
+    assert response = @gateway.authorize(@amount, reference, { order_id: generate_unique_id })
     assert_success response
   end
 

--- a/test/remote/gateways/remote_ixopay_test.rb
+++ b/test/remote/gateways/remote_ixopay_test.rb
@@ -17,7 +17,7 @@ class RemoteIxopayTest < Test::Unit::TestCase
       stored_credential: stored_credential(:initial)
     }
 
-    @extra_data = {extra_data: { customData1: 'some data', customData2: 'Can be anything really' }}
+    @extra_data = { extra_data: { customData1: 'some data', customData2: 'Can be anything really' } }
   end
 
   def test_successful_purchase

--- a/test/remote/gateways/remote_jetpay_test.rb
+++ b/test/remote/gateways/remote_jetpay_test.rb
@@ -32,7 +32,7 @@ class RemoteJetpayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_origin
-    assert response = @gateway.purchase(9900, @credit_card, {origin: 'RECURRING'})
+    assert response = @gateway.purchase(9900, @credit_card, { origin: 'RECURRING' })
     assert_success response
     assert_equal 'APPROVED', response.message
     assert_not_nil response.authorization

--- a/test/remote/gateways/remote_jetpay_v2_test.rb
+++ b/test/remote/gateways/remote_jetpay_v2_test.rb
@@ -36,7 +36,7 @@ class RemoteJetpayV2Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_minimal_options
-    assert response = @gateway.purchase(@amount_approved, @credit_card, {device: 'spreedly', application: 'spreedly'})
+    assert response = @gateway.purchase(@amount_approved, @credit_card, { device: 'spreedly', application: 'spreedly' })
     assert_success response
     assert_equal 'APPROVED', response.message
     assert_not_nil response.authorization

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -53,7 +53,7 @@ class RemoteKushkiTest < Test::Unit::TestCase
 
   def test_successful_authorize
     # Kushki only allows preauthorization for PEN, CLP, and UF.
-    response = @gateway.authorize(@amount, @credit_card, {currency: 'PEN'})
+    response = @gateway.authorize(@amount, @credit_card, { currency: 'PEN' })
     assert_success response
     assert_equal 'Succeeded', response.message
     assert_match %r(^\d+$), response.authorization

--- a/test/remote/gateways/remote_linkpoint_test.rb
+++ b/test/remote/gateways/remote_linkpoint_test.rb
@@ -91,9 +91,9 @@ class LinkpointTest < Test::Unit::TestCase
 
   def test_successfull_purchase_with_item_entity
     @options[:line_items] = [
-      {id: '123456', description: 'Logo T-Shirt', price: '12.00', quantity: '1',
-       options: [{name: 'Color', value: 'Red'}, {name: 'Size', value: 'XL'}]},
-      {id: '111', description: 'keychain', price: '3.00', quantity: '1'}
+      { id: '123456', description: 'Logo T-Shirt', price: '12.00', quantity: '1',
+       options: [{ name: 'Color', value: 'Red' }, { name: 'Size', value: 'XL' }] },
+      { id: '111', description: 'keychain', price: '3.00', quantity: '1' }
     ]
     assert purchase = @gateway.purchase(1500, @credit_card, @options)
     assert_success purchase

--- a/test/remote/gateways/remote_litle_certification_test.rb
+++ b/test/remote/gateways/remote_litle_certification_test.rb
@@ -171,7 +171,7 @@ class RemoteLitleCertification < Test::Unit::TestCase
     puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
 
     # 6A. void
-    assert response = @gateway.void(response.authorization, {order_id: '6A'})
+    assert response = @gateway.void(response.authorization, { order_id: '6A' })
     assert_equal '360', response.params['response']
     assert_equal 'No transaction found with specified transaction Id', response.message
     puts "Test #{options[:order_id]}A: #{txn_id(response)}"
@@ -1173,15 +1173,15 @@ class RemoteLitleCertification < Test::Unit::TestCase
     assert_equal auth_code(options[:order_id]), response.params['authCode']
 
     # 1A: capture
-    assert response = @gateway.capture(amount, response.authorization, {id: transaction_id})
+    assert response = @gateway.capture(amount, response.authorization, { id: transaction_id })
     assert_equal 'Approved', response.message
 
     # 1B: credit
-    assert response = @gateway.credit(amount, response.authorization, {id: transaction_id})
+    assert response = @gateway.credit(amount, response.authorization, { id: transaction_id })
     assert_equal 'Approved', response.message
 
     # 1C: void
-    assert response = @gateway.void(response.authorization, {id: transaction_id})
+    assert response = @gateway.void(response.authorization, { id: transaction_id })
     assert_equal 'Approved', response.message
   end
 
@@ -1203,11 +1203,11 @@ class RemoteLitleCertification < Test::Unit::TestCase
     # assert_equal auth_code(options[:order_id]), response.params['authCode']
 
     # 1B: credit
-    assert response = @gateway.credit(amount, response.authorization, {id: transaction_id})
+    assert response = @gateway.credit(amount, response.authorization, { id: transaction_id })
     assert_equal 'Approved', response.message
 
     # 1C: void
-    assert response = @gateway.void(response.authorization, {id: transaction_id})
+    assert response = @gateway.void(response.authorization, { id: transaction_id })
     assert_equal 'Approved', response.message
   end
 

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -595,7 +595,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     token = store_response.authorization
     assert_equal store_response.params['litleToken'], token
 
-    assert response = @gateway.purchase(10010, token, {basis_expiration_month: '01', basis_expiration_year: '2024'})
+    assert response = @gateway.purchase(10010, token, { basis_expiration_month: '01', basis_expiration_year: '2024' })
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/remote/gateways/remote_merchant_e_solutions_test.rb
+++ b/test/remote/gateways/remote_merchant_e_solutions_test.rb
@@ -44,7 +44,7 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
   end
 
   def test_purchase_with_long_order_id
-    options = {order_id: 'thisislongerthan17characters'}
+    options = { order_id: 'thisislongerthan17characters' }
     assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal 'This transaction has been approved', response.message
@@ -193,7 +193,7 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
   def test_successful_purchase_with_3dsecure_params
     options = @options.merge(
       { xid: 'ERERERERERERERERERERERERERE=',
-        cavv: 'ERERERERERERERERERERERERERE='}
+        cavv: 'ERERERERERERERERERERERERERE=' }
     )
     assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response

--- a/test/remote/gateways/remote_merchant_ware_test.rb
+++ b/test/remote/gateways/remote_merchant_ware_test.rb
@@ -6,7 +6,7 @@ class RemoteMerchantWareTest < Test::Unit::TestCase
 
     @amount = rand(200..1199)
 
-    @credit_card = credit_card('5424180279791732', {brand: 'master'})
+    @credit_card = credit_card('5424180279791732', { brand: 'master' })
 
     @options = {
       order_id: generate_unique_id,

--- a/test/remote/gateways/remote_merchant_ware_version_four_test.rb
+++ b/test/remote/gateways/remote_merchant_ware_version_four_test.rb
@@ -4,7 +4,7 @@ class RemoteMerchantWareVersionFourTest < Test::Unit::TestCase
   def setup
     @gateway = MerchantWareVersionFourGateway.new(fixtures(:merchant_ware_version_four))
     @amount = rand(200..1199)
-    @credit_card = credit_card('5424180279791732', {brand: 'master'})
+    @credit_card = credit_card('5424180279791732', { brand: 'master' })
     @declined_card = credit_card('1234567890123')
 
     @options = {

--- a/test/remote/gateways/remote_mercury_test.rb
+++ b/test/remote/gateways/remote_mercury_test.rb
@@ -101,7 +101,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
       },
       response.avs_result
     )
-    assert_equal({'code' => 'M', 'message' => 'CVV matches'}, response.cvv_result)
+    assert_equal({ 'code' => 'M', 'message' => 'CVV matches' }, response.cvv_result)
   end
 
   def test_avs_and_cvv_results_with_track_data
@@ -118,7 +118,7 @@ class RemoteMercuryTest < Test::Unit::TestCase
       },
       response.avs_result
     )
-    assert_equal({'code' => 'P', 'message' => 'CVV not processed'}, response.cvv_result)
+    assert_equal({ 'code' => 'P', 'message' => 'CVV not processed' }, response.cvv_result)
   end
 
   def test_partial_capture

--- a/test/remote/gateways/remote_migs_test.rb
+++ b/test/remote/gateways/remote_migs_test.rb
@@ -211,7 +211,7 @@ class RemoteMigsTest < Test::Unit::TestCase
 
   def https_response(url, cookie = nil)
     retry_exceptions do
-      headers = cookie ? {'Cookie' => cookie} : {}
+      headers = cookie ? { 'Cookie' => cookie } : {}
       response = raw_ssl_request(:get, url, nil, headers)
       if response.is_a?(Net::HTTPRedirection)
         new_cookie = [cookie, response['Set-Cookie']].compact.join(';')

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -278,20 +278,20 @@ class MonerisRemoteTest < Test::Unit::TestCase
   def test_cvv_match_when_not_enabled
     assert response = @gateway.purchase(1039, @credit_card, @options)
     assert_success response
-    assert_equal({'code' => nil, 'message' => nil}, response.cvv_result)
+    assert_equal({ 'code' => nil, 'message' => nil }, response.cvv_result)
   end
 
   def test_cvv_no_match_when_not_enabled
     assert response = @gateway.purchase(1053, @credit_card, @options)
     assert_success response
-    assert_equal({'code' => nil, 'message' => nil}, response.cvv_result)
+    assert_equal({ 'code' => nil, 'message' => nil }, response.cvv_result)
   end
 
   def test_cvv_match_when_enabled
     gateway = MonerisGateway.new(fixtures(:moneris).merge(cvv_enabled: true))
     assert response = gateway.purchase(1039, @credit_card, @options)
     assert_success response
-    assert_equal({'code' => 'M', 'message' => 'CVV matches'}, response.cvv_result)
+    assert_equal({ 'code' => 'M', 'message' => 'CVV matches' }, response.cvv_result)
   end
 
   def test_avs_result_valid_when_enabled

--- a/test/remote/gateways/remote_mundipagg_test.rb
+++ b/test/remote/gateways/remote_mundipagg_test.rb
@@ -18,7 +18,7 @@ class RemoteMundipaggTest < Test::Unit::TestCase
 
     @options = {
       gateway_affiliation_id: fixtures(:mundipagg)[:gateway_affiliation_id],
-      billing_address: address({neighborhood: 'Sesame Street'}),
+      billing_address: address({ neighborhood: 'Sesame Street' }),
       description: 'Store Purchase'
     }
 
@@ -48,7 +48,7 @@ class RemoteMundipaggTest < Test::Unit::TestCase
       }
     }
 
-    @excess_length_neighborhood = address({neighborhood: 'Super Long Neighborhood Name' * 5})
+    @excess_length_neighborhood = address({ neighborhood: 'Super Long Neighborhood Name' * 5 })
     @neighborhood_length_error = 'Invalid parameters; The request is invalid. | The field neighborhood must be a string with a maximum length of 64.'
   end
 
@@ -271,7 +271,7 @@ class RemoteMundipaggTest < Test::Unit::TestCase
   def test_gateway_id_fallback
     gateway = MundipaggGateway.new(api_key: fixtures(:mundipagg)[:api_key], gateway_id: fixtures(:mundipagg)[:gateway_id])
     options = {
-      billing_address: address({neighborhood: 'Sesame Street'}),
+      billing_address: address({ neighborhood: 'Sesame Street' }),
       description: 'Store Purchase'
     }
     response = gateway.purchase(@amount, @credit_card, options)

--- a/test/remote/gateways/remote_nab_transact_test.rb
+++ b/test/remote/gateways/remote_nab_transact_test.rb
@@ -67,7 +67,7 @@ class RemoteNabTransactTest < Test::Unit::TestCase
       merchant_location: 'Melbourne'
     }
     card_acceptor_options.each do |key, value|
-      options = @options.merge({key => value})
+      options = @options.merge({ key => value })
       assert response = @gateway.purchase(@amount, @credit_card, options)
       assert_failure response
       assert_equal 'Permission denied', response.message
@@ -132,7 +132,7 @@ class RemoteNabTransactTest < Test::Unit::TestCase
       merchant_location: 'Melbourne'
     }
     card_acceptor_options.each do |key, value|
-      options = @options.merge({key => value})
+      options = @options.merge({ key => value })
       assert response = @gateway.authorize(@amount, @credit_card, options)
       assert_failure response
       assert_equal 'Permission denied', response.message
@@ -161,11 +161,11 @@ class RemoteNabTransactTest < Test::Unit::TestCase
   # You need to speak to NAB Transact to have this feature enabled on
   # your account otherwise you will receive a "Permission denied" error
   def test_credit
-    assert response = @gateway.credit(@amount, @credit_card, {order_id: '1'})
+    assert response = @gateway.credit(@amount, @credit_card, { order_id: '1' })
     assert_failure response
     assert_equal 'Permission denied', response.message
 
-    assert response = @privileged_gateway.credit(@amount, @credit_card, {order_id: '1'})
+    assert response = @privileged_gateway.credit(@amount, @credit_card, { order_id: '1' })
     assert_success response
     assert_equal 'Approved', response.message
   end
@@ -204,11 +204,11 @@ class RemoteNabTransactTest < Test::Unit::TestCase
   def test_duplicate_store
     @gateway.unstore(1236)
 
-    assert response = @gateway.store(@credit_card, {billing_id: 1236})
+    assert response = @gateway.store(@credit_card, { billing_id: 1236 })
     assert_success response
     assert_equal 'Successful', response.message
 
-    assert response = @gateway.store(@credit_card, {billing_id: 1236})
+    assert response = @gateway.store(@credit_card, { billing_id: 1236 })
     assert_failure response
     assert_equal 'Duplicate CRN Found', response.message
   end
@@ -239,7 +239,7 @@ class RemoteNabTransactTest < Test::Unit::TestCase
     trigger_amount = 0
     @gateway.unstore(gateway_id)
 
-    assert response = @gateway.store(@credit_card, {billing_id: gateway_id, amount: 150})
+    assert response = @gateway.store(@credit_card, { billing_id: gateway_id, amount: 150 })
     assert_success response
     assert_equal 'Successful', response.message
 

--- a/test/remote/gateways/remote_netbanx_test.rb
+++ b/test/remote/gateways/remote_netbanx_test.rb
@@ -247,7 +247,7 @@ class RemoteNetbanxTest < Test::Unit::TestCase
 
   def test_successful_purchase_using_stored_card
     merchant_customer_id = SecureRandom.hex
-    assert store = @gateway.store(@credit_card, @options.merge({locale: 'en_GB', merchant_customer_id: merchant_customer_id, email: 'email@example.com'}))
+    assert store = @gateway.store(@credit_card, @options.merge({ locale: 'en_GB', merchant_customer_id: merchant_customer_id, email: 'email@example.com' }))
     assert_success store
 
     assert response = @gateway.purchase(@amount, store.authorization.split('|').last)

--- a/test/remote/gateways/remote_netbilling_test.rb
+++ b/test/remote/gateways/remote_netbilling_test.rb
@@ -11,7 +11,7 @@ class RemoteNetbillingTest < Test::Unit::TestCase
                   state: 'CA',
                   country: 'US',
                   zip: '94043',
-                  phone: '650-253-0001'}
+                  phone: '650-253-0001' }
 
     @options = {
       billing_address: @address,

--- a/test/remote/gateways/remote_omise_test.rb
+++ b/test/remote/gateways/remote_omise_test.rb
@@ -6,7 +6,7 @@ class RemoteOmiseTest < Test::Unit::TestCase
     @amount  = 8888
     @credit_card   = credit_card('4242424242424242')
     @declined_card = credit_card('4255555555555555')
-    @invalid_cvc   = credit_card('4111111111160001', {verification_value: ''})
+    @invalid_cvc   = credit_card('4111111111160001', { verification_value: '' })
     @options = {
       description: 'Active Merchant',
       email: 'active.merchant@testing.test',
@@ -54,7 +54,7 @@ class RemoteOmiseTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase_with_token
-    response = @gateway.purchase(@amount, nil, {token_id: 'tokn_invalid_12345'})
+    response = @gateway.purchase(@amount, nil, { token_id: 'tokn_invalid_12345' })
     assert_failure response
   end
 

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -93,15 +93,15 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     ]
 
     @test_suite = [
-      {card: :visa, AVSzip: 11111, CVD: 111,  amount: 3000},
-      {card: :visa, AVSzip: 33333, CVD: nil,  amount: 3801},
-      {card: :mc,   AVSzip: 44444, CVD: nil,  amount: 4100},
-      {card: :mc,   AVSzip: 88888, CVD: 666,  amount: 1102},
-      {card: :amex, AVSzip: 55555, CVD: nil,  amount: 105500},
-      {card: :amex, AVSzip: 66666, CVD: 2222, amount: 7500},
-      {card: :ds,   AVSzip: 77777, CVD: nil,  amount: 1000},
-      {card: :ds,   AVSzip: 88888, CVD: 444,  amount: 6303},
-      {card: :jcb,  AVSzip: 33333, CVD: nil,  amount: 2900}
+      { card: :visa, AVSzip: 11111, CVD: 111,  amount: 3000 },
+      { card: :visa, AVSzip: 33333, CVD: nil,  amount: 3801 },
+      { card: :mc,   AVSzip: 44444, CVD: nil,  amount: 4100 },
+      { card: :mc,   AVSzip: 88888, CVD: 666,  amount: 1102 },
+      { card: :amex, AVSzip: 55555, CVD: nil,  amount: 105500 },
+      { card: :amex, AVSzip: 66666, CVD: 2222, amount: 7500 },
+      { card: :ds,   AVSzip: 77777, CVD: nil,  amount: 1000 },
+      { card: :ds,   AVSzip: 88888, CVD: 444,  amount: 6303 },
+      { card: :jcb,  AVSzip: 33333, CVD: nil,  amount: 2900 }
     ]
   end
 

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -63,7 +63,7 @@ class RemotePayeezyTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_echeck
-    options = @options.merge({customer_id_type: '1', customer_id_number: '1', client_email: 'test@example.com'})
+    options = @options.merge({ customer_id_type: '1', customer_id_number: '1', client_email: 'test@example.com' })
     assert response = @gateway.purchase(@amount, @check, options)
     assert_match(/Transaction Normal/, response.message)
     assert_success response

--- a/test/remote/gateways/remote_payex_test.rb
+++ b/test/remote/gateways/remote_payex_test.rb
@@ -79,7 +79,7 @@ class RemotePayexTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'OK', response.message
 
-    assert response = @gateway.purchase(@amount, response.authorization, @options.merge({order_id: '5678'}))
+    assert response = @gateway.purchase(@amount, response.authorization, @options.merge({ order_id: '5678' }))
     assert_success response
     assert_equal 'OK', response.message
   end
@@ -89,7 +89,7 @@ class RemotePayexTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'OK', response.message
 
-    assert response = @gateway.authorize(@amount, response.authorization, @options.merge({order_id: '5678'}))
+    assert response = @gateway.authorize(@amount, response.authorization, @options.merge({ order_id: '5678' }))
     assert_success response
     assert_equal 'OK', response.message
     assert response.authorization

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -145,7 +145,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_successful_incomplete_captures
     auth = @gateway.authorize(100, @credit_card, @params)
     assert_success auth
-    response = @gateway.capture(60, auth.authorization, {complete_type: 'NotComplete'})
+    response = @gateway.capture(60, auth.authorization, { complete_type: 'NotComplete' })
     assert_success response
     assert response.params['transaction_id']
     assert_equal '0.60', response.params['gross_amount']
@@ -233,7 +233,7 @@ class PaypalTest < Test::Unit::TestCase
     assert_success response
 
     response = @gateway.transfer([@amount, 'joe@example.com'],
-      [600, 'jane@example.com', {note: 'Thanks for taking care of that'}],
+      [600, 'jane@example.com', { note: 'Thanks for taking care of that' }],
       subject: 'Your money')
     assert_success response
   end

--- a/test/remote/gateways/remote_payway_test.rb
+++ b/test/remote/gateways/remote_payway_test.rb
@@ -4,7 +4,7 @@ class PaywayTest < Test::Unit::TestCase
   def setup
     @amount = 1100
 
-    @options = {order_id: generate_unique_id}
+    @options = { order_id: generate_unique_id }
 
     @gateway = ActiveMerchant::Billing::PaywayGateway.new(fixtures(:payway))
 

--- a/test/remote/gateways/remote_quantum_test.rb
+++ b/test/remote/gateways/remote_quantum_test.rb
@@ -53,7 +53,7 @@ class RemoteQuantumTest < Test::Unit::TestCase
   end
 
   def test_passing_billing_address
-    options = {billing_address: address}
+    options = { billing_address: address }
     assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal 'Transaction is APPROVED', response.message

--- a/test/remote/gateways/remote_quickbooks_test.rb
+++ b/test/remote/gateways/remote_quickbooks_test.rb
@@ -13,7 +13,7 @@ class RemoteTest < Test::Unit::TestCase
       order_id: '1',
       billing_address: address({ zip: 90210,
                                  country: 'US',
-                                 state: 'CA'}),
+                                 state: 'CA' }),
       description: 'Store Purchase'
     }
   end

--- a/test/remote/gateways/remote_quickpay_v10_test.rb
+++ b/test/remote/gateways/remote_quickpay_v10_test.rb
@@ -24,7 +24,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_short_country
-    options = @options.merge({billing_address: address(country: 'DK')})
+    options = @options.merge({ billing_address: address(country: 'DK') })
     assert response = @gateway.purchase(@amount, @valid_card, options)
 
     assert_equal 'OK', response.message
@@ -34,7 +34,7 @@ class RemoteQuickPayV10Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_order_id_format
-    options = @options.merge({order_id: "##{Time.new.to_f}"})
+    options = @options.merge({ order_id: "##{Time.new.to_f}" })
     assert response = @gateway.purchase(@amount, @valid_card, options)
 
     assert_equal 'OK', response.message

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -14,7 +14,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     @gateway = SecurePayAuGateway.new(fixtures(:secure_pay_au))
 
     @amount = 100
-    @credit_card = credit_card('4242424242424242', {month: 9, year: 15})
+    @credit_card = credit_card('4242424242424242', { month: 9, year: 15 })
 
     @options = {
       order_id: '2',
@@ -120,7 +120,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
   end
 
   def test_successful_unstore
-    @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000}) rescue nil
+    @gateway.store(@credit_card, { billing_id: 'test1234', amount: 15000 }) rescue nil
 
     assert response = @gateway.unstore('test1234')
     assert_success response
@@ -139,23 +139,23 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
   def test_successful_store
     @gateway.unstore('test1234') rescue nil
 
-    assert response = @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000})
+    assert response = @gateway.store(@credit_card, { billing_id: 'test1234', amount: 15000 })
     assert_success response
 
     assert_equal 'Successful', response.message
   end
 
   def test_failed_store
-    @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000}) rescue nil # Ensure it already exists
+    @gateway.store(@credit_card, { billing_id: 'test1234', amount: 15000 }) rescue nil # Ensure it already exists
 
-    assert response = @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000})
+    assert response = @gateway.store(@credit_card, { billing_id: 'test1234', amount: 15000 })
     assert_failure response
 
     assert_equal 'Duplicate Client ID Found', response.message
   end
 
   def test_successful_triggered_payment
-    @gateway.store(@credit_card, {billing_id: 'test1234', amount: 15000}) rescue nil # Ensure it already exists
+    @gateway.store(@credit_card, { billing_id: 'test1234', amount: 15000 }) rescue nil # Ensure it already exists
 
     assert response = @gateway.purchase(12300, 'test1234', @options)
     assert_success response

--- a/test/remote/gateways/remote_so_easy_pay_test.rb
+++ b/test/remote/gateways/remote_so_easy_pay_test.rb
@@ -5,7 +5,7 @@ class RemoteSoEasyPayTest < Test::Unit::TestCase
     @gateway = SoEasyPayGateway.new(fixtures(:so_easy_pay))
 
     @amount = 100
-    @credit_card = credit_card('4111111111111111', {verification_value: '000', month: '12', year: '2015'})
+    @credit_card = credit_card('4111111111111111', { verification_value: '000', month: '12', year: '2015' })
     @declined_card = credit_card('4000300011112220')
 
     @options = {

--- a/test/remote/gateways/remote_spreedly_core_test.rb
+++ b/test/remote/gateways/remote_spreedly_core_test.rb
@@ -7,7 +7,7 @@ class RemoteSpreedlyCoreTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('5555555555554444')
     @declined_card = credit_card('4012888888881881')
-    @check = check({routing_number: '021000021', account_number: '9876543210'})
+    @check = check({ routing_number: '021000021', account_number: '9876543210' })
     @existing_payment_method = '3rEkRlZur2hXKbwwRBidHJAIUTO'
     @declined_payment_method = 'UPfh3J3JbekLeYC88BP741JWnS5'
     @existing_transaction = 'PJ5ICgM6h7v9pBNxDCJjRHDDxBC'

--- a/test/remote/gateways/remote_stripe_3ds_test.rb
+++ b/test/remote/gateways/remote_stripe_3ds_test.rb
@@ -63,7 +63,7 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
   end
 
   def test_create_webhook_endpoint_on_connected_account
-    response = @gateway.send(:create_webhook_endpoint, @options.merge({stripe_account: @stripe_account}), ['source.chargeable'])
+    response = @gateway.send(:create_webhook_endpoint, @options.merge({ stripe_account: @stripe_account }), ['source.chargeable'])
     assert_includes response.params['enabled_events'], 'source.chargeable'
     assert_equal @options[:callback_url], response.params['url']
     assert_equal 'enabled', response.params['status']
@@ -81,7 +81,7 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
   end
 
   def test_delete_webhook_endpoint_on_connected_account
-    webhook = @gateway.send(:create_webhook_endpoint, @options.merge({stripe_account: @stripe_account}), ['source.chargeable'])
+    webhook = @gateway.send(:create_webhook_endpoint, @options.merge({ stripe_account: @stripe_account }), ['source.chargeable'])
     response = @gateway.send(:delete_webhook_endpoint, @options.merge(webhook_id: webhook.params['id']))
     assert_equal response.params['id'], webhook.params['id']
     assert_equal true, response.params['deleted']
@@ -100,8 +100,8 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
   end
 
   def test_show_webhook_endpoint_on_connected_account
-    webhook = @gateway.send(:create_webhook_endpoint, @options.merge({stripe_account: @stripe_account}), ['source.chargeable'])
-    response = @gateway.send(:show_webhook_endpoint,  @options.merge({webhook_id: webhook.params['id'], stripe_account: @stripe_account}))
+    webhook = @gateway.send(:create_webhook_endpoint, @options.merge({ stripe_account: @stripe_account }), ['source.chargeable'])
+    response = @gateway.send(:show_webhook_endpoint,  @options.merge({ webhook_id: webhook.params['id'], stripe_account: @stripe_account }))
 
     assert_includes response.params['enabled_events'], 'source.chargeable'
     assert_equal @options[:callback_url], response.params['url']
@@ -114,11 +114,11 @@ class RemoteStripe3DSTest < Test::Unit::TestCase
 
   def test_list_webhook_endpoints
     webhook1 = @gateway.send(:create_webhook_endpoint, @options, ['source.chargeable'])
-    webhook2 = @gateway.send(:create_webhook_endpoint, @options.merge({stripe_account: @stripe_account}), ['source.chargeable'])
+    webhook2 = @gateway.send(:create_webhook_endpoint, @options.merge({ stripe_account: @stripe_account }), ['source.chargeable'])
     assert_nil webhook1.params['application']
     assert_not_nil webhook2.params['application']
 
-    response = @gateway.send(:list_webhook_endpoints, @options.merge({limit: 100}))
+    response = @gateway.send(:list_webhook_endpoints, @options.merge({ limit: 100 }))
     assert_not_nil response.params
     assert_equal 'list', response.params['object']
     assert response.params['data'].size >= 2

--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -54,7 +54,7 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_store_with_apple_pay_payment_token
-    assert response = @gateway.store(@apple_pay_payment_token, {description: 'Active Merchant Test Customer', email: 'email@example.com'})
+    assert response = @gateway.store(@apple_pay_payment_token, { description: 'Active Merchant Test Customer', email: 'email@example.com' })
     assert_success response
     assert_equal 'customer', response.params['object']
     assert_equal 'Active Merchant Test Customer', response.params['description']
@@ -66,10 +66,10 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_store_with_existing_customer_and_apple_pay_payment_token
-    assert response = @gateway.store(@credit_card, {description: 'Active Merchant Test Customer'})
+    assert response = @gateway.store(@credit_card, { description: 'Active Merchant Test Customer' })
     assert_success response
 
-    assert response = @gateway.store(@apple_pay_payment_token, {customer: response.params['id'], description: 'Active Merchant Test Customer', email: 'email@example.com'})
+    assert response = @gateway.store(@apple_pay_payment_token, { customer: response.params['id'], description: 'Active Merchant Test Customer', email: 'email@example.com' })
     assert_success response
     assert_equal 2, response.responses.size
 
@@ -86,7 +86,7 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_recurring_with_apple_pay_payment_token
-    assert response = @gateway.store(@apple_pay_payment_token, {description: 'Active Merchant Test Customer', email: 'email@example.com'})
+    assert response = @gateway.store(@apple_pay_payment_token, { description: 'Active Merchant Test Customer', email: 'email@example.com' })
     assert_success response
     assert recharge_options = @options.merge(customer: response.params['id'])
     assert response = @gateway.purchase(@amount, nil, recharge_options)

--- a/test/remote/gateways/remote_stripe_emv_test.rb
+++ b/test/remote/gateways/remote_stripe_emv_test.rb
@@ -140,7 +140,7 @@ class RemoteStripeEmvTest < Test::Unit::TestCase
   end
 
   def test_authorization_emv_credit_card_in_us_with_metadata
-    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'}))
+    assert authorization = @gateway.authorize(@amount, @emv_credit_cards[:us], @options.merge({ metadata: { this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell' }, order_id: '42', email: 'foo@wonderfullyfakedomain.com' }))
     assert_success authorization
   end
 end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -46,7 +46,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_blank_referer
-    options = @options.merge({referrer: ''})
+    options = @options.merge({ referrer: '' })
     assert response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -519,7 +519,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_unstore
-    creation = @gateway.store(@credit_card, {description: 'Active Merchant Unstore Customer'})
+    creation = @gateway.store(@credit_card, { description: 'Active Merchant Unstore Customer' })
     card_id = creation.params['sources']['data'].first['id']
 
     assert response = @gateway.unstore(creation.authorization)
@@ -530,7 +530,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_unstore_using_deprecated_api
-    creation = @gateway.store(@credit_card, {description: 'Active Merchant Unstore Customer'})
+    creation = @gateway.store(@credit_card, { description: 'Active Merchant Unstore Customer' })
     card_id = creation.params['sources']['data'].first['id']
     customer_id = creation.params['id']
 
@@ -615,7 +615,7 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_update
-    creation    = @gateway.store(@credit_card, {description: 'Active Merchant Update Credit Card'})
+    creation    = @gateway.store(@credit_card, { description: 'Active Merchant Update Credit Card' })
     customer_id = creation.params['id']
     card_id     = creation.params['sources']['data'].first['id']
 

--- a/test/remote/gateways/remote_trust_commerce_test.rb
+++ b/test/remote/gateways/remote_trust_commerce_test.rb
@@ -6,7 +6,7 @@ class TrustCommerceTest < Test::Unit::TestCase
 
     @credit_card = credit_card('4111111111111111')
     @declined_credit_card = credit_card('4111111111111112')
-    @check = check({account_number: 55544433221, routing_number: 789456124})
+    @check = check({ account_number: 55544433221, routing_number: 789456124 })
 
     @amount = 100
 

--- a/test/remote/gateways/remote_usa_epay_advanced_test.rb
+++ b/test/remote/gateways/remote_usa_epay_advanced_test.rb
@@ -36,8 +36,8 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     )
 
     cc_method = [
-      {name: 'My CC', sort: 5, method: @credit_card},
-      {name: 'Other CC', sort: 12, method: @credit_card}
+      { name: 'My CC', sort: 5, method: @credit_card },
+      { name: 'Other CC', sort: 12, method: @credit_card }
     ]
 
     @options = {
@@ -167,7 +167,7 @@ class RemoteUsaEpayAdvancedTest < Test::Unit::TestCase
     response = @gateway.add_customer(@options.merge(@customer_options))
     customer_number = response.params['add_customer_return']
 
-    response = @gateway.quick_update_customer({customer_number: customer_number, update_data: @update_customer_options})
+    response = @gateway.quick_update_customer({ customer_number: customer_number, update_data: @update_customer_options })
     assert response.params['quick_update_customer_return']
   end
 

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -100,8 +100,8 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_line_items
     line_items = [
-      {sku: 'abc123', cost: 119, quantity: 1},
-      {sku: 'def456', cost: 200, quantity: 2, name: 'an item' }
+      { sku: 'abc123', cost: 119, quantity: 1 },
+      { sku: 'def456', cost: 200, quantity: 2, name: 'an item' }
     ]
 
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(line_items: line_items))

--- a/test/remote/gateways/remote_webpay_test.rb
+++ b/test/remote/gateways/remote_webpay_test.rb
@@ -38,7 +38,7 @@ class RemoteWebpayTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, { email: 'email@example.com' })
     assert_equal 'email@example.com', response.params['description'], 'Use the email if no description is specified.'
 
-    assert response = @gateway.purchase(@amount, @credit_card, { })
+    assert response = @gateway.purchase(@amount, @credit_card, {})
     assert_nil response.params['description'], 'No description or email specified.'
   end
 
@@ -104,7 +104,7 @@ class RemoteWebpayTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    assert response = @gateway.store(@credit_card, {description: 'Active Merchant Test Customer', email: 'email@example.com'})
+    assert response = @gateway.store(@credit_card, { description: 'Active Merchant Test Customer', email: 'email@example.com' })
     assert_success response
     assert_equal 'customer', response.params['object']
     assert_equal 'Active Merchant Test Customer', response.params['description']
@@ -113,7 +113,7 @@ class RemoteWebpayTest < Test::Unit::TestCase
   end
 
   def test_successful_update
-    creation = @gateway.store(@credit_card, {description: 'Active Merchant Update Customer'})
+    creation = @gateway.store(@credit_card, { description: 'Active Merchant Update Customer' })
     assert response = @gateway.update(creation.params['id'], @new_credit_card)
     assert_success response
     assert_equal 'Active Merchant Update Customer', response.params['description']
@@ -121,7 +121,7 @@ class RemoteWebpayTest < Test::Unit::TestCase
   end
 
   def test_successful_unstore
-    creation = @gateway.store(@credit_card, {description: 'Active Merchant Unstore Customer'})
+    creation = @gateway.store(@credit_card, { description: 'Active Merchant Unstore Customer' })
     assert response = @gateway.unstore(creation.params['id'])
     assert_success response
     assert_equal true, response.params['deleted']

--- a/test/remote/gateways/remote_wepay_test.rb
+++ b/test/remote/gateways/remote_wepay_test.rb
@@ -128,7 +128,7 @@ class RemoteWepayTest < Test::Unit::TestCase
   # end
 
   def test_successful_store_with_defaulted_email
-    response = @gateway.store(@credit_card, {billing_address: address})
+    response = @gateway.store(@credit_card, { billing_address: address })
     assert_success response
   end
 

--- a/test/remote/gateways/remote_wirecard_test.rb
+++ b/test/remote/gateways/remote_wirecard_test.rb
@@ -119,14 +119,14 @@ class RemoteWirecardTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_german_address_no_state_and_invalid_phone
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: @german_address.merge({state: nil, phone: '1234'})))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: @german_address.merge({ state: nil, phone: '1234' })))
 
     assert_success response
     assert response.message[/THIS IS A DEMO/]
   end
 
   def test_successful_purchase_with_german_address_and_valid_phone
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: @german_address.merge({phone: '+049-261-1234-123'})))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: @german_address.merge({ phone: '+049-261-1234-123' })))
 
     assert_success response
     assert response.message[/THIS IS A DEMO/]

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -66,14 +66,14 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   end
 
   def test_successful_3ds2_authorize
-    options = @options.merge({execute_threed: true, three_ds_version: '2.0'})
+    options = @options.merge({ execute_threed: true, three_ds_version: '2.0' })
     assert response = @gateway.authorize(@amount, @threeDS2_card, options)
     assert_success response
     assert_equal 'SUCCESS', response.message
   end
 
   def test_successful_authorize_with_risk_data
-    options = @options.merge({execute_threed: true, three_ds_version: '2.0', risk_data: risk_data})
+    options = @options.merge({ execute_threed: true, three_ds_version: '2.0', risk_data: risk_data })
     assert response = @gateway.authorize(@amount, @threeDS2_card, options)
     assert_success response
     assert_equal 'SUCCESS', response.message
@@ -187,7 +187,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       network_transaction_id: nil
     }
 
-    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge({stored_credential: stored_credential_params}))
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
     assert_success auth
     assert auth.authorization
     assert auth.params['scheme_response']

--- a/test/remote/gateways/remote_worldpay_us_test.rb
+++ b/test/remote/gateways/remote_worldpay_us_test.rb
@@ -23,7 +23,7 @@ class RemoteWorldpayUsTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_on_backup_url
-    gateway = WorldpayUsGateway.new(fixtures(:worldpay_us).merge({ use_backup_url: true}))
+    gateway = WorldpayUsGateway.new(fixtures(:worldpay_us).merge({ use_backup_url: true }))
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Succeeded', response.message

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -29,7 +29,7 @@ class ConnectionTest < Test::Unit::TestCase
     spy = Net::HTTP.new('example.com', 443)
     Net::HTTP.expects(:new).with('example.com', 443, :ENV, nil).returns(spy)
     spy.expects(:start).returns(true)
-    spy.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)
+    spy.expects(:get).with('/tx.php', { 'connection' => 'close' }).returns(@ok)
     @connection.request(:get, nil, {})
   end
 
@@ -39,13 +39,13 @@ class ConnectionTest < Test::Unit::TestCase
     spy = Net::HTTP.new('example.com', 443)
     Net::HTTP.expects(:new).with('example.com', 443, 'proxy.example.com', 8080).returns(spy)
     spy.expects(:start).returns(true)
-    spy.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)
+    spy.expects(:get).with('/tx.php', { 'connection' => 'close' }).returns(@ok)
     @connection.request(:get, nil, {})
   end
 
   def test_connection_does_not_mutate_headers_argument
     headers = { 'Content-Type' => 'text/xml' }.freeze
-    Net::HTTP.any_instance.expects(:get).with('/tx.php', headers.merge({'connection' => 'close'})).returns(@ok)
+    Net::HTTP.any_instance.expects(:get).with('/tx.php', headers.merge({ 'connection' => 'close' })).returns(@ok)
     Net::HTTP.any_instance.expects(:start).returns(true)
     @connection.request(:get, nil, headers)
     assert_equal({ 'Content-Type' => 'text/xml' }, headers)
@@ -53,28 +53,28 @@ class ConnectionTest < Test::Unit::TestCase
 
   def test_successful_get_request
     @connection.logger.expects(:info).twice
-    Net::HTTP.any_instance.expects(:get).with('/tx.php', {'connection' => 'close'}).returns(@ok)
+    Net::HTTP.any_instance.expects(:get).with('/tx.php', { 'connection' => 'close' }).returns(@ok)
     Net::HTTP.any_instance.expects(:start).returns(true)
     response = @connection.request(:get, nil, {})
     assert_equal 'success', response.body
   end
 
   def test_successful_post_request
-    Net::HTTP.any_instance.expects(:post).with('/tx.php', 'data', ActiveMerchant::Connection::RUBY_184_POST_HEADERS.merge({'connection' => 'close'})).returns(@ok)
+    Net::HTTP.any_instance.expects(:post).with('/tx.php', 'data', ActiveMerchant::Connection::RUBY_184_POST_HEADERS.merge({ 'connection' => 'close' })).returns(@ok)
     Net::HTTP.any_instance.expects(:start).returns(true)
     response = @connection.request(:post, 'data', {})
     assert_equal 'success', response.body
   end
 
   def test_successful_put_request
-    Net::HTTP.any_instance.expects(:put).with('/tx.php', 'data', {'connection' => 'close'}).returns(@ok)
+    Net::HTTP.any_instance.expects(:put).with('/tx.php', 'data', { 'connection' => 'close' }).returns(@ok)
     Net::HTTP.any_instance.expects(:start).returns(true)
     response = @connection.request(:put, 'data', {})
     assert_equal 'success', response.body
   end
 
   def test_successful_delete_request
-    Net::HTTP.any_instance.expects(:delete).with('/tx.php', {'connection' => 'close'}).returns(@ok)
+    Net::HTTP.any_instance.expects(:delete).with('/tx.php', { 'connection' => 'close' }).returns(@ok)
     Net::HTTP.any_instance.expects(:start).returns(true)
     response = @connection.request(:delete, nil, {})
     assert_equal 'success', response.body

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -59,7 +59,7 @@ class AdyenTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       order_id: '345123',
       installments: 2,
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: { reason_type: 'unscheduled' },
       email: 'john.smith@test.com',
       ip: '77.110.174.153'
     }
@@ -78,7 +78,7 @@ class AdyenTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       billing_address: address(),
       order_id: '123',
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
         channel: 'browser',
         browser_info: {
@@ -148,7 +148,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_recurring_contract_type
     stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge({recurring_contract_type: 'ONECLICK'}))
+      @gateway.authorize(100, @credit_card, @options.merge({ recurring_contract_type: 'ONECLICK' }))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'ONECLICK', JSON.parse(data)['recurring']['contract']
     end.respond_with(successful_authorize_response)
@@ -292,7 +292,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_successful_maestro_purchase
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge({selected_brand: 'maestro', overwrite_brand: 'true'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ selected_brand: 'maestro', overwrite_brand: 'true' }))
     end.check_request do |endpoint, data, _headers|
       if /authorise/.match?(endpoint)
         assert_match(/"overwriteBrand":true/, data)
@@ -331,7 +331,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_capture_delay_hours_sent
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({capture_delay_hours: 4}))
+      @gateway.authorize(@amount, @credit_card, @options.merge({ capture_delay_hours: 4 }))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 4, JSON.parse(data)['captureDelayHours']
     end.respond_with(successful_authorize_response)
@@ -339,7 +339,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_custom_routing_sent
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({custom_routing_flag: 'abcdefg'}))
+      @gateway.authorize(@amount, @credit_card, @options.merge({ custom_routing_flag: 'abcdefg' }))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'abcdefg', JSON.parse(data)['additionalData']['customRoutingFlag']
     end.respond_with(successful_authorize_response)
@@ -373,7 +373,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_execute_threed_false_with_additional_data
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({execute_threed: false, overwrite_brand: true, selected_brand: 'maestro'}))
+      @gateway.authorize(@amount, @credit_card, @options.merge({ execute_threed: false, overwrite_brand: true, selected_brand: 'maestro' }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/"additionalData":{"overwriteBrand":true,"executeThreeD":false}/, data)
       assert_match(/"selectedBrand":"maestro"/, data)
@@ -382,7 +382,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_execute_threed_false_sent_3ds2
     stub_comms do
-      @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({execute_threed: false}))
+      @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({ execute_threed: false }))
     end.check_request do |_endpoint, data, _headers|
       refute JSON.parse(data)['additionalData']['scaExemption']
       assert_false JSON.parse(data)['additionalData']['executeThreeD']
@@ -391,7 +391,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_sca_exemption_not_sent_if_execute_threed_missing_3ds2
     stub_comms do
-      @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({scaExemption: 'lowValue'}))
+      @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({ scaExemption: 'lowValue' }))
     end.check_request do |_endpoint, data, _headers|
       refute JSON.parse(data)['additionalData']['scaExemption']
       refute JSON.parse(data)['additionalData']['executeThreeD']
@@ -400,7 +400,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_sca_exemption_and_execute_threed_false_sent_3ds2
     stub_comms do
-      @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({sca_exemption: 'lowValue', execute_threed: false}))
+      @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({ sca_exemption: 'lowValue', execute_threed: false }))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'lowValue', JSON.parse(data)['additionalData']['scaExemption']
       assert_false JSON.parse(data)['additionalData']['executeThreeD']
@@ -409,7 +409,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_sca_exemption_and_execute_threed_true_sent_3ds2
     stub_comms do
-      @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({sca_exemption: 'lowValue', execute_threed: true}))
+      @gateway.authorize(@amount, '123', @normalized_3ds_2_options.merge({ sca_exemption: 'lowValue', execute_threed: true }))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'lowValue', JSON.parse(data)['additionalData']['scaExemption']
       assert JSON.parse(data)['additionalData']['executeThreeD']
@@ -418,7 +418,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_sca_exemption_not_sent_when_execute_threed_true_3ds1
     stub_comms do
-      @gateway.authorize(@amount, '123', @options.merge({sca_exemption: 'lowValue', execute_threed: true}))
+      @gateway.authorize(@amount, '123', @options.merge({ sca_exemption: 'lowValue', execute_threed: true }))
     end.check_request do |_endpoint, data, _headers|
       refute JSON.parse(data)['additionalData']['scaExemption']
       assert JSON.parse(data)['additionalData']['executeThreeD']
@@ -427,7 +427,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_sca_exemption_not_sent_when_execute_threed_false_3ds1
     stub_comms do
-      @gateway.authorize(@amount, '123', @options.merge({sca_exemption: 'lowValue', execute_threed: false}))
+      @gateway.authorize(@amount, '123', @options.merge({ sca_exemption: 'lowValue', execute_threed: false }))
     end.check_request do |_endpoint, data, _headers|
       refute JSON.parse(data)['additionalData']['scaExemption']
       refute JSON.parse(data)['additionalData']['executeThreeD']
@@ -436,7 +436,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_update_shopper_statement_and_industry_usage_sent
     stub_comms do
-      @gateway.adjust(@amount, '123', @options.merge({update_shopper_statement: 'statement note', industry_usage: 'DelayedCharge'}))
+      @gateway.adjust(@amount, '123', @options.merge({ update_shopper_statement: 'statement note', industry_usage: 'DelayedCharge' }))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'statement note', JSON.parse(data)['additionalData']['updateShopperStatement']
       assert_equal 'DelayedCharge', JSON.parse(data)['additionalData']['industryUsage']
@@ -445,7 +445,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_risk_data_sent
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({risk_data: {'operatingSystem' => 'HAL9000'}}))
+      @gateway.authorize(@amount, @credit_card, @options.merge({ risk_data: { 'operatingSystem' => 'HAL9000' } }))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'HAL9000', JSON.parse(data)['additionalData']['riskdata.operatingSystem']
     end.respond_with(successful_authorize_response)
@@ -458,7 +458,7 @@ class AdyenTest < Test::Unit::TestCase
         'basket.item.productTitle' => 'Blue T Shirt',
         'promotions.promotion.promotionName' => 'Big Sale promotion'
       }
-      @gateway.authorize(@amount, @credit_card, @options.merge({risk_data: risk_data}))
+      @gateway.authorize(@amount, @credit_card, @options.merge({ risk_data: risk_data }))
     end.check_request do |_endpoint, data, _headers|
       parsed = JSON.parse(data)
       assert_equal 'express', parsed['additionalData']['riskdata.deliveryMethod']
@@ -659,7 +659,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_successful_tokenize_only_store
     response = stub_comms do
-      @gateway.store(@credit_card, @options.merge({tokenize_only: true}))
+      @gateway.store(@credit_card, @options.merge({ tokenize_only: true }))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'CardOnFile', JSON.parse(data)['recurringProcessingModel']
     end.respond_with(successful_store_response)
@@ -678,7 +678,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_successful_store_with_recurring_contract_type
     stub_comms do
-      @gateway.store(@credit_card, @options.merge({recurring_contract_type: 'ONECLICK'}))
+      @gateway.store(@credit_card, @options.merge({ recurring_contract_type: 'ONECLICK' }))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'ONECLICK', JSON.parse(data)['recurring']['contract']
     end.respond_with(successful_store_response)
@@ -755,21 +755,21 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_shopper_data
-    post = {card: {billingAddress: {}}}
+    post = { card: { billingAddress: {} } }
     @gateway.send(:add_shopper_data, post, @options)
     assert_equal 'john.smith@test.com', post[:shopperEmail]
     assert_equal '77.110.174.153', post[:shopperIP]
   end
 
   def test_shopper_data_backwards_compatibility
-    post = {card: {billingAddress: {}}}
+    post = { card: { billingAddress: {} } }
     @gateway.send(:add_shopper_data, post, @options_shopper_data)
     assert_equal 'john2.smith@test.com', post[:shopperEmail]
     assert_equal '192.168.100.100', post[:shopperIP]
   end
 
   def test_add_address
-    post = {card: {billingAddress: {}}}
+    post = { card: { billingAddress: {} } }
     @options[:billing_address].delete(:address1)
     @options[:billing_address].delete(:address2)
     @options[:billing_address].delete(:state)

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -17,7 +17,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     @credit_card = credit_card
     @check = check
     @apple_pay_payment_token = ActiveMerchant::Billing::ApplePayPaymentToken.new(
-      {data: 'encoded_payment_data'},
+      { data: 'encoded_payment_data' },
       payment_instrument_name: 'SomeBank Visa',
       payment_network: 'Visa',
       transaction_identifier: 'transaction123'
@@ -141,7 +141,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
     [TRACK1_DATA, TRACK2_DATA].each do |track|
       @credit_card.track_data = track
       stub_comms do
-        @gateway.purchase(@amount, @credit_card, {device_type: 1})
+        @gateway.purchase(@amount, @credit_card, { device_type: 1 })
       end.check_request do |_endpoint, data, _headers|
         parse(data) do |doc|
           assert_not_nil doc.at_xpath('//retail')
@@ -474,7 +474,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     @gateway.expects(:ssl_post).returns(successful_purchase_using_stored_card_response_with_pipe_delimiter)
 
-    response = @gateway.purchase(@amount, store.authorization, {delimiter: '|', description: 'description, with, commas'})
+    response = @gateway.purchase(@amount, store.authorization, { delimiter: '|', description: 'description, with, commas' })
     assert_success response
 
     assert_equal '2235700270#XXXX2224#cim_purchase', response.authorization
@@ -492,7 +492,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
     @gateway.expects(:ssl_post).returns(successful_purchase_using_stored_card_response_with_pipe_delimiter_and_quotes)
 
-    response = @gateway.purchase(@amount, store.authorization, {delimiter: '|', description: 'description, with, commas'})
+    response = @gateway.purchase(@amount, store.authorization, { delimiter: '|', description: 'description, with, commas' })
     assert_success response
 
     assert_equal '12345667#XXXX1111#cim_purchase', response.authorization
@@ -750,7 +750,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_address
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO', phone: '(555)555-5555', fax: '(555)555-4444'})
+      @gateway.authorize(@amount, @credit_card, billing_address: { address1: '164 Waverley Street', country: 'US', state: 'CO', phone: '(555)555-5555', fax: '(555)555-4444' })
     end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'CO', doc.at_xpath('//billTo/state').content, data
@@ -778,7 +778,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_address_with_address2_present
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', address2: 'Apt 1234', country: 'US', state: 'CO', phone: '(555)555-5555', fax: '(555)555-4444'})
+      @gateway.authorize(@amount, @credit_card, billing_address: { address1: '164 Waverley Street', address2: 'Apt 1234', country: 'US', state: 'CO', phone: '(555)555-5555', fax: '(555)555-4444' })
     end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'CO', doc.at_xpath('//billTo/state').content, data
@@ -792,7 +792,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_address_north_america_with_defaults
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', country: 'US'})
+      @gateway.authorize(@amount, @credit_card, billing_address: { address1: '164 Waverley Street', country: 'US' })
     end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'NC', doc.at_xpath('//billTo/state').content, data
@@ -804,7 +804,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_address_outsite_north_america
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', country: 'DE'})
+      @gateway.authorize(@amount, @credit_card, billing_address: { address1: '164 Waverley Street', country: 'DE' })
     end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'n/a', doc.at_xpath('//billTo/state').content, data
@@ -816,7 +816,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_address_outsite_north_america_with_address2_present
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, billing_address: {address1: '164 Waverley Street', address2: 'Apt 1234', country: 'DE'})
+      @gateway.authorize(@amount, @credit_card, billing_address: { address1: '164 Waverley Street', address2: 'Apt 1234', country: 'DE' })
     end.check_request do |_endpoint, data, _headers|
       parse(data) do |doc|
         assert_equal 'n/a', doc.at_xpath('//billTo/state').content, data

--- a/test/unit/gateways/axcessms_test.rb
+++ b/test/unit/gateways/axcessms_test.rb
@@ -129,7 +129,7 @@ class AxcessmsTest < Test::Unit::TestCase
 
   def test_setting_mode_sets_proper_element
     stub_comms do
-      @gateway.purchase(@amount, 'MY_AUTHORIZE_VALUE', {mode: 'CRAZY_TEST_MODE'})
+      @gateway.purchase(@amount, 'MY_AUTHORIZE_VALUE', { mode: 'CRAZY_TEST_MODE' })
     end.check_request do |_endpoint, body, _headers|
       assert_xpath_text(body, '//Transaction/@mode', 'CRAZY_TEST_MODE')
     end.respond_with(successful_authorize_response)

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -109,7 +109,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
       shopper_reference: 'John Smith',
       billing_address: address(),
       order_id: '123',
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
         channel: 'browser',
         browser_info: {
@@ -328,7 +328,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_successful_third_party_payout
     response = stub_comms do
-      @gateway.credit(@amount, @credit_card, @options_with_credit_fields.merge({third_party_payout: true}))
+      @gateway.credit(@amount, @credit_card, @options_with_credit_fields.merge({ third_party_payout: true }))
     end.check_request do |endpoint, data, _headers|
       if /storeDetailAndSubmitThirdParty/.match?(endpoint)
         assert_match(%r{/storeDetailAndSubmitThirdParty}, endpoint)
@@ -408,7 +408,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_execute_threed_false_sent_3ds2
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({execute_threed: false}))
+      @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({ execute_threed: false }))
     end.check_request do |_endpoint, data, _headers|
       refute_match(/additionalData.scaExemption/, data)
       assert_match(/additionalData.executeThreeD=false/, data)
@@ -417,7 +417,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_sca_exemption_not_sent_if_execute_threed_missing_3ds2
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({scaExemption: 'lowValue'}))
+      @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({ scaExemption: 'lowValue' }))
     end.check_request do |_endpoint, data, _headers|
       refute_match(/additionalData.scaExemption/, data)
       refute_match(/additionalData.executeThreeD=false/, data)
@@ -426,7 +426,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_sca_exemption_and_execute_threed_false_sent_3ds2
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({sca_exemption: 'lowValue', execute_threed: false}))
+      @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({ sca_exemption: 'lowValue', execute_threed: false }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/additionalData.scaExemption=lowValue/, data)
       assert_match(/additionalData.executeThreeD=false/, data)
@@ -435,7 +435,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_sca_exemption_and_execute_threed_true_sent_3ds2
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({sca_exemption: 'lowValue', execute_threed: true}))
+      @gateway.authorize(@amount, @credit_card, @normalized_3ds_2_options.merge({ sca_exemption: 'lowValue', execute_threed: true }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/additionalData.scaExemption=lowValue/, data)
       assert_match(/additionalData.executeThreeD=true/, data)
@@ -444,7 +444,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_sca_exemption_not_sent_when_execute_threed_true_3ds1
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({sca_exemption: 'lowValue', execute_threed: true}))
+      @gateway.authorize(@amount, @credit_card, @options.merge({ sca_exemption: 'lowValue', execute_threed: true }))
     end.check_request do |_endpoint, data, _headers|
       refute_match(/additionalData.scaExemption/, data)
       assert_match(/additionalData.executeThreeD=true/, data)
@@ -453,7 +453,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_sca_exemption_not_sent_when_execute_threed_false_3ds1
     stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({sca_exemption: 'lowValue', execute_threed: false}))
+      @gateway.authorize(@amount, @credit_card, @options.merge({ sca_exemption: 'lowValue', execute_threed: false }))
     end.check_request do |_endpoint, data, _headers|
       refute_match(/additionalData.scaExemption/, data)
       refute_match(/additionalData.executeThreeD/, data)

--- a/test/unit/gateways/be2bill_test.rb
+++ b/test/unit/gateways/be2bill_test.rb
@@ -41,11 +41,11 @@ class Be2billTest < Test::Unit::TestCase
 
   # Place raw successful response from gateway here
   def successful_purchase_response
-    {'OPERATIONTYPE' => 'payment', 'TRANSACTIONID' => 'A189063', 'EXECCODE' => '0000', 'MESSAGE' => 'The transaction has been accepted.', 'ALIAS' => 'A189063', 'DESCRIPTOR' => 'RENTABILITEST'}.to_json
+    { 'OPERATIONTYPE' => 'payment', 'TRANSACTIONID' => 'A189063', 'EXECCODE' => '0000', 'MESSAGE' => 'The transaction has been accepted.', 'ALIAS' => 'A189063', 'DESCRIPTOR' => 'RENTABILITEST' }.to_json
   end
 
   # Place raw failed response from gateway here
   def failed_purchase_response
-    {'OPERATIONTYPE' => 'payment', 'TRANSACTIONID' => 'A189063', 'EXECCODE' => '1001', 'MESSAGE' => "The parameter \"CARDCODE\" is missing.\n", 'DESCRIPTOR' => 'RENTABILITEST'}.to_json
+    { 'OPERATIONTYPE' => 'payment', 'TRANSACTIONID' => 'A189063', 'EXECCODE' => '1001', 'MESSAGE' => "The parameter \"CARDCODE\" is missing.\n", 'DESCRIPTOR' => 'RENTABILITEST' }.to_json
   end
 end

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -273,7 +273,7 @@ class BeanstreamTest < Test::Unit::TestCase
   end
 
   def test_no_state_and_zip_default_with_missing_country
-    address = { }
+    address = {}
     @options[:billing_address] = address
     @options[:shipping_address] = address
     response = stub_comms(@gateway, :ssl_request) do

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -21,7 +21,7 @@ class BluePayTest < Test::Unit::TestCase
     @check = check
     @rebill_id = '100096219669'
     @rebill_status = 'active'
-    @options = {ip: '192.168.0.1'}
+    @options = { ip: '192.168.0.1' }
   end
 
   def test_successful_authorization
@@ -66,7 +66,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_add_address_outsite_north_america
     result = {}
 
-    @gateway.send(:add_address, result, billing_address: {address1: '123 Test St.', address2: '5F', city: 'Testville', company: 'Test Company', country: 'DE', state: ''})
+    @gateway.send(:add_address, result, billing_address: { address1: '123 Test St.', address2: '5F', city: 'Testville', company: 'Test Company', country: 'DE', state: '' })
     assert_equal %w[ADDR1 ADDR2 CITY COMPANY_NAME COUNTRY PHONE STATE ZIP], result.stringify_keys.keys.sort
     assert_equal 'n/a', result[:STATE]
     assert_equal '123 Test St.', result[:ADDR1]
@@ -76,7 +76,7 @@ class BluePayTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, billing_address: {address1: '123 Test St.', address2: '5F', city: 'Testville', company: 'Test Company', country: 'US', state: 'AK'})
+    @gateway.send(:add_address, result, billing_address: { address1: '123 Test St.', address2: '5F', city: 'Testville', company: 'Test Company', country: 'US', state: 'AK' })
 
     assert_equal %w[ADDR1 ADDR2 CITY COMPANY_NAME COUNTRY PHONE STATE ZIP], result.stringify_keys.keys.sort
     assert_equal 'AK', result[:STATE]
@@ -88,7 +88,7 @@ class BluePayTest < Test::Unit::TestCase
     result = {}
 
     @gateway.send(:add_creditcard, result, @credit_card)
-    @gateway.send(:add_address, result, billing_address: {address1: '123 Test St.', address2: '5F', city: 'Testville', company: 'Test Company', country: 'US', state: 'AK'})
+    @gateway.send(:add_address, result, billing_address: { address1: '123 Test St.', address2: '5F', city: 'Testville', company: 'Test Company', country: 'US', state: 'AK' })
 
     assert_equal @credit_card.first_name, result[:NAME1]
     assert_equal @credit_card.last_name, result[:NAME2]
@@ -121,7 +121,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_successful_refund
     response = stub_comms do
-      @gateway.refund(@amount, '100134230412', @options.merge({card_number: @credit_card.number}))
+      @gateway.refund(@amount, '100134230412', @options.merge({ card_number: @credit_card.number }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
     end.respond_with(successful_refund_response)
@@ -133,7 +133,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_refund_passing_extra_info
     response = stub_comms do
-      @gateway.refund(50, '123456789', @options.merge({card_number: @credit_card.number, first_name: 'Bob', last_name: 'Smith', zip: '12345', doc_type: 'WEB'}))
+      @gateway.refund(50, '123456789', @options.merge({ card_number: @credit_card.number, first_name: 'Bob', last_name: 'Smith', zip: '12345', doc_type: 'WEB' }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/NAME1=Bob/, data)
       assert_match(/NAME2=Smith/, data)
@@ -147,7 +147,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_failed_refund
     response = stub_comms do
-      @gateway.refund(@amount, '123456789', @options.merge({card_number: @credit_card.number}))
+      @gateway.refund(@amount, '123456789', @options.merge({ card_number: @credit_card.number }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
     end.respond_with(failed_refund_response)
@@ -161,7 +161,7 @@ class BluePayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert_deprecation_warning('credit should only be used to credit a payment method') do
       response = stub_comms do
-        @gateway.credit(@amount, '123456789', @options.merge({card_number: @credit_card.number}))
+        @gateway.credit(@amount, '123456789', @options.merge({ card_number: @credit_card.number }))
       end.check_request do |_endpoint, data, _headers|
         assert_match(/CUSTOMER_IP=192\.168\.0\.1/, data)
       end.respond_with(failed_refund_response)
@@ -174,7 +174,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_successful_credit_with_check
     response = stub_comms do
-      @gateway.credit(50, @check, @options.merge({doc_type: 'PPD'}))
+      @gateway.credit(50, @check, @options.merge({ doc_type: 'PPD' }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/DOC_TYPE=PPD/, data)
     end.respond_with(successful_credit_response)

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -78,7 +78,7 @@ class BogusTest < Test::Unit::TestCase
   end
 
   def test_credit_uses_refund
-    options = {foo: :bar}
+    options = { foo: :bar }
     @gateway.expects(:refund).with(1000, '1337', options)
     assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE) do
       @gateway.credit(1000, '1337', options)
@@ -170,26 +170,26 @@ class BogusTest < Test::Unit::TestCase
   end
 
   def test_authorize_emv
-    approve_response = @gateway.authorize(1000, credit_card('123', {icc_data: 'DEADBEEF'}))
+    approve_response = @gateway.authorize(1000, credit_card('123', { icc_data: 'DEADBEEF' }))
     assert approve_response.success?
     assert_equal '8A023030', approve_response.emv_authorization
-    decline_response = @gateway.authorize(1005, credit_card('123', {icc_data: 'DEADBEEF'}))
+    decline_response = @gateway.authorize(1005, credit_card('123', { icc_data: 'DEADBEEF' }))
     refute decline_response.success?
     assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], decline_response.error_code
     assert_equal '8A023035', decline_response.emv_authorization
     e = assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.authorize(1001, credit_card('123', {icc_data: 'DEADBEEF'}))
+      @gateway.authorize(1001, credit_card('123', { icc_data: 'DEADBEEF' }))
     end
     assert_equal('Bogus Gateway: Use amount ending in 00 for success, 05 for failure and anything else for exception', e.message)
   end
 
   def test_purchase_emv
-    assert @gateway.purchase(1000, credit_card('123', {icc_data: 'DEADBEEF'})).success?
-    response = @gateway.purchase(1005, credit_card('123', {icc_data: 'DEADBEEF'}))
+    assert @gateway.purchase(1000, credit_card('123', { icc_data: 'DEADBEEF' })).success?
+    response = @gateway.purchase(1005, credit_card('123', { icc_data: 'DEADBEEF' }))
     refute response.success?
     assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     e = assert_raises(ActiveMerchant::Billing::Error) do
-      @gateway.purchase(1001, credit_card('123', {icc_data: 'DEADBEEF'}))
+      @gateway.purchase(1001, credit_card('123', { icc_data: 'DEADBEEF' }))
     end
     assert_equal('Bogus Gateway: Use amount ending in 00 for success, 05 for failure and anything else for exception', e.message)
   end

--- a/test/unit/gateways/borgun_test.rb
+++ b/test/unit/gateways/borgun_test.rb
@@ -65,7 +65,7 @@ class BorgunTest < Test::Unit::TestCase
       'PassengerName' => 'Jane Doe'
     }
     response = stub_comms do
-      @gateway.authorize(@amount, @credit_card, {passenger_itinerary_data: passenger_itinerary_data})
+      @gateway.authorize(@amount, @credit_card, { passenger_itinerary_data: passenger_itinerary_data })
     end.check_request do |_endpoint, data, _headers|
       assert_match('PassengerItineraryData', data)
     end.respond_with(successful_authorize_response)

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -541,18 +541,18 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_merge_credit_card_options_ignores_bad_option
-    params = {first_name: 'John', credit_card: {cvv: '123'}}
-    options = {verify_card: true, bogus: 'ignore me'}
+    params = { first_name: 'John', credit_card: { cvv: '123' } }
+    options = { verify_card: true, bogus: 'ignore me' }
     merged_params = @gateway.send(:merge_credit_card_options, params, options)
-    expected_params = {first_name: 'John', credit_card: {cvv: '123', options: {verify_card: true}}}
+    expected_params = { first_name: 'John', credit_card: { cvv: '123', options: { verify_card: true } } }
     assert_equal expected_params, merged_params
   end
 
   def test_merge_credit_card_options_handles_nil_credit_card
-    params = {first_name: 'John'}
-    options = {verify_card: true, bogus: 'ignore me'}
+    params = { first_name: 'John' }
+    options = { verify_card: true, bogus: 'ignore me' }
     merged_params = @gateway.send(:merge_credit_card_options, params, options)
-    expected_params = {first_name: 'John', credit_card: {options: {verify_card: true}}}
+    expected_params = { first_name: 'John', credit_card: { options: { verify_card: true } } }
     assert_equal expected_params, merged_params
   end
 
@@ -564,8 +564,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
       zip: '60622',
       country: 'US'
     }
-    params = {first_name: 'John'}
-    options = {billing_address: billing_address}
+    params = { first_name: 'John' }
+    options = { billing_address: billing_address }
     expected_params = {
       first_name: 'John',
       credit_card: {
@@ -586,7 +586,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_merge_credit_card_options_only_includes_billing_address_when_present
-    params = {first_name: 'John'}
+    params = { first_name: 'John' }
     options = {}
     expected_params = {
       first_name: 'John',
@@ -601,46 +601,46 @@ class BraintreeBlueTest < Test::Unit::TestCase
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_alpha2] == 'US')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country: 'US'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: { country: 'US' })
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_alpha2] == 'US')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country_code_alpha2: 'US'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: { country_code_alpha2: 'US' })
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_name] == 'United States of America')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country_name: 'United States of America'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: { country_name: 'United States of America' })
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_alpha3] == 'USA')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country_code_alpha3: 'USA'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: { country_code_alpha3: 'USA' })
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:country_code_numeric] == 840)
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {country_code_numeric: 840})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: { country_code_numeric: 840 })
   end
 
   def test_address_zip_handling
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:postal_code] == '12345')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {zip: '12345'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: { zip: '12345' })
 
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:postal_code] == nil)
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: {zip: '1234567890'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: { zip: '1234567890' })
   end
 
   def test_cardholder_name_passing_with_card
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:credit_card][:cardholder_name] == 'Longbob Longsen')
     end.returns(braintree_result)
-    @gateway.purchase(100, credit_card('41111111111111111111'), customer: {first_name: 'Longbob', last_name: 'Longsen'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), customer: { first_name: 'Longbob', last_name: 'Longsen' })
   end
 
   def test_three_d_secure_pass_thru_handling_version_1
@@ -654,7 +654,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       })).
       returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: {cavv: 'cavv', eci: 'eci', xid: 'xid'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: { cavv: 'cavv', eci: 'eci', xid: 'xid' })
   end
 
   def test_three_d_secure_pass_thru_handling_version_2
@@ -672,7 +672,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       ))).
       returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: {version: '2.0', cavv: 'cavv', eci: 'eci', ds_transaction_id: 'trans_id', cavv_algorithm: 'algorithm', directory_response_status: 'directory', authentication_response_status: 'auth'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: { version: '2.0', cavv: 'cavv', eci: 'eci', ds_transaction_id: 'trans_id', cavv_algorithm: 'algorithm', directory_response_status: 'directory', authentication_response_status: 'auth' })
   end
 
   def test_three_d_secure_pass_thru_some_fields
@@ -687,7 +687,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       ))).
       returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: {version: '2.0', cavv: 'cavv', eci: 'eci', ds_transaction_id: 'trans_id'})
+    @gateway.purchase(100, credit_card('41111111111111111111'), three_d_secure: { version: '2.0', cavv: 'cavv', eci: 'eci', ds_transaction_id: 'trans_id' })
   end
 
   def test_purchase_string_based_payment_method_nonce_removes_customer
@@ -827,7 +827,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   def test_successful_purchase_with_device_data
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:device_data] == 'device data string')
-    end.returns(braintree_result({risk_data: {id: 123456, decision: 'Decline', device_data_captured: true, fraud_service_provider: 'kount'}}))
+    end.returns(braintree_result({ risk_data: { id: 123456, decision: 'Decline', device_data_captured: true, fraud_service_provider: 'kount' } }))
 
     response = @gateway.purchase(100, credit_card('41111111111111111111'), device_data: 'device data string')
 
@@ -882,9 +882,9 @@ class BraintreeBlueTest < Test::Unit::TestCase
       with(
         amount: '1.00',
         order_id: '1',
-        customer: {id: nil, email: nil, phone: nil,
-                   first_name: 'Longbob', last_name: 'Longsen'},
-        options: {store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil},
+        customer: { id: nil, email: nil, phone: nil,
+                   first_name: 'Longbob', last_name: 'Longsen' },
+        options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
         custom_fields: nil,
         apple_pay_card: {
           number: '4111111111111111',
@@ -912,9 +912,9 @@ class BraintreeBlueTest < Test::Unit::TestCase
       with(
         amount: '1.00',
         order_id: '1',
-        customer: {id: nil, email: nil, phone: nil,
-                   first_name: 'Longbob', last_name: 'Longsen'},
-        options: {store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil},
+        customer: { id: nil, email: nil, phone: nil,
+                   first_name: 'Longbob', last_name: 'Longsen' },
+        options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
         custom_fields: nil,
         android_pay_card: {
           number: '4111111111111111',
@@ -945,9 +945,9 @@ class BraintreeBlueTest < Test::Unit::TestCase
       with(
         amount: '1.00',
         order_id: '1',
-        customer: {id: nil, email: nil, phone: nil,
-                   first_name: 'Longbob', last_name: 'Longsen'},
-        options: {store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil},
+        customer: { id: nil, email: nil, phone: nil,
+                   first_name: 'Longbob', last_name: 'Longsen' },
+        options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
         custom_fields: nil,
         android_pay_card: {
           number: '4111111111111111',
@@ -978,7 +978,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_transaction_returns_id_when_available
-    Braintree::TransactionGateway.any_instance.expects(:sale).returns(braintree_error_result(transaction: {id: 'transaction_id'}))
+    Braintree::TransactionGateway.any_instance.expects(:sale).returns(braintree_error_result(transaction: { id: 'transaction_id' }))
     assert response = @gateway.purchase(100, credit_card('41111111111111111111'))
     refute response.success?
     assert response.authorization.present?
@@ -1044,7 +1044,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, :initial)})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, :initial) })
   end
 
   def test_stored_credential_recurring_cit_used
@@ -1060,7 +1060,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, id: '123ABC')})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, id: '123ABC') })
   end
 
   def test_stored_credential_recurring_mit_initial
@@ -1075,7 +1075,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, :initial)})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, :initial) })
   end
 
   def test_stored_credential_recurring_mit_used
@@ -1091,7 +1091,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, id: '123ABC')})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, id: '123ABC') })
   end
 
   def test_stored_credential_installment_cit_initial
@@ -1106,7 +1106,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :installment, :initial)})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :installment, :initial) })
   end
 
   def test_stored_credential_installment_cit_used
@@ -1122,7 +1122,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :installment, id: '123ABC')})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :installment, id: '123ABC') })
   end
 
   def test_stored_credential_installment_mit_initial
@@ -1137,7 +1137,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :installment, :initial)})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :installment, :initial) })
   end
 
   def test_stored_credential_installment_mit_used
@@ -1153,7 +1153,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :installment, id: '123ABC')})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :installment, id: '123ABC') })
   end
 
   def test_stored_credential_unscheduled_cit_initial
@@ -1168,7 +1168,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :unscheduled, :initial)})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :unscheduled, :initial) })
   end
 
   def test_stored_credential_unscheduled_cit_used
@@ -1184,7 +1184,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :unscheduled, id: '123ABC')})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :unscheduled, id: '123ABC') })
   end
 
   def test_stored_credential_unscheduled_mit_initial
@@ -1199,7 +1199,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, :initial)})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, :initial) })
   end
 
   def test_stored_credential_unscheduled_mit_used
@@ -1215,17 +1215,17 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), {test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, id: '123ABC')})
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, id: '123ABC') })
   end
 
   private
 
   def braintree_result(options = {})
-    Braintree::SuccessfulResult.new(transaction: Braintree::Transaction._new(nil, {id: 'transaction_id'}.merge(options)))
+    Braintree::SuccessfulResult.new(transaction: Braintree::Transaction._new(nil, { id: 'transaction_id' }.merge(options)))
   end
 
   def braintree_error_result(options = {})
-    Braintree::ErrorResult.new(@internal_gateway, {errors: {}}.merge(options))
+    Braintree::ErrorResult.new(@internal_gateway, { errors: {} }.merge(options))
   end
 
   def with_braintree_configuration_restoration(&block)
@@ -1245,9 +1245,9 @@ class BraintreeBlueTest < Test::Unit::TestCase
     {
       amount: '1.00',
       order_id: '1',
-      customer: {id: nil, email: nil, phone: nil,
-                 first_name: 'Longbob', last_name: 'Longsen'},
-      options: {store_in_vault: false, submit_for_settlement: true, hold_in_escrow: nil},
+      customer: { id: nil, email: nil, phone: nil,
+                 first_name: 'Longbob', last_name: 'Longsen' },
+      options: { store_in_vault: false, submit_for_settlement: true, hold_in_escrow: nil },
       custom_fields: nil,
       credit_card: {
         number: '41111111111111111111',

--- a/test/unit/gateways/braintree_orange_test.rb
+++ b/test/unit/gateways/braintree_orange_test.rb
@@ -47,7 +47,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_add_processor
     result = {}
 
-    @gateway.send(:add_processor, result, {processor: 'ccprocessorb'})
+    @gateway.send(:add_processor, result, { processor: 'ccprocessorb' })
     assert_equal ['processor_id'], result.stringify_keys.keys.sort
     assert_equal 'ccprocessorb', result[:processor_id]
   end
@@ -86,7 +86,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, {address1: '164 Waverley Street', country: 'US', state: 'CO'})
+    @gateway.send(:add_address, result, { address1: '164 Waverley Street', country: 'US', state: 'CO' })
     assert_equal %w[address1 city company country phone state zip], result.stringify_keys.keys.sort
     assert_equal 'CO', result['state']
     assert_equal '164 Waverley Street', result['address1']
@@ -96,7 +96,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
   def test_add_shipping_address
     result = {}
 
-    @gateway.send(:add_address, result, {address1: '164 Waverley Street', country: 'US', state: 'CO'}, 'shipping')
+    @gateway.send(:add_address, result, { address1: '164 Waverley Street', country: 'US', state: 'CO' }, 'shipping')
     assert_equal %w[shipping_address1 shipping_city shipping_company shipping_country shipping_phone shipping_state shipping_zip], result.stringify_keys.keys.sort
     assert_equal 'CO', result['shipping_state']
     assert_equal '164 Waverley Street', result['shipping_address1']
@@ -155,7 +155,7 @@ class BraintreeOrangeTest < Test::Unit::TestCase
     @gateway.purchase(@amount, @credit_card, {})
 
     @gateway.expects(:commit).with { |_, _, parameters| parameters[:billing_method] == 'recurring' }
-    @gateway.purchase(@amount, @credit_card, {eci: 'recurring'})
+    @gateway.purchase(@amount, @credit_card, { eci: 'recurring' })
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/card_save_test.rb
+++ b/test/unit/gateways/card_save_test.rb
@@ -6,7 +6,7 @@ class CardSaveTest < Test::Unit::TestCase
     @gateway = CardSaveGateway.new(login: 'login', password: 'password')
     @credit_card = credit_card
     @amount = 100
-    @options = {order_id: '1', billing_address: address, description: 'Store Purchase'}
+    @options = { order_id: '1', billing_address: address, description: 'Store Purchase' }
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -236,7 +236,7 @@ class CardStreamTest < Test::Unit::TestCase
 
   def test_successful_purchase_without_street_address
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert response = @gateway.purchase(142, @visacreditcard, billing_address: {state: 'Northampton'})
+    assert response = @gateway.purchase(142, @visacreditcard, billing_address: { state: 'Northampton' })
     assert_equal 'APPROVED', response.message
   end
 

--- a/test/unit/gateways/cardprocess_test.rb
+++ b/test/unit/gateways/cardprocess_test.rb
@@ -167,7 +167,7 @@ class CardprocessTest < Test::Unit::TestCase
       '800.800.202' => :invalid_zip
     }
     codes.each_pair do |code, key|
-      response = {'result' => {'code' => code}}
+      response = { 'result' => { 'code' => code } }
       assert_equal Gateway::STANDARD_ERROR_CODE[key], @gateway.send(:error_code_from, response), "expecting #{code} => #{key}"
     end
   end

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -76,7 +76,7 @@ class Cashnet < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, billing_address: {address1: '123 Test St.', address2: '5F', city: 'Testville', zip: '12345', state: 'AK'})
+    @gateway.send(:add_address, result, billing_address: { address1: '123 Test St.', address2: '5F', city: 'Testville', zip: '12345', state: 'AK' })
 
     assert_equal %w[addr_g city_g state_g zip_g], result.stringify_keys.keys.sort
     assert_equal '123 Test St.,5F', result[:addr_g]

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -42,7 +42,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_using_network_token
-    network_token = network_tokenization_credit_card({source: :network_token})
+    network_token = network_tokenization_credit_card({ source: :network_token })
     response = stub_comms do
       @gateway.purchase(@amount, network_token)
     end.respond_with(successful_purchase_with_network_token_response)
@@ -73,7 +73,7 @@ class CheckoutV2Test < Test::Unit::TestCase
 
   def test_purchase_with_additional_fields
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, {descriptor_city: 'london', descriptor_name: 'sherlock'})
+      @gateway.purchase(@amount, @credit_card, { descriptor_city: 'london', descriptor_name: 'sherlock' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/"billing_descriptor\":{\"name\":\"sherlock\",\"city\":\"london\"}/, data)
     end.respond_with(successful_purchase_response)
@@ -131,7 +131,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   def test_moto_transaction_is_properly_set
     response = stub_comms do
       options = {
-        metadata: { manual_entry: true}
+        metadata: { manual_entry: true }
       }
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|

--- a/test/unit/gateways/citrus_pay_test.rb
+++ b/test/unit/gateways/citrus_pay_test.rb
@@ -91,7 +91,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
   def test_passing_alpha3_country_code
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, billing_address: {country: 'US'})
+      @gateway.authorize(@amount, @credit_card, billing_address: { country: 'US' })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/USA/, data)
     end.respond_with(successful_authorize_response)
@@ -99,7 +99,7 @@ class CitrusPayTest < Test::Unit::TestCase
 
   def test_non_existent_country
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, billing_address: {country: 'Blah'})
+      @gateway.authorize(@amount, @credit_card, billing_address: { country: 'Blah' })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"country":null/, data)
     end.respond_with(successful_authorize_response)

--- a/test/unit/gateways/clearhaus_test.rb
+++ b/test/unit/gateways/clearhaus_test.rb
@@ -67,8 +67,8 @@ class ClearhausTest < Test::Unit::TestCase
       assert_success response
       assert response.test?
     end.check_request do |_endpoint, data, _headers|
-      order_expr = { reference: '123'}.to_query
-      tos_expr   = { text_on_statement: 'test'}.to_query
+      order_expr = { reference: '123' }.to_query
+      tos_expr   = { text_on_statement: 'test' }.to_query
 
       assert_match order_expr, data
       assert_match tos_expr, data
@@ -445,8 +445,8 @@ Conn close
         'captures' => {
           'href' => '/authorizations/77d08c40-cfa9-42e3-993d-795f772b70a4/captures'
         },
-        'voids' => { 'href' => '/authorizations/77d08c40-cfa9-42e3-993d-795f772b70a4/voids'},
-        'refunds' => { 'href' => '/authorizations/77d08c40-cfa9-42e3-993d-795f772b70a4/refunds'}
+        'voids' => { 'href' => '/authorizations/77d08c40-cfa9-42e3-993d-795f772b70a4/voids' },
+        'refunds' => { 'href' => '/authorizations/77d08c40-cfa9-42e3-993d-795f772b70a4/refunds' }
       }
     }
   end
@@ -476,6 +476,6 @@ Conn close
   end
 
   def failed_ch_response
-    { 'status' => { 'code' => 40000, 'message' => 'General input error' }}.to_json
+    { 'status' => { 'code' => 40000, 'message' => 'General input error' } }.to_json
   end
 end

--- a/test/unit/gateways/conekta_test.rb
+++ b/test/unit/gateways/conekta_test.rb
@@ -69,7 +69,7 @@ class ConektaTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_installments
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({monthly_installments: '3'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ monthly_installments: '3' }))
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match %r{monthly_installments=3}, data
     end.respond_with(successful_purchase_response)
@@ -154,7 +154,7 @@ class ConektaTest < Test::Unit::TestCase
     }
 
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, 'tok_xxxxxxxxxxxxxxxx', @options.merge(application: application, meta: {its_so_meta: 'even this acronym'}))
+      @gateway.purchase(@amount, 'tok_xxxxxxxxxxxxxxxx', @options.merge(application: application, meta: { its_so_meta: 'even this acronym' }))
     end.check_request do |_method, _endpoint, _data, headers|
       assert_match(/\"application\"/, headers['X-Conekta-Client-User-Agent'])
       assert_match(/\"name\":\"app\"/, headers['X-Conekta-Client-User-Agent'])

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -23,7 +23,7 @@ class CredoraxTest < Test::Unit::TestCase
       order_id: '123',
       execute_threed: true,
       three_ds_challenge_window_size: '01',
-      stored_credential: {reason_type: 'unscheduled'},
+      stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
         channel: 'browser',
         notification_url: 'www.example.com',
@@ -310,7 +310,7 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def test_purchase_adds_3d_secure_fields
-    options_with_3ds = @options.merge({eci: 'sample-eci', cavv: 'sample-cavv', xid: 'sample-xid', three_ds_version: '1'})
+    options_with_3ds = @options.merge({ eci: 'sample-eci', cavv: 'sample-cavv', xid: 'sample-xid', three_ds_version: '1' })
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
@@ -341,7 +341,7 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def test_authorize_adds_3d_secure_fields
-    options_with_3ds = @options.merge({eci: 'sample-eci', cavv: 'sample-cavv', xid: 'sample-xid'})
+    options_with_3ds = @options.merge({ eci: 'sample-eci', cavv: 'sample-cavv', xid: 'sample-xid' })
 
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options_with_3ds)
@@ -357,7 +357,7 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def test_defaults_3d_secure_cavv_field_to_none_if_not_present
-    options_with_3ds = @options.merge({eci: 'sample-eci', xid: 'sample-xid'})
+    options_with_3ds = @options.merge({ eci: 'sample-eci', xid: 'sample-xid' })
 
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
@@ -416,7 +416,7 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def test_purchase_adds_a9_field
-    options_with_3ds = @options.merge({transaction_type: '8'})
+    options_with_3ds = @options.merge({ transaction_type: '8' })
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
     end.check_request do |_endpoint, data, _headers|
@@ -425,7 +425,7 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def test_authorize_adds_a9_field
-    options_with_3ds = @options.merge({transaction_type: '8'})
+    options_with_3ds = @options.merge({ transaction_type: '8' })
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options_with_3ds)
     end.check_request do |_endpoint, data, _headers|
@@ -434,7 +434,7 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def test_credit_adds_a9_field
-    options_with_3ds = @options.merge({transaction_type: '8'})
+    options_with_3ds = @options.merge({ transaction_type: '8' })
     stub_comms do
       @gateway.credit(@amount, @credit_card, options_with_3ds)
     end.check_request do |_endpoint, data, _headers|
@@ -443,7 +443,7 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def test_authorize_adds_authorization_details
-    options_with_auth_details = @options.merge({authorization_type: '2', multiple_capture_count: '5' })
+    options_with_auth_details = @options.merge({ authorization_type: '2', multiple_capture_count: '5' })
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options_with_auth_details)
     end.check_request do |_endpoint, data, _headers|
@@ -870,7 +870,7 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def test_3ds_2_optional_fields_adds_fields_to_the_root_of_the_post
-    post = { }
+    post = {}
     options = { three_ds_2: { optional: { '3ds_optional_field_1': :a, '3ds_optional_field_2': :b } } }
 
     @gateway.add_3ds_2_optional_fields(post, options)
@@ -888,12 +888,12 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def test_3ds_2_optional_fields_does_not_empty_fields
-    post = { }
+    post = {}
     options = { three_ds_2: { optional: { '3ds_optional_field_1': '', '3ds_optional_field_2': 'null', '3ds_optional_field_3': nil } } }
 
     @gateway.add_3ds_2_optional_fields(post, options)
 
-    assert_equal post, { }
+    assert_equal post, {}
   end
 
   private

--- a/test/unit/gateways/data_cash_test.rb
+++ b/test/unit/gateways/data_cash_test.rb
@@ -96,7 +96,7 @@ class DataCashTest < Test::Unit::TestCase
 
   def test_purchase_does_not_raise_exception_with_missing_billing_address
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
-    assert @gateway.authorize(100, @credit_card, {order_id: generate_unique_id }).is_a?(ActiveMerchant::Billing::Response)
+    assert @gateway.authorize(100, @credit_card, { order_id: generate_unique_id }).is_a?(ActiveMerchant::Billing::Response)
   end
 
   def test_continuous_authority_purchase_with_missing_continuous_authority_reference

--- a/test/unit/gateways/digitzs_test.rb
+++ b/test/unit/gateways/digitzs_test.rb
@@ -103,7 +103,7 @@ class DigitzsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_get).returns(customer_id_exists_response)
     @gateway.expects(:ssl_post).times(3).returns(successful_app_token_response, successful_create_customer_response, successful_token_response)
 
-    assert response = @gateway.store(@credit_card, @options.merge({customer_id: 'pre_existing_customer_id'}))
+    assert response = @gateway.store(@credit_card, @options.merge({ customer_id: 'pre_existing_customer_id' }))
     assert_success response
     assert_equal 'spreedly-susanswidg-32268973-2091076-148408385-2894006614343495-148710226|c0302d83-a694-4bec-9086-d1886b9eefd9-148710226', response.authorization
   end

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -319,7 +319,7 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_custom_fields_in_request
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(customer_number: '123', custom_fields: {a_key: 'a value'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge(customer_number: '123', custom_fields: { a_key: 'a value' }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/customer_number=123/, data)
       assert_match(/a_key/, data)

--- a/test/unit/gateways/epay_test.rb
+++ b/test/unit/gateways/epay_test.rb
@@ -10,7 +10,7 @@ class EpayTest < Test::Unit::TestCase
     )
 
     @credit_card = credit_card
-    @options = {three_d_secure: { eci: '7', xid: '123', cavv: '456', version: '2', ds_transaction_id: '798' }}
+    @options = { three_d_secure: { eci: '7', xid: '123', cavv: '456', version: '2', ds_transaction_id: '798' } }
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/evo_ca_test.rb
+++ b/test/unit/gateways/evo_ca_test.rb
@@ -99,7 +99,7 @@ class EvoCaTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, address: {address1: '123 Main Street', country: 'CA', state: 'BC'})
+    @gateway.send(:add_address, result, address: { address1: '123 Main Street', country: 'CA', state: 'BC' })
     assert_equal %w{address1 address2 city company country firstname lastname phone state zip}, result.stringify_keys.keys.sort
     assert_equal 'BC', result[:state]
     assert_equal '123 Main Street', result[:address1]
@@ -109,7 +109,7 @@ class EvoCaTest < Test::Unit::TestCase
   def test_add_shipping_address
     result = {}
 
-    @gateway.send(:add_address, result, shipping_address: {address1: '123 Main Street', country: 'CA', state: 'BC'})
+    @gateway.send(:add_address, result, shipping_address: { address1: '123 Main Street', country: 'CA', state: 'BC' })
     assert_equal %w{shipping_address1 shipping_address2 shipping_city shipping_company shipping_country shipping_firstname shipping_lastname shipping_state shipping_zip}, result.stringify_keys.keys.sort
     assert_equal 'BC', result[:shipping_state]
     assert_equal '123 Main Street', result[:shipping_address1]

--- a/test/unit/gateways/eway_managed_test.rb
+++ b/test/unit/gateways/eway_managed_test.rb
@@ -36,7 +36,7 @@ class EwayManagedTest < Test::Unit::TestCase
 
   def test_should_require_billing_address_on_store
     assert_raise ArgumentError do
-      @gateway.store(@credit_card, { })
+      @gateway.store(@credit_card, {})
     end
     assert_raise ArgumentError do
       @gateway.store(@credit_card, { billing_address: {} })
@@ -55,7 +55,7 @@ class EwayManagedTest < Test::Unit::TestCase
 
   def test_should_require_billing_address_on_update
     assert_raise ArgumentError do
-      @gateway.update(@valid_customer_id, @credit_card, { })
+      @gateway.update(@valid_customer_id, @credit_card, {})
     end
     assert_raise ArgumentError do
       @gateway.update(@valid_customer_id, @credit_card, { billing_address: {} })

--- a/test/unit/gateways/federated_canada_test.rb
+++ b/test/unit/gateways/federated_canada_test.rb
@@ -20,7 +20,7 @@ class FederatedCanadaTest < Test::Unit::TestCase
 
   def test_successful_authorization
     @gateway.expects(:ssl_post).returns(successful_authorization_response)
-    options = {billing_address: {address1: '888', address2: 'apt 13', country: 'CA', state: 'SK', city: 'Big Beaver', zip: '77777'}}
+    options = { billing_address: { address1: '888', address2: 'apt 13', country: 'CA', state: 'SK', city: 'Big Beaver', zip: '77777' } }
     assert response = @gateway.authorize(@amount, @credit_card, options)
     assert_instance_of Response, response
     assert_success response
@@ -47,7 +47,7 @@ class FederatedCanadaTest < Test::Unit::TestCase
 
   def test_add_address
     result = {}
-    @gateway.send(:add_address, result, billing_address: {address1: '123 Happy Town Road', address2: 'apt 13', country: 'CA', state: 'SK', phone: '1234567890'})
+    @gateway.send(:add_address, result, billing_address: { address1: '123 Happy Town Road', address2: 'apt 13', country: 'CA', state: 'SK', phone: '1234567890' })
     assert_equal %w[address1 address2 city company country phone state zip], result.stringify_keys.keys.sort
     assert_equal 'SK', result[:state]
     assert_equal '123 Happy Town Road', result[:address1]
@@ -63,7 +63,7 @@ class FederatedCanadaTest < Test::Unit::TestCase
   end
 
   def test_purchase_is_valid_csv
-    params = {amount: @amount}
+    params = { amount: @amount }
     @gateway.send(:add_creditcard, params, @credit_card)
 
     assert data = @gateway.send(:post_data, 'auth', params)
@@ -71,7 +71,7 @@ class FederatedCanadaTest < Test::Unit::TestCase
   end
 
   def test_purchase_meets_minimum_requirements
-    params = {amount: @amount}
+    params = { amount: @amount }
     @gateway.send(:add_creditcard, params, @credit_card)
     assert data = @gateway.send(:post_data, 'auth', params)
     minimum_requirements.each do |key|

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -42,7 +42,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_specified_currency
-    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    options_with_specified_currency = @options.merge({ currency: 'GBP' })
     @gateway.expects(:ssl_post).returns(successful_purchase_with_specified_currency_response)
     assert response = @gateway.purchase(@amount, @credit_card, options_with_specified_currency)
     assert_success response
@@ -61,7 +61,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_specified_currency_and_token
-    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    options_with_specified_currency = @options.merge({ currency: 'GBP' })
     @gateway.expects(:ssl_post).returns(successful_purchase_with_specified_currency_response)
     assert response = @gateway.purchase(@amount, '8938737759041111;visa;Longbob;Longsen;9;2014',
       options_with_specified_currency)
@@ -82,7 +82,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_successful_refund_with_specified_currency
-    options_with_specified_currency = @options.merge({currency: 'GBP'})
+    options_with_specified_currency = @options.merge({ currency: 'GBP' })
     @gateway.expects(:ssl_post).returns(successful_refund_with_specified_currency_response)
     assert response = @gateway.refund(@amount, @authorization, options_with_specified_currency)
     assert_success response
@@ -167,7 +167,7 @@ class FirstdataE4Test < Test::Unit::TestCase
 
   def test_requests_scrub_newline_and_return_characters_from_verification_string_components
     stub_comms do
-      options_with_newline_and_return_characters_in_address = @options.merge({billing_address: address({ address1: "123 My\nStreet", address2: "K1C2N6\r", city: "Ottawa\r\n" })})
+      options_with_newline_and_return_characters_in_address = @options.merge({ billing_address: address({ address1: "123 My\nStreet", address2: "K1C2N6\r", city: "Ottawa\r\n" }) })
       @gateway.purchase(@amount, @credit_card, options_with_newline_and_return_characters_in_address)
     end.check_request do |_endpoint, data, _headers|
       assert_match '<VerificationStr1>123 My Street|K1C2N6|Ottawa|ON|CA</VerificationStr1>', data

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -51,7 +51,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
 
   def test_successful_purchase_with_wallet
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge!({wallet_provider_id: 4}))
+      @gateway.purchase(@amount, @credit_card, @options.merge!({ wallet_provider_id: 4 }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/WalletProviderID>4</, data)
     end.respond_with(successful_purchase_response)
@@ -170,7 +170,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
 
   def test_requests_scrub_newline_and_return_characters_from_verification_string_components
     stub_comms do
-      options_with_newline_and_return_characters_in_address = @options.merge({billing_address: address({ address1: "456 My\nStreet", address2: nil, city: "Ottawa\r\n", state: 'ON', country: 'CA', zip: 'K1C2N6' })})
+      options_with_newline_and_return_characters_in_address = @options.merge({ billing_address: address({ address1: "456 My\nStreet", address2: nil, city: "Ottawa\r\n", state: 'ON', country: 'CA', zip: 'K1C2N6' }) })
       @gateway.purchase(@amount, @credit_card, options_with_newline_and_return_characters_in_address)
     end.check_request do |_endpoint, data, _headers|
       assert_match '<Address><Address1>456 My Street</Address1><City>Ottawa</City><State>ON</State><Zip>K1C2N6</Zip><CountryCode>CA</CountryCode></Address>', data

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -147,7 +147,7 @@ class GatewayTest < Test::Unit::TestCase
   def test_add_field_to_post_if_present
     order_id = 'abc123'
 
-    post = { }
+    post = {}
     options = { order_id: order_id, do_not_add: 24 }
 
     @gateway.add_field_to_post_if_present(post, options, :order_id)
@@ -160,7 +160,7 @@ class GatewayTest < Test::Unit::TestCase
     order_id = 'abc123'
     transaction_number = 500
 
-    post = { }
+    post = {}
     options = { order_id: order_id, transaction_number: transaction_number, do_not_add: 24 }
 
     @gateway.add_fields_to_post_if_present(post, options, %i[order_id transaction_number])

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -66,13 +66,13 @@ class GlobalCollectTest < Test::Unit::TestCase
             date: '20190810',
             carrier_code: 'SA',
             number: 596,
-            airline_class: 'ZZ'},
+            airline_class: 'ZZ' },
           { arrival_airport: 'RDU',
             origin_airport: 'BDL',
             date: '20190817',
             carrier_code: 'SA',
             number: 597,
-            airline_class: 'ZZ'}
+            airline_class: 'ZZ' }
         ]
       }
     )
@@ -163,7 +163,7 @@ class GlobalCollectTest < Test::Unit::TestCase
   end
 
   def test_handles_blank_names
-    credit_card = credit_card('4567350000427977', { first_name: nil, last_name: nil})
+    credit_card = credit_card('4567350000427977', { first_name: nil, last_name: nil })
 
     response = stub_comms do
       @gateway.authorize(@accepted_amount, credit_card, @options)
@@ -256,7 +256,7 @@ class GlobalCollectTest < Test::Unit::TestCase
 
   def test_refund_passes_currency_code
     stub_comms do
-      @gateway.refund(@accepted_amount, '000000142800000000920000100001', {currency: 'COP'})
+      @gateway.refund(@accepted_amount, '000000142800000000920000100001', { currency: 'COP' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/"currencyCode\":\"COP\"/, data)
     end.respond_with(failed_refund_response)

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -4,7 +4,7 @@ class HpsTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = HpsGateway.new({secret_api_key: '12'})
+    @gateway = HpsGateway.new({ secret_api_key: '12' })
 
     @credit_card = credit_card
     @amount = 100

--- a/test/unit/gateways/inspire_test.rb
+++ b/test/unit/gateways/inspire_test.rb
@@ -60,7 +60,7 @@ class InspireTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, nil, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO'})
+    @gateway.send(:add_address, result, nil, billing_address: { address1: '164 Waverley Street', country: 'US', state: 'CO' })
     assert_equal %w[address1 city company country phone state zip], result.stringify_keys.keys.sort
     assert_equal 'CO', result[:state]
     assert_equal '164 Waverley Street', result[:address1]

--- a/test/unit/gateways/ixopay_test.rb
+++ b/test/unit/gateways/ixopay_test.rb
@@ -22,7 +22,7 @@ class IxopayTest < Test::Unit::TestCase
       ip: '192.168.1.1'
     }
 
-    @extra_data = {extra_data: { customData1: 'some data', customData2: 'Can be anything really' }}
+    @extra_data = { extra_data: { customData1: 'some data', customData2: 'Can be anything really' } }
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/jetpay_test.rb
+++ b/test/unit/gateways/jetpay_test.rb
@@ -137,7 +137,7 @@ class JetpayTest < Test::Unit::TestCase
   def test_purchase_sends_order_origin
     @gateway.expects(:ssl_post).with(anything, regexp_matches(/<Origin>RECURRING<\/Origin>/)).returns(successful_purchase_response)
 
-    @gateway.purchase(@amount, @credit_card, {origin: 'RECURRING'})
+    @gateway.purchase(@amount, @credit_card, { origin: 'RECURRING' })
   end
 
   private

--- a/test/unit/gateways/jetpay_v2_test.rb
+++ b/test/unit/gateways/jetpay_v2_test.rb
@@ -168,7 +168,7 @@ class JetpayV2Test < Test::Unit::TestCase
       with(anything, regexp_matches(/<UDField3>Value3<\/UDField3>/)).
       returns(successful_purchase_response)
 
-    @gateway.purchase(@amount, @credit_card, {tax: '777', ud_field_1: 'Value1', ud_field_2: 'Value2', ud_field_3: 'Value3'})
+    @gateway.purchase(@amount, @credit_card, { tax: '777', ud_field_1: 'Value1', ud_field_2: 'Value2', ud_field_3: 'Value3' })
   end
 
   private

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -157,7 +157,7 @@ class LitleTest < Test::Unit::TestCase
 
   def test_passing_basis_date
     stub_comms do
-      @gateway.purchase(@amount, 'token', {basis_expiration_month: '04', basis_expiration_year: '2027'})
+      @gateway.purchase(@amount, 'token', { basis_expiration_month: '04', basis_expiration_year: '2027' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<expDate>0427<\/expDate>/, data)
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -304,15 +304,15 @@ class MercadoPagoTest < Test::Unit::TestCase
 
   def test_includes_deviceid_header
     @options[:device_id] = '1a2b3c'
-    @gateway.expects(:ssl_post).with(anything, anything, {'Content-Type' => 'application/json'}).returns(successful_purchase_response)
-    @gateway.expects(:ssl_post).with(anything, anything, {'Content-Type' => 'application/json', 'X-meli-session-id' => '1a2b3c'}).returns(successful_purchase_response)
+    @gateway.expects(:ssl_post).with(anything, anything, { 'Content-Type' => 'application/json' }).returns(successful_purchase_response)
+    @gateway.expects(:ssl_post).with(anything, anything, { 'Content-Type' => 'application/json', 'X-meli-session-id' => '1a2b3c' }).returns(successful_purchase_response)
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
   end
 
   def test_includes_additional_data
-    @options[:additional_info] = {'foo' => 'bar', 'baz' => 'quux'}
+    @options[:additional_info] = { 'foo' => 'bar', 'baz' => 'quux' }
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_endpoint, data, _headers|

--- a/test/unit/gateways/merchant_e_solutions_test.rb
+++ b/test/unit/gateways/merchant_e_solutions_test.rb
@@ -38,7 +38,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
   end
 
   def test_purchase_with_long_order_id_truncates_id
-    options = {order_id: 'thisislongerthan17characters'}
+    options = { order_id: 'thisislongerthan17characters' }
     @gateway.expects(:ssl_post).with(
       anything,
       all_of(
@@ -143,7 +143,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
 
   def test_visa_3dsecure_params_submitted
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({xid: '1', cavv: '2'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ xid: '1', cavv: '2' }))
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/xid=1/, data)
       assert_match(/cavv=2/, data)
@@ -152,7 +152,7 @@ class MerchantESolutionsTest < Test::Unit::TestCase
 
   def test_mastercard_3dsecure_params_submitted
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({ucaf_collection_ind: '1', ucaf_auth_data: '2'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ ucaf_collection_ind: '1', ucaf_auth_data: '2' }))
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/ucaf_collection_ind=1/, data)
       assert_match(/ucaf_auth_data=2/, data)

--- a/test/unit/gateways/merchant_ware_test.rb
+++ b/test/unit/gateways/merchant_ware_test.rb
@@ -110,7 +110,7 @@ class MerchantWareTest < Test::Unit::TestCase
 
   def test_add_swipe_data_with_creditcard
     @credit_card.track_data = 'Track Data'
-    options = {order_id: '1'}
+    options = { order_id: '1' }
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|

--- a/test/unit/gateways/metrics_global_test.rb
+++ b/test/unit/gateways/metrics_global_test.rb
@@ -45,7 +45,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
   def test_add_address_outsite_north_america
     result = {}
 
-    @gateway.send(:add_address, result, billing_address: {address1: '164 Waverley Street', country: 'DE', state: ''})
+    @gateway.send(:add_address, result, billing_address: { address1: '164 Waverley Street', country: 'DE', state: '' })
 
     assert_equal %w[address city company country phone state zip], result.stringify_keys.keys.sort
     assert_equal 'n/a', result[:state]
@@ -56,7 +56,7 @@ class MetricsGlobalTest < Test::Unit::TestCase
   def test_add_address
     result = {}
 
-    @gateway.send(:add_address, result, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO'})
+    @gateway.send(:add_address, result, billing_address: { address1: '164 Waverley Street', country: 'US', state: 'CO' })
 
     assert_equal %w[address city company country phone state zip], result.stringify_keys.keys.sort
     assert_equal 'CO', result[:state]

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -13,7 +13,7 @@ class MonerisTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4242424242424242')
-    @options = { order_id: '1', customer: '1', billing_address: address}
+    @options = { order_id: '1', customer: '1', billing_address: address }
   end
 
   def test_default_options
@@ -230,7 +230,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_successful_purchase_with_vault
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     test_successful_store
-    assert response = @gateway.purchase(100, @data_key, {order_id: generate_unique_id, customer: generate_unique_id})
+    assert response = @gateway.purchase(100, @data_key, { order_id: generate_unique_id, customer: generate_unique_id })
     assert_success response
     assert_equal 'Approved', response.message
     assert response.authorization.present?
@@ -249,7 +249,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_successful_authorization_with_vault
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     test_successful_store
-    assert response = @gateway.authorize(100, @data_key, {order_id: generate_unique_id, customer: generate_unique_id})
+    assert response = @gateway.authorize(100, @data_key, { order_id: generate_unique_id, customer: generate_unique_id })
     assert_success response
     assert_equal 'Approved', response.message
     assert response.authorization.present?

--- a/test/unit/gateways/money_movers_test.rb
+++ b/test/unit/gateways/money_movers_test.rb
@@ -44,7 +44,7 @@ class MoneyMoversTest < Test::Unit::TestCase
 
   def test_add_address
     result = {}
-    @gateway.send(:add_address, result, billing_address: {address1: '1 Main St.', address2: 'apt 13', country: 'US', state: 'MI', phone: '1234567890'})
+    @gateway.send(:add_address, result, billing_address: { address1: '1 Main St.', address2: 'apt 13', country: 'US', state: 'MI', phone: '1234567890' })
     assert_equal %w[address1 address2 city company country phone state zip], result.stringify_keys.keys.sort
     assert_equal 'MI', result[:state]
     assert_equal '1 Main St.', result[:address1]
@@ -60,7 +60,7 @@ class MoneyMoversTest < Test::Unit::TestCase
   end
 
   def test_purchase_is_valid_csv
-    params = {amount: @amount}
+    params = { amount: @amount }
     @gateway.send(:add_creditcard, params, @credit_card)
 
     assert data = @gateway.send(:post_data, 'auth', params)
@@ -68,7 +68,7 @@ class MoneyMoversTest < Test::Unit::TestCase
   end
 
   def test_purchase_meets_minimum_requirements
-    params = {amount: @amount}
+    params = { amount: @amount }
     @gateway.send(:add_creditcard, params, @credit_card)
     assert data = @gateway.send(:post_data, 'auth', params)
     minimum_requirements.each do |key|

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -108,14 +108,14 @@ class NabTransactTest < Test::Unit::TestCase
 
   def test_successful_refund
     @gateway.expects(:ssl_post).with(&check_transaction_type(:refund)).returns(successful_refund_response)
-    assert_success @gateway.refund(@amount, '009887', {order_id: '1'})
+    assert_success @gateway.refund(@amount, '009887', { order_id: '1' })
   end
 
   def test_successful_refund_with_merchant_descriptor
     name, location = 'Active Merchant', 'USA'
 
     response = assert_metadata(name, location) do
-      response = @gateway.refund(@amount, '009887', {order_id: '1', merchant_name: name, merchant_location: location})
+      response = @gateway.refund(@amount, '009887', { order_id: '1', merchant_name: name, merchant_location: location })
     end
 
     assert response
@@ -125,13 +125,13 @@ class NabTransactTest < Test::Unit::TestCase
 
   def test_successful_credit
     @gateway.expects(:ssl_post).with(&check_transaction_type(:unmatched_refund)).returns(successful_refund_response)
-    assert_success @gateway.credit(@amount, @credit_card, {order_id: '1'})
+    assert_success @gateway.credit(@amount, @credit_card, { order_id: '1' })
   end
 
   def test_failed_refund
     @gateway.expects(:ssl_post).with(&check_transaction_type(:refund)).returns(failed_refund_response)
 
-    response = @gateway.refund(@amount, '009887', {order_id: '1'})
+    response = @gateway.refund(@amount, '009887', { order_id: '1' })
     assert_failure response
     assert_equal 'Only $1.00 available for refund', response.message
   end

--- a/test/unit/gateways/omise_test.rb
+++ b/test/unit/gateways/omise_test.rb
@@ -50,7 +50,7 @@ class OmiseTest < Test::Unit::TestCase
   end
 
   def test_post_data
-    post_data = @gateway.send(:post_data, { card: {number: '4242424242424242'} })
+    post_data = @gateway.send(:post_data, { card: { number: '4242424242424242' } })
     assert_equal '{"card":{"number":"4242424242424242"}}', post_data
   end
 
@@ -138,7 +138,7 @@ class OmiseTest < Test::Unit::TestCase
   def test_add_customer_without_card
     result = {}
     customer_id = 'cust_test_4zjzcgm8kpdt4xdhdw2'
-    @gateway.send(:add_customer, result, {customer_id: customer_id})
+    @gateway.send(:add_customer, result, { customer_id: customer_id })
     assert_equal 'cust_test_4zjzcgm8kpdt4xdhdw2', result[:customer]
   end
 
@@ -146,21 +146,21 @@ class OmiseTest < Test::Unit::TestCase
     result = {}
     customer_id   = 'cust_test_4zjzcgm8kpdt4xdhdw2'
     result[:card] = 'card_test_4zguktjcxanu3dw171a'
-    @gateway.send(:add_customer, result, {customer_id: customer_id})
+    @gateway.send(:add_customer, result, { customer_id: customer_id })
     assert_equal customer_id, result[:customer]
   end
 
   def test_add_amount
     result = {}
     desc = 'Charge for order 3947'
-    @gateway.send(:add_amount, result, @amount, {description: desc})
+    @gateway.send(:add_amount, result, @amount, { description: desc })
     assert_equal desc, result[:description]
   end
 
   def test_add_amount_with_correct_currency
     result = {}
     jpy_currency = 'JPY'
-    @gateway.send(:add_amount, result, @amount, {currency: jpy_currency})
+    @gateway.send(:add_amount, result, @amount, { currency: jpy_currency })
     assert_equal jpy_currency, result[:currency]
   end
 

--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -113,7 +113,7 @@ class OpenpayTest < Test::Unit::TestCase
   def test_successful_purchase_with_card_id
     @gateway.expects(:ssl_request).returns(successful_purchase_response)
 
-    assert response = @gateway.purchase(@amount, {credit_card: 'a2b79p8xmzeyvmolqfja'}, @options)
+    assert response = @gateway.purchase(@amount, { credit_card: 'a2b79p8xmzeyvmolqfja' }, @options)
     assert_instance_of Response, response
     assert_success response
 

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -173,7 +173,7 @@ class OppTest < Test::Unit::TestCase
   end
 
   def test_passes_3d_secure_fields
-    options = @complete_request_options.merge({eci: 'eci', cavv: 'cavv', xid: 'xid'})
+    options = @complete_request_options.merge({ eci: 'eci', cavv: 'cavv', xid: 'xid' })
 
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @valid_card, options)

--- a/test/unit/gateways/optimal_payment_test.rb
+++ b/test/unit/gateways/optimal_payment_test.rb
@@ -99,7 +99,7 @@ class OptimalPaymentTest < Test::Unit::TestCase
   end
 
   def test_purchase_with_shipping_address
-    @options[:shipping_address] = {country: 'CA'}
+    @options[:shipping_address] = { country: 'CA' }
     @gateway.expects(:ssl_post).with do |_url, data|
       xml = data.split('&').detect { |string| string =~ /txnRequest=/ }.gsub('txnRequest=', '')
       doc = Nokogiri::XML.parse(CGI.unescape(xml))

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -750,7 +750,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         assert_deprecation_warning do
-          @gateway.add_customer_profile(credit_card, managed_billing: {start_date: '10-10-2014' })
+          @gateway.add_customer_profile(credit_card, managed_billing: { start_date: '10-10-2014' })
         end
       end
     end.check_request do |_endpoint, data, _headers|
@@ -1120,7 +1120,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_cvv_indicator_absent_for_recurring
     stub_comms do
-      @gateway.purchase(50, credit_card(nil, {verification_value: nil}), @options)
+      @gateway.purchase(50, credit_card(nil, { verification_value: nil }), @options)
     end.check_request do |_endpoint, data, _headers|
       assert_no_match %r{<CardSecValInd>}, data
       assert_no_match %r{<CardSecVal>}, data

--- a/test/unit/gateways/pac_net_raven_test.rb
+++ b/test/unit/gateways/pac_net_raven_test.rb
@@ -179,7 +179,7 @@ class PacNetRavenGatewayTest < Test::Unit::TestCase
 
   def test_add_address
     result = {}
-    @gateway.send(:add_address, result, billing_address: {address1: 'Address 1', address2: 'Address 2', zip: 'ZIP'})
+    @gateway.send(:add_address, result, billing_address: { address1: 'Address 1', address2: 'Address 2', zip: 'ZIP' })
     assert_equal %w[BillingPostalCode BillingStreetAddressLineFour BillingStreetAddressLineOne], result.stringify_keys.keys.sort
     assert_equal 'ZIP', result['BillingPostalCode']
     assert_equal 'Address 2', result['BillingStreetAddressLineFour']
@@ -203,13 +203,13 @@ class PacNetRavenGatewayTest < Test::Unit::TestCase
 
   def test_add_currency_code_from_options
     result = {}
-    @gateway.send(:add_currency_code, result, 100, {currency: 'CAN'})
+    @gateway.send(:add_currency_code, result, 100, { currency: 'CAN' })
     assert_equal 'CAN', result['Currency']
   end
 
   def test_parse
     result = @gateway.send(:parse, 'key1=value1&key2=value2')
-    h = {'key1' => 'value1', 'key2' => 'value2'}
+    h = { 'key1' => 'value1', 'key2' => 'value2' }
     assert_equal h, result
   end
 

--- a/test/unit/gateways/pago_facil_test.rb
+++ b/test/unit/gateways/pago_facil_test.rb
@@ -70,9 +70,9 @@ class PagoFacilTest < Test::Unit::TestCase
   private
 
   def successful_purchase_response
-    {'WebServices_Transacciones' =>
-      {'transaccion' =>
-        {'autorizado' => '1',
+    { 'WebServices_Transacciones' =>
+      { 'transaccion' =>
+        { 'autorizado' => '1',
          'autorizacion' => '305638',
          'transaccion' => 'S-PFE12S12I12568',
          'texto' => 'Transaction has been successful!-Approved',
@@ -87,7 +87,7 @@ class PagoFacilTest < Test::Unit::TestCase
          'param5' => '',
          'TipoTC' => 'Visa',
          'data' =>
-          {'anyoExpiracion' => '(2) **',
+          { 'anyoExpiracion' => '(2) **',
            'apellidos' => 'Reyes Garza',
            'calleyNumero' => 'Anatole France 311',
            'celular' => '5550123456',
@@ -108,9 +108,9 @@ class PagoFacilTest < Test::Unit::TestCase
            'pais' => 'Mexico',
            'telefono' => '5550220910',
            'transFechaHora' => '1393363998',
-           'bin' => '(6) ***1'},
+           'bin' => '(6) ***1' },
          'dataVal' =>
-          {'idSucursal' => '12',
+          { 'idSucursal' => '12',
            'cp' => '11560',
            'nombre' => 'Juan',
            'apellidos' => 'Reyes Garza',
@@ -138,13 +138,13 @@ class PagoFacilTest < Test::Unit::TestCase
            'noMail' => '',
            'notaMail' => '',
            'settingsTransaction' =>
-            {'noMontoMes' => '0.00',
+            { 'noMontoMes' => '0.00',
              'noTransaccionesDia' => '0',
              'minTransaccionTc' => '5',
              'tiempoDevolucion' => '30',
              'sendPdfTransCliente' => '1',
              'noMontoDia' => '0.00',
-             'noTransaccionesMes' => '0'},
+             'noTransaccionesMes' => '0' },
            'email' => 'comprador@correo.com',
            'telefono' => '5550220910',
            'celular' => '5550123456',
@@ -156,19 +156,19 @@ class PagoFacilTest < Test::Unit::TestCase
            'idCaja' => '',
            'paisDetectedIP' => 'MX',
            'qa' => '1',
-           'https' => 'on'},
-         'status' => 'success'}}}.to_json
+           'https' => 'on' },
+         'status' => 'success' } } }.to_json
   end
 
   def failed_purchase_response
-    {'WebServices_Transacciones' =>
-      {'transaccion' =>
-        {'autorizado' => '0',
+    { 'WebServices_Transacciones' =>
+      { 'transaccion' =>
+        { 'autorizado' => '0',
          'transaccion' => 'n/a',
          'autorizacion' => 'n/a',
          'texto' => 'Errores en los datos de entrada Validaciones',
          'error' =>
-          {'numeroTarjeta' => "'1111111111111111' no es de una institucion permitida"},
+          { 'numeroTarjeta' => "'1111111111111111' no es de una institucion permitida" },
          'empresa' => 'Sin determinar',
          'TransIni' => '16:10:20 pm 25/02/2014',
          'TransFin' => '16:10:20 pm 25/02/2014',
@@ -179,7 +179,7 @@ class PagoFacilTest < Test::Unit::TestCase
          'param5' => '',
          'TipoTC' => '',
          'data' =>
-          {'anyoExpiracion' => '(2) **',
+          { 'anyoExpiracion' => '(2) **',
            'apellidos' => 'Reyes Garza',
            'calleyNumero' => 'Anatole France 311',
            'celular' => '5550123456',
@@ -200,9 +200,9 @@ class PagoFacilTest < Test::Unit::TestCase
            'pais' => 'Mexico',
            'telefono' => '5550220910',
            'transFechaHora' => '1393366220',
-           'bin' => '(6) ***1'},
+           'bin' => '(6) ***1' },
          'dataVal' =>
-          {'email' => 'comprador@correo.com',
+          { 'email' => 'comprador@correo.com',
            'telefono' => '5550220910',
            'celular' => '5550123456',
            'calleyNumero' => 'Anatole France 311',
@@ -215,8 +215,8 @@ class PagoFacilTest < Test::Unit::TestCase
            'cvt' => '',
            'anyoExpiracion' => '',
            'mesExpiracion' => '',
-           'https' => 'on'},
-         'status' => 'success'}}}.to_json
+           'https' => 'on' },
+         'status' => 'success' } } }.to_json
   end
 
   def invalid_json_response

--- a/test/unit/gateways/pay_hub_test.rb
+++ b/test/unit/gateways/pay_hub_test.rb
@@ -190,7 +190,7 @@ class PayHubTest < Test::Unit::TestCase
   def test_unsuccessful_request
     @gateway.expects(:ssl_request).returns(failed_purchase_or_authorize_response)
 
-    @gateway.options.merge!({mode: 'live', test: false})
+    @gateway.options.merge!({ mode: 'live', test: false })
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
@@ -200,7 +200,7 @@ class PayHubTest < Test::Unit::TestCase
   def test_unsuccessful_authorize
     @gateway.expects(:ssl_request).returns(failed_purchase_or_authorize_response)
 
-    @gateway.options.merge!({mode: 'live', test: false})
+    @gateway.options.merge!({ mode: 'live', test: false })
 
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/pay_junction_v2_test.rb
+++ b/test/unit/gateways/pay_junction_v2_test.rb
@@ -207,7 +207,7 @@ class PayJunctionV2Test < Test::Unit::TestCase
   end
 
   def test_add_address
-    post = {card: {billingAddress: {}}}
+    post = { card: { billingAddress: {} } }
     @gateway.send(:add_address, post, @options)
     assert_equal @options[:billing_address][:first_name], post[:billingFirstName]
     assert_equal @options[:billing_address][:last_name], post[:billingLastName]

--- a/test/unit/gateways/payex_test.rb
+++ b/test/unit/gateways/payex_test.rb
@@ -98,7 +98,7 @@ class PayexTest < Test::Unit::TestCase
 
   def test_successful_store
     @gateway.expects(:ssl_post).times(3).returns(successful_store_response, successful_initialize_response, successful_purchase_response)
-    assert response = @gateway.store(@credit_card, @options.merge({merchant_ref: '9876'}))
+    assert response = @gateway.store(@credit_card, @options.merge({ merchant_ref: '9876' }))
     assert_success response
     assert_equal 'OK', response.message
     assert_equal 'bcea4ac8d1f44640bff7a8c93caa249c', response.authorization
@@ -115,7 +115,7 @@ class PayexTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_stored_card
     @gateway.expects(:ssl_post).returns(successful_autopay_response)
-    assert response = @gateway.purchase(@amount, 'fakeauth', @options.merge({order_id: '5678'}))
+    assert response = @gateway.purchase(@amount, 'fakeauth', @options.merge({ order_id: '5678' }))
     assert_success response
     assert_equal 'OK', response.message
     assert_equal '2624657', response.authorization

--- a/test/unit/gateways/payflow_express_test.rb
+++ b/test/unit/gateways/payflow_express_test.rb
@@ -26,7 +26,7 @@ class PayflowExpressTest < Test::Unit::TestCase
                  state: 'ON',
                  zip: 'K1C2N6',
                  country: 'Canada',
-                 phone: '(555)555-5555'}
+                 phone: '(555)555-5555' }
   end
 
   def teardown
@@ -161,7 +161,7 @@ class PayflowExpressTest < Test::Unit::TestCase
 
   private
 
-  def successful_get_express_details_response(options = {street: '111 Main St.'})
+  def successful_get_express_details_response(options = { street: '111 Main St.' })
     <<~RESPONSE
       <XMLPayResponse xmlns='http://www.verisign.com/XMLPay'>
         <ResponseData>

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -314,7 +314,7 @@ class PayflowTest < Test::Unit::TestCase
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         @gateway.recurring(@amount, @credit_card,
           periodicity: :monthly,
-          initial_transaction: { })
+          initial_transaction: {})
       end
     end
   end

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -112,9 +112,9 @@ class PaymentExpressTest < Test::Unit::TestCase
       use_custom_payment_token: true
     )
 
-    @gateway.expects(:ssl_post).returns(successful_store_response({billing_id: 'TEST1234'}))
+    @gateway.expects(:ssl_post).returns(successful_store_response({ billing_id: 'TEST1234' }))
 
-    assert response = @gateway.store(@visa, {billing_id: 'TEST1234'})
+    assert response = @gateway.store(@visa, { billing_id: 'TEST1234' })
     assert_equal 'TEST1234', response.token
 
     @gateway.expects(:ssl_post).returns(successful_billing_id_token_purchase_response)
@@ -187,7 +187,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_web
-    options = {client_type: :web}
+    options = { client_type: :web }
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>Web<\/ClientType>/, body)
@@ -195,7 +195,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_ivr
-    options = {client_type: :ivr}
+    options = { client_type: :ivr }
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>IVR<\/ClientType>/, body)
@@ -203,7 +203,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_moto
-    options = {client_type: :moto}
+    options = { client_type: :moto }
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>MOTO<\/ClientType>/, body)
@@ -211,7 +211,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_unattended
-    options = {client_type: :unattended}
+    options = { client_type: :unattended }
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>Unattended<\/ClientType>/, body)
@@ -219,7 +219,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_internet
-    options = {client_type: :internet}
+    options = { client_type: :internet }
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>Internet<\/ClientType>/, body)
@@ -227,7 +227,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_recurring
-    options = {client_type: :recurring}
+    options = { client_type: :recurring }
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientType>Recurring<\/ClientType>/, body)
@@ -235,7 +235,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_client_type_as_symbol_for_unknown_type_omits_element
-    options = {client_type: :unknown}
+    options = { client_type: :unknown }
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_no_match(/<ClientType>/, body)
@@ -243,7 +243,7 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_pass_ip_as_client_info
-    options = {ip: '192.168.0.1'}
+    options = { ip: '192.168.0.1' }
 
     perform_each_transaction_type_with_request_body_assertions(options) do |body|
       assert_match(/<ClientInfo>192.168.0.1<\/ClientInfo>/, body)
@@ -252,7 +252,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_purchase_truncates_order_id_to_16_chars
     stub_comms do
-      @gateway.purchase(@amount, @visa, {order_id: '16chars---------EXTRA'})
+      @gateway.purchase(@amount, @visa, { order_id: '16chars---------EXTRA' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
@@ -260,7 +260,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_authorize_truncates_order_id_to_16_chars
     stub_comms do
-      @gateway.authorize(@amount, @visa, {order_id: '16chars---------EXTRA'})
+      @gateway.authorize(@amount, @visa, { order_id: '16chars---------EXTRA' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
@@ -268,7 +268,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_capture_truncates_order_id_to_16_chars
     stub_comms do
-      @gateway.capture(@amount, 'identification', {order_id: '16chars---------EXTRA'})
+      @gateway.capture(@amount, 'identification', { order_id: '16chars---------EXTRA' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
@@ -276,7 +276,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_refund_truncates_order_id_to_16_chars
     stub_comms do
-      @gateway.refund(@amount, 'identification', {description: 'refund', order_id: '16chars---------EXTRA'})
+      @gateway.refund(@amount, 'identification', { description: 'refund', order_id: '16chars---------EXTRA' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<TxnId>16chars---------<\/TxnId>/, data)
     end.respond_with(successful_authorization_response)
@@ -284,7 +284,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_purchase_truncates_description_to_50_chars
     stub_comms do
-      @gateway.purchase(@amount, @visa, {description: '50chars-------------------------------------------EXTRA'})
+      @gateway.purchase(@amount, @visa, { description: '50chars-------------------------------------------EXTRA' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
@@ -292,7 +292,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_authorize_truncates_description_to_50_chars
     stub_comms do
-      @gateway.authorize(@amount, @visa, {description: '50chars-------------------------------------------EXTRA'})
+      @gateway.authorize(@amount, @visa, { description: '50chars-------------------------------------------EXTRA' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
@@ -300,7 +300,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_capture_truncates_description_to_50_chars
     stub_comms do
-      @gateway.capture(@amount, 'identification', {description: '50chars-------------------------------------------EXTRA'})
+      @gateway.capture(@amount, 'identification', { description: '50chars-------------------------------------------EXTRA' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
@@ -308,7 +308,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
   def test_refund_truncates_description_to_50_chars
     stub_comms do
-      @gateway.capture(@amount, 'identification', {description: '50chars-------------------------------------------EXTRA'})
+      @gateway.capture(@amount, 'identification', { description: '50chars-------------------------------------------EXTRA' })
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantReference>50chars-------------------------------------------<\/MerchantReference>/, data)
     end.respond_with(successful_authorization_response)
@@ -344,7 +344,7 @@ class PaymentExpressTest < Test::Unit::TestCase
 
     # refund
     stub_comms do
-      @gateway.refund(@amount, 'identification', {description: 'description'}.merge(options))
+      @gateway.refund(@amount, 'identification', { description: 'description' }.merge(options))
     end.check_request do |_endpoint, data, _headers|
       yield data
     end.respond_with(successful_authorization_response)

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -44,25 +44,25 @@ class PaypalCommonApiTest < Test::Unit::TestCase
   end
 
   def test_add_payment_details_adds_express_only_payment_details_when_necessary
-    options = {express_request: true}
+    options = { express_request: true }
     @gateway.expects(:add_express_only_payment_details)
     @gateway.send(:add_payment_details, xml_builder, 100, 'USD', options)
   end
 
   def test_add_payment_details_adds_items_details
-    options = {items: [1]}
+    options = { items: [1] }
     @gateway.expects(:add_payment_details_items_xml)
     @gateway.send(:add_payment_details, xml_builder, 100, 'USD', options)
   end
 
   def test_add_payment_details_adds_address
-    options = {shipping_address: @address}
+    options = { shipping_address: @address }
     @gateway.expects(:add_address)
     @gateway.send(:add_payment_details, xml_builder, 100, 'USD', options)
   end
 
   def test_add_payment_details_adds_items_details_elements
-    options = {items: [{name: 'foo'}]}
+    options = { items: [{ name: 'foo' }] }
     request = wrap_xml do |xml|
       @gateway.send(:add_payment_details, xml, 100, 'USD', options)
     end
@@ -105,7 +105,7 @@ class PaypalCommonApiTest < Test::Unit::TestCase
 
   def test_add_express_only_payment_details_adds_non_blank_fields
     request = wrap_xml do |xml|
-      @gateway.send(:add_express_only_payment_details, xml, {payment_action: 'Sale', payment_request_id: ''})
+      @gateway.send(:add_express_only_payment_details, xml, { payment_action: 'Sale', payment_request_id: '' })
     end
     assert_equal 'Sale', REXML::XPath.first(request, '//n2:PaymentAction').text
     assert_nil REXML::XPath.first(request, '//n2:PaymentRequestID')

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -142,13 +142,13 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_includes_correct_payment_action
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { }))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {}))
 
     assert_equal 'SetExpressCheckout', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentAction').text
   end
 
   def test_includes_custom_tag_if_specified
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {custom: 'Foo'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { custom: 'Foo' }))
 
     assert_equal 'Foo', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:Custom').text
   end
@@ -180,7 +180,7 @@ class PaypalExpressTest < Test::Unit::TestCase
           description: 'item two description',
           amount: 20000,
           number: 2,
-          quantity: 4}
+          quantity: 4 }
       ]
     }))
 
@@ -206,7 +206,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_callback_url_is_included_if_specified_in_build_setup_request
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {callback_url: 'http://example.com/update_callback'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { callback_url: 'http://example.com/update_callback' }))
 
     assert_equal 'http://example.com/update_callback', REXML::XPath.first(xml, '//n2:CallbackURL').text
   end
@@ -218,7 +218,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_callback_timeout_is_included_if_specified_in_build_setup_request
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {callback_timeout: 2}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { callback_timeout: 2 }))
 
     assert_equal '2', REXML::XPath.first(xml, '//n2:CallbackTimeout').text
   end
@@ -230,7 +230,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_callback_version_is_included_if_specified_in_build_setup_request
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {callback_version: '53.0'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { callback_version: '53.0' }))
 
     assert_equal '53.0', REXML::XPath.first(xml, '//n2:CallbackVersion').text
   end
@@ -305,7 +305,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_removes_fractional_amounts_with_twd_currency
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 150, {currency: 'TWD'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 150, { currency: 'TWD' }))
 
     assert_equal '1', REXML::XPath.first(xml, '//n2:OrderTotal').text
   end
@@ -410,7 +410,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_does_not_add_allow_note_if_not_specified
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, { }))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0, {}))
 
     assert_nil REXML::XPath.first(xml, '//n2:AllowNote')
   end
@@ -632,14 +632,14 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_allow_guest_checkout
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {allow_guest_checkout: true}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, { allow_guest_checkout: true }))
 
     assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
     assert_equal 'Billing', REXML::XPath.first(xml, '//n2:LandingPage').text
   end
 
   def test_paypal_chooses_landing_page
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {allow_guest_checkout: true, paypal_chooses_landing_page: true}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, { allow_guest_checkout: true, paypal_chooses_landing_page: true }))
 
     assert_equal 'Sole', REXML::XPath.first(xml, '//n2:SolutionType').text
     assert_nil REXML::XPath.first(xml, '//n2:LandingPage')
@@ -652,7 +652,7 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_adds_brand_name_if_specified
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {brand_name: 'Acme'}))
+    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, { brand_name: 'Acme' }))
     assert_equal 'Acme', REXML::XPath.first(xml, '//n2:BrandName').text
   end
 
@@ -670,15 +670,15 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_adds_buyer_optin_if_specified
-    allow_optin_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {allow_buyer_optin: true}))
-    do_not_allow_optin_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {allow_buyer_optin: false}))
+    allow_optin_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, { allow_buyer_optin: true }))
+    do_not_allow_optin_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, { allow_buyer_optin: false }))
 
     assert_equal '1', REXML::XPath.first(allow_optin_xml, '//n2:BuyerEmailOptInEnable').text
     assert_equal '0', REXML::XPath.first(do_not_allow_optin_xml, '//n2:BuyerEmailOptInEnable').text
   end
 
   def test_add_total_type_if_specified
-    total_type_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {total_type: 'EstimatedTotal'}))
+    total_type_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, { total_type: 'EstimatedTotal' }))
     no_total_type_xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 10, {}))
 
     assert_equal 'EstimatedTotal', REXML::XPath.first(total_type_xml, '//n2:TotalType').text
@@ -696,7 +696,7 @@ class PaypalExpressTest < Test::Unit::TestCase
       header_border_color: 'CAFE00',
       background_color: 'CAFE00',
       email: 'joe@example.com',
-      billing_agreement: {type: 'MerchantInitiatedBilling', description: '9.99 per month for a year'},
+      billing_agreement: { type: 'MerchantInitiatedBilling', description: '9.99 per month for a year' },
       allow_note: true,
       allow_buyer_optin: true,
       subtotal: 35,
@@ -727,7 +727,7 @@ class PaypalExpressTest < Test::Unit::TestCase
       callback_url: 'http://example.com/update_callback',
       callback_timeout: 2,
       callback_version: '53.0',
-      funding_sources: {source: 'BML'},
+      funding_sources: { source: 'BML' },
       shipping_options: [
         {
           default: true,

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -15,7 +15,7 @@ class PaypalTest < Test::Unit::TestCase
 
     @credit_card = credit_card('4242424242424242')
     @options = { billing_address: address, ip: '127.0.0.1' }
-    @recurring_required_fields = {start_date: Date.today, frequency: :Month, period: 'Month', description: 'A description'}
+    @recurring_required_fields = { start_date: Date.today, frequency: :Month, period: 'Month', description: 'A description' }
   end
 
   def test_no_ip_address
@@ -102,7 +102,7 @@ class PaypalTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_auth_signature
     @gateway = PaypalGateway.new(login: 'cody', password: 'test', pem: 'PEM', auth_signature: 123)
-    expected_header = {'X-PP-AUTHORIZATION' => 123, 'X-PAYPAL-MESSAGE-PROTOCOL' => 'SOAP11'}
+    expected_header = { 'X-PP-AUTHORIZATION' => 123, 'X-PAYPAL-MESSAGE-PROTOCOL' => 'SOAP11' }
     @gateway.expects(:ssl_post).with(anything, anything, expected_header).returns(successful_purchase_response)
     @gateway.expects(:add_credentials).never
 

--- a/test/unit/gateways/payscout_test.rb
+++ b/test/unit/gateways/payscout_test.rb
@@ -230,7 +230,7 @@ class PayscoutTest < Test::Unit::TestCase
 
   def test_add_invoice
     post = {}
-    options = {description: 'Order Description', order_id: '123'}
+    options = { description: 'Order Description', order_id: '123' }
     @gateway.send(:add_invoice, post, options)
 
     assert_equal 'Order Description', post[:orderdescription]
@@ -281,25 +281,25 @@ class PayscoutTest < Test::Unit::TestCase
   end
 
   def test_message_from_for_approved_response
-    assert_equal 'The transaction has been approved', @gateway.send(:message_from, {'response' => '1'})
+    assert_equal 'The transaction has been approved', @gateway.send(:message_from, { 'response' => '1' })
   end
 
   def test_message_from_for_declined_response
-    assert_equal 'The transaction has been declined', @gateway.send(:message_from, {'response' => '2'})
+    assert_equal 'The transaction has been declined', @gateway.send(:message_from, { 'response' => '2' })
   end
 
   def test_message_from_for_failed_response
-    assert_equal 'Error message', @gateway.send(:message_from, {'response' => '3', 'responsetext' => 'Error message'})
+    assert_equal 'Error message', @gateway.send(:message_from, { 'response' => '3', 'responsetext' => 'Error message' })
   end
 
   def test_success
-    assert @gateway.send(:success?, {'response' => '1'})
-    refute @gateway.send(:success?, {'response' => '2'})
-    refute @gateway.send(:success?, {'response' => '3'})
+    assert @gateway.send(:success?, { 'response' => '1' })
+    refute @gateway.send(:success?, { 'response' => '2' })
+    refute @gateway.send(:success?, { 'response' => '3' })
   end
 
   def test_post_data
-    parameters = {param1: 'value1', param2: 'value2'}
+    parameters = { param1: 'value1', param2: 'value2' }
     result = @gateway.send(:post_data, 'auth', parameters)
 
     assert_match 'username=xxx', result

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -130,7 +130,7 @@ class PinTest < Test::Unit::TestCase
 
   def test_successful_refund
     token = 'ch_encBuMDf17qTabmVjDsQlg'
-    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", {amount: '100'}.to_json, instance_of(Hash)).returns(successful_refund_response)
+    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", { amount: '100' }.to_json, instance_of(Hash)).returns(successful_refund_response)
 
     assert response = @gateway.refund(100, token)
     assert_equal 'rf_d2C7M6Mn4z2m3APqarNN6w', response.authorization
@@ -140,7 +140,7 @@ class PinTest < Test::Unit::TestCase
 
   def test_unsuccessful_refund
     token = 'ch_encBuMDf17qTabmVjDsQlg'
-    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", {amount: '100'}.to_json, instance_of(Hash)).returns(failed_refund_response)
+    @gateway.expects(:ssl_request).with(:post, "https://test-api.pinpayments.com/1/charges/#{token}/refunds", { amount: '100' }.to_json, instance_of(Hash)).returns(failed_refund_response)
 
     assert response = @gateway.refund(100, token)
     assert_failure response

--- a/test/unit/gateways/plugnpay_test.rb
+++ b/test/unit/gateways/plugnpay_test.rb
@@ -42,7 +42,7 @@ class PlugnpayTest < Test::Unit::TestCase
 
   def test_capture_full_amount
     @gateway.expects(:ssl_post).with(anything, all_of(regexp_matches(/mode=mark/), regexp_matches(/card_amount=1.00/)), anything).returns('')
-    @gateway.expects(:parse).returns({'auth_msg' => 'Blah blah blah Transaction may not be reauthorized'}, {})
+    @gateway.expects(:parse).returns({ 'auth_msg' => 'Blah blah blah Transaction may not be reauthorized' }, {})
     @gateway.capture(@amount, @credit_card, @options)
   end
 
@@ -69,7 +69,7 @@ class PlugnpayTest < Test::Unit::TestCase
   def test_add_address_outsite_north_america
     result = PlugnpayGateway::PlugnpayPostData.new
 
-    @gateway.send(:add_addresses, result, billing_address: {address1: '164 Waverley Street', country: 'DE', state: 'Dortmund'})
+    @gateway.send(:add_addresses, result, billing_address: { address1: '164 Waverley Street', country: 'DE', state: 'Dortmund' })
 
     assert_equal result[:state], 'ZZ'
     assert_equal result[:province], 'Dortmund'
@@ -84,7 +84,7 @@ class PlugnpayTest < Test::Unit::TestCase
   def test_add_address
     result = PlugnpayGateway::PlugnpayPostData.new
 
-    @gateway.send(:add_addresses, result, billing_address: {address1: '164 Waverley Street', country: 'US', state: 'CO'})
+    @gateway.send(:add_addresses, result, billing_address: { address1: '164 Waverley Street', country: 'US', state: 'CO' })
 
     assert_equal result[:card_state], 'CO'
     assert_equal result[:card_address1], '164 Waverley Street'

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -89,7 +89,7 @@ class QuickpayV10Test < Test::Unit::TestCase
       assert response.test?
     end.check_request do |endpoint, _data, _headers|
       assert_match %r{/payments/1145/cancel}, endpoint
-    end.respond_with({'id' => 1145}.to_json)
+    end.respond_with({ 'id' => 1145 }.to_json)
   end
 
   def test_failed_authorization
@@ -127,7 +127,7 @@ class QuickpayV10Test < Test::Unit::TestCase
       assert response.test?
     end.check_request do |endpoint, _data, _headers|
       assert_match %r{/cards/\d+/cancel}, endpoint
-    end.respond_with({'id' => '123'}.to_json)
+    end.respond_with({ 'id' => '123' }.to_json)
   end
 
   def test_successful_verify
@@ -141,7 +141,7 @@ class QuickpayV10Test < Test::Unit::TestCase
   def test_failed_verify
     response = stub_comms do
       @gateway.verify(@credit_card, @options)
-    end.respond_with(failed_authorization_response, {'id' => 1145}.to_json)
+    end.respond_with(failed_authorization_response, { 'id' => 1145 }.to_json)
     assert_failure response
     assert_equal 'Validation error', response.message
   end
@@ -222,7 +222,7 @@ class QuickpayV10Test < Test::Unit::TestCase
       'variables' => {},
       'acquirer' => 'clearhaus',
       'operations' => [],
-      'metadata' => {'type' => 'card', 'brand' => 'quickpay-test-card', 'last4' => '0008', 'exp_month' => 9, 'exp_year' => 2016, 'country' => 'DK', 'is_3d_secure' => false, 'customer_ip' => nil, 'customer_country' => nil},
+      'metadata' => { 'type' => 'card', 'brand' => 'quickpay-test-card', 'last4' => '0008', 'exp_month' => 9, 'exp_year' => 2016, 'country' => 'DK', 'is_3d_secure' => false, 'customer_ip' => nil, 'customer_country' => nil },
       'created_at' => '2015-03-30T16:56:17Z',
       'balance' => 0,
       'currency' => 'DKK'

--- a/test/unit/gateways/quickpay_v4to7_test.rb
+++ b/test/unit/gateways/quickpay_v4to7_test.rb
@@ -46,7 +46,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
     @gateway.expects(:generate_check_hash).returns(mock_md5_hash)
 
     response = stub_comms do
-      @gateway.store(@credit_card, {order_id: 'fa73664073e23597bbdd', description: 'Storing Card'})
+      @gateway.store(@credit_card, { order_id: 'fa73664073e23597bbdd', description: 'Storing Card' })
     end.check_request do |_endpoint, data, _headers|
       assert_equal(expected_store_parameters_v6, CGI::parse(data))
     end.respond_with(successful_store_response_v6)
@@ -61,7 +61,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
     @gateway.expects(:generate_check_hash).returns(mock_md5_hash)
 
     response = stub_comms do
-      @gateway.store(@credit_card, {order_id: 'ed7546cb4ceb8f017ea4', description: 'Storing Card'})
+      @gateway.store(@credit_card, { order_id: 'ed7546cb4ceb8f017ea4', description: 'Storing Card' })
     end.check_request do |_endpoint, data, _headers|
       assert_equal(expected_store_parameters_v7, CGI::parse(data))
     end.respond_with(successful_store_response_v7)
@@ -133,7 +133,7 @@ class QuickpayV4to7Test < Test::Unit::TestCase
   end
 
   def test_add_testmode_does_not_add_testmode_if_transaction_id_present
-    post_hash = {transaction: '12345'}
+    post_hash = { transaction: '12345' }
     @gateway.send(:add_testmode, post_hash)
     assert_equal nil, post_hash[:testmode]
   end

--- a/test/unit/gateways/qvalent_test.rb
+++ b/test/unit/gateways/qvalent_test.rb
@@ -177,7 +177,7 @@ class QvalentTest < Test::Unit::TestCase
 
   def test_3d_secure_fields
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, {xid: '123', cavv: '456', eci: '5'})
+      @gateway.purchase(@amount, @credit_card, { xid: '123', cavv: '456', eci: '5' })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/xid=123/, data)
       assert_match(/cavv=456/, data)
@@ -189,7 +189,7 @@ class QvalentTest < Test::Unit::TestCase
 
   def test_stored_credential_fields_initial
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, {stored_credential: {initial_transaction: true, reason_type: 'unscheduled', initiator: 'merchant'}})
+      @gateway.purchase(@amount, @credit_card, { stored_credential: { initial_transaction: true, reason_type: 'unscheduled', initiator: 'merchant' } })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=MANUAL/, data)
       assert_match(/storedCredentialUsage=INITIAL_STORAGE/, data)
@@ -201,7 +201,7 @@ class QvalentTest < Test::Unit::TestCase
 
   def test_stored_credential_fields_recurring
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, {stored_credential: {reason_type: 'recurring', initiator: 'merchant', network_transaction_id: '7890'}})
+      @gateway.purchase(@amount, @credit_card, { stored_credential: { reason_type: 'recurring', initiator: 'merchant', network_transaction_id: '7890' } })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=STORED_CREDENTIAL/, data)
       assert_match(/storedCredentialUsage=RECURRING/, data)
@@ -214,7 +214,7 @@ class QvalentTest < Test::Unit::TestCase
 
   def test_stored_credential_fields_unscheduled
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, {stored_credential: {reason_type: 'unscheduled', initiator: 'merchant', network_transaction_id: '7890'}})
+      @gateway.purchase(@amount, @credit_card, { stored_credential: { reason_type: 'unscheduled', initiator: 'merchant', network_transaction_id: '7890' } })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=STORED_CREDENTIAL/, data)
       assert_match(/storedCredentialUsage=UNSCHEDULED/, data)
@@ -227,7 +227,7 @@ class QvalentTest < Test::Unit::TestCase
 
   def test_stored_credential_fields_cardholder_initiated
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, {stored_credential: {reason_type: 'unscheduled', initiator: 'cardholder', network_transaction_id: '7890'}})
+      @gateway.purchase(@amount, @credit_card, { stored_credential: { reason_type: 'unscheduled', initiator: 'cardholder', network_transaction_id: '7890' } })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=STORED_CREDENTIAL/, data)
       refute_match(/storedCredentialUsage/, data)
@@ -241,7 +241,7 @@ class QvalentTest < Test::Unit::TestCase
   def test_stored_credential_fields_mastercard
     @credit_card.brand = 'master'
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, {stored_credential: {reason_type: 'recurring', initiator: 'merchant', network_transaction_id: '7890'}})
+      @gateway.purchase(@amount, @credit_card, { stored_credential: { reason_type: 'recurring', initiator: 'merchant', network_transaction_id: '7890' } })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=STORED_CREDENTIAL/, data)
       refute_match(/storedCredentialUsage/, data)

--- a/test/unit/gateways/sage_test.rb
+++ b/test/unit/gateways/sage_test.rb
@@ -157,7 +157,7 @@ class SageGatewayTest < Test::Unit::TestCase
 
   def test_include_customer_number_for_numeric_values
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge({customer: '123'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ customer: '123' }))
     end.check_request do |_method, data|
       assert data =~ /T_customer_number=123/
     end.respond_with(successful_authorization_response)
@@ -165,7 +165,7 @@ class SageGatewayTest < Test::Unit::TestCase
 
   def test_dont_include_customer_number_for_numeric_values
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge({customer: 'bob@test.com'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ customer: 'bob@test.com' }))
     end.check_request do |_method, data|
       assert data !~ /T_customer_number/
     end.respond_with(successful_authorization_response)
@@ -188,7 +188,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_address_with_state
     post = {}
     options = {
-      billing_address: { country: 'US', state: 'CA'}
+      billing_address: { country: 'US', state: 'CA' }
     }
     @gateway.send(:add_addresses, post, options)
 
@@ -199,7 +199,7 @@ class SageGatewayTest < Test::Unit::TestCase
   def test_address_without_state
     post = {}
     options = {
-      billing_address: { country: 'NZ', state: ''}
+      billing_address: { country: 'NZ', state: '' }
     }
     @gateway.send(:add_addresses, post, options)
 

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -166,7 +166,7 @@ class SecurePayAuTest < Test::Unit::TestCase
   def test_successful_store
     @gateway.expects(:ssl_post).returns(successful_store_response)
 
-    assert response = @gateway.store(@credit_card, {billing_id: 'test3', amount: 123})
+    assert response = @gateway.store(@credit_card, { billing_id: 'test3', amount: 123 })
     assert_instance_of Response, response
     assert_equal 'Successful', response.message
     assert_equal 'test3', response.params['client_id']

--- a/test/unit/gateways/securion_pay_test.rb
+++ b/test/unit/gateways/securion_pay_test.rb
@@ -122,7 +122,7 @@ class SecurionPayTest < Test::Unit::TestCase
   end
 
   def test_add_address
-    post = { card: { } }
+    post = { card: {} }
     @gateway.send(:add_address, post, @options)
     assert_equal @options[:billing_address][:zip], post[:card][:addressZip]
     assert_equal @options[:billing_address][:state], post[:card][:addressState]

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -545,7 +545,7 @@ class StripeTest < Test::Unit::TestCase
     }
 
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, 'cus_xxx|card_xxx', @options.merge({application: application}))
+      @gateway.purchase(@amount, 'cus_xxx|card_xxx', @options.merge({ application: application }))
     end.check_request do |_method, _endpoint, _data, headers|
       assert_match(/\"application\"/, headers['X-Stripe-Client-User-Agent'])
       assert_match(/\"name\":\"app\"/, headers['X-Stripe-Client-User-Agent'])
@@ -631,7 +631,7 @@ class StripeTest < Test::Unit::TestCase
       post.include?('metadata[first_value]=true')
     end.returns(successful_purchase_response(true))
 
-    assert response = @gateway.void('ch_test_charge', {metadata: {first_value: true}})
+    assert response = @gateway.void('ch_test_charge', { metadata: { first_value: true } })
     assert_success response
   end
 
@@ -640,7 +640,7 @@ class StripeTest < Test::Unit::TestCase
       post.include?('reason=fraudulent')
     end.returns(successful_purchase_response(true))
 
-    assert response = @gateway.void('ch_test_charge', {reason: 'fraudulent'})
+    assert response = @gateway.void('ch_test_charge', { reason: 'fraudulent' })
     assert_success response
   end
 
@@ -713,7 +713,7 @@ class StripeTest < Test::Unit::TestCase
       post.include?('metadata[first_value]=true')
     end.returns(successful_partially_refunded_response)
 
-    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', {metadata: {first_value: true}})
+    assert response = @gateway.refund(@refund_amount, 'ch_test_charge', { metadata: { first_value: true } })
     assert_success response
   end
 
@@ -961,7 +961,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_application_fee_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({application_fee: 144}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ application_fee: 144 }))
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/application_fee=144/, data)
     end.respond_with(successful_purchase_response)
@@ -969,7 +969,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_application_fee_is_submitted_for_capture
     stub_comms(@gateway, :ssl_request) do
-      @gateway.capture(@amount, 'ch_test_charge', @options.merge({application_fee: 144}))
+      @gateway.capture(@amount, 'ch_test_charge', @options.merge({ application_fee: 144 }))
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/application_fee=144/, data)
     end.respond_with(successful_capture_response)
@@ -977,7 +977,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_exchange_rate_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({exchange_rate: 0.96251}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ exchange_rate: 0.96251 }))
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/exchange_rate=0.96251/, data)
     end.respond_with(successful_purchase_response)
@@ -985,7 +985,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_exchange_rate_is_submitted_for_capture
     stub_comms(@gateway, :ssl_request) do
-      @gateway.capture(@amount, 'ch_test_charge', @options.merge({exchange_rate: 0.96251}))
+      @gateway.capture(@amount, 'ch_test_charge', @options.merge({ exchange_rate: 0.96251 }))
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/exchange_rate=0.96251/, data)
     end.respond_with(successful_capture_response)
@@ -993,7 +993,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_destination_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({destination: 'subaccountid'}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ destination: 'subaccountid' }))
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/destination\[account\]=subaccountid/, data)
     end.respond_with(successful_purchase_response)
@@ -1001,7 +1001,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_destination_amount_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options.merge({destination: 'subaccountid', destination_amount: @amount - 20}))
+      @gateway.purchase(@amount, @credit_card, @options.merge({ destination: 'subaccountid', destination_amount: @amount - 20 }))
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/destination\[amount\]=#{@amount - 20}/, data)
     end.respond_with(successful_purchase_response)
@@ -1009,7 +1009,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_purchase
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', order_id: '42', email: 'foo@wonderfullyfakedomain.com', receipt_email: 'receipt-receiver@wonderfullyfakedomain.com', referrer: 'http://www.shopify.com'})
+      updated_options = @options.merge({ description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', order_id: '42', email: 'foo@wonderfullyfakedomain.com', receipt_email: 'receipt-receiver@wonderfullyfakedomain.com', referrer: 'http://www.shopify.com' })
       @gateway.purchase(@amount, @credit_card, updated_options)
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/description=a\+test\+customer/, data)
@@ -1026,7 +1026,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_purchase_without_email_or_order
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', referrer: 'http://www.shopify.com'})
+      updated_options = @options.merge({ description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', referrer: 'http://www.shopify.com' })
       @gateway.purchase(@amount, @credit_card, updated_options)
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/description=a\+test\+customer/, data)
@@ -1040,7 +1040,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_metadata_in_options
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'})
+      updated_options = @options.merge({ metadata: { this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell' }, order_id: '42', email: 'foo@wonderfullyfakedomain.com' })
       @gateway.purchase(@amount, @credit_card, updated_options)
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
@@ -1052,7 +1052,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_metadata_in_options_with_emv_credit_card_purchase
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'})
+      updated_options = @options.merge({ metadata: { this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell' }, order_id: '42', email: 'foo@wonderfullyfakedomain.com' })
       @gateway.purchase(@amount, @emv_credit_card, updated_options)
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
@@ -1065,7 +1065,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_client_data_submitted_with_metadata_in_options_with_emv_credit_card_authorize
     stub_comms(@gateway, :ssl_request) do
-      updated_options = @options.merge({metadata: {this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell'}, order_id: '42', email: 'foo@wonderfullyfakedomain.com'})
+      updated_options = @options.merge({ metadata: { this_is_a_random_key_name: 'with a random value', i_made_up_this_key_too: 'canyoutell' }, order_id: '42', email: 'foo@wonderfullyfakedomain.com' })
       @gateway.authorize(@amount, @emv_credit_card, updated_options)
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/metadata\[this_is_a_random_key_name\]=with\+a\+random\+value/, data)
@@ -1095,7 +1095,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def test_add_address
-    post = {card: {}}
+    post = { card: {} }
     @gateway.send(:add_address, post, @options)
     assert_equal @options[:billing_address][:zip], post[:card][:address_zip]
     assert_equal @options[:billing_address][:state], post[:card][:address_state]
@@ -1143,7 +1143,7 @@ class StripeTest < Test::Unit::TestCase
 
   def test_metadata_header
     @gateway.expects(:ssl_request).once.with { |_method, _url, _post, headers|
-      headers && headers['X-Stripe-Client-User-Metadata'] == {ip: '1.1.1.1'}.to_json
+      headers && headers['X-Stripe-Client-User-Metadata'] == { ip: '1.1.1.1' }.to_json
     }.returns(successful_purchase_response)
 
     @gateway.purchase(@amount, @credit_card, @options.merge(ip: '1.1.1.1'))
@@ -1260,7 +1260,7 @@ class StripeTest < Test::Unit::TestCase
   end
 
   def generate_options_should_allow_key
-    assert_equal({key: '12345'}, generate_options({key: '12345'}))
+    assert_equal({ key: '12345' }, generate_options({ key: '12345' }))
   end
 
   def test_passing_expand_parameters

--- a/test/unit/gateways/tns_test.rb
+++ b/test/unit/gateways/tns_test.rb
@@ -91,7 +91,7 @@ class TnsTest < Test::Unit::TestCase
 
   def test_passing_alpha3_country_code
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, billing_address: {country: 'US'})
+      @gateway.authorize(@amount, @credit_card, billing_address: { country: 'US' })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/USA/, data)
     end.respond_with(successful_authorize_response)
@@ -99,7 +99,7 @@ class TnsTest < Test::Unit::TestCase
 
   def test_non_existent_country
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(@amount, @credit_card, billing_address: {country: 'Blah'})
+      @gateway.authorize(@amount, @credit_card, billing_address: { country: 'Blah' })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"country":null/, data)
     end.respond_with(successful_authorize_response)

--- a/test/unit/gateways/trexle_test.rb
+++ b/test/unit/gateways/trexle_test.rb
@@ -123,7 +123,7 @@ class TrexleTest < Test::Unit::TestCase
 
   def test_successful_refund
     token = 'charge_0cfad7ee5ffe75f58222bff214bfa5cc7ad7c367'
-    @gateway.expects(:ssl_request).with(:post, "https://core.trexle.com/api/v1/charges/#{token}/refunds", {amount: '100'}.to_json, instance_of(Hash)).returns(successful_refund_response)
+    @gateway.expects(:ssl_request).with(:post, "https://core.trexle.com/api/v1/charges/#{token}/refunds", { amount: '100' }.to_json, instance_of(Hash)).returns(successful_refund_response)
 
     assert response = @gateway.refund(100, token)
     assert_equal 'refund_7f696a86f9cb136520c51ea90c17f687b8df40b0', response.authorization
@@ -133,7 +133,7 @@ class TrexleTest < Test::Unit::TestCase
 
   def test_unsuccessful_refund
     token = 'charge_0cfad7ee5ffe75f58222bff214bfa5cc7ad7c367'
-    @gateway.expects(:ssl_request).with(:post, "https://core.trexle.com/api/v1/charges/#{token}/refunds", {amount: '100'}.to_json, instance_of(Hash)).returns(failed_refund_response)
+    @gateway.expects(:ssl_request).with(:post, "https://core.trexle.com/api/v1/charges/#{token}/refunds", { amount: '100' }.to_json, instance_of(Hash)).returns(failed_refund_response)
 
     assert response = @gateway.refund(100, token)
     assert_failure response

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -203,7 +203,7 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
   def test_successful_quick_update_customer
     @gateway.expects(:ssl_post).returns(successful_customer_response('quickUpdateCustomer'))
 
-    assert response = @gateway.quick_update_customer({customer_number: @options[:customer_number], update_data: @customer_options})
+    assert response = @gateway.quick_update_customer({ customer_number: @options[:customer_number], update_data: @customer_options })
     assert_instance_of Response, response
     assert response.test?
     assert_success response

--- a/test/unit/gateways/webpay_test.rb
+++ b/test/unit/gateways/webpay_test.rb
@@ -121,24 +121,24 @@ class WebpayTest < Test::Unit::TestCase
 
   def test_add_customer
     post = {}
-    @gateway.send(:add_customer, post, 'card_token', {customer: 'test_customer'})
+    @gateway.send(:add_customer, post, 'card_token', { customer: 'test_customer' })
     assert_equal 'test_customer', post[:customer]
   end
 
   def test_doesnt_add_customer_if_card
     post = {}
-    @gateway.send(:add_customer, post, @credit_card, {customer: 'test_customer'})
+    @gateway.send(:add_customer, post, @credit_card, { customer: 'test_customer' })
     assert !post[:customer]
   end
 
   def test_add_customer_data
     post = {}
-    @gateway.send(:add_customer_data, post, {description: 'a test customer'})
+    @gateway.send(:add_customer_data, post, { description: 'a test customer' })
     assert_equal 'a test customer', post[:description]
   end
 
   def test_add_address
-    post = {card: {}}
+    post = { card: {} }
     @gateway.send(:add_address, post, @options)
     assert_equal @options[:billing_address][:zip], post[:card][:address_zip]
     assert_equal @options[:billing_address][:state], post[:card][:address_state]
@@ -159,7 +159,7 @@ class WebpayTest < Test::Unit::TestCase
 
   def test_metadata_header
     @gateway.expects(:ssl_request).once.with { |_method, _url, _post, headers|
-      headers && headers['X-Webpay-Client-User-Metadata'] == {ip: '1.1.1.1'}.to_json
+      headers && headers['X-Webpay-Client-User-Metadata'] == { ip: '1.1.1.1' }.to_json
     }.returns(successful_purchase_response)
 
     @gateway.purchase(@amount, @credit_card, @options.merge(ip: '1.1.1.1'))
@@ -342,7 +342,7 @@ class WebpayTest < Test::Unit::TestCase
   end
 
   def successful_partially_refunded_response(options = {})
-    options = {livemode: false}.merge!(options)
+    options = { livemode: false }.merge!(options)
     <<~RESPONSE
       {
         "id": "ch_test_charge",

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -20,7 +20,7 @@ class WorldpayTest < Test::Unit::TestCase
       verification_value: '737',
       brand: 'elo')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
-    @options = {order_id: 1}
+    @options = { order_id: 1 }
     @store_options = {
       customer: '59424549c291397379f30c5c082dbed8',
       email: 'wow@example.com'
@@ -49,7 +49,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_exemption_in_request
     response = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({exemption_type: 'LV', exemption_placement: 'AUTHENTICATION'}))
+      @gateway.authorize(@amount, @credit_card, @options.merge({ exemption_type: 'LV', exemption_placement: 'AUTHENTICATION' }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/exemption/, data)
       assert_match(/AUTHENTICATION/, data)
@@ -116,7 +116,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_successful_reference_transaction_authorize_with_merchant_code
     response = stub_comms do
-      @gateway.authorize(@amount, @options[:order_id].to_s, @options.merge({ merchant_code: 'testlogin2'}))
+      @gateway.authorize(@amount, @options[:order_id].to_s, @options.merge({ merchant_code: 'testlogin2' }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/testlogin2/, data)
     end.respond_with(successful_authorize_response)
@@ -236,8 +236,8 @@ class WorldpayTest < Test::Unit::TestCase
       authorization = "#{@options[:order_id]}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"
       @gateway.void(authorization, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('orderInquiry', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderInquiry .*?>).match?(data)
-      assert_tag_with_attributes('orderModification', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderModification .*?>).match?(data)
+      assert_tag_with_attributes('orderInquiry', { 'orderCode' => @options[:order_id].to_s }, data) if %r(<orderInquiry .*?>).match?(data)
+      assert_tag_with_attributes('orderModification', { 'orderCode' => @options[:order_id].to_s }, data) if %r(<orderModification .*?>).match?(data)
     end.respond_with(successful_void_inquiry_response, successful_void_response)
     assert_success response
     assert_equal 'SUCCESS', response.message
@@ -296,8 +296,8 @@ class WorldpayTest < Test::Unit::TestCase
       authorization = "#{@options[:order_id]}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"
       @gateway.refund(@amount, authorization, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('orderInquiry', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderInquiry .*?>).match?(data)
-      assert_tag_with_attributes('orderModification', {'orderCode' => @options[:order_id].to_s}, data) if %r(<orderModification .*?>).match?(data)
+      assert_tag_with_attributes('orderInquiry', { 'orderCode' => @options[:order_id].to_s }, data) if %r(<orderInquiry .*?>).match?(data)
+      assert_tag_with_attributes('orderModification', { 'orderCode' => @options[:order_id].to_s }, data) if %r(<orderModification .*?>).match?(data)
     end.respond_with(successful_refund_inquiry_response('CAPTURED'), successful_refund_response)
     assert_success response
   end
@@ -316,7 +316,7 @@ class WorldpayTest < Test::Unit::TestCase
       authorization = "#{response.authorization}|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8"
       @gateway.capture(@amount, authorization, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('orderModification', {'orderCode' => response.authorization}, data) if %r(<orderModification .*?>).match?(data)
+      assert_tag_with_attributes('orderModification', { 'orderCode' => response.authorization }, data) if %r(<orderModification .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
   end
@@ -376,7 +376,7 @@ class WorldpayTest < Test::Unit::TestCase
       if /capture/.match?(data)
         t = Time.now
         assert_tag_with_attributes 'date',
-          {'dayOfMonth' => t.day.to_s, 'month' => t.month.to_s, 'year' => t.year.to_s},
+          { 'dayOfMonth' => t.day.to_s, 'month' => t.month.to_s, 'year' => t.year.to_s },
           data
       end
     end.respond_with(successful_inquiry_response, successful_capture_response)
@@ -387,7 +387,7 @@ class WorldpayTest < Test::Unit::TestCase
       @gateway.authorize(100, @credit_card, @options)
     end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes 'amount',
-        {'value' => '100', 'exponent' => '2', 'currencyCode' => 'GBP'},
+        { 'value' => '100', 'exponent' => '2', 'currencyCode' => 'GBP' },
         data
     end.respond_with(successful_authorize_response)
   end
@@ -397,7 +397,7 @@ class WorldpayTest < Test::Unit::TestCase
       @gateway.authorize(10000, @credit_card, @options.merge(currency: :JPY))
     end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes 'amount',
-        {'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY'},
+        { 'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY' },
         data
     end.respond_with(successful_authorize_response)
 
@@ -405,7 +405,7 @@ class WorldpayTest < Test::Unit::TestCase
       @gateway.authorize(10000, @credit_card, @options.merge(currency: :OMR))
     end.check_request do |_endpoint, data, _headers|
       assert_tag_with_attributes 'amount',
-        {'value' => '10000', 'exponent' => '3', 'currencyCode' => 'OMR'},
+        { 'value' => '10000', 'exponent' => '3', 'currencyCode' => 'OMR' },
         data
     end.respond_with(successful_authorize_response)
   end
@@ -588,7 +588,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_parsing
     response = stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(address: {address1: '123 Anystreet', country: 'US'}))
+      @gateway.authorize(100, @credit_card, @options.merge(address: { address1: '123 Anystreet', country: 'US' }))
     end.respond_with(successful_authorize_response)
 
     assert_equal({
@@ -800,9 +800,9 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @token, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
+      assert_tag_with_attributes('order', { 'orderCode' => @options[:order_id].to_s }, data)
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data
-      assert_tag_with_attributes 'TOKEN-SSL', {'tokenScope' => 'shopper'}, data
+      assert_tag_with_attributes 'TOKEN-SSL', { 'tokenScope' => 'shopper' }, data
       assert_match %r(<paymentTokenID>99411111780163871111</paymentTokenID>), data
     end.respond_with(successful_authorize_response)
 
@@ -822,7 +822,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @token, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
+      assert_tag_with_attributes('order', { 'orderCode' => @options[:order_id].to_s }, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
 
     assert_success response
@@ -833,7 +833,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.verify(@token, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
+      assert_tag_with_attributes('order', { 'orderCode' => @options[:order_id].to_s }, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_void_response)
 
     assert_success response
@@ -844,10 +844,10 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.credit(@amount, @token, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
+      assert_tag_with_attributes('order', { 'orderCode' => @options[:order_id].to_s }, data)
       assert_match(/<paymentDetails action="REFUND">/, data)
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data
-      assert_tag_with_attributes 'TOKEN-SSL', {'tokenScope' => 'shopper'}, data
+      assert_tag_with_attributes 'TOKEN-SSL', { 'tokenScope' => 'shopper' }, data
       assert_match '<paymentTokenID>99411111780163871111</paymentTokenID>', data
     end.respond_with(successful_visa_credit_response)
 
@@ -858,7 +858,7 @@ class WorldpayTest < Test::Unit::TestCase
 
   def test_optional_idempotency_key_header
     response = stub_comms do
-      @gateway.authorize(@amount, @token, @options.merge({idempotency_key: 'test123'}))
+      @gateway.authorize(@amount, @token, @options.merge({ idempotency_key: 'test123' }))
     end.check_request do |_endpoint, _data, headers|
       headers && headers['Idempotency-Key'] == 'test123'
     end.respond_with(successful_authorize_response)
@@ -907,9 +907,9 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @token, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
+      assert_tag_with_attributes('order', { 'orderCode' => @options[:order_id].to_s }, data)
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data
-      assert_tag_with_attributes 'TOKEN-SSL', {'tokenScope' => 'shopper'}, data
+      assert_tag_with_attributes 'TOKEN-SSL', { 'tokenScope' => 'shopper' }, data
       assert_match %r(<paymentTokenID>99411111780163871111</paymentTokenID>), data
     end.respond_with(successful_authorize_response)
 
@@ -922,7 +922,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @token, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
+      assert_tag_with_attributes('order', { 'orderCode' => @options[:order_id].to_s }, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
 
     assert_success response
@@ -934,7 +934,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.verify(@token, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data) if %r(<order .*?>).match?(data)
+      assert_tag_with_attributes('order', { 'orderCode' => @options[:order_id].to_s }, data) if %r(<order .*?>).match?(data)
     end.respond_with(successful_authorize_response, successful_void_response)
 
     assert_success response
@@ -946,10 +946,10 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.credit(@amount, @token, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes('order', {'orderCode' => @options[:order_id].to_s}, data)
+      assert_tag_with_attributes('order', { 'orderCode' => @options[:order_id].to_s }, data)
       assert_match(/<paymentDetails action="REFUND">/, data)
       assert_match %r(<authenticatedShopperID>59424549c291397379f30c5c082dbed8</authenticatedShopperID>), data
-      assert_tag_with_attributes 'TOKEN-SSL', {'tokenScope' => 'shopper'}, data
+      assert_tag_with_attributes 'TOKEN-SSL', { 'tokenScope' => 'shopper' }, data
       assert_match '<paymentTokenID>99411111780163871111</paymentTokenID>', data
     end.respond_with(successful_visa_credit_response)
 

--- a/test/unit/multi_response_test.rb
+++ b/test/unit/multi_response_test.rb
@@ -34,16 +34,16 @@ class MultiResponseTest < Test::Unit::TestCase
     r1 = Response.new(
       true,
       '1',
-      {'one' => 1},
+      { 'one' => 1 },
       test: true,
       authorization: 'auth1',
-      avs_result: {code: 'AVS1'},
+      avs_result: { code: 'AVS1' },
       cvv_result: 'CVV1',
       error_code: :card_declined,
       fraud_review: true
     )
     m.process { r1 }
-    assert_equal({'one' => 1}, m.params)
+    assert_equal({ 'one' => 1 }, m.params)
     assert_equal '1', m.message
     assert m.test
     assert_equal 'auth1', m.authorization
@@ -56,15 +56,15 @@ class MultiResponseTest < Test::Unit::TestCase
     r2 = Response.new(
       true,
       '2',
-      {'two' => 2},
+      { 'two' => 2 },
       test: false,
       authorization: 'auth2',
-      avs_result: {code: 'AVS2'},
+      avs_result: { code: 'AVS2' },
       cvv_result: 'CVV2',
       fraud_review: false
     )
     m.process { r2 }
-    assert_equal({'two' => 2}, m.params)
+    assert_equal({ 'two' => 2 }, m.params)
     assert_equal '2', m.message
     assert !m.test
     assert_equal 'auth2', m.authorization
@@ -80,15 +80,15 @@ class MultiResponseTest < Test::Unit::TestCase
     r1 = Response.new(
       true,
       '1',
-      {'one' => 1},
+      { 'one' => 1 },
       test: true,
       authorization: 'auth1',
-      avs_result: {code: 'AVS1'},
+      avs_result: { code: 'AVS1' },
       cvv_result: 'CVV1',
       fraud_review: true
     )
     m.process { r1 }
-    assert_equal({'one' => 1}, m.params)
+    assert_equal({ 'one' => 1 }, m.params)
     assert_equal '1', m.message
     assert m.test
     assert_equal 'auth1', m.authorization
@@ -100,15 +100,15 @@ class MultiResponseTest < Test::Unit::TestCase
     r2 = Response.new(
       true,
       '2',
-      {'two' => 2},
+      { 'two' => 2 },
       test: false,
       authorization: 'auth2',
-      avs_result: {code: 'AVS2'},
+      avs_result: { code: 'AVS2' },
       cvv_result: 'CVV2',
       fraud_review: false
     )
     m.process { r2 }
-    assert_equal({'one' => 1}, m.params)
+    assert_equal({ 'one' => 1 }, m.params)
     assert_equal '1', m.message
     assert m.test
     assert_equal 'auth1', m.authorization

--- a/test/unit/network_connection_retries_test.rb
+++ b/test/unit/network_connection_retries_test.rb
@@ -171,7 +171,7 @@ class NetworkConnectionRetriesTest < Test::Unit::TestCase
     @requester.expects(:post).raises(MyNewError)
 
     assert_raises(ActiveMerchant::ConnectionError) do
-      retry_exceptions connection_exceptions: {MyNewError => 'my message'} do
+      retry_exceptions connection_exceptions: { MyNewError => 'my message' } do
         @requester.post
       end
     end


### PR DESCRIPTION
Fixes the RuboCop to-do for [Layout/SpaceInsideHashLiteralBraces](https://docs.rubocop.org/rubocop/0.85/cops_layout.html#layoutspaceinsidehashliteralbraces).

All unit tests:
4565 tests, 72404 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed