### PR TITLE
Decidir: Add csmdds gsf for fraud detection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@
 * NMI: Add standardized 3DS fields [meagabeth] #3775
 * Mundipagg: Add support for SubMerchant fields [meagabeth] #3779
 * Stripe Payment Intents: Add request_three_d_secure option [molbrown] #3787
+* Decidir: Add support for csmdds fields [naashton] #3786
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -209,6 +209,7 @@ module ActiveMerchant #:nodoc:
           hsh[:send_to_cs] = options[:send_to_cs] if valid_fraud_detection_option?(options[:send_to_cs]) # true/false
           hsh[:channel] = options[:channel] if valid_fraud_detection_option?(options[:channel])
           hsh[:dispatch_method] = options[:dispatch_method] if valid_fraud_detection_option?(options[:dispatch_method])
+          hsh[:csmdds] = options[:csmdds] if valid_fraud_detection_option?(options[:csmdds])
         end
       end
 

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -77,7 +77,13 @@ class RemoteDecidirTest < Test::Unit::TestCase
       fraud_detection: {
         send_to_cs: false,
         channel: 'Web',
-        dispatch_method: 'Store Pick Up'
+        dispatch_method: 'Store Pick Up',
+        csmdds: [
+          {
+            code: 17,
+            description: 'Campo MDD17'
+          }
+        ]
       },
       installments: '12',
       site_id: '99999999'
@@ -90,6 +96,27 @@ class RemoteDecidirTest < Test::Unit::TestCase
     assert_equal '99999999', response.params['site_id']
     assert_equal({'status' => nil}, response.params['fraud_detection'])
     assert response.authorization
+  end
+
+  def test_failed_purchase_with_bad_csmdds
+    options = {
+      fraud_detection: {
+        send_to_cs: false,
+        channel: 'Web',
+        dispatch_method: 'Store Pick Up',
+        csmdds: [
+          {
+            codee: 17,
+            descriptione: 'Campo MDD17'
+          }
+        ]
+      }
+    }
+
+    response = @gateway_for_purchase.purchase(@amount, credit_card('4509790112684851'), @options.merge(options))
+    assert_failure response
+    assert_equal 'param_required: fraud_detection.csmdds.[0].code, param_required: fraud_detection.csmdds.[0].description', response.message
+    assert_equal(nil, response.params['fraud_detection'])
   end
 
   def test_failed_purchase

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -39,7 +39,13 @@ class DecidirTest < Test::Unit::TestCase
       fraud_detection: {
         send_to_cs: false,
         channel: 'Web',
-        dispatch_method: 'Store Pick Up'
+        dispatch_method: 'Store Pick Up',
+        csmdds: [
+          {
+            code: 17,
+            description: 'Campo MDD17'
+          }
+        ]
       },
       installments: 12,
       site_id: '99999999'
@@ -54,7 +60,7 @@ class DecidirTest < Test::Unit::TestCase
       assert data =~ /"number":"123456"/
       assert data =~ /"establishment_name":"Heavenly Buffaloes"/
       assert data =~ /"site_id":"99999999"/
-      assert data =~ /"fraud_detection":{"send_to_cs":false,"channel":"Web","dispatch_method":"Store Pick Up"}/
+      assert data =~ /"fraud_detection":{"send_to_cs":false,"channel":"Web","dispatch_method":"Store Pick Up","csmdds":\[{"code":17,"description":"Campo MDD17"}\]}/
     end.respond_with(successful_purchase_response)
 
     assert_equal 7719132, response.authorization


### PR DESCRIPTION
Allow for csmdds array to be passed to fraud detection

CE-1048

Unit: 34 tests, 165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 22 tests, 77 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90.9091% passed