### PR TITLE
Spreedly<>Credorax: Support for AMEX & error code '1A' 

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -25,7 +25,7 @@ module ActiveMerchant #:nodoc:
       self.currencies_with_three_decimal_places = %w(BHD IQD JOD KWD LYD OMR TND)
 
       self.money_format = :cents
-      self.supported_cardtypes = %i[visa master maestro]
+      self.supported_cardtypes = %i[visa master maestro american_express]
 
       RESPONSE_MESSAGES = {
         '00' => 'Approved or completed successfully',
@@ -117,7 +117,8 @@ module ActiveMerchant #:nodoc:
         '96' => 'System malfunction',
         'R0' => 'Stop Payment Order',
         'R1' => 'Revocation of Authorisation Order',
-        'R3' => 'Revocation of all Authorisations Order'
+        'R3' => 'Revocation of all Authorisations Order',
+        '1A' => 'Strong Customer Authentication required'
       }
 
       def initialize(options = {})


### PR DESCRIPTION
Issue: https://github.com/activemerchant/active_merchant/issues/3791

## Description of the Issue

Paddle are integrating the Credorax gateway, via Spreedly. We have noted two issues regarding the Credorax gateway integration: 


1. The card type `american_express` is not supported by the activemerchant library. Though AMEX is supported by credorax, so this should be included as a supported card type by activemerchant. 


2. There is an error code missing in the `RESPONSE_MESSAGES` hash, based on the Credorax documentation. See: [Credorax API Docs v1.7](https://epower.credorax.com/wp-content/uploads/2020/10/Credorax-Source-Payment-API-Specifications-v1.7-.pdf) - page 72, `Appendix D`.

The error code missing is as follows: 

```
'1A' => 'Strong Customer Authentication required'
``` 




## What has been done

- Added `american_express` into the `supported_cardtypes` array;
- Added the missing response code: `1A` into the `RESPONSE_MESSAGES` hash.


## Tests

Unit: 69 tests, 329 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed