### PR TITLE
[Cybersource] Use firstname/lastname from the address instead of the payment method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805
 * GlobalCollect: Add support for Third-party 3DS2 data [molbrown] #3801
+* Cybersource: Use firstname/lastname from address instead of the payment method [pi3r] #3798
 
 == Version 1.116.0 (October 28th)
 * Remove Braintree specific version dependency [pi3r] #3800

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -520,9 +520,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(xml, payment_method, address, options, shipTo = false)
+        first_name, last_name = address_names(address[:name], payment_method)
+
         xml.tag! shipTo ? 'shipTo' : 'billTo' do
-          xml.tag! 'firstName',             payment_method.first_name if payment_method
-          xml.tag! 'lastName',              payment_method.last_name if payment_method
+          xml.tag! 'firstName',             first_name if first_name
+          xml.tag! 'lastName',              last_name if last_name
           xml.tag! 'street1',               address[:address1]
           xml.tag! 'street2',               address[:address2] unless address[:address2].blank?
           xml.tag! 'city',                  address[:city]
@@ -537,6 +539,16 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'driversLicenseNumber',  options[:drivers_license_number]  unless options[:drivers_license_number].blank?
           xml.tag! 'driversLicenseState',   options[:drivers_license_state]   unless options[:drivers_license_state].blank?
         end
+      end
+
+      def address_names(address_name, payment_method)
+        names = split_names(address_name)
+        return names if names.any?(&:present?)
+
+        [
+          payment_method&.first_name,
+          payment_method&.last_name
+        ]
       end
 
       def add_creditcard(xml, creditcard)


### PR DESCRIPTION
Some merchants reached out as the firstname/lastname don't match in Cybersource.
This change will use the firstname/lastname from the billing/shipping address instead of
the payment method. We have reached to Cybersource to ensure this is a safe change.

Email I got with Scott Griffiths at Cybersource:
```
Since this code is not owned by Cybersource, but rather an active_merchant opensource repository, we are not sure why the payment method first/last name is persisted to the shipTo and billTo elements.  

Yes, you can safely send the actual shipTo and billTo first and last names to Cybersource.
```