### PR TITLE
Authorize.net: Don't pass isFirstSubsequentAuth

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805
 * GlobalCollect: Add support for Third-party 3DS2 data [molbrown] #3801
 * Authorize.net: Pass stored credentials [therufs] #3804
+* Authorize.net: Don't pass isFirstRecurringPayment [therufs] #3805
 
 == Version 1.116.0 (October 28th)
 * Remove Braintree specific version dependency [pi3r] #3800

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -710,7 +710,7 @@ module ActiveMerchant
         xml.processingOptions do
           if options[:stored_credential][:initial_transaction]
             xml.isFirstSubsequentAuth 'true'
-            xml.isFirstRecurringPayment 'true' if options[:stored_credential][:reason_type] == 'recurring'
+            # xml.isFirstRecurringPayment 'true' if options[:stored_credential][:reason_type] == 'recurring'
           elsif options[:stored_credential][:initiator] == 'cardholder'
             xml.isStoredCredentials 'true'
           else

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -211,10 +211,66 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_success purchase
   end
 
-  def test_successful_auth_and_capture_with_stored_credential
+  def test_successful_auth_and_capture_with_recurring_stored_credential
+    stored_credential_params = {
+      initial_transaction: true,
+      reason_type: 'recurring',
+      initiator: 'merchant',
+      network_transaction_id: nil
+    }
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+    assert_success auth
+    assert auth.authorization
+
+    assert capture = @gateway.capture(@amount, auth.authorization, authorization_validated: true)
+    assert_success capture
+
+    @options[:stored_credential] = {
+      initial_transaction: false,
+      reason_type: 'recurring',
+      initiator: 'merchant',
+      network_transaction_id: auth.params['transaction_identifier']
+    }
+
+    assert next_auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert next_auth.authorization
+
+    assert capture = @gateway.capture(@amount, next_auth.authorization, authorization_validated: true)
+    assert_success capture
+  end
+
+  def test_successful_auth_and_capture_with_unscheduled_stored_credential
     stored_credential_params = {
       initial_transaction: true,
       reason_type: 'unscheduled',
+      initiator: 'merchant',
+      network_transaction_id: nil
+    }
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+    assert_success auth
+    assert auth.authorization
+
+    assert capture = @gateway.capture(@amount, auth.authorization, authorization_validated: true)
+    assert_success capture
+
+    @options[:stored_credential] = {
+      initial_transaction: false,
+      reason_type: 'unscheduled',
+      initiator: 'merchant',
+      network_transaction_id: auth.params['transaction_identifier']
+    }
+
+    assert next_auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert next_auth.authorization
+
+    assert capture = @gateway.capture(@amount, next_auth.authorization, authorization_validated: true)
+    assert_success capture
+  end
+
+  def test_successful_auth_and_capture_with_installment_stored_credential
+    stored_credential_params = {
+      initial_transaction: true,
+      reason_type: 'installment',
       initiator: 'merchant',
       network_transaction_id: nil
     }


### PR DESCRIPTION
Though authorize.net [appears to specify in docs](https://developer.authorize.net/api/reference/index.html#payment-transactions) that `isFirstSubsequentAuth` should be passed in `processingOptions`, doing so results in failure. 

    Unit:
    101 tests, 601 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed
    
    Remote:
    73 tests, 269 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed
    
    CE-1026
