### PR TITLE
GlobalCollect: Add support for Third-party 3DS2 data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,9 +2,10 @@
 
 == HEAD
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805
+* GlobalCollect: Add support for Third-party 3DS2 data [molbrown] #3801
 
 == Version 1.116.0 (October 28th)
-* Remove Braintree specific version dependency [pi3r] #38000
+* Remove Braintree specific version dependency [pi3r] #3800
 
 == Version 1.115.0 (October 27th)
 * Checkout v2: $0 Auth on gateway [jessiagee] #3762

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -32,6 +32,7 @@ module ActiveMerchant #:nodoc:
         add_address(post, payment, options)
         add_creator_info(post, options)
         add_fraud_fields(post, options)
+        add_external_cardholder_authentication_data(post, options)
         commit(:authorize, post)
       end
 
@@ -230,6 +231,24 @@ module ActiveMerchant #:nodoc:
         fraud_fields[:customerIpAddress] = options[:ip] if options[:ip]
 
         post['fraudFields'] = fraud_fields unless fraud_fields.empty?
+      end
+
+      def add_external_cardholder_authentication_data(post, options)
+        return unless threeds_2_options = options[:three_d_secure]
+
+        authentication_data = {}
+        authentication_data[:acsTransactionId] = threeds_2_options[:acs_transaction_id] if threeds_2_options[:acs_transaction_id]
+        authentication_data[:cavv] = threeds_2_options[:cavv] if threeds_2_options[:cavv]
+        authentication_data[:cavvAlgorithm] = threeds_2_options[:cavv_algorithm] if threeds_2_options[:cavv_algorithm]
+        authentication_data[:directoryServerTransactionId] = threeds_2_options[:ds_transaction_id] if threeds_2_options[:ds_transaction_id]
+        authentication_data[:eci] = threeds_2_options[:eci] if threeds_2_options[:eci]
+        authentication_data[:threeDSecureVersion] = threeds_2_options[:version] if threeds_2_options[:version]
+        authentication_data[:validationResult] = threeds_2_options[:authentication_response_status] if threeds_2_options[:authentication_response_status]
+        authentication_data[:xid] = threeds_2_options[:xid] if threeds_2_options[:xid]
+
+        post['cardPaymentMethodSpecificInput'] ||= {}
+        post['cardPaymentMethodSpecificInput']['threeDSecure'] ||= {}
+        post['cardPaymentMethodSpecificInput']['threeDSecure']['externalCardholderAuthenticationData'] = authentication_data unless authentication_data.empty?
       end
 
       def add_number_of_installments(post, options)

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -84,6 +84,26 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
   end
 
+  def test_successful_authorize_via_normalized_3ds2_fields
+    options = @options.merge(
+      three_d_secure: {
+        version: '2.1.0',
+        eci: '05',
+        cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
+        xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC',
+        acs_transaction_id: '13c701a3-5a88-4c45-89e9-ef65e50a8bf9',
+        cavv_algorithm: 1,
+        authentication_response_status: 'Y'
+      }
+    )
+
+    response = @gateway.authorize(@amount, @credit_card, options)
+    assert_success response
+    assert_match 'jJ81HADVRtXfCBATEp01CJUAAAA=', response.params['payment']['paymentOutput']['cardPaymentMethodSpecificOutput']['threeDSecureResults']['cavv']
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_airline_data
     options = @options.merge(
       airline_data: {


### PR DESCRIPTION
Uses standardized three_d_secure data fields to include 3DS2
authenticated data on the Global Collect gateway

Also adds acs_transaction_id to standardized list (change to
contributing wiki pending approval here). This is another common auth
field that has not been required yet, but is fitting for the
standardized fields.

ECS-1435

Unit:
24 tests, 105 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
23 tests, 57 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.6522% passed
One unrelated failure, also failing on master