### PR TITLE
RuboCop: Fix Performance/StringReplacement

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -153,21 +153,6 @@ Naming/VariableName:
     - 'test/unit/gateways/card_stream_test.rb'
     - 'test/unit/gateways/worldpay_online_payments_test.rb'
 
-# Offense count: 11
-# Cop supports --auto-correct.
-Performance/StringReplacement:
-  Exclude:
-    - 'lib/active_merchant/billing/compatibility.rb'
-    - 'lib/active_merchant/billing/gateways/card_connect.rb'
-    - 'lib/active_merchant/billing/gateways/firstdata_e4.rb'
-    - 'lib/active_merchant/billing/gateways/merchant_ware.rb'
-    - 'lib/active_merchant/billing/gateways/merchant_ware_version_four.rb'
-    - 'lib/active_merchant/billing/gateways/orbital.rb'
-    - 'lib/active_merchant/billing/gateways/quickbooks.rb'
-    - 'lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb'
-    - 'lib/active_merchant/billing/gateways/realex.rb'
-    - 'test/unit/gateways/nab_transact_test.rb'
-
 # Offense count: 2
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: inline, group

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Mundipagg: Add support for SubMerchant fields [meagabeth] #3779
 * Stripe Payment Intents: Add request_three_d_secure option [molbrown] #3787
 * Decidir: Add support for csmdds fields [naashton] #3786
+* RuboCop: Fix Performance/StringReplacement [leila-alderman] #3782
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/compatibility.rb
+++ b/lib/active_merchant/billing/compatibility.rb
@@ -28,7 +28,7 @@ module ActiveMerchant
       def self.humanize(lower_case_and_underscored_word)
         result = lower_case_and_underscored_word.to_s.dup
         result.gsub!(/_id$/, '')
-        result.gsub!(/_/, ' ')
+        result.tr!('_', ' ')
         result.gsub(/([a-z\d]*)/i, &:downcase).gsub(/^\w/) { $&.upcase }
       end
     end

--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -233,7 +233,7 @@ module ActiveMerchant #:nodoc:
           post[:items] = options[:items].map do |item|
             updated = {}
             item.each_pair do |k, v|
-              updated.merge!(k.to_s.gsub(/_/, '') => v)
+              updated.merge!(k.to_s.delete('_') => v)
             end
             updated
           end

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -395,7 +395,7 @@ module ActiveMerchant #:nodoc:
             credit_card.last_name,
             credit_card.month,
             credit_card.year
-          ].map { |value| value.to_s.gsub(/;/, '') }.join(';')
+          ].map { |value| value.to_s.delete(';') }.join(';')
         else
           raise StandardError, "TransArmor support is not enabled on your #{display_name} account"
         end

--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -272,7 +272,7 @@ module ActiveMerchant #:nodoc:
           response[element.name] = element.text
         end
 
-        response[:message] = response['faultstring'].to_s.gsub("\n", ' ')
+        response[:message] = response['faultstring'].to_s.tr("\n", ' ')
         response
       rescue REXML::ParseException
         response[:http_body]        = http_response.body

--- a/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
@@ -243,7 +243,7 @@ module ActiveMerchant #:nodoc:
           response[element.name] = element.text
         end
 
-        response[:message] = response['ErrorMessage'].to_s.gsub("\n", ' ')
+        response[:message] = response['ErrorMessage'].to_s.tr("\n", ' ')
         response
       rescue REXML::ParseException
         response[:http_body]        = http_response.body

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -34,7 +34,7 @@ module ActiveMerchant #:nodoc:
 
       POST_HEADERS = {
         'MIME-Version' => '1.1',
-        'Content-Type' => "application/PTI#{API_VERSION.gsub(/\./, '')}",
+        'Content-Type' => "application/PTI#{API_VERSION.delete('.')}",
         'Content-transfer-encoding' => 'text',
         'Request-number' => '1',
         'Document-type' => 'Request',
@@ -859,7 +859,7 @@ module ActiveMerchant #:nodoc:
       # 3. PINless Debit transactions can only use uppercase and lowercase alpha (A-Z, a-z) and numeric (0-9)
       def format_order_id(order_id)
         illegal_characters = /[^,$@&\- \w]/
-        order_id = order_id.to_s.gsub(/\./, '-')
+        order_id = order_id.to_s.tr('.', '-')
         order_id.gsub!(illegal_characters, '')
         order_id.lstrip!
         order_id[0...22]

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -260,7 +260,7 @@ module ActiveMerchant #:nodoc:
         hmac_signature = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha1'), oauth_signing_key, oauth_signature_base_string)
 
         # append signature to required OAuth parameters
-        oauth_parameters[:oauth_signature] = CGI.escape(Base64.encode64(hmac_signature).chomp.gsub(/\n/, ''))
+        oauth_parameters[:oauth_signature] = CGI.escape(Base64.encode64(hmac_signature).chomp.delete("\n"))
 
         # prepare Authorization header string
         oauth_parameters = Hash[oauth_parameters.sort_by { |k, _| k }]

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -263,7 +263,7 @@ module ActiveMerchant
       end
 
       def format_order_id(order_id)
-        truncate(order_id.to_s.gsub(/#/, ''), 20)
+        truncate(order_id.to_s.delete('#'), 20)
       end
 
       def headers

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -300,7 +300,7 @@ module ActiveMerchant
         end
         xml.tag! 'supplementarydata' do
           xml.tag! 'item', 'type' => 'mobile' do
-            xml.tag! 'field01', payment.source.to_s.gsub('_', '-')
+            xml.tag! 'field01', payment.source.to_s.tr('_', '-')
           end
         end
       end

--- a/test/unit/gateways/nab_transact_test.rb
+++ b/test/unit/gateways/nab_transact_test.rb
@@ -222,7 +222,7 @@ class NabTransactTest < Test::Unit::TestCase
   end
 
   def valid_metadata(name, location)
-    return <<-XML.gsub(/^\s{4}/, '').gsub(/\n/, '')
+    return <<-XML.gsub(/^\s{4}/, '').delete("\n")
     <metadata><meta name="ca_name" value="#{name}"/><meta name="ca_location" value="#{location}"/></metadata>
     XML
   end


### PR DESCRIPTION
Fixes the RuboCop to-do for [Performance/StringReplacement](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancestringreplacement).

All unit tests:
4565 tests, 72404 assertions, 0 failures, 0 errors, 0 pendings, 0
omissions, 0 notifications
100% passed