### PR TITLE
Update openssl require

### DIFF
--- a/lib/active_merchant.rb
+++ b/lib/active_merchant.rb
@@ -42,6 +42,7 @@ require 'cgi'
 require 'rexml/document'
 require 'timeout'
 require 'socket'
+require 'openssl'
 
 require 'active_merchant/network_connection_retries'
 require 'active_merchant/connection'


### PR DESCRIPTION
In order to ensure openssl is required early enough in the gem to
prevent uninitialized constants for the OpenSSL library, this adds the
require in the top level file for the gem.