### PR TITLE
Checkout V2: Support for attempt_n3d 3DS field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * RuboCop: Fix Style/AndOr [leila-alderman] #3783
 * Checkout V2: Support ability to pass attempt_n3d 3ds field [naashton] #3788
 * Elavon: Upgrade to `processxml.do` [therufs] #3784
+* Checkout V2: Support for attempt_n3d 3DS field [naashton] #3790
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -151,7 +151,7 @@ module ActiveMerchant #:nodoc:
           post[:'3ds'][:cryptogram] = options[:three_d_secure][:cavv] if options[:three_d_secure][:cavv]
           post[:'3ds'][:version] = options[:three_d_secure][:version] if options[:three_d_secure][:version]
           post[:'3ds'][:xid] = options[:three_d_secure][:ds_transaction_id] || options[:three_d_secure][:xid]
-          post[:'3ds'][:attempt_n3d] = options[:three_d_secure][:attempt_n3d] if options[:three_d_secure][:attempt_n3d]
+          post[:'3ds'][:attempt_n3d] = options[:attempt_n3d] if options[:attempt_n3d]
         end
       end
 

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -39,12 +39,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     )
     @additional_options_3ds2 = @options.merge(
       execute_threed: true,
+      attempt_n3d: true,
       three_d_secure: {
         version: '2.0.0',
         eci: '06',
         cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
-        ds_transaction_id: 'MDAwMDAwMDAwMDAwMDAwMzIyNzY=',
-        attempt_n3d: true
+        ds_transaction_id: 'MDAwMDAwMDAwMDAwMDAwMzIyNzY='
       }
     )
   end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -176,12 +176,12 @@ class CheckoutV2Test < Test::Unit::TestCase
     response = stub_comms do
       options = {
         execute_threed: true,
+        attempt_n3d: true,
         three_d_secure: {
           version: '1.0.2',
           eci: '05',
           cryptogram: '1234',
-          xid: '1234',
-          attempt_n3d: true
+          xid: '1234'
         }
       }
       @gateway.authorize(@amount, @credit_card, options)


### PR DESCRIPTION
This updates the support for the attempt_n3d field when it is passed
outside of the three_d_secure context

CE-1080

Unit: 29 tests, 129 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 33 tests, 83 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed