### PR TITLE
Remove Braintree specific version dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem 'rubocop', '~> 0.60.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.98.0'
+  gem 'braintree', '>= 2.98.0', '< 3.0'
   gem 'mechanize'
 end


### PR DESCRIPTION
A new major version of the Braintree gem was released on October 19th (v3.0). Sadly we have this bit of code that ensures that the Braintree gem's version is in an exact range that 3.0 now exceeds.

https://github.com/activemerchant/active_merchant/blob/90be621c434909f3afd5d482870eca53edf7187a/lib/active_merchant/billing/gateways/braintree_blue.rb#L10

Since we install the latest Braintree version on CI this causes the following error:
```
Error: test_address_country_handling(BraintreeBlueTest): RuntimeError: Need braintree gem >= 2.78.0. Run `gem install braintree --version '~>2.78'` to get the correct version.
```
https://travis-ci.org/github/activemerchant/active_merchant/jobs/739300791

I have no idea if this check is still relevant but at this time I do not want to figure it out, I just want CI to pass. On our side we run ActiveMerchant in an environment that has a fixed Braintree version set at `2.98`.