### PR TITLE
Checkout V2: Pass attempt_n3d along with 3ds enabled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805
 
 == Version 1.116.0 (October 28th)
 * Remove Braintree specific version dependency [pi3r] #38000

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -144,6 +144,7 @@ module ActiveMerchant #:nodoc:
           post[:'3ds'][:enabled] = true
           post[:success_url] = options[:callback_url] if options[:callback_url]
           post[:failure_url] = options[:callback_url] if options[:callback_url]
+          post[:'3ds'][:attempt_n3d] = options[:attempt_n3d] if options[:attempt_n3d]
         end
 
         if options[:three_d_secure]
@@ -151,7 +152,6 @@ module ActiveMerchant #:nodoc:
           post[:'3ds'][:cryptogram] = options[:three_d_secure][:cavv] if options[:three_d_secure][:cavv]
           post[:'3ds'][:version] = options[:three_d_secure][:version] if options[:three_d_secure][:version]
           post[:'3ds'][:xid] = options[:three_d_secure][:ds_transaction_id] || options[:three_d_secure][:xid]
-          post[:'3ds'][:attempt_n3d] = options[:attempt_n3d] if options[:attempt_n3d]
         end
       end
 


### PR DESCRIPTION
In some cases `three_d_secure` may not be set while `execute_threed` is
leading to `attempt_n3d` not being passed when `[:'3ds'][:enabled]` is

CE-1080

Unit: 29 tests, 129 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:33 tests, 83 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed