### PR TITLE
Litle: Add support for general credit transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * GlobalCollect: Add support for Third-party 3DS2 data [molbrown] #3801
 * Authorize.net: Pass stored credentials [therufs] #3804
 * Authorize.net: Don't pass isFirstRecurringPayment [therufs] #3805
+* Litle: Add support for general credit transactions [naashton] #3807
 
 == Version 1.116.0 (October 28th)
 * Remove Braintree specific version dependency [pi3r] #3800

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
             elsif check?(payment)
               add_echeck_purchase_params(doc, money, payment, options)
             else
-              add_auth_purchase_params(doc, money, payment, options)
+              add_credit_params(doc, money, payment, options)
             end
           end
         end
@@ -225,6 +225,17 @@ module ActiveMerchant #:nodoc:
         add_merchant_data(doc, options)
         add_debt_repayment(doc, options)
         add_stored_credential_params(doc, options)
+      end
+
+      def add_credit_params(doc, money, payment_method, options)
+        doc.orderId(truncate(options[:order_id], 24))
+        doc.amount(money)
+        add_order_source(doc, payment_method, options)
+        add_billing_address(doc, payment_method, options)
+        add_payment_method(doc, payment_method, options)
+        add_pos(doc, payment_method)
+        add_descriptor(doc, options)
+        add_merchant_data(doc, options)
       end
 
       def add_merchant_data(doc, options = {})

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -476,6 +476,18 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'No transaction found with specified Transaction Id', void.message
   end
 
+  def test_successful_credit
+    assert credit = @gateway.credit(123456, @credit_card1, @options)
+    assert_success credit
+    assert_equal 'Approved', credit.message
+  end
+
+  def test_failed_credit
+    @credit_card1.number = '1234567890'
+    assert credit = @gateway.credit(1, @credit_card1, @options)
+    assert_failure credit
+  end
+
   def test_partial_refund
     assert purchase = @gateway.purchase(10010, @credit_card1, @options)
 

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -259,6 +259,23 @@ class LitleTest < Test::Unit::TestCase
     assert_equal '360', response.params['response']
   end
 
+  def test_successful_credit
+    credit = stub_comms do
+      @gateway.credit(@amount, @credit_card)
+    end.respond_with(successful_credit_response)
+
+    assert_success credit
+    assert_equal 'Approved', credit.message
+  end
+
+  def test_failed_credit
+    credit = stub_comms do
+      @gateway.credit(@amount, @credit_card)
+    end.respond_with(failed_credit_response)
+
+    assert_failure credit
+  end
+
   def test_successful_void_of_authorization
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)
@@ -762,6 +779,28 @@ class LitleTest < Test::Unit::TestCase
           <message>No transaction found with specified litleTxnId</message>
         </creditResponse>
       </litleOnlineResponse>
+    )
+  end
+
+  def successful_credit_response
+    %(
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <litleOnlineResponse version="9.14" response="0" message="Valid Format">
+        <creditResponse id="1" reportGroup="Default Report Group">
+          <litleTxnId>908410935514139173</litleTxnId>
+          <orderId>1</orderId>
+          <response>000</response>
+          <responseTime>2020-10-30T19:19:38.935</responseTime>
+          <message>Approved</message>
+        </creditResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def failed_credit_response
+    %(
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <litleOnlineResponse version="9.14" response="1" message="Error validating xml data against the schema: cvc-minLength-valid: Value '1234567890' with length = '10' is not facet-valid with respect to minLength '13' for type 'ccAccountNumberType'."/>
     )
   end
 


### PR DESCRIPTION
Add support for general credit transactions

CE-1072

Unit: 48 tests, 208 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 45 tests, 193 assertions, 13 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
71.1111% passed

Failing remote tests area also failing on main