### PR TITLE
Elavon: Upgrade to `processxml.do`

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -1,4 +1,5 @@
 require 'active_merchant/billing/gateways/viaklix'
+require 'nokogiri'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -7,13 +8,15 @@ module ActiveMerchant #:nodoc:
 
       class_attribute :test_url, :live_url, :delimiter, :actions
 
-      self.test_url = 'https://api.demo.convergepay.com/VirtualMerchantDemo/process.do'
-      self.live_url = 'https://api.convergepay.com/VirtualMerchant/process.do'
+      self.test_url = 'https://api.demo.convergepay.com/VirtualMerchantDemo/processxml.do'
+      self.live_url = 'https://api.convergepay.com/VirtualMerchant/processxml.do'
 
       self.display_name = 'Elavon MyVirtualMerchant'
       self.supported_countries = %w(US CA PR DE IE NO PL LU BE NL MX)
       self.supported_cardtypes = %i[visa master american_express discover]
       self.homepage_url = 'http://www.elavon.com/'
+      self.money_format = :dollars
+      self.default_currency = 'USD'
 
       self.delimiter = "\n"
       self.actions = {
@@ -35,115 +38,143 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(money, payment_method, options = {})
-        form = {}
-        add_salestax(form, options)
-        add_invoice(form, options)
-        if payment_method.is_a?(String)
-          add_token(form, payment_method)
-        else
-          add_creditcard(form, payment_method)
+        request = build_xml_request do |xml|
+          xml.ssl_transaction_type  self.actions[:purchase]
+          xml.ssl_amount            amount(money)
+
+          if payment_method.is_a?(String)
+            add_token(xml, payment_method)
+          else
+            add_creditcard(xml, payment_method)
+          end
+
+          add_invoice(xml, options)
+          add_salestax(xml, options)
+          add_currency(xml, money, options)
+          add_address(xml, options)
+          add_customer_email(xml, options)
+          add_test_mode(xml, options)
+          add_ip(xml, options)
+          add_auth_purchase_params(xml, options)
+          add_level_3_fields(xml, options) if options[:level_3_data]
         end
-        add_currency(form, money, options)
-        add_address(form, options)
-        add_customer_data(form, options)
-        add_test_mode(form, options)
-        add_ip(form, options)
-        add_auth_purchase_params(form, options)
-        add_level_3_fields(form, options) if options[:level_3_data]
-        commit(:purchase, money, form, options)
+        commit(request)
       end
 
       def authorize(money, creditcard, options = {})
-        form = {}
-        add_salestax(form, options)
-        add_invoice(form, options)
-        add_creditcard(form, creditcard)
-        add_currency(form, money, options)
-        add_address(form, options)
-        add_customer_data(form, options)
-        add_test_mode(form, options)
-        add_ip(form, options)
-        add_auth_purchase_params(form, options)
-        add_level_3_fields(form, options) if options[:level_3_data]
-        commit(:authorize, money, form, options)
+        request = build_xml_request do |xml|
+          xml.ssl_transaction_type  self.actions[:authorize]
+          xml.ssl_amount            amount(money)
+
+          add_salestax(xml, options)
+          add_invoice(xml, options)
+          add_creditcard(xml, creditcard)
+          add_currency(xml, money, options)
+          add_address(xml, options)
+          add_customer_email(xml, options)
+          add_test_mode(xml, options)
+          add_ip(xml, options)
+          add_auth_purchase_params(xml, options)
+          add_level_3_fields(xml, options) if options[:level_3_data]
+        end
+        commit(request)
       end
 
       def capture(money, authorization, options = {})
-        form = {}
-        if options[:credit_card]
-          action = :capture
-          add_salestax(form, options)
-          add_approval_code(form, authorization)
-          add_invoice(form, options)
-          add_creditcard(form, options[:credit_card])
-          add_currency(form, money, options)
-          add_address(form, options)
-          add_customer_data(form, options)
-          add_test_mode(form, options)
-        else
-          action = :capture_complete
-          add_txn_id(form, authorization)
-          add_partial_shipment_flag(form, options)
-          add_test_mode(form, options)
+        request = build_xml_request do |xml|
+          if options[:credit_card]
+            xml.ssl_transaction_type self.actions[:capture]
+            xml.ssl_amount amount(money)
+            add_salestax(xml, options)
+            add_approval_code(xml, authorization)
+            add_invoice(xml, options)
+            add_creditcard(xml, options[:credit_card])
+            add_currency(xml, money, options)
+            add_address(xml, options)
+            add_customer_email(xml, options)
+            add_test_mode(xml, options)
+          else
+            xml.ssl_transaction_type self.actions[:capture_complete]
+            xml.ssl_amount amount(money)
+            add_currency(xml, money, options)
+            add_txn_id(xml, authorization)
+            add_partial_shipment_flag(xml, options)
+            add_test_mode(xml, options)
+          end
         end
-        commit(action, money, form, options)
+        commit(request)
       end
 
       def refund(money, identification, options = {})
-        form = {}
-        add_txn_id(form, identification)
-        add_test_mode(form, options)
-        commit(:refund, money, form, options)
+        request = build_xml_request do |xml|
+          xml.ssl_transaction_type  self.actions[:refund]
+          xml.ssl_amount            amount(money)
+          add_txn_id(xml, identification)
+          add_test_mode(xml, options)
+        end
+        commit(request)
       end
 
       def void(identification, options = {})
-        form = {}
-        add_txn_id(form, identification)
-        add_test_mode(form, options)
-        commit(:void, nil, form, options)
+        request = build_xml_request do |xml|
+          xml.ssl_transaction_type  self.actions[:void]
+
+          add_txn_id(xml, identification)
+          add_test_mode(xml, options)
+        end
+        commit(request)
       end
 
       def credit(money, creditcard, options = {})
         raise ArgumentError, 'Reference credits are not supported. Please supply the original credit card or use the #refund method.' if creditcard.is_a?(String)
 
-        form = {}
-        add_invoice(form, options)
-        add_creditcard(form, creditcard)
-        add_currency(form, money, options)
-        add_address(form, options)
-        add_customer_data(form, options)
-        add_test_mode(form, options)
-        commit(:credit, money, form, options)
+        request = build_xml_request do |xml|
+          xml.ssl_transaction_type  self.actions[:credit]
+          xml.ssl_amount            amount(money)
+          add_invoice(xml, options)
+          add_creditcard(xml, creditcard)
+          add_currency(xml, money, options)
+          add_address(xml, options)
+          add_customer_email(xml, options)
+          add_test_mode(xml, options)
+        end
+        commit(request)
       end
 
       def verify(credit_card, options = {})
-        form = {}
-        add_creditcard(form, credit_card)
-        add_address(form, options)
-        add_test_mode(form, options)
-        add_ip(form, options)
-        commit(:verify, 0, form, options)
+        request = build_xml_request do |xml|
+          xml.ssl_transaction_type  self.actions[:verify]
+          add_creditcard(xml, credit_card)
+          add_address(xml, options)
+          add_test_mode(xml, options)
+          add_ip(xml, options)
+        end
+        commit(request)
       end
 
       def store(creditcard, options = {})
-        form = {}
-        add_creditcard(form, creditcard)
-        add_address(form, options)
-        add_customer_data(form, options)
-        add_test_mode(form, options)
-        add_verification(form, options)
-        form[:add_token] = 'Y'
-        commit(:store, nil, form, options)
+        request = build_xml_request do |xml|
+          xml.ssl_transaction_type  self.actions[:store]
+          xml.ssl_add_token 'Y'
+          add_creditcard(xml, creditcard)
+          add_address(xml, options)
+          add_customer_email(xml, options)
+          add_test_mode(xml, options)
+          add_verification(xml, options)
+        end
+        commit(request)
       end
 
       def update(token, creditcard, options = {})
-        form = {}
-        add_token(form, token)
-        add_creditcard(form, creditcard)
-        add_address(form, options)
-        add_customer_data(form, options)
-        add_test_mode(form, options)
-        commit(:update, nil, form, options)
+        request = build_xml_request do |xml|
+          xml.ssl_transaction_type  self.actions[:update]
+          add_token(xml, token)
+          add_creditcard(xml, creditcard)
+          add_address(xml, options)
+          add_customer_email(xml, options)
+          add_test_mode(xml, options)
+        end
+        commit(request)
       end
 
       def supports_scrubbing?
@@ -152,216 +183,205 @@ module ActiveMerchant #:nodoc:
 
       def scrub(transcript)
         transcript.
-          gsub(%r((&?ssl_pin=)[^&]*)i, '\1[FILTERED]').
-          gsub(%r((&?ssl_card_number=)[^&\\n\r\n]*)i, '\1[FILTERED]').
-          gsub(%r((&?ssl_cvv2cvc2=)[^&]*)i, '\1[FILTERED]')
+          gsub(%r((<ssl_pin>)(.*)(</ssl_pin>)), '\1[FILTERED]\3').
+          gsub(%r((<ssl_card_number>)(.*)(</ssl_card_number>)), '\1[FILTERED]\3').
+          gsub(%r((<ssl_cvv2cvc2>)(.*)(</ssl_cvv2cvc2>)), '\1[FILTERED]\3')
       end
 
       private
 
-      def add_invoice(form, options)
-        form[:invoice_number] = truncate((options[:order_id] || options[:invoice]), 10)
-        form[:description] = truncate(options[:description], 255)
+      def add_invoice(xml, options)
+        xml.ssl_invoice_number    truncate((options[:order_id] || options[:invoice]), 25)
+        xml.ssl_description       truncate(options[:description], 255)
       end
 
-      def add_approval_code(form, authorization)
-        form[:approval_code] = authorization.split(';').first
+      def add_approval_code(xml, authorization)
+        xml.ssl_approval_code authorization.split(';').first
       end
 
-      def add_txn_id(form, authorization)
-        form[:txn_id] = authorization.split(';').last
+      def add_txn_id(xml, authorization)
+        xml.ssl_txn_id authorization.split(';').last
       end
 
-      def authorization_from(response)
-        [response['approval_code'], response['txn_id']].join(';')
+      def add_creditcard(xml, creditcard)
+        xml.ssl_card_number   creditcard.number
+        xml.ssl_exp_date      expdate(creditcard)
+
+        add_verification_value(xml, creditcard) if creditcard.verification_value?
+
+        xml.ssl_first_name    truncate(creditcard.first_name, 20)
+        xml.ssl_last_name     truncate(creditcard.last_name, 30)
       end
 
-      def add_creditcard(form, creditcard)
-        form[:card_number] = creditcard.number
-        form[:exp_date] = expdate(creditcard)
-
-        add_verification_value(form, creditcard) if creditcard.verification_value?
-
-        form[:first_name] = truncate(creditcard.first_name, 20)
-        form[:last_name] = truncate(creditcard.last_name, 30)
-      end
-
-      def add_currency(form, money, options)
+      def add_currency(xml, money, options)
         currency = options[:currency] || currency(money)
-        form[:transaction_currency] = currency if currency && (@options[:multi_currency] || options[:multi_currency])
+        return unless currency && (@options[:multi_currency] || options[:multi_currency])
+
+        xml.ssl_transaction_currency currency
       end
 
-      def add_token(form, token)
-        form[:token] = token
+      def add_token(xml, token)
+        xml.ssl_token token
       end
 
-      def add_verification_value(form, creditcard)
-        form[:cvv2cvc2] = creditcard.verification_value
-        form[:cvv2cvc2_indicator] = '1'
+      def add_verification_value(xml, creditcard)
+        xml.ssl_cvv2cvc2            creditcard.verification_value
+        xml.ssl_cvv2cvc2_indicator  1
       end
 
-      def add_customer_data(form, options)
-        form[:email] = truncate(options[:email], 100) unless empty?(options[:email])
-        form[:customer_code] = truncate(options[:customer], 10) unless empty?(options[:customer])
-        form[:customer_number] = options[:customer_number] unless empty?(options[:customer_number])
-        options[:custom_fields]&.each do |key, value|
-          form[key.to_s] = value
-        end
+      def add_customer_email(xml, options)
+        xml.ssl_email truncate(options[:email], 100) unless empty?(options[:email])
       end
 
-      def add_salestax(form, options)
-        form[:salestax] = options[:tax] if options[:tax].present?
+      def add_salestax(xml, options)
+        return unless options[:tax].present?
+
+        xml.ssl_salestax options[:tax]
       end
 
-      def add_address(form, options)
+      def add_address(xml, options)
         billing_address = options[:billing_address] || options[:address]
 
         if billing_address
-          form[:avs_address]    = truncate(billing_address[:address1], 30)
-          form[:address2]       = truncate(billing_address[:address2], 30)
-          form[:avs_zip]        = truncate(billing_address[:zip].to_s.gsub(/[^a-zA-Z0-9]/, ''), 9)
-          form[:city]           = truncate(billing_address[:city], 30)
-          form[:state]          = truncate(billing_address[:state], 10)
-          form[:company]        = truncate(billing_address[:company], 50)
-          form[:phone]          = truncate(billing_address[:phone], 20)
-          form[:country]        = truncate(billing_address[:country], 50)
+          xml.ssl_avs_address     truncate(billing_address[:address1], 30)
+          xml.ssl_address2        truncate(billing_address[:address2], 30)
+          xml.ssl_avs_zip         truncate(billing_address[:zip].to_s.gsub(/[^a-zA-Z0-9]/, ''), 9)
+          xml.ssl_city            truncate(billing_address[:city], 30)
+          xml.ssl_state           truncate(billing_address[:state], 10)
+          xml.ssl_company         truncate(billing_address[:company], 50)
+          xml.ssl_phone           truncate(billing_address[:phone], 20)
+          xml.ssl_country         truncate(billing_address[:country], 50)
         end
 
         if shipping_address = options[:shipping_address]
-          first_name, last_name = split_names(shipping_address[:name])
-          form[:ship_to_first_name]     = truncate(first_name, 20)
-          form[:ship_to_last_name]      = truncate(last_name, 30)
-          form[:ship_to_address1]       = truncate(shipping_address[:address1], 30)
-          form[:ship_to_address2]       = truncate(shipping_address[:address2], 30)
-          form[:ship_to_city]           = truncate(shipping_address[:city], 30)
-          form[:ship_to_state]          = truncate(shipping_address[:state], 10)
-          form[:ship_to_company]        = truncate(shipping_address[:company], 50)
-          form[:ship_to_country]        = truncate(shipping_address[:country], 50)
-          form[:ship_to_zip]            = truncate(shipping_address[:zip], 10)
+          xml.ssl_ship_to_address1    truncate(shipping_address[:address1], 30)
+          xml.ssl_ship_to_address2    truncate(shipping_address[:address2], 30)
+          xml.ssl_ship_to_city        truncate(shipping_address[:city], 30)
+          xml.ssl_ship_to_company     truncate(shipping_address[:company], 50)
+          xml.ssl_ship_to_country     truncate(shipping_address[:country], 50)
+          xml.ssl_ship_to_first_name  truncate(shipping_address[:first_name], 20)
+          xml.ssl_ship_to_last_name   truncate(shipping_address[:last_name], 30)
+          xml.ssl_ship_to_phone       truncate(shipping_address[:phone], 10)
+          xml.ssl_ship_to_state       truncate(shipping_address[:state], 2)
+          xml.ssl_ship_to_zip         truncate(shipping_address[:zip], 10)
         end
       end
 
-      def add_verification(form, options)
-        form[:verify] = 'Y' if options[:verify]
+      def add_verification(xml, options)
+        xml.ssl_verify 'Y' if options[:verify]
       end
 
-      def add_test_mode(form, options)
-        form[:test_mode] = 'TRUE' if options[:test_mode]
+      def add_test_mode(xml, options)
+        xml.ssl_test_mode 'TRUE' if options[:test_mode]
       end
 
-      def add_partial_shipment_flag(form, options)
-        form[:partial_shipment_flag] = 'Y' if options[:partial_shipment_flag]
+      def add_partial_shipment_flag(xml, options)
+        xml.ssl_partial_shipment_flag 'Y' if options[:partial_shipment_flag]
       end
 
-      def add_ip(form, options)
-        form[:cardholder_ip] = options[:ip] if options.has_key?(:ip)
+      def add_ip(xml, options)
+        xml.ssl_cardholder_ip options[:ip] if options.has_key?(:ip)
       end
 
-      def add_auth_purchase_params(form, options)
-        form[:dynamic_dba] = options[:dba] if options.has_key?(:dba)
-        form[:merchant_initiated_unscheduled] = options[:merchant_initiated_unscheduled] if options.has_key?(:merchant_initiated_unscheduled)
+      def add_auth_purchase_params(xml, options)
+        xml.ssl_dynamic_dba                     options[:dba] if options.has_key?(:dba)
+        xml.ssl_merchant_initiated_unscheduled  options[:merchant_initiated_unscheduled] if options.has_key?(:merchant_initiated_unscheduled)
+        xml.ssl_customer_code                   options[:customer] if options.has_key?(:customer)
+        xml.ssl_customer_number                 options[:customer_number] if options.has_key?(:customer_number)
+        add_custom_fields(xml, options) if options[:custom_fields]
       end
 
-      def add_level_3_fields(form, options)
+      def add_custom_fields(xml, options)
+        options[:custom_fields]&.each do |key, value|
+          xml.send(key.to_sym, value)
+        end
+      end
+
+      def add_level_3_fields(xml, options)
         level_3_data = options[:level_3_data]
-        form[:customer_code] = level_3_data[:customer_code] if level_3_data[:customer_code]
-        form[:salestax] = level_3_data[:salestax] if level_3_data[:salestax]
-        form[:salestax_indicator] = level_3_data[:salestax_indicator] if level_3_data[:salestax_indicator]
-        form[:level3_indicator] = level_3_data[:level3_indicator] if level_3_data[:level3_indicator]
-        form[:ship_to_zip] = level_3_data[:ship_to_zip] if level_3_data[:ship_to_zip]
-        form[:ship_to_country] = level_3_data[:ship_to_country] if level_3_data[:ship_to_country]
-        form[:shipping_amount] = level_3_data[:shipping_amount] if level_3_data[:shipping_amount]
-        form[:ship_from_postal_code] = level_3_data[:ship_from_postal_code] if level_3_data[:ship_from_postal_code]
-        form[:discount_amount] = level_3_data[:discount_amount] if level_3_data[:discount_amount]
-        form[:duty_amount] = level_3_data[:duty_amount] if level_3_data[:duty_amount]
-        form[:national_tax_indicator] = level_3_data[:national_tax_indicator] if level_3_data[:national_tax_indicator]
-        form[:national_tax_amount] = level_3_data[:national_tax_amount] if level_3_data[:national_tax_amount]
-        form[:order_date] = level_3_data[:order_date] if level_3_data[:order_date]
-        form[:other_tax] = level_3_data[:other_tax] if level_3_data[:other_tax]
-        form[:summary_commodity_code] = level_3_data[:summary_commodity_code] if level_3_data[:summary_commodity_code]
-        form[:merchant_vat_number] = level_3_data[:merchant_vat_number] if level_3_data[:merchant_vat_number]
-        form[:customer_vat_number] = level_3_data[:customer_vat_number] if level_3_data[:customer_vat_number]
-        form[:freight_tax_amount] = level_3_data[:freight_tax_amount] if level_3_data[:freight_tax_amount]
-        form[:vat_invoice_number] = level_3_data[:vat_invoice_number] if level_3_data[:vat_invoice_number]
-        form[:tracking_number] = level_3_data[:tracking_number] if level_3_data[:tracking_number]
-        form[:shipping_company] = level_3_data[:shipping_company] if level_3_data[:shipping_company]
-        form[:other_fees] = level_3_data[:other_fees] if level_3_data[:other_fees]
-        add_line_items(form, level_3_data) if level_3_data[:line_items]
+        xml.ssl_customer_code           level_3_data[:customer_code] if level_3_data[:customer_code]
+        xml.ssl_salestax                level_3_data[:salestax] if level_3_data[:salestax]
+        xml.ssl_salestax_indicator      level_3_data[:salestax_indicator] if level_3_data[:salestax_indicator]
+        xml.ssl_level3_indicator        level_3_data[:level3_indicator] if level_3_data[:level3_indicator]
+        xml.ssl_ship_to_zip             level_3_data[:ship_to_zip] if level_3_data[:ship_to_zip]
+        xml.ssl_ship_to_country         level_3_data[:ship_to_country] if level_3_data[:ship_to_country]
+        xml.ssl_shipping_amount         level_3_data[:shipping_amount] if level_3_data[:shipping_amount]
+        xml.ssl_ship_from_postal_code   level_3_data[:ship_from_postal_code] if level_3_data[:ship_from_postal_code]
+        xml.ssl_discount_amount         level_3_data[:discount_amount] if level_3_data[:discount_amount]
+        xml.ssl_duty_amount             level_3_data[:duty_amount] if level_3_data[:duty_amount]
+        xml.ssl_national_tax_indicator  level_3_data[:national_tax_indicator] if level_3_data[:national_tax_indicator]
+        xml.ssl_national_tax_amount     level_3_data[:national_tax_amount] if level_3_data[:national_tax_amount]
+        xml.ssl_order_date              level_3_data[:order_date] if level_3_data[:order_date]
+        xml.ssl_other_tax               level_3_data[:other_tax] if level_3_data[:other_tax]
+        xml.ssl_summary_commodity_code  level_3_data[:summary_commodity_code] if level_3_data[:summary_commodity_code]
+        xml.ssl_merchant_vat_number     level_3_data[:merchant_vat_number] if level_3_data[:merchant_vat_number]
+        xml.ssl_customer_vat_number     level_3_data[:customer_vat_number] if level_3_data[:customer_vat_number]
+        xml.ssl_freight_tax_amount      level_3_data[:freight_tax_amount] if level_3_data[:freight_tax_amount]
+        xml.ssl_vat_invoice_number      level_3_data[:vat_invoice_number] if level_3_data[:vat_invoice_number]
+        xml.ssl_tracking_number         level_3_data[:tracking_number] if level_3_data[:tracking_number]
+        xml.ssl_shipping_company        level_3_data[:shipping_company] if level_3_data[:shipping_company]
+        xml.ssl_other_fees              level_3_data[:other_fees] if level_3_data[:other_fees]
+        add_line_items(xml, level_3_data) if level_3_data[:line_items]
       end
 
-      def add_line_items(form, level_3_data)
-        items = []
-        level_3_data[:line_items].each do |line_item|
-          item = {}
-          line_item.each do |key, value|
-            prefixed_key = "ssl_line_Item_#{key}"
-            item[prefixed_key.to_sym] = value
+      def add_line_items(xml, level_3_data)
+        xml.LineItemProducts {
+          level_3_data[:line_items].each do |line_item|
+            xml.product {
+              line_item.each do |key, value|
+                prefixed_key = "ssl_line_Item_#{key}"
+                xml.send(prefixed_key, value)
+              end
+            }
           end
-          items << item
+        }
+      end
+
+      def build_xml_request
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+          xml.txn do
+            xml.ssl_merchant_id       @options[:login]
+            xml.ssl_user_id           @options[:user]
+            xml.ssl_pin               @options[:password]
+            yield(xml)
+          end
         end
-        form[:LineItemProducts] = { product: items }
+
+        builder.to_xml.gsub("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n", '')
       end
 
-      def message_from(response)
-        success?(response) ? response['result_message'] : response['errorMessage']
-      end
+      def commit(request)
+        request = "xmldata=#{request}"
+        response = parse(ssl_post(test? ? self.test_url : self.live_url, request, headers))
 
-      def success?(response)
-        !response.has_key?('errorMessage')
-      end
-
-      def commit(action, money, parameters, options)
-        parameters[:amount] = amount(money)
-        parameters[:transaction_type] = self.actions[action]
-
-        response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(parameters, options)))
-
-        Response.new(response['result'] == '0', message_from(response), response,
+        Response.new(
+          response[:result] == '0',
+          response[:result_message] || response[:errorMessage],
+          response,
           test: @options[:test] || test?,
           authorization: authorization_from(response),
-          avs_result: { code: response['avs_response'] },
-          cvv_result: response['cvv2_response'])
+          error_code: response[:errorCode],
+          avs_result: { code: response[:avs_response] },
+          cvv_result: response[:cvv2_response]
+        )
       end
 
-      def post_data(parameters, options)
-        result = preamble
-        result.merge!(parameters)
-        result.collect { |key, value| post_data_string(key, value, options) }.join('&')
-      end
-
-      def post_data_string(key, value, options)
-        if custom_field?(key, options) || key == :LineItemProducts
-          "#{key}=#{CGI.escape(value.to_s)}"
-        else
-          "ssl_#{key}=#{CGI.escape(value.to_s)}"
-        end
-      end
-
-      def custom_field?(field_name, options)
-        return true if options[:custom_fields]&.include?(field_name.to_sym)
-
-        field_name == :customer_number
-      end
-
-      def preamble
-        result = {
-          'merchant_id'   => @options[:login],
-          'pin'           => @options[:password],
-          'show_form'     => 'false',
-          'result_format' => 'ASCII'
+      def headers
+        {
+          'Accept' => 'application/xml',
+          'Content-type' => 'application/x-www-form-urlencoded'
         }
-
-        result['user_id'] = @options[:user] unless empty?(@options[:user])
-        result
       end
 
-      def parse(msg)
-        resp = {}
-        msg.split(self.delimiter).collect { |li|
-          key, value = li.split('=')
-          resp[key.to_s.strip.gsub(/^ssl_/, '')] = value.to_s.strip
-        }
-        resp
+      def parse(body)
+        xml = Nokogiri::XML(body)
+        response = Hash.from_xml(xml.to_s)['txn']
+
+        response.deep_transform_keys { |key| key.gsub('ssl_', '').to_sym }
+      end
+
+      def authorization_from(response)
+        [response[:approval_code], response[:txn_id]].join(';')
       end
     end
   end

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -3,9 +3,11 @@ require 'test_helper'
 class RemoteElavonTest < Test::Unit::TestCase
   def setup
     @gateway = ElavonGateway.new(fixtures(:elavon))
+    @tokenization_gateway = fixtures(:elavon_tokenization) ? ElavonGateway.new(fixtures(:elavon_tokenization)) : ElavonGateway.new(fixtures(:elavon))
+    @bad_creds_gateway = ElavonGateway.new(login: 'foo', password: 'bar', user: 'me')
     @multi_currency_gateway = ElavonGateway.new(fixtures(:elavon_multi_currency))
 
-    @credit_card = credit_card('4124939999999990')
+    @credit_card = credit_card('4000000000000002')
     @bad_credit_card = credit_card('invalid')
 
     @options = {
@@ -14,6 +16,74 @@ class RemoteElavonTest < Test::Unit::TestCase
       billing_address: address,
       ip: '203.0.113.0',
       merchant_initiated_unscheduled: 'N'
+    }
+    @shipping_address = {
+      address1: '733 Foster St.',
+      city: 'Durham',
+      state: 'NC',
+      phone: '8887277750',
+      country: 'USA',
+      zip: '27701'
+    }
+    @level_3_data = {
+      customer_code: 'bob',
+      salestax: '3.45',
+      salestax_indicator: 'Y',
+      level3_indicator: 'Y',
+      ship_to_zip: '12345',
+      ship_to_country: 'US',
+      shipping_amount: '1234',
+      ship_from_postal_code: '54321',
+      discount_amount: '5',
+      duty_amount: '2',
+      national_tax_indicator: '0',
+      national_tax_amount: '10',
+      order_date: '280810',
+      other_tax: '3',
+      summary_commodity_code: '123',
+      merchant_vat_number: '222',
+      customer_vat_number: '333',
+      freight_tax_amount: '4',
+      vat_invoice_number: '26',
+      tracking_number: '45',
+      shipping_company: 'UFedzon',
+      other_fees: '2',
+      line_items: [
+        {
+          description: 'thing',
+          product_code: '23',
+          commodity_code: '444',
+          quantity: '15',
+          unit_of_measure: 'kropogs',
+          unit_cost: '4.5',
+          discount_indicator: 'Y',
+          tax_indicator: 'Y',
+          discount_amount: '1',
+          tax_rate: '8.25',
+          tax_amount: '12',
+          tax_type: '000',
+          extended_total: '500',
+          total: '525',
+          alternative_tax: '111'
+        },
+        {
+          description: 'thing2',
+          product_code: '23',
+          commodity_code: '444',
+          quantity: '15',
+          unit_of_measure: 'kropogs',
+          unit_cost: '4.5',
+          discount_indicator: 'Y',
+          tax_indicator: 'Y',
+          discount_amount: '1',
+          tax_rate: '8.25',
+          tax_amount: '12',
+          tax_type: '000',
+          extended_total: '500',
+          total: '525',
+          alternative_tax: '111'
+        }
+      ]
     }
     @amount = 100
   end
@@ -138,71 +208,72 @@ class RemoteElavonTest < Test::Unit::TestCase
   end
 
   def test_successful_store_without_verify
-    assert response = @gateway.store(@credit_card, @options)
+    assert response = @tokenization_gateway.store(@credit_card, @options)
     assert_success response
     assert_nil response.message
     assert response.test?
   end
 
   def test_successful_store_with_verify_false
-    assert response = @gateway.store(@credit_card, @options.merge(verify: false))
+    assert response = @tokenization_gateway.store(@credit_card, @options.merge(verify: false))
     assert_success response
     assert_nil response.message
     assert response.test?
   end
 
   def test_successful_store_with_verify_true
-    assert response = @gateway.store(@credit_card, @options.merge(verify: true))
+    assert response = @tokenization_gateway.store(@credit_card, @options.merge(verify: true))
     assert_success response
     assert_equal 'APPROVAL', response.message
     assert response.test?
   end
 
   def test_unsuccessful_store
-    assert response = @gateway.store(@bad_credit_card, @options)
+    assert response = @tokenization_gateway.store(@bad_credit_card, @options)
     assert_failure response
     assert_equal 'The Credit Card Number supplied in the authorization request appears to be invalid.', response.message
     assert response.test?
   end
 
   def test_successful_update
-    store_response = @gateway.store(@credit_card, @options)
+    store_response = @tokenization_gateway.store(@credit_card, @options)
     token = store_response.params['token']
-    credit_card = credit_card('4124939999999990', month: 10)
-    assert response = @gateway.update(token, credit_card, @options)
+    credit_card = credit_card('4000000000000002', month: 10)
+    assert response = @tokenization_gateway.update(token, credit_card, @options)
     assert_success response
     assert response.test?
   end
 
   def test_unsuccessful_update
-    assert response = @gateway.update('ABC123', @credit_card, @options)
+    assert response = @tokenization_gateway.update('ABC123', @credit_card, @options)
     assert_failure response
     assert_match %r{invalid}i, response.message
     assert response.test?
   end
 
   def test_successful_purchase_with_token
-    store_response = @gateway.store(@credit_card, @options)
+    store_response = @tokenization_gateway.store(@credit_card, @options)
     token = store_response.params['token']
-    assert response = @gateway.purchase(@amount, token, @options)
+    assert response = @tokenization_gateway.purchase(@amount, token, @options)
     assert_success response
     assert response.test?
     assert_equal 'APPROVAL', response.message
   end
 
   def test_failed_purchase_with_token
-    assert response = @gateway.purchase(@amount, 'ABC123', @options)
+    assert response = @tokenization_gateway.purchase(@amount, 'ABC123', @options)
     assert_failure response
     assert response.test?
     assert_match %r{invalid}i, response.message
   end
 
   def test_successful_purchase_with_custom_fields
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(custom_fields: { a_key: 'a value' }))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(custom_fields: { my_field: 'a value' }))
 
     assert_success response
-    assert response.test?
+    assert_match response.params['my_field'], 'a value'
     assert_equal 'APPROVAL', response.message
+    assert response.test?
     assert response.authorization
   end
 
@@ -235,68 +306,23 @@ class RemoteElavonTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_level_3_fields
-    level_3_data = {
-      customer_code: 'bob',
-      salestax: '3.45',
-      salestax_indicator: 'Y',
-      level3_indicator: 'Y',
-      ship_to_zip: '12345',
-      ship_to_country: 'US',
-      shipping_amount: '1234',
-      ship_from_postal_code: '54321',
-      discount_amount: '5',
-      duty_amount: '2',
-      national_tax_indicator: '0',
-      national_tax_amount: '10',
-      order_date: '280810',
-      other_tax: '3',
-      summary_commodity_code: '123',
-      merchant_vat_number: '222',
-      customer_vat_number: '333',
-      freight_tax_amount: '4',
-      vat_invoice_number: '26',
-      tracking_number: '45',
-      shipping_company: 'UFedzon',
-      other_fees: '2',
-      line_items: [
-        {
-          description: 'thing',
-          product_code: '23',
-          commodity_code: '444',
-          quantity: '15',
-          unit_of_measure: 'kropogs',
-          unit_cost: '4.5',
-          discount_indicator: 'Y',
-          tax_indicator: 'Y',
-          discount_amount: '1',
-          tax_rate: '8.25',
-          tax_amount: '12',
-          tax_type: 'state',
-          extended_total: '500',
-          total: '525',
-          alternative_tax: '111'
-        },
-        {
-          description: 'thing2',
-          product_code: '23',
-          commodity_code: '444',
-          quantity: '15',
-          unit_of_measure: 'kropogs',
-          unit_cost: '4.5',
-          discount_indicator: 'Y',
-          tax_indicator: 'Y',
-          discount_amount: '1',
-          tax_rate: '8.25',
-          tax_amount: '12',
-          tax_type: 'state',
-          extended_total: '500',
-          total: '525',
-          alternative_tax: '111'
-        }
-      ]
-    }
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(level_3_data: @level_3_data))
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(level_3_data: level_3_data))
+    assert_success response
+    assert_equal 'APPROVAL', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_shipping_address
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(shipping_address: @shipping_address))
+
+    assert_success response
+    assert_equal 'APPROVAL', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_shipping_address_and_l3
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(shipping_address: @shipping_address).merge(level_3_data: @level_3_data))
 
     assert_success response
     assert_equal 'APPROVAL', response.message
@@ -310,7 +336,15 @@ class RemoteElavonTest < Test::Unit::TestCase
     transcript = @gateway.scrub(transcript)
 
     assert_scrubbed(@credit_card.number, transcript)
-    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed("<ssl_cvv2cvc2>#{@credit_card.verification_value}</ssl_cvv2cvc2>", transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+  def test_invalid_login
+    assert response = @bad_creds_gateway.purchase(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert response.test?
+    assert_equal 'The credentials supplied in the authorization request are invalid.', response.message
   end
 end

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -32,7 +32,7 @@ class ElavonTest < Test::Unit::TestCase
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
-    assert_equal '123456;00000000-0000-0000-0000-00000000000', response.authorization
+    assert_equal '093840;180820AD3-27AEE6EF-8CA7-4811-8D1F-E420C3B5041E', response.authorization
     assert response.test?
   end
 
@@ -43,8 +43,8 @@ class ElavonTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_success response
 
-    assert_equal '123456;00000000-0000-0000-0000-00000000000', response.authorization
-    assert_equal 'APPROVED', response.message
+    assert_equal '259404;150920ED4-3EB7A2DF-A5A7-48E6-97B6-D98A9DC0BD59', response.authorization
+    assert_equal 'APPROVAL', response.message
     assert response.test?
   end
 
@@ -58,44 +58,44 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
-    authorization = '123456;00000000-0000-0000-0000-00000000000'
+    authorization = '070213;110820ED4-23CA2F2B-A88C-40E1-AC46-9219F800A520'
 
     assert response = @gateway.capture(@amount, authorization, credit_card: @credit_card)
     assert_instance_of Response, response
     assert_success response
 
-    assert_equal '123456;00000000-0000-0000-0000-00000000000', response.authorization
+    assert_equal '070213;110820ED4-23CA2F2B-A88C-40E1-AC46-9219F800A520', response.authorization
     assert_equal 'APPROVAL', response.message
     assert response.test?
   end
 
   def test_successful_capture_with_auth_code
     @gateway.expects(:ssl_post).returns(successful_capture_response)
-    authorization = '123456;00000000-0000-0000-0000-00000000000'
+    authorization = '070213;110820ED4-23CA2F2B-A88C-40E1-AC46-9219F800A520'
 
     assert response = @gateway.capture(@amount, authorization)
     assert_instance_of Response, response
     assert_success response
 
-    assert_equal '123456;00000000-0000-0000-0000-00000000000', response.authorization
+    assert_equal '070213;110820ED4-23CA2F2B-A88C-40E1-AC46-9219F800A520', response.authorization
     assert_equal 'APPROVAL', response.message
     assert response.test?
   end
 
   def test_successful_capture_with_additional_options
-    authorization = '123456;00000000-0000-0000-0000-00000000000'
+    authorization = '070213;110820ED4-23CA2F2B-A88C-40E1-AC46-9219F800A520'
     response = stub_comms do
       @gateway.capture(@amount, authorization, test_mode: true, partial_shipment_flag: true)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/ssl_transaction_type=CCCOMPLETE/, data)
-      assert_match(/ssl_test_mode=TRUE/, data)
-      assert_match(/ssl_partial_shipment_flag=Y/, data)
+      assert_match(/<ssl_transaction_type>CCCOMPLETE<\/ssl_transaction_type>/, data)
+      assert_match(/<ssl_test_mode>TRUE<\/ssl_test_mode>/, data)
+      assert_match(/<ssl_partial_shipment_flag>Y<\/ssl_partial_shipment_flag>/, data)
     end.respond_with(successful_capture_response)
 
     assert_instance_of Response, response
     assert_success response
 
-    assert_equal '123456;00000000-0000-0000-0000-00000000000', response.authorization
+    assert_equal '070213;110820ED4-23CA2F2B-A88C-40E1-AC46-9219F800A520', response.authorization
     assert_equal 'APPROVAL', response.message
     assert response.test?
   end
@@ -104,8 +104,7 @@ class ElavonTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(ip: '203.0.113.0'))
     end.check_request do |_endpoint, data, _headers|
-      parsed = CGI.parse(data)
-      assert_equal ['203.0.113.0'], parsed['ssl_cardholder_ip']
+      assert_match(/203.0.113.0/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -115,8 +114,7 @@ class ElavonTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(ip: '203.0.113.0'))
     end.check_request do |_endpoint, data, _headers|
-      parsed = CGI.parse(data)
-      assert_equal ['203.0.113.0'], parsed['ssl_cardholder_ip']
+      assert_match(/<ssl_cardholder_ip>203.0.113.0<\/ssl_cardholder_ip>/, data)
     end.respond_with(successful_authorization_response)
 
     assert_success response
@@ -126,8 +124,7 @@ class ElavonTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(dba: 'MANYMAG*BAKERS MONTHLY'))
     end.check_request do |_endpoint, data, _headers|
-      parsed = CGI.parse(data)
-      assert_equal ['MANYMAG*BAKERS MONTHLY'], parsed['ssl_dynamic_dba']
+      assert_match(/<ssl_dynamic_dba>MANYMAG\*BAKERS MONTHLY<\/ssl_dynamic_dba>/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -137,8 +134,7 @@ class ElavonTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(merchant_initiated_unscheduled: 'Y'))
     end.check_request do |_endpoint, data, _headers|
-      parsed = CGI.parse(data)
-      assert_equal ['Y'], parsed['ssl_merchant_initiated_unscheduled']
+      assert_match(/<ssl_merchant_initiated_unscheduled>Y<\/ssl_merchant_initiated_unscheduled>/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -148,8 +144,7 @@ class ElavonTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(dba: 'MANYMAG*BAKERS MONTHLY'))
     end.check_request do |_endpoint, data, _headers|
-      parsed = CGI.parse(data)
-      assert_equal ['MANYMAG*BAKERS MONTHLY'], parsed['ssl_dynamic_dba']
+      assert_match(/<ssl_dynamic_dba>MANYMAG\*BAKERS MONTHLY<\/ssl_dynamic_dba>/, data)
     end.respond_with(successful_authorization_response)
 
     assert_success response
@@ -157,9 +152,9 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_multi_currency
     response = stub_comms(@multi_currency_gateway) do
-      @multi_currency_gateway.purchase(@amount, @credit_card, @options.merge(currency: 'EUR'))
+      @multi_currency_gateway.purchase(@amount, @credit_card, @options.merge(currency: 'JPY'))
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/ssl_transaction_currency=EUR/, data)
+      assert_match(/<ssl_transaction_currency>JPY<\/ssl_transaction_currency>/, data)
     end.respond_with(successful_purchase_with_multi_currency_response)
 
     assert_success response
@@ -221,7 +216,7 @@ class ElavonTest < Test::Unit::TestCase
 
     assert response = @gateway.refund(123, '456')
     assert_failure response
-    assert_equal 'The refund amount exceeds the original transaction amount.', response.message
+    assert_equal 'The amount exceeded the original transaction amount. Amount must be equal or lower than the original transaction amount.', response.message
   end
 
   def test_successful_verify
@@ -244,8 +239,8 @@ class ElavonTest < Test::Unit::TestCase
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
 
-    assert_equal '7000', response.params['result']
-    assert_equal 'The VirtualMerchant ID and/or User ID supplied in the authorization request is invalid.', response.message
+    assert_equal '4025', response.params['errorCode']
+    assert_equal 'The credentials supplied in the authorization request are invalid.', response.message
     assert_failure response
   end
 
@@ -256,13 +251,13 @@ class ElavonTest < Test::Unit::TestCase
   def test_avs_result
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     response = @gateway.purchase(@amount, @credit_card)
-    assert_equal 'X', response.avs_result['code']
+    assert_equal 'M', response.avs_result['code']
   end
 
   def test_cvv_result
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     response = @gateway.purchase(@amount, @credit_card)
-    assert_equal 'P', response.cvv_result['code']
+    assert_equal 'M', response.cvv_result['code']
   end
 
   def test_successful_store
@@ -270,7 +265,7 @@ class ElavonTest < Test::Unit::TestCase
 
     assert response = @gateway.store(@credit_card, @options)
     assert_success response
-    assert_equal '7595301425001111', response.params['token']
+    assert_equal '4421912014039990', response.params['token']
     assert response.test?
   end
 
@@ -304,7 +299,7 @@ class ElavonTest < Test::Unit::TestCase
 
     @options[:billing_address][:zip] = bad_zip
 
-    @gateway.expects(:commit).with(anything, anything, has_entries(avs_zip: stripped_zip), anything)
+    @gateway.expects(:commit).with(includes("<ssl_avs_zip>#{stripped_zip}</ssl_avs_zip>"))
 
     @gateway.purchase(@amount, @credit_card, @options)
   end
@@ -312,7 +307,7 @@ class ElavonTest < Test::Unit::TestCase
   def test_zip_codes_with_letters_are_left_intact
     @options[:billing_address][:zip] = '.K1%Z_5E3-'
 
-    @gateway.expects(:commit).with(anything, anything, has_entries(avs_zip: 'K1Z5E3'), anything)
+    @gateway.expects(:commit).with(includes('<ssl_avs_zip>K1Z5E3</ssl_avs_zip>'))
 
     @gateway.purchase(@amount, @credit_card, @options)
   end
@@ -321,9 +316,8 @@ class ElavonTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(customer_number: '123', custom_fields: { a_key: 'a value' }))
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/customer_number=123/, data)
-      assert_match(/a_key/, data)
-      refute_match(/ssl_a_key/, data)
+      assert_match(/<ssl_customer_number>123<\/ssl_customer_number>/, data)
+      assert_match(/<a_key>a value<\/a_key>/, data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -393,43 +387,65 @@ class ElavonTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/ssl_customer_code=bob/, data)
-      assert_match(/ssl_salestax=3.45/, data)
-      assert_match(/ssl_salestax_indicator=Y/, data)
-      assert_match(/ssl_level3_indicator=Y/, data)
-      assert_match(/ssl_ship_to_zip=12345/, data)
-      assert_match(/ssl_ship_to_country=US/, data)
-      assert_match(/ssl_shipping_amount=1234/, data)
-      assert_match(/ssl_ship_from_postal_code=54321/, data)
-      assert_match(/ssl_discount_amount=5/, data)
-      assert_match(/ssl_duty_amount=2/, data)
-      assert_match(/ssl_national_tax_indicator=0/, data)
-      assert_match(/ssl_national_tax_amount=10/, data)
-      assert_match(/ssl_order_date=280810/, data)
-      assert_match(/ssl_other_tax=3/, data)
-      assert_match(/ssl_summary_commodity_code=123/, data)
-      assert_match(/ssl_merchant_vat_number=222/, data)
-      assert_match(/ssl_customer_vat_number=333/, data)
-      assert_match(/ssl_freight_tax_amount=4/, data)
-      assert_match(/ssl_vat_invoice_number=26/, data)
-      assert_match(/ssl_tracking_number=45/, data)
-      assert_match(/ssl_shipping_company=UFedzon/, data)
-      assert_match(/ssl_other_fees=2/, data)
-      assert_match(/ssl_line_Item_description/, data)
-      assert_match(/ssl_line_Item_product_code/, data)
-      assert_match(/ssl_line_Item_commodity_code/, data)
-      assert_match(/ssl_line_Item_quantity/, data)
-      assert_match(/ssl_line_Item_unit_of_measure/, data)
-      assert_match(/ssl_line_Item_unit_cost/, data)
-      assert_match(/ssl_line_Item_discount_indicator/, data)
-      assert_match(/ssl_line_Item_tax_indicator/, data)
-      assert_match(/ssl_line_Item_discount_amount/, data)
-      assert_match(/ssl_line_Item_tax_rate/, data)
-      assert_match(/ssl_line_Item_tax_amount/, data)
-      assert_match(/ssl_line_Item_tax_type/, data)
-      assert_match(/ssl_line_Item_extended_total/, data)
-      assert_match(/ssl_line_Item_total/, data)
-      assert_match(/ssl_line_Item_alternative_tax/, data)
+      assert_match(/<ssl_customer_code>bob/, data)
+      assert_match(/<ssl_salestax>3.45/, data)
+      assert_match(/<ssl_salestax_indicator>Y/, data)
+      assert_match(/<ssl_level3_indicator>Y/, data)
+      assert_match(/<ssl_ship_to_zip>12345/, data)
+      assert_match(/<ssl_ship_to_country>US/, data)
+      assert_match(/<ssl_shipping_amount>1234/, data)
+      assert_match(/<ssl_ship_from_postal_code>54321/, data)
+      assert_match(/<ssl_discount_amount>5/, data)
+      assert_match(/<ssl_duty_amount>2/, data)
+      assert_match(/<ssl_national_tax_indicator>0/, data)
+      assert_match(/<ssl_national_tax_amount>10/, data)
+      assert_match(/<ssl_order_date>280810/, data)
+      assert_match(/<ssl_other_tax>3/, data)
+      assert_match(/<ssl_summary_commodity_code>123/, data)
+      assert_match(/<ssl_merchant_vat_number>222/, data)
+      assert_match(/<ssl_customer_vat_number>333/, data)
+      assert_match(/<ssl_freight_tax_amount>4/, data)
+      assert_match(/<ssl_vat_invoice_number>26/, data)
+      assert_match(/<ssl_tracking_number>45/, data)
+      assert_match(/<ssl_shipping_company>UFedzon/, data)
+      assert_match(/<ssl_other_fees>2/, data)
+      assert_match(/<ssl_line_Item_description>/, data)
+      assert_match(/<ssl_line_Item_product_code>/, data)
+      assert_match(/<ssl_line_Item_commodity_code>/, data)
+      assert_match(/<ssl_line_Item_quantity>/, data)
+      assert_match(/<ssl_line_Item_unit_of_measure>/, data)
+      assert_match(/<ssl_line_Item_unit_cost>/, data)
+      assert_match(/<ssl_line_Item_discount_indicator>/, data)
+      assert_match(/<ssl_line_Item_tax_indicator>/, data)
+      assert_match(/<ssl_line_Item_discount_amount>/, data)
+      assert_match(/<ssl_line_Item_tax_rate>/, data)
+      assert_match(/<ssl_line_Item_tax_amount>/, data)
+      assert_match(/<ssl_line_Item_tax_type>/, data)
+      assert_match(/<ssl_line_Item_extended_total>/, data)
+      assert_match(/<ssl_line_Item_total>/, data)
+      assert_match(/<ssl_line_Item_alternative_tax>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_shipping_address_in_request
+    shipping_address = {
+      address1: '733 Foster St.',
+      city: 'Durham',
+      state: 'NC',
+      phone: '8887277750',
+      country: 'USA',
+      zip: '27701'
+    }
+    options = @options.merge(shipping_address: shipping_address)
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_ship_to_address1>733 Foster St./, data)
+      assert_match(/<ssl_ship_to_city>Durham/, data)
+      assert_match(/<ssl_ship_to_state>NC/, data)
+      assert_match(/<ssl_ship_to_phone>8887277750/, data)
+      assert_match(/<ssl_ship_to_country>USA/, data)
+      assert_match(/<ssl_ship_to_zip>27701/, data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -441,229 +457,434 @@ class ElavonTest < Test::Unit::TestCase
   private
 
   def successful_purchase_response
-    "ssl_card_number=42********4242
-    ssl_exp_date=0910
-    ssl_amount=1.00
-    ssl_invoice_number=
-    ssl_description=Test Transaction
-    ssl_result=0
-    ssl_result_message=APPROVED
-    ssl_txn_id=00000000-0000-0000-0000-00000000000
-    ssl_approval_code=123456
-    ssl_cvv2_response=P
-    ssl_avs_response=X
-    ssl_account_balance=0.00
-    ssl_txn_time=08/07/2009 09:54:18 PM"
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+      <txn>
+        <ssl_issuer_response>00</ssl_issuer_response>
+        <ssl_last_name>Longsen</ssl_last_name>
+        <ssl_company>Widgets Inc</ssl_company>
+        <ssl_phone>(555)555-5555</ssl_phone>
+        <ssl_card_number>41**********9990</ssl_card_number>
+        <ssl_departure_date></ssl_departure_date>
+        <ssl_oar_data>010012318808182231420000047554200000000000093840023122123188</ssl_oar_data>
+        <ssl_result>0</ssl_result>
+        <ssl_txn_id>180820AD3-27AEE6EF-8CA7-4811-8D1F-E420C3B5041E</ssl_txn_id>
+        <ssl_avs_response>M</ssl_avs_response>
+        <ssl_approval_code>093840</ssl_approval_code>
+        <ssl_email>paul@domain.com</ssl_email>
+        <ssl_amount>100.00</ssl_amount>
+        <ssl_avs_zip>K1C2N6</ssl_avs_zip>
+        <ssl_txn_time>08/18/2020 06:31:42 PM</ssl_txn_time>
+        <ssl_exp_date>0921</ssl_exp_date>
+        <ssl_card_short_description>VISA</ssl_card_short_description>
+        <ssl_completion_date></ssl_completion_date>
+        <ssl_address2>Apt 1</ssl_address2>
+        <ssl_country>CA</ssl_country>
+        <ssl_card_type>CREDITCARD</ssl_card_type>
+        <ssl_transaction_type>AUTHONLY</ssl_transaction_type>
+        <ssl_salestax></ssl_salestax>
+        <ssl_avs_address>456 My Street</ssl_avs_address>
+        <ssl_account_balance>0.00</ssl_account_balance>
+        <ssl_ps2000_data>A8181831435010530042VE</ssl_ps2000_data>
+        <ssl_state>ON</ssl_state>
+        <ssl_city>Ottawa</ssl_city>
+        <ssl_result_message>APPROVAL</ssl_result_message>
+        <ssl_first_name>Longbob</ssl_first_name>
+        <ssl_invoice_number></ssl_invoice_number>
+        <ssl_cvv2_response>M</ssl_cvv2_response>
+        <ssl_partner_app_id>VM</ssl_partner_app_id>
+      </txn>
+    XML
   end
 
   def successful_purchase_with_multi_currency_response
-    "ssl_card_number=42********4242
-    ssl_exp_date=0910
-    ssl_amount=1.00
-    ssl_invoice_number=
-    ssl_description=Test Transaction
-    ssl_result=0
-    ssl_result_message=APPROVED
-    ssl_txn_id=00000000-0000-0000-0000-00000000000
-    ssl_approval_code=123456
-    ssl_cvv2_response=P
-    ssl_avs_response=X
-    ssl_account_balance=0.00
-    ssl_transaction_currency=EUR
-    ssl_txn_time=08/07/2009 09:54:18 PM"
+    <<-XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <txn>
+        <ssl_issuer_response>00</ssl_issuer_response>
+        <ssl_issue_points></ssl_issue_points>
+        <ssl_card_number>41**********9990</ssl_card_number>
+        <ssl_departure_date></ssl_departure_date>
+        <ssl_oar_data>010012316708182238060000047554200000000000093864023122123167</ssl_oar_data>
+        <ssl_result>0</ssl_result>
+        <ssl_txn_id>180820ED3-1DD371B9-64DF-4902-B377-EBD095E6DAF0</ssl_txn_id>
+        <ssl_loyalty_program></ssl_loyalty_program>
+        <ssl_avs_response>M</ssl_avs_response>
+        <ssl_approval_code>093864</ssl_approval_code>
+        <ssl_account_status></ssl_account_status>
+        <ssl_amount>100</ssl_amount>
+        <ssl_transaction_currency>JPY</ssl_transaction_currency>
+        <ssl_txn_time>08/18/2020 06:38:06 PM</ssl_txn_time>
+        <ssl_promo_code></ssl_promo_code>
+        <ssl_exp_date>0921</ssl_exp_date>
+        <ssl_card_short_description>VISA</ssl_card_short_description>
+        <ssl_completion_date></ssl_completion_date>
+        <ssl_card_type>CREDITCARD</ssl_card_type>
+        <ssl_access_code></ssl_access_code>
+        <ssl_transaction_type>SALE</ssl_transaction_type>
+        <ssl_loyalty_account_balance></ssl_loyalty_account_balance>
+        <ssl_salestax>0.00</ssl_salestax>
+        <ssl_enrollment></ssl_enrollment>
+        <ssl_account_balance>0.00</ssl_account_balance>
+        <ssl_ps2000_data>A8181838065010780213VE</ssl_ps2000_data>
+        <ssl_result_message>APPROVAL</ssl_result_message>
+        <ssl_invoice_number></ssl_invoice_number>
+        <ssl_cvv2_response></ssl_cvv2_response>
+        <ssl_tender_amount></ssl_tender_amount>
+        <ssl_partner_app_id>VM</ssl_partner_app_id>
+      </txn>
+    XML
   end
 
   def successful_refund_response
-    "ssl_card_number=42*****2222
-    ssl_exp_date=
-    ssl_amount=1.00
-    ssl_customer_code=
-    ssl_invoice_number=
-    ssl_description=
-    ssl_company=
-    ssl_first_name=
-    ssl_last_name=
-    ssl_avs_address=
-    ssl_address2=
-    ssl_city=
-    ssl_state=
-    ssl_avs_zip=
-    ssl_country=
-    ssl_phone=
-    ssl_email=
-    ssl_result=0
-    ssl_result_message=APPROVAL
-    ssl_txn_id=AA49315-C3D2B7BA-237C-1168-405A-CD5CAF928B0C
-    ssl_approval_code=
-    ssl_cvv2_response=
-    ssl_avs_response=
-    ssl_account_balance=0.00
-    ssl_txn_time=08/21/2012 05:43:46 PM"
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <ssl_issuer_response>00</ssl_issuer_response>
+      <ssl_last_name>Longsen</ssl_last_name>
+      <ssl_company>Widgets Inc</ssl_company>
+      <ssl_phone>(555)555-5555    </ssl_phone>
+      <ssl_card_number>41**********9990</ssl_card_number>
+      <ssl_departure_date></ssl_departure_date>
+      <ssl_result>0</ssl_result>
+      <ssl_txn_id>180820AD3-4BACDE38-63F3-427D-BFC1-1B3EB046056B</ssl_txn_id>
+      <ssl_avs_response></ssl_avs_response>
+      <ssl_approval_code>094012</ssl_approval_code>
+      <ssl_email>paul@domain.com</ssl_email>
+      <ssl_amount>100.00</ssl_amount>
+      <ssl_avs_zip>K1C2N6</ssl_avs_zip>
+      <ssl_txn_time>08/18/2020 07:04:49 PM</ssl_txn_time>
+      <ssl_exp_date>0921</ssl_exp_date>
+      <ssl_card_short_description>VISA</ssl_card_short_description>
+      <ssl_completion_date></ssl_completion_date>
+      <ssl_address2>Apt 1</ssl_address2>
+      <ssl_customer_code></ssl_customer_code>
+      <ssl_country>CA</ssl_country>
+      <ssl_card_type>CREDITCARD</ssl_card_type>
+      <ssl_transaction_type>RETURN</ssl_transaction_type>
+      <ssl_salestax></ssl_salestax>
+      <ssl_avs_address>456 My Street</ssl_avs_address>
+      <ssl_account_balance>0.00</ssl_account_balance>
+      <ssl_state>ON</ssl_state>
+      <ssl_city>Ottawa</ssl_city>
+      <ssl_result_message>APPROVAL</ssl_result_message>
+      <ssl_first_name>Longbob</ssl_first_name>
+      <ssl_invoice_number></ssl_invoice_number>
+      <ssl_cvv2_response></ssl_cvv2_response>
+      <ssl_partner_app_id>VM</ssl_partner_app_id>
+    </txn>
+    XML
   end
 
   def successful_void_response
-    "ssl_card_number=42*****2222
-    ssl_exp_date=0913
-    ssl_amount=1.00
-    ssl_invoice_number=
-    ssl_description=
-    ssl_company=
-    ssl_first_name=
-    ssl_last_name=
-    ssl_avs_address=
-    ssl_address2=
-    ssl_city=
-    ssl_state=
-    ssl_avs_zip=
-    ssl_country=
-    ssl_phone=
-    ssl_email=
-    ssl_result=0
-    ssl_result_message=APPROVAL
-    ssl_txn_id=AA49315-F04216E3-E556-E2E0-ADE9-4186A5F69105
-    ssl_approval_code=
-    ssl_cvv2_response=
-    ssl_avs_response=
-    ssl_account_balance=1.00
-    ssl_txn_time=08/21/2012 05:37:19 PM"
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <ssl_last_name>Longsen</ssl_last_name>
+      <ssl_service_fee_amount></ssl_service_fee_amount>
+      <ssl_company>Widgets Inc</ssl_company>
+      <ssl_phone>(555)555-5555</ssl_phone>
+      <ssl_card_number>41**********9990</ssl_card_number>
+      <ssl_result>0</ssl_result>
+      <ssl_txn_id>180820AD3-2E02E02D-A1FB-4926-A957-3930D3F7B869</ssl_txn_id>
+      <ssl_email>paul@domain.com</ssl_email>
+      <ssl_amount>100.00</ssl_amount>
+      <ssl_avs_zip>K1C2N6</ssl_avs_zip>
+      <ssl_txn_time>08/18/2020 06:56:27 PM</ssl_txn_time>
+      <ssl_exp_date>0921</ssl_exp_date>
+      <ssl_card_short_description>VISA</ssl_card_short_description>
+      <ssl_address2>Apt 1</ssl_address2>
+      <ssl_credit_surcharge_amount></ssl_credit_surcharge_amount>
+      <ssl_country>CA</ssl_country>
+      <ssl_card_type>CREDITCARD</ssl_card_type>
+      <ssl_transaction_type>DELETE</ssl_transaction_type>
+      <ssl_salestax></ssl_salestax>
+      <ssl_avs_address>456 My Street</ssl_avs_address>
+      <ssl_state>ON</ssl_state>
+      <ssl_city>Ottawa</ssl_city>
+      <ssl_result_message>APPROVAL</ssl_result_message>
+      <ssl_first_name>Longbob</ssl_first_name>
+      <ssl_invoice_number></ssl_invoice_number>
+      <ssl_partner_app_id>VM</ssl_partner_app_id>
+    </txn>
+    XML
   end
 
   def successful_verify_response
-    "ssl_card_number=41**********9990
-    ssl_exp_date=0921
-    ssl_card_short_description=VISA
-    ssl_result=0
-    ssl_result_message=APPROVAL
-    ssl_transaction_type=CARDVERIFICATION
-    ssl_txn_id=010520ED3-56D114FC-B7D0-4ACF-BB3E-B1F0DA5A1EC7
-    ssl_approval_code=401169
-    ssl_cvv2_response=M
-    ssl_avs_response=M
-    ssl_account_balance=0.00
-    ssl_txn_time=05/01/2020 11:30:56 AM
-    ssl_card_type=CREDITCARD
-    ssl_partner_app_id=VM"
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <ssl_issuer_response>85</ssl_issuer_response>
+      <ssl_transaction_type>CARDVERIFICATION</ssl_transaction_type>
+      <ssl_card_number>41**********9990</ssl_card_number>
+      <ssl_oar_data>010012309508182257450000047554200000000000093964023122123095</ssl_oar_data>
+      <ssl_result>0</ssl_result>
+      <ssl_txn_id>180820ED4-85DA9146-51AB-4FEC-8004-91C607047E5C</ssl_txn_id>
+      <ssl_avs_response>M</ssl_avs_response>
+      <ssl_approval_code>093964</ssl_approval_code>
+      <ssl_avs_address>456 My Street</ssl_avs_address>
+      <ssl_avs_zip>K1C2N6</ssl_avs_zip>
+      <ssl_txn_time>08/18/2020 06:57:45 PM</ssl_txn_time>
+      <ssl_account_balance>0.00</ssl_account_balance>
+      <ssl_ps2000_data>A8181857455011610042VE</ssl_ps2000_data>
+      <ssl_exp_date>0921</ssl_exp_date>
+      <ssl_result_message>APPROVAL</ssl_result_message>
+      <ssl_card_short_description>VISA</ssl_card_short_description>
+      <ssl_card_type>CREDITCARD</ssl_card_type>
+      <ssl_cvv2_response>M</ssl_cvv2_response>
+      <ssl_partner_app_id>VM</ssl_partner_app_id>
+    </txn>
+    XML
   end
 
   def failed_purchase_response
-    "errorCode=5000
-    errorName=Credit Card Number Invalid
-    errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <errorCode>5000</errorCode>
+      <errorName>Credit Card Number Invalid</errorName>
+      <errorMessage>The Credit Card Number supplied in the authorization request appears to be invalid.</errorMessage>
+    </txn>
+    XML
   end
 
   def failed_refund_response
-    "errorCode=5091
-    errorName=Invalid Refund Amount
-    errorMessage=The refund amount exceeds the original transaction amount."
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <errorCode>5091</errorCode>
+      <errorName>Invalid amount</errorName>
+      <errorMessage>The amount exceeded the original transaction amount. Amount must be equal or lower than the original transaction amount.</errorMessage>
+    </txn>
+    XML
   end
 
   def failed_void_response
-    "errorCode=5040
-    errorName=Invalid Transaction ID
-    errorMessage=The transaction ID is invalid for this transaction type"
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <errorCode>5040</errorCode>
+      <errorName>Invalid Transaction ID</errorName>
+      <errorMessage>The transaction ID is invalid for this transaction type</errorMessage>
+    </txn>
+    XML
   end
 
   def failed_verify_response
-    "errorCode=5000
-    errorName=Credit Card Number Invalid
-    errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <errorCode>5000</errorCode>
+      <errorName>Credit Card Number Invalid</errorName>
+      <errorMessage>The Credit Card Number supplied in the authorization request appears to be invalid.</errorMessage>
+    </txn>
+    XML
   end
 
   def invalid_login_response
-    <<-RESPONSE
-    ssl_result=7000\r
-    ssl_result_message=The VirtualMerchant ID and/or User ID supplied in the authorization request is invalid.\r
-    RESPONSE
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <errorCode>4025</errorCode>
+      <errorName>Invalid Credentials</errorName>
+      <errorMessage>The credentials supplied in the authorization request are invalid.</errorMessage>
+    </txn>
+    XML
   end
 
   def successful_authorization_response
-    "ssl_card_number=42********4242
-    ssl_exp_date=0910
-    ssl_amount=1.00
-    ssl_invoice_number=
-    ssl_description=Test Transaction
-    ssl_result=0
-    ssl_result_message=APPROVED
-    ssl_txn_id=00000000-0000-0000-0000-00000000000
-    ssl_approval_code=123456
-    ssl_cvv2_response=P
-    ssl_avs_response=X
-    ssl_account_balance=0.00
-    ssl_txn_time=08/07/2009 09:56:11 PM"
+    <<-XML
+    <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <txn>
+      <ssl_issuer_response>00</ssl_issuer_response>
+      <ssl_transaction_type>AUTHONLY</ssl_transaction_type>
+      <ssl_card_number>41**********9990</ssl_card_number>
+      <ssl_departure_date></ssl_departure_date>
+      <ssl_oar_data>010012312309152159540000047554200000000000259404025921123123</ssl_oar_data>
+      <ssl_result>0</ssl_result>
+      <ssl_txn_id>150920ED4-3EB7A2DF-A5A7-48E6-97B6-D98A9DC0BD59</ssl_txn_id>
+      <ssl_avs_response>M</ssl_avs_response>
+      <ssl_approval_code>259404</ssl_approval_code>
+      <ssl_salestax></ssl_salestax>
+      <ssl_amount>100.00</ssl_amount>
+      <ssl_txn_time>09/15/2020 05:59:54 PM</ssl_txn_time>
+      <ssl_account_balance>0.00</ssl_account_balance>
+      <ssl_ps2000_data>A9151759546571260030VE</ssl_ps2000_data>
+      <ssl_exp_date>0921</ssl_exp_date>
+      <ssl_result_message>APPROVAL</ssl_result_message>
+      <ssl_card_short_description>VISA</ssl_card_short_description>
+      <ssl_completion_date></ssl_completion_date>
+      <ssl_eci_ind>3</ssl_eci_ind>
+      <ssl_card_type>CREDITCARD</ssl_card_type>
+      <ssl_invoice_number></ssl_invoice_number>
+      <ssl_cvv2_response>M</ssl_cvv2_response>
+      <ssl_partner_app_id>01</ssl_partner_app_id>
+    </txn>
+    XML
   end
 
   def failed_authorization_response
-    "errorCode=5000
-    errorName=Credit Card Number Invalid
-    errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <errorCode>5000</errorCode>
+      <errorName>Credit Card Number Invalid</errorName>
+      <errorMessage>The Credit Card Number supplied in the authorization request appears to be invalid.</errorMessage>
+    </txn>
+    XML
   end
 
   def successful_capture_response
-    "ssl_card_number=42********4242
-    ssl_exp_date=0910
-    ssl_amount=1.00
-    ssl_customer_code=
-    ssl_salestax=
-    ssl_invoice_number=
-    ssl_result=0
-    ssl_result_message=APPROVAL
-    ssl_txn_id=00000000-0000-0000-0000-00000000000
-    ssl_approval_code=123456
-    ssl_cvv2_response=P
-    ssl_avs_response=X
-    ssl_account_balance=0.00
-    ssl_txn_time=08/07/2009 09:56:11 PM"
+    <<~XML
+      <txn>
+        <ssl_last_name>Longsen</ssl_last_name>
+        <ssl_company>Widgets Inc</ssl_company>
+        <ssl_phone>(555)555-5555</ssl_phone>
+        <ssl_card_number>41**********9990</ssl_card_number>
+        <ssl_departure_date></ssl_departure_date>
+        <ssl_result>0</ssl_result>
+        <ssl_txn_id>110820ED4-23CA2F2B-A88C-40E1-AC46-9219F800A520</ssl_txn_id>
+        <ssl_avs_response></ssl_avs_response>
+        <ssl_approval_code>070213</ssl_approval_code>
+        <ssl_email>paul@domain.com</ssl_email>
+        <ssl_amount>100.00</ssl_amount>
+        <ssl_avs_zip>K1C2N6</ssl_avs_zip>
+        <ssl_txn_time>08/11/2020 10:08:14 PM</ssl_txn_time>
+        <ssl_exp_date>0921</ssl_exp_date>
+        <ssl_card_short_description>VISA</ssl_card_short_description>
+        <ssl_completion_date></ssl_completion_date>
+        <ssl_address2>Apt 1</ssl_address2>
+        <ssl_country>CA</ssl_country>
+        <ssl_card_type>CREDITCARD</ssl_card_type>
+        <ssl_transaction_type>FORCE</ssl_transaction_type>
+        <ssl_salestax></ssl_salestax>
+        <ssl_avs_address>456 My Street</ssl_avs_address>
+        <ssl_account_balance>0.00</ssl_account_balance>
+        <ssl_state>ON</ssl_state>
+        <ssl_city>Ottawa</ssl_city>
+        <ssl_result_message>APPROVAL</ssl_result_message>
+        <ssl_first_name>Longbob</ssl_first_name>
+        <ssl_invoice_number></ssl_invoice_number>
+        <ssl_cvv2_response></ssl_cvv2_response>
+        <ssl_partner_app_id>VM</ssl_partner_app_id>
+      </txn>
+    XML
   end
 
   def failed_capture_response
-    "errorCode=5040
-    errorName=Invalid Transaction ID
-    errorMessage=The transaction ID is invalid for this transaction type"
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <errorCode>5004</errorCode>
+      <errorName>Invalid Approval Code</errorName>
+      <errorMessage>The FORCE Approval Code supplied in the authorization request appears to be invalid or blank.  The FORCE Approval Code must be 6 or less alphanumeric characters.</errorMessage>
+    </txn>
+    XML
   end
 
   def successful_store_response
-    "ssl_transaction_type=CCGETTOKEN
-     ssl_result=0
-     ssl_token=7595301425001111
-     ssl_card_number=41**********1111
-     ssl_token_response=SUCCESS
-     ssl_add_token_response=Card Updated
-     vu_aamc_id="
+    <<-XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <txn>
+      <ssl_last_name>Longsen</ssl_last_name>
+      <ssl_company>Widgets Inc</ssl_company>
+      <ssl_phone>(555)555-5555</ssl_phone>
+      <ssl_card_number>41**********9990</ssl_card_number>
+      <ssl_result>0</ssl_result>
+      <ssl_txn_id></ssl_txn_id>
+      <ssl_avs_response></ssl_avs_response>
+      <ssl_approval_code></ssl_approval_code>
+      <ssl_email>paul@domain.com</ssl_email>
+      <ssl_avs_zip>K1C2N6</ssl_avs_zip>
+      <ssl_txn_time>08/18/2020 07:01:16 PM</ssl_txn_time>
+      <ssl_exp_date>0921</ssl_exp_date>
+      <ssl_card_short_description>VISA</ssl_card_short_description>
+      <ssl_address2>Apt 1</ssl_address2>
+      <ssl_token_response>SUCCESS</ssl_token_response>
+      <ssl_country>CA</ssl_country>
+      <ssl_card_type>CREDITCARD</ssl_card_type>
+      <ssl_transaction_type>GETTOKEN</ssl_transaction_type>
+      <ssl_salestax></ssl_salestax>
+      <ssl_avs_address>456 My Street</ssl_avs_address>
+      <ssl_customer_id></ssl_customer_id>
+      <ssl_account_balance>0.00</ssl_account_balance>
+      <ssl_state>ON</ssl_state>
+      <ssl_city>Ottawa</ssl_city>
+      <ssl_result_message></ssl_result_message>
+      <ssl_first_name>Longbob</ssl_first_name>
+      <ssl_invoice_number></ssl_invoice_number>
+      <ssl_cvv2_response></ssl_cvv2_response>
+      <ssl_token>4421912014039990</ssl_token>
+      <ssl_add_token_response>Card Updated</ssl_add_token_response>
+    </txn>
+    XML
   end
 
   def failed_store_response
-    "errorCode=5000
-    errorName=Credit Card Number Invalid
-    errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
+    <<-XML
+      <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+      <txn>
+        <errorCode>5000</errorCode>
+        <errorName>Credit Card Number Invalid</errorName>
+        <errorMessage>The Credit Card Number supplied in the authorization request appears to be invalid.</errorMessage>
+      </txn>
+    XML
   end
 
   def successful_update_response
-    "ssl_token=7595301425001111
-    ssl_card_type=VISA
-    ssl_card_number=************1111
-    ssl_exp_date=1015
-    ssl_company=
-    ssl_customer_id=
-    ssl_first_name=John
-    ssl_last_name=Doe
-    ssl_avs_address=
-    ssl_address2=
-    ssl_avs_zip=
-    ssl_city=
-    ssl_state=
-    ssl_country=
-    ssl_phone=
-    ssl_email=
-    ssl_description=
-    ssl_user_id=webpage
-    ssl_token_response=SUCCESS
-    ssl_result=0"
+    <<-XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <txn>
+        <ssl_token>4421912014039990</ssl_token>
+        <ssl_card_type>VISA</ssl_card_type>
+        <ssl_card_number>************9990</ssl_card_number>
+        <ssl_exp_date>1021</ssl_exp_date>
+        <ssl_company>Widgets Inc</ssl_company>
+        <ssl_customer_id></ssl_customer_id>
+        <ssl_first_name>Longbob</ssl_first_name>
+        <ssl_last_name>Longsen</ssl_last_name>
+        <ssl_avs_address>456 My Street</ssl_avs_address>
+        <ssl_address2>Apt 1</ssl_address2>
+        <ssl_city>Ottawa</ssl_city>
+        <ssl_state>ON</ssl_state>
+        <ssl_avs_zip>K1C2N6</ssl_avs_zip>
+        <ssl_country>CA</ssl_country>
+        <ssl_phone>(555)555-5555</ssl_phone>
+        <ssl_email>paul@domain.com</ssl_email>
+        <ssl_description></ssl_description>
+        <ssl_user_id>webpage</ssl_user_id>
+        <ssl_token_response>SUCCESS</ssl_token_response>
+        <ssl_result>0</ssl_result>
+      </txn>
+    XML
   end
 
   def failed_update_response
-    "errorCode=5000
-    errorName=Credit Card Number Invalid
-    errorMessage=The Credit Card Number supplied in the authorization request appears to be invalid."
+    <<-XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <txn>
+        <ssl_token>4421912014039990</ssl_token>
+        <ssl_card_type>VISA</ssl_card_type>
+        <ssl_card_number>************9990</ssl_card_number>
+        <ssl_exp_date>1021</ssl_exp_date>
+        <ssl_company>Widgets Inc</ssl_company>
+        <ssl_customer_id></ssl_customer_id>
+        <ssl_first_name>Longbob</ssl_first_name>
+        <ssl_last_name>Longsen</ssl_last_name>
+        <ssl_avs_address>456 My Street</ssl_avs_address>
+        <ssl_address2>Apt 1</ssl_address2>
+        <ssl_city>Ottawa</ssl_city>
+        <ssl_state>ON</ssl_state>
+        <ssl_avs_zip>K1C2N6</ssl_avs_zip>
+        <ssl_country>CA</ssl_country>
+        <ssl_phone>(555)555-5555</ssl_phone>
+        <ssl_email>paul@domain.com</ssl_email>
+        <ssl_description></ssl_description>
+        <ssl_user_id>apiuser</ssl_user_id>
+        <ssl_token_response>Failed</ssl_token_response>
+        <ssl_result>1</ssl_result>
+      </txn>
+    XML
   end
 
   def pre_scrub
@@ -672,35 +893,38 @@ opening connection to api.demo.convergepay.com:443...
 opened
 starting SSL for api.demo.convergepay.com:443...
 SSL established
-<- "POST /VirtualMerchantDemo/process.do HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.demo.convergepay.com\r\nContent-Length: 616\r\n\r\n"
-<- "ssl_merchant_id=000127&ssl_pin=IERAOBEE5V0D6Q3Q6R51TG89XAIVGEQ3LGLKMKCKCVQBGGGAU7FN627GPA54P5HR&ssl_show_form=false&ssl_result_format=ASCII&ssl_user_id=ssltest&ssl_invoice_number=&ssl_description=Test+Transaction&ssl_card_number=4124939999999990&ssl_exp_date=0919&ssl_cvv2cvc2=123&ssl_cvv2cvc2_indicator=1&ssl_first_name=Longbob&ssl_last_name=Longsen&ssl_avs_address=456+My+Street&ssl_address2=Apt+1&ssl_avs_zip=K1C2N6&ssl_city=Ottawa&ssl_state=ON&ssl_company=Widgets+Inc&ssl_phone=%28555%29555-5555&ssl_country=CA&ssl_email=paul%40domain.com&ssl_cardholder_ip=203.0.113.0&ssl_amount=1.00&ssl_transaction_type=CCSALE"
+<- "POST /VirtualMerchantDemo/processxml.do HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/xml\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: api.demo.convergepay.com\r\nContent-Length: 1026\r\n\r\n"
+<- "xmldata=<txn>\n  <ssl_merchant_id>2020701</ssl_merchant_id>\n  <ssl_user_id>apiuser</ssl_user_id>\n  <ssl_pin>ULV2VQJXA5UR19KFXZ8TUWEFWMFY5MYXJVVOS8JN69EWV8XTN8Y0HYCR8B11DIUU</ssl_pin>\n  <ssl_transaction_type>CCSALE</ssl_transaction_type>\n  <ssl_amount>100</ssl_amount>\n  <ssl_card_number>4124939999999990</ssl_card_number>\n  <ssl_exp_date>0921</ssl_exp_date>\n  <ssl_cvv2cvc2>123</ssl_cvv2cvc2>\n  <ssl_cvv2cvc2_indicator>1</ssl_cvv2cvc2_indicator>\n  <ssl_first_name>Longbob</ssl_first_name>\n  <ssl_last_name>Longsen</ssl_last_name>\n  <ssl_invoice_number/>\n  <ssl_description>Test Transaction</ssl_description>\n  <ssl_avs_address>456 My Street</ssl_avs_address>\n  <ssl_address2>Apt 1</ssl_address2>\n  <ssl_avs_zip>K1C2N6</ssl_avs_zip>\n  <ssl_city>Ottawa</ssl_city>\n  <ssl_state>ON</ssl_state>\n  <ssl_company>Widgets Inc</ssl_company>\n  <ssl_phone>(555)555-5555</ssl_phone>\n  <ssl_country>CA</ssl_country>\n  <ssl_email>paul@domain.com</ssl_email>\n  <ssl_merchant_initiated_unscheduled>N</ssl_merchant_initiated_unscheduled>\n</txn>\n"
 -> "HTTP/1.1 200 OK\r\n"
--> "Date: Wed, 03 Jan 2018 21:40:26 GMT\r\n"
--> "Pragma: no-cache\r\n"
--> "Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\n"
+-> "Date: Tue, 15 Sep 2020 23:09:31 GMT\r\n"
+-> "Server: Apache\r\n"
+-> "X-Frame-Options: SAMEORIGIN\r\n"
+-> "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload\r\n"
 -> "Expires: 0\r\n"
--> "Content-Disposition: inline; filename=response.txt\r\n"
+-> "Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\n"
 -> "AuthApproved: true\r\n"
+-> "Pragma: no-cache\r\n"
+-> "X-Frame-Options: SAMEORIGIN\r\n"
+-> "Content-Security-Policy: frame-ancestors 'self'\r\n"
+-> "Content-Disposition: inline; filename=response.xml\r\n"
+-> "CPID: ED4-dff741a6-df1a-463c-920e-2e4842eda7bf\r\n"
 -> "AuthResponse: AA\r\n"
--> "Set-Cookie: JSESSIONID=00007wKfJV3-JFME8QiC_RCDjuI:14j4qkv92; HTTPOnly; Path=/; Secure\r\n"
--> "Set-Cookie: JSESSIONID=0000uW6woWZ84eAJunhFLfJz8hS:14j4qkv92; HTTPOnly; Path=/; Secure\r\n"
+-> "Content-Type: text/xml\r\n"
+-> "Set-Cookie: JSESSIONID=UtM16S1VJSFsHChVlcYvM0cGVDWHMW1XD0vZ5T47.svplknxcnvrgdapp02; path=/VirtualMerchantDemo; secure; HttpOnly\r\n"
 -> "Connection: close\r\n"
--> "Content-Type: text/plain\r\n"
--> "Content-Language: en-US\r\n"
--> "Content-Encoding: gzip\r\n"
 -> "Transfer-Encoding: chunked\r\n"
 -> "\r\n"
--> "1A5 \r\n"
-reading 421 bytes...
--> "\x1F\x8B\b\x00\x00\x00\x00\x00\x00\x03MR\xEFk\xDB0\x10\xFD\xDE\xBF\xC2\x1F\xB7\x81[\xC9\xB1\x1D\xBB \x98\x7FtP\xD66!+\xDBGs\xB1o\x99\xC0\x96\x84%{q\xFF\xFA\xC9R\x12f\x10\xDC\xBDw\xBEw\xEF8\xAD\xFB\xA6\x85\xB1k\xC44\x1Cqd1\xFDr\xFB\xF2<'w\xDA\x16\xE0Y5\x1D\x18d$\xA7\xB9C`\x90\x930\x8C\xDE\x13_\xA1\xA1Gm\xE0\xCC\\\xC6\xC5,y\x8B\xD7\x9E\x0E\x130\xA0\x8FV9\x1Fu\xA8`4\xD3\x88\xBE\xFB\xDD;WM\xE1;\xFBJ9\xA8\x1E\r\x97\xE2Rp\x05A,\xEC\x17\xEFNht\xF0,Z\x87\xFF\xE6\xA36^\xE6E\x8A\xD3Q\x1E\x1D\xDC\xC3\xFF\xA8F\xE1P\x98u\x03]7\xA2\xD6,N\xD2\xE0u\t~\x98\x11\xD1x\xD63\x11+\x94\t\xA8W\xE5fa;c\xE0/\xB8\xDC\x9A\xB5\x03\xED\xDEn\xDD>\xB8b\xDFi\x15\xBD\xA5\xBE~u1.\xAC*\\\xAA\xFEH\x81\xECS\x92$\x9F\xED\v\xEDK\x1C\x8E\x03\xF0\x9E)\x98\xFA\xAF\x9D\xB4\xB1\xB8\xB7\xF6\x1Cc\a\x98z\xC3\xFCz}\xD2\fv(8!+\xF6\xFB\xC3\xEEg\xF1\xE28s\x16\r\xEF\x18\xD9\x10J\xB3\x82&!\xA9\xD3:O\xF3*|\x8A\xEA2\x8C\xB34\t\xB3o\xDB$,\xD3\xA2,\xB3tC\xB7E\xE9\xFE\x04\xA5F9\xC3:l\x87,\xDEnI\x1C9\xA2\x9D\xE7h\xD5TR\xE8\xCB\xD6W\x8B7\xE4\xE2\xBAu&\x9B#\xF4 Z{\x1C\xD7cX'2\xDCn\x9C\xD0\a\xB2y\x88\b\xCD\x02\x12?\xC6\xE41\xDA\x06\xFBW/\xB1\xDE\x9CY\x14\xB2\xEA\xF0T?\xBFW\xC5\xA1\xFE\aC\x85\x1DS\x8C\x02\x00\x00"
-read 421 bytes
+-> "44b\r\n"
+reading 1099 bytes...
+-> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<txn><ssl_issuer_response>00</ssl_issuer_response><ssl_transaction_type>SALE</ssl_transaction_type><ssl_card_number>41**********9990</ssl_card_number><ssl_departure_date></ssl_departure_date><ssl_oar_data>010012344309152309280000047554200000000000259849025923123443</ssl_oar_data><ssl_result>0</ssl_result><ssl_txn_id>150920ED4-48E1CA31-F2C5-411B-9543-AEA81EFB81B9</ssl_txn_id><ssl_avs_response>M</ssl_avs_response><ssl_approval_code>259849</ssl_approval_code><ssl_salestax></ssl_salestax><ssl_amount>100.00</ssl_amount><ssl_txn_time>09/15/2020 07:09:28 PM</ssl_txn_time><ssl_account_balance>0.00</ssl_account_balance><ssl_ps2000_data>A9151909286574590030VE</ssl_ps2000_data><ssl_exp_date>0921</ssl_exp_date><ssl_result_message>APPROVAL</ssl_result_message><ssl_card_short_description>VISA</ssl_card_short_description><ssl_completion_date></ssl_completion_date><ssl_eci_ind>3</ssl_eci_ind><ssl_card_type>CREDITCARD</ssl_card_type><ssl_invoice_number></ssl_invoice_number><ssl_cvv2_response>M</ssl_cvv2_response><ssl_partner_app_id>01</ssl_partner_app_id></txn>"
+read 1099 bytes
 reading 2 bytes...
 -> "\r\n"
 read 2 bytes
 -> "0\r\n"
 -> "\r\n"
 Conn close
-}}
+  }
   end
 
   def post_scrub
@@ -709,34 +933,37 @@ opening connection to api.demo.convergepay.com:443...
 opened
 starting SSL for api.demo.convergepay.com:443...
 SSL established
-<- "POST /VirtualMerchantDemo/process.do HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.demo.convergepay.com\r\nContent-Length: 616\r\n\r\n"
-<- "ssl_merchant_id=000127&ssl_pin=[FILTERED]&ssl_show_form=false&ssl_result_format=ASCII&ssl_user_id=ssltest&ssl_invoice_number=&ssl_description=Test+Transaction&ssl_card_number=[FILTERED]&ssl_exp_date=0919&ssl_cvv2cvc2=[FILTERED]&ssl_cvv2cvc2_indicator=1&ssl_first_name=Longbob&ssl_last_name=Longsen&ssl_avs_address=456+My+Street&ssl_address2=Apt+1&ssl_avs_zip=K1C2N6&ssl_city=Ottawa&ssl_state=ON&ssl_company=Widgets+Inc&ssl_phone=%28555%29555-5555&ssl_country=CA&ssl_email=paul%40domain.com&ssl_cardholder_ip=203.0.113.0&ssl_amount=1.00&ssl_transaction_type=CCSALE"
+<- "POST /VirtualMerchantDemo/processxml.do HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/xml\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: api.demo.convergepay.com\r\nContent-Length: 1026\r\n\r\n"
+<- "xmldata=<txn>\n  <ssl_merchant_id>2020701</ssl_merchant_id>\n  <ssl_user_id>apiuser</ssl_user_id>\n  <ssl_pin>[FILTERED]</ssl_pin>\n  <ssl_transaction_type>CCSALE</ssl_transaction_type>\n  <ssl_amount>100</ssl_amount>\n  <ssl_card_number>[FILTERED]</ssl_card_number>\n  <ssl_exp_date>0921</ssl_exp_date>\n  <ssl_cvv2cvc2>[FILTERED]</ssl_cvv2cvc2>\n  <ssl_cvv2cvc2_indicator>1</ssl_cvv2cvc2_indicator>\n  <ssl_first_name>Longbob</ssl_first_name>\n  <ssl_last_name>Longsen</ssl_last_name>\n  <ssl_invoice_number/>\n  <ssl_description>Test Transaction</ssl_description>\n  <ssl_avs_address>456 My Street</ssl_avs_address>\n  <ssl_address2>Apt 1</ssl_address2>\n  <ssl_avs_zip>K1C2N6</ssl_avs_zip>\n  <ssl_city>Ottawa</ssl_city>\n  <ssl_state>ON</ssl_state>\n  <ssl_company>Widgets Inc</ssl_company>\n  <ssl_phone>(555)555-5555</ssl_phone>\n  <ssl_country>CA</ssl_country>\n  <ssl_email>paul@domain.com</ssl_email>\n  <ssl_merchant_initiated_unscheduled>N</ssl_merchant_initiated_unscheduled>\n</txn>\n"
 -> "HTTP/1.1 200 OK\r\n"
--> "Date: Wed, 03 Jan 2018 21:40:26 GMT\r\n"
--> "Pragma: no-cache\r\n"
--> "Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\n"
+-> "Date: Tue, 15 Sep 2020 23:09:31 GMT\r\n"
+-> "Server: Apache\r\n"
+-> "X-Frame-Options: SAMEORIGIN\r\n"
+-> "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload\r\n"
 -> "Expires: 0\r\n"
--> "Content-Disposition: inline; filename=response.txt\r\n"
+-> "Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\n"
 -> "AuthApproved: true\r\n"
+-> "Pragma: no-cache\r\n"
+-> "X-Frame-Options: SAMEORIGIN\r\n"
+-> "Content-Security-Policy: frame-ancestors 'self'\r\n"
+-> "Content-Disposition: inline; filename=response.xml\r\n"
+-> "CPID: ED4-dff741a6-df1a-463c-920e-2e4842eda7bf\r\n"
 -> "AuthResponse: AA\r\n"
--> "Set-Cookie: JSESSIONID=00007wKfJV3-JFME8QiC_RCDjuI:14j4qkv92; HTTPOnly; Path=/; Secure\r\n"
--> "Set-Cookie: JSESSIONID=0000uW6woWZ84eAJunhFLfJz8hS:14j4qkv92; HTTPOnly; Path=/; Secure\r\n"
+-> "Content-Type: text/xml\r\n"
+-> "Set-Cookie: JSESSIONID=UtM16S1VJSFsHChVlcYvM0cGVDWHMW1XD0vZ5T47.svplknxcnvrgdapp02; path=/VirtualMerchantDemo; secure; HttpOnly\r\n"
 -> "Connection: close\r\n"
--> "Content-Type: text/plain\r\n"
--> "Content-Language: en-US\r\n"
--> "Content-Encoding: gzip\r\n"
 -> "Transfer-Encoding: chunked\r\n"
 -> "\r\n"
--> "1A5 \r\n"
-reading 421 bytes...
--> "\x1F\x8B\b\x00\x00\x00\x00\x00\x00\x03MR\xEFk\xDB0\x10\xFD\xDE\xBF\xC2\x1F\xB7\x81[\xC9\xB1\x1D\xBB \x98\x7FtP\xD66!+\xDBGs\xB1o\x99\xC0\x96\x84%{q\xFF\xFA\xC9R\x12f\x10\xDC\xBDw\xBEw\xEF8\xAD\xFB\xA6\x85\xB1k\xC44\x1Cqd1\xFDr\xFB\xF2<'w\xDA\x16\xE0Y5\x1D\x18d$\xA7\xB9C`\x90\x930\x8C\xDE\x13_\xA1\xA1Gm\xE0\xCC\\\xC6\xC5,y\x8B\xD7\x9E\x0E\x130\xA0\x8FV9\x1Fu\xA8`4\xD3\x88\xBE\xFB\xDD;WM\xE1;\xFBJ9\xA8\x1E\r\x97\xE2Rp\x05A,\xEC\x17\xEFNht\xF0,Z\x87\xFF\xE6\xA36^\xE6E\x8A\xD3Q\x1E\x1D\xDC\xC3\xFF\xA8F\xE1P\x98u\x03]7\xA2\xD6,N\xD2\xE0u\t~\x98\x11\xD1x\xD63\x11+\x94\t\xA8W\xE5fa;c\xE0/\xB8\xDC\x9A\xB5\x03\xED\xDEn\xDD>\xB8b\xDFi\x15\xBD\xA5\xBE~u1.\xAC*\\\xAA\xFEH\x81\xECS\x92$\x9F\xED\v\xEDK\x1C\x8E\x03\xF0\x9E)\x98\xFA\xAF\x9D\xB4\xB1\xB8\xB7\xF6\x1Cc\a\x98z\xC3\xFCz}\xD2\fv(8!+\xF6\xFB\xC3\xEEg\xF1\xE28s\x16\r\xEF\x18\xD9\x10J\xB3\x82&!\xA9\xD3:O\xF3*|\x8A\xEA2\x8C\xB34\t\xB3o\xDB$,\xD3\xA2,\xB3tC\xB7E\xE9\xFE\x04\xA5F9\xC3:l\x87,\xDEnI\x1C9\xA2\x9D\xE7h\xD5TR\xE8\xCB\xD6W\x8B7\xE4\xE2\xBAu&\x9B#\xF4 Z{\x1C\xD7cX'2\xDCn\x9C\xD0\a\xB2y\x88\b\xCD\x02\x12?\xC6\xE41\xDA\x06\xFBW/\xB1\xDE\x9CY\x14\xB2\xEA\xF0T?\xBFW\xC5\xA1\xFE\aC\x85\x1DS\x8C\x02\x00\x00"
-read 421 bytes
+-> "44b\r\n"
+reading 1099 bytes...
+-> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<txn><ssl_issuer_response>00</ssl_issuer_response><ssl_transaction_type>SALE</ssl_transaction_type><ssl_card_number>[FILTERED]</ssl_card_number><ssl_departure_date></ssl_departure_date><ssl_oar_data>010012344309152309280000047554200000000000259849025923123443</ssl_oar_data><ssl_result>0</ssl_result><ssl_txn_id>150920ED4-48E1CA31-F2C5-411B-9543-AEA81EFB81B9</ssl_txn_id><ssl_avs_response>M</ssl_avs_response><ssl_approval_code>259849</ssl_approval_code><ssl_salestax></ssl_salestax><ssl_amount>100.00</ssl_amount><ssl_txn_time>09/15/2020 07:09:28 PM</ssl_txn_time><ssl_account_balance>0.00</ssl_account_balance><ssl_ps2000_data>A9151909286574590030VE</ssl_ps2000_data><ssl_exp_date>0921</ssl_exp_date><ssl_result_message>APPROVAL</ssl_result_message><ssl_card_short_description>VISA</ssl_card_short_description><ssl_completion_date></ssl_completion_date><ssl_eci_ind>3</ssl_eci_ind><ssl_card_type>CREDITCARD</ssl_card_type><ssl_invoice_number></ssl_invoice_number><ssl_cvv2_response>M</ssl_cvv2_response><ssl_partner_app_id>01</ssl_partner_app_id></txn>"
+read 1099 bytes
 reading 2 bytes...
 -> "\r\n"
 read 2 bytes
 -> "0\r\n"
 -> "\r\n"
 Conn close
-}}
+  }
   end
 end


### PR DESCRIPTION
Elavon has deprecated the old `process.do` endpoint; to be able to display passed L3 fields in Elavon's UI, the new `processxml.do` endpoint must be used. 

`process.do` passed and received data as a string of parameters; `processxml.do` passes a querystring-formatted block of XML in the request body.