### PR TITLE
Stripe Payment Intents: Add request_three_d_secure option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@
 * RuboCop: Fix Layout/MultilineMethodCallBraceLayout [leila-alderman] #3763
 * NMI: Add standardized 3DS fields [meagabeth] #3775
 * Mundipagg: Add support for SubMerchant fields [meagabeth] #3779
+* Stripe Payment Intents: Add request_three_d_secure option [molbrown] #3787
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -29,6 +29,7 @@ module ActiveMerchant #:nodoc:
         add_shipping_address(post, options)
         setup_future_usage(post, options)
         add_exemption(post, options)
+        request_three_d_secure(post, options)
 
         CREATE_INTENT_ATTRIBUTES.each do |attribute|
           add_whitelisted_attribute(post, options, attribute)
@@ -265,6 +266,14 @@ module ActiveMerchant #:nodoc:
         post[:payment_method_options] ||= {}
         post[:payment_method_options][:card] ||= {}
         post[:payment_method_options][:card][:moto] = true if options[:moto]
+      end
+
+      def request_three_d_secure(post, options = {})
+        return unless options[:request_three_d_secure] && %w(any automatic).include?(options[:request_three_d_secure])
+
+        post[:payment_method_options] ||= {}
+        post[:payment_method_options][:card] ||= {}
+        post[:payment_method_options][:card][:request_three_d_secure] = options[:request_three_d_secure]
       end
 
       def setup_future_usage(post, options = {})

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -13,11 +13,15 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     @three_ds_credit_card = credit_card('4000000000003220',
       verification_value: '737',
       month: 10,
-      year: 2020)
+      year: 2021)
+    @three_ds_not_required_card = credit_card('4000000000003055',
+      verification_value: '737',
+      month: 10,
+      year: 2021)
     @visa_card = credit_card('4242424242424242',
       verification_value: '737',
       month: 10,
-      year: 2020)
+      year: 2021)
     @destination_account = fixtures(:stripe_destination)[:stripe_user_id]
   end
 
@@ -640,6 +644,21 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
 
     assert_failure purchase
     assert_equal 'Your card was declined. This transaction requires authentication.', purchase.message
+  end
+
+  def test_request_three_d_secure
+    options = {
+      currency: 'GBP',
+      request_three_d_secure: 'any'
+    }
+    assert purchase = @gateway.purchase(@amount, @three_ds_not_required_card, options)
+    assert_equal 'requires_action', purchase.params['status']
+
+    options = {
+      currency: 'GBP'
+    }
+    assert purchase = @gateway.purchase(@amount, @three_ds_not_required_card, options)
+    assert_equal 'succeeded', purchase.params['status']
   end
 
   def test_transcript_scrubbing

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -85,6 +85,35 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_create_intent_response)
   end
 
+  def test_request_three_d_secure
+    request_three_d_secure = 'any'
+    options = @options.merge(request_three_d_secure: request_three_d_secure)
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_intent(@amount, @visa_token, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/\[request_three_d_secure\]=any/, data)
+    end.respond_with(successful_request_three_d_secure_response)
+
+    request_three_d_secure = 'automatic'
+    options = @options.merge(request_three_d_secure: request_three_d_secure)
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_intent(@amount, @visa_token, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/\[request_three_d_secure\]=automatic/, data)
+    end.respond_with(successful_request_three_d_secure_response)
+
+    request_three_d_secure = true
+    options = @options.merge(request_three_d_secure: request_three_d_secure)
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_intent(@amount, @visa_token, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      refute_match(/\[request_three_d_secure\]/, data)
+    end.respond_with(successful_request_three_d_secure_response)
+  end
+
   def test_failed_capture_after_creation
     @gateway.expects(:ssl_request).returns(failed_capture_response)
 
@@ -347,6 +376,131 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
           "transfer_data": null,
           "transfer_group": null
         }
+    RESPONSE
+  end
+
+  def successful_request_three_d_secure_response
+    <<-RESPONSE
+    {"id"=>"pi_1HZJGPAWOtgoysogrKURP11Q",
+      "object"=>"payment_intent",
+      "amount"=>2000,
+      "amount_capturable"=>0,
+      "amount_received"=>2000,
+      "application"=>nil,
+      "application_fee_amount"=>nil,
+      "canceled_at"=>nil,
+      "cancellation_reason"=>nil,
+      "capture_method"=>"automatic",
+      "charges"=>
+       {"object"=>"list",
+        "data"=>
+         [{"id"=>"ch_1HZJGQAWOtgoysogEpbZTGIl",
+           "object"=>"charge",
+           "amount"=>2000,
+           "amount_captured"=>2000,
+           "amount_refunded"=>0,
+           "application"=>nil,
+           "application_fee"=>nil,
+           "application_fee_amount"=>nil,
+           "balance_transaction"=>"txn_1HZJGQAWOtgoysogEKwV2r5N",
+           "billing_details"=>
+            {"address"=>{"city"=>nil, "country"=>nil, "line1"=>nil, "line2"=>nil, "postal_code"=>nil, "state"=>nil}, "email"=>nil, "name"=>nil, "phone"=>nil},
+           "calculated_statement_descriptor"=>"SPREEDLY",
+           "captured"=>true,
+           "created"=>1602002626,
+           "currency"=>"gbp",
+           "customer"=>nil,
+           "description"=>nil,
+           "destination"=>nil,
+           "dispute"=>nil,
+           "disputed"=>false,
+           "failure_code"=>nil,
+           "failure_message"=>nil,
+           "fraud_details"=>{},
+           "invoice"=>nil,
+           "livemode"=>false,
+           "metadata"=>{},
+           "on_behalf_of"=>nil,
+           "order"=>nil,
+           "outcome"=>
+            {"network_status"=>"approved_by_network",
+             "reason"=>nil,
+             "risk_level"=>"normal",
+             "risk_score"=>16,
+             "seller_message"=>"Payment complete.",
+             "type"=>"authorized"},
+           "paid"=>true,
+           "payment_intent"=>"pi_1HZJGPAWOtgoysogrKURP11Q",
+           "payment_method"=>"pm_1HZJGOAWOtgoysogvnMsnnG1",
+           "payment_method_details"=>
+            {"card"=>
+              {"brand"=>"visa",
+               "checks"=>{"address_line1_check"=>nil, "address_postal_code_check"=>nil, "cvc_check"=>"pass"},
+               "country"=>"US",
+               "ds_transaction_id"=>nil,
+               "exp_month"=>10,
+               "exp_year"=>2020,
+               "fingerprint"=>"hfaVNMiXc0dYSiC5",
+               "funding"=>"credit",
+               "installments"=>nil,
+               "last4"=>"4242",
+               "moto"=>nil,
+               "network"=>"visa",
+               "network_transaction_id"=>"1041029786787710",
+               "three_d_secure"=>
+                {"authenticated"=>false,
+                 "authentication_flow"=>nil,
+                 "electronic_commerce_indicator"=>"06",
+                 "result"=>"attempt_acknowledged",
+                 "result_reason"=>nil,
+                 "succeeded"=>true,
+                 "transaction_id"=>"d1VlRVF6a1BVNXN1cjMzZVl0RU0=",
+                 "version"=>"1.0.2"},
+               "wallet"=>nil},
+             "type"=>"card"},
+           "receipt_email"=>nil,
+           "receipt_number"=>nil,
+           "receipt_url"=>"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1HZJGQAWOtgoysogEpbZTGIl/rcpt_I9cVpN9xAeS39FhMqTS33Fj8gHsjjuX",
+           "refunded"=>false,
+           "refunds"=>{"object"=>"list", "data"=>[], "has_more"=>false, "total_count"=>0, "url"=>"/v1/charges/ch_1HZJGQAWOtgoysogEpbZTGIl/refunds"},
+           "review"=>nil,
+           "shipping"=>nil,
+           "source"=>nil,
+           "source_transfer"=>nil,
+           "statement_descriptor"=>nil,
+           "statement_descriptor_suffix"=>nil,
+           "status"=>"succeeded",
+           "transfer_data"=>nil,
+           "transfer_group"=>nil}],
+        "has_more"=>false,
+        "total_count"=>1,
+        "url"=>"/v1/charges?payment_intent=pi_1HZJGPAWOtgoysogrKURP11Q"},
+      "client_secret"=>"pi_1HZJGPAWOtgoysogrKURP11Q_secret_dJNY00dYXC22Fc9nPscAmhFMt",
+      "confirmation_method"=>"automatic",
+      "created"=>1602002625,
+      "currency"=>"gbp",
+      "customer"=>nil,
+      "description"=>nil,
+      "invoice"=>nil,
+      "last_payment_error"=>nil,
+      "livemode"=>false,
+      "metadata"=>{},
+      "next_action"=>nil,
+      "on_behalf_of"=>nil,
+      "payment_method"=>"pm_1HZJGOAWOtgoysogvnMsnnG1",
+      "payment_method_options"=>{"card"=>{"installments"=>nil, "network"=>nil, "request_three_d_secure"=>"any"}},
+      "payment_method_types"=>["card"],
+      "receipt_email"=>nil,
+      "review"=>nil,
+      "setup_future_usage"=>nil,
+      "shipping"=>nil,
+      "source"=>nil,
+      "statement_descriptor"=>nil,
+      "statement_descriptor_suffix"=>nil,
+      "status"=>"succeeded",
+      "transfer_data"=>nil,
+      "transfer_group"=>nil
+      }
     RESPONSE
   end
 


### PR DESCRIPTION
Enable override of Stripe's SCA engine and directly request 3DS using
the request_three_d_secure option. When 3DS is not supported for the
card being charged, liability is still shifted, as indicated by the
'attempt_acknowledged' response in
`payment_method_details.three_d_secure.result`.

Details of field use: https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_options-card-request_three_d_secure

3DS Result values: https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card-three_d_secure-result

Unit:
14 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
42 tests, 192 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-1455