### PR TITLE
Checkout V2: Support ability to pass attempt_n3d 3ds field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@
 * BlueSnap: Add address fields to contact info [naashton] #3777
 * RuboCop: Fix Layout/SpaceInsideHashLiteralBraces [leila-alderman] #3780
 * RuboCop: Fix Style/AndOr [leila-alderman] #3783
+* Checkout V2: Support ability to pass attempt_n3d 3ds field [naashton] #3788
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -151,6 +151,7 @@ module ActiveMerchant #:nodoc:
           post[:'3ds'][:cryptogram] = options[:three_d_secure][:cavv] if options[:three_d_secure][:cavv]
           post[:'3ds'][:version] = options[:three_d_secure][:version] if options[:three_d_secure][:version]
           post[:'3ds'][:xid] = options[:three_d_secure][:ds_transaction_id] || options[:three_d_secure][:xid]
+          post[:'3ds'][:attempt_n3d] = options[:three_d_secure][:attempt_n3d] if options[:three_d_secure][:attempt_n3d]
         end
       end
 

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -43,7 +43,8 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
         version: '2.0.0',
         eci: '06',
         cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
-        ds_transaction_id: 'MDAwMDAwMDAwMDAwMDAwMzIyNzY='
+        ds_transaction_id: 'MDAwMDAwMDAwMDAwMDAwMzIyNzY=',
+        attempt_n3d: true
       }
     )
   end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -180,7 +180,8 @@ class CheckoutV2Test < Test::Unit::TestCase
           version: '1.0.2',
           eci: '05',
           cryptogram: '1234',
-          xid: '1234'
+          xid: '1234',
+          attempt_n3d: true
         }
       }
       @gateway.authorize(@amount, @credit_card, options)


### PR DESCRIPTION
Give the option to pass attempt_n3d which will attempt non-3d secure if
the card issure is not enrolled

CE-1080

Unit: 29 tests, 129 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 33 tests, 83 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed