### PR TITLE
Safe charge standarized mpi

### DIFF
--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -24,6 +24,8 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:sg_APIType] = 1 if options[:three_d_secure]
         trans_type = options[:three_d_secure] ? 'Sale3D' : 'Sale'
+
+        add_external_mpi_data(post, options) if options[:three_d_secure]
         add_transaction_data(trans_type, post, money, options)
         add_payment(post, payment, options)
         add_customer_details(post, payment, options)
@@ -33,6 +35,7 @@ module ActiveMerchant #:nodoc:
 
       def authorize(money, payment, options = {})
         post = {}
+
         add_transaction_data('Auth', post, money, options)
         add_payment(post, payment, options)
         add_customer_details(post, payment, options)
@@ -69,8 +72,10 @@ module ActiveMerchant #:nodoc:
 
       def credit(money, payment, options = {})
         post = {}
+
         add_payment(post, payment, options)
         add_transaction_data('Credit', post, money, options)
+
         post[:sg_CreditType] = 1
 
         commit(post)
@@ -152,6 +157,15 @@ module ActiveMerchant #:nodoc:
         end
 
         post[:sg_Email] = options[:email]
+      end
+
+      def add_external_mpi_data(post, options)
+        post[:sg_eci] = options[:eci]
+        post[:sg_cavv] = options[:cavv]
+        post[:sg_dsTransID] = options[:ds_transaction_id]
+        post[:sg_threeDSProtocolVersion] = options[:ds_transaction_id] ? '2' : '1'
+        post[:sg_xid] = options[:xid]
+        post[:sg_IsExternalMPI] = 1
       end
 
       def parse(xml)

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -56,6 +56,68 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_mpi_options_3ds_1
+    options = @options.merge({
+      three_d_secure: {
+        xid: '00000000000000000501',
+        eci: '05',
+        cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA='
+      }
+    })
+
+    response = @gateway.purchase(@amount, @three_ds_enrolled_card, options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
+  def test_successful_purchase_with_mpi_options_3ds_2
+    options = @options.merge({
+      three_d_secure: {
+        version: '2.1.0',
+        ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
+        xid: '00000000000000000501',
+        eci: '05',
+        cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo='
+      }
+    })
+
+    response = @gateway.purchase(@amount, @three_ds_enrolled_card, options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
+  def test_failed_purchase_with_mpi_options_3ds_2
+    options = @options.merge({
+      three_d_secure: {
+        version: '2.1.0',
+        ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
+        xid: '00000000000000000501',
+        eci: '05',
+        cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo='
+      }
+    })
+
+    response = @gateway.purchase(@amount, @declined_card, options)
+    assert_failure response
+    assert_equal 'Decline', response.message
+  end
+
+  def test_successful_authorize_with_mpi_options_3ds_2
+    options = @options.merge({
+      three_d_secure: {
+        version: '2.1.0',
+        ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
+        xid: '00000000000000000501',
+        eci: '05',
+        cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo='
+      }
+    })
+
+    response = @gateway.authorize(@amount, @three_ds_enrolled_card, options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_successful_purchase_with_more_options
     options = {
       order_id: '1',

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -23,10 +23,12 @@ class SafeChargeTest < Test::Unit::TestCase
 
     @three_ds_options = @options.merge(three_d_secure: true)
 
-    @mpi_options = @three_ds_options.merge({
-      ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
-      eci: '05',
-      cavv: 'MAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    @mpi_options = @options.merge({
+      three_d_secure: {
+        ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
+        eci: '05',
+        cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo='
+      }
     })
   end
 
@@ -236,7 +238,7 @@ class SafeChargeTest < Test::Unit::TestCase
   def test_mpi_response_fail
     purchase = stub_comms do
       @gateway.purchase(@amount, @three_ds_enrolled_card, @mpi_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_, data, _|
       assert_match(/sg_eci/, data)
       assert_match(/sg_cavv/, data)
       assert_match(/sg_IsExternalMPI/, data)
@@ -250,7 +252,7 @@ class SafeChargeTest < Test::Unit::TestCase
   def test_mpi_response_success
     purchase = stub_comms do
       @gateway.purchase(@amount, @three_ds_enrolled_card, @mpi_options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_, data, _|
       assert_match(/sg_eci/, data)
       assert_match(/sg_cavv/, data)
       assert_match(/sg_IsExternalMPI/, data)
@@ -399,13 +401,13 @@ reading 727 bytes...
 
   def successful_mpi_response
     %(
-      <Response><Version>4.1.0</Version><ClientLoginID>testSworld2.TRX</ClientLoginID><ClientUniqueID /><TransactionID>1110000000007383613</TransactionID><Status>APPROVED</Status><AuthCode>111946</AuthCode><AVSCode /><CVV2Reply /><ReasonCodes><Reason code="0" /></ReasonCodes><ErrCode>0</ErrCode><ExErrCode>0</ExErrCode><Token>MQBLAGUANQBJAG0ANgB0AFEAMABXAFsAXABdAFYAPgApAGsASwBwAE8AVwBCAHYANgBYAHkAXgA+AD0AQABEAGIALwBdAD4AVwAlADMAKgBvAGsAMwA=</Token><CustomData /><AcquirerID>19</AcquirerID><IssuerBankName>River Valley Credit Union</IssuerBankName><IssuerBankCountry>gb</IssuerBankCountry><Reference /><AGVCode /><AGVError /><UniqueCC>yKHZK4vGCyf0c/Se7rujEvNQtN8=</UniqueCC><CustomData2 /><ThreeDFlow>1</ThreeDFlow><CreditCardInfo><IsPrepaid>0</IsPrepaid><CardType>Credit</CardType><CardProgram /><CardProduct /></CreditCardInfo><IsPartialApproval>0</IsPartialApproval><AmountInfo><RequestedAmount>200</RequestedAmount><RequestedCurrency>USD</RequestedCurrency><ProcessedAmount>200</ProcessedAmount><ProcessedCurrency>USD</ProcessedCurrency></AmountInfo><RRN /><ICC /><CVVReply /><FraudResponse /></Response>
+      <Response><Version>4.1.0</Version><ClientLoginID>SpreedlyTestTRX</ClientLoginID><ClientUniqueID>27822c1132eba4c731ebe24b6190646f</ClientUniqueID><TransactionID>1110000000009330260</TransactionID><Status>APPROVED</Status><AuthCode>111447</AuthCode><AVSCode></AVSCode><CVV2Reply></CVV2Reply><ReasonCodes><Reason code="0"></Reason></ReasonCodes><ErrCode>0</ErrCode><ExErrCode>0</ExErrCode><Token>UQBzAFEAdABvAG0ATgA5AEwAagBHAGwAPwA7AF0ANgA1AD4AfABOADUAdAA/AD4AZQA3AEcAXQBnAGgAQQA4AG4APABNACUARABFADgAMQBrAFIAMwA=</Token><CustomData></CustomData><ThreeDResponse><VerifyAuth3DResponse><Result></Result><ECI>5</ECI><CAVV>Vk83Y2t0cHRzRFZzRlZlR0JIQXo=</CAVV><WhitelistStatus></WhitelistStatus><XID>00000000000000000501</XID><ThreeDReason></ThreeDReason><ThreeDSVersion></ThreeDSVersion><ThreeDSServerTransID></ThreeDSServerTransID><AcsTransID></AcsTransID><DSTransID>c5b808e7-1de1-4069-a17b-f70d3b3b1645</DSTransID></VerifyAuth3DResponse></ThreeDResponse><AcquirerID>19</AcquirerID><IssuerBankName>Visa Production Support Client Bid 1</IssuerBankName><IssuerBankCountry>gb</IssuerBankCountry><Reference></Reference><AGVCode></AGVCode><AGVError></AGVError><UniqueCC>rDNDlh6XR8R6CVdGQyqDkZzdqE0=</UniqueCC><CustomData2></CustomData2><CreditCardInfo><IsPrepaid>0</IsPrepaid><CardType>Debit</CardType><CardProgram></CardProgram><CardProduct></CardProduct></CreditCardInfo><IsPartialApproval>0</IsPartialApproval><AmountInfo><RequestedAmount>1</RequestedAmount><RequestedCurrency>EUR</RequestedCurrency><ProcessedAmount>1</ProcessedAmount><ProcessedCurrency>EUR</ProcessedCurrency></AmountInfo><RRN></RRN><ICC></ICC><CVVReply></CVVReply><FraudResponse><FinalDecision>Accept</FinalDecision><Recommendations /><Rule /></FraudResponse></Response>
     )
   end
 
   def failed_mpi_response
     %(
-      <Response><Version>4.1.0</Version><ClientLoginID>testSworld2.TRX</ClientLoginID><ClientUniqueID></ClientUniqueID><TransactionID>1110000000007383719</TransactionID><Status>DECLINED</Status><AuthCode></AuthCode><AVSCode></AVSCode><CVV2Reply></CVV2Reply><ReasonCodes><Reason code="0">Decline</Reason></ReasonCodes><ErrCode>-1</ErrCode><ExErrCode>0</ExErrCode><Token>ZQBVAEcAcwBxAE8AVwBpAEcAZAA8AFMAVwBPAFsALwBEAEgAWABJACMAdQBaAFMAVgB6AEsAJwAqACUAegBoAFYAYgBUADsAVABcAGQAewBrAEIAMwA=</Token><CustomData></CustomData><AcquirerID>19</AcquirerID><IssuerBankName>R Raphael &amp; Sons PLC</IssuerBankName><IssuerBankCountry>gb</IssuerBankCountry><Reference></Reference><AGVCode></AGVCode><AGVError></AGVError><UniqueCC>adHQpo22N7Jw85jUAsLu0+Q5ZPs=</UniqueCC><CustomData2></CustomData2><ThreeDFlow>1</ThreeDFlow><CreditCardInfo><IsPrepaid>1</IsPrepaid><CardType>Debit</CardType><CardProgram></CardProgram><CardProduct></CardProduct></CreditCardInfo><IsPartialApproval>0</IsPartialApproval><AmountInfo><RequestedAmount>200</RequestedAmount><RequestedCurrency>USD</RequestedCurrency><ProcessedAmount>200</ProcessedAmount><ProcessedCurrency>USD</ProcessedCurrency></AmountInfo><RRN></RRN><ICC></ICC><CVVReply></CVVReply><FraudResponse /></Response>
+      <Response><Version>4.1.0</Version><ClientLoginID>SpreedlyTestTRX</ClientLoginID><ClientUniqueID>040b37ca7af949daeb38a8cff0a16f1b</ClientUniqueID><TransactionID>1110000000009330310</TransactionID><Status>DECLINED</Status><AuthCode></AuthCode><AVSCode></AVSCode><CVV2Reply></CVV2Reply><ReasonCodes><Reason code="0">Decline</Reason></ReasonCodes><ErrCode>-1</ErrCode><ExErrCode>0</ExErrCode><Token>UQBLAEcAdABRAE8AWABPADUANgBCADAAcABGAEUANwArADgAewBTACcAcwAlAF8APABQAEEAXgBVACUAYQBLACMALwBWAEUANQApAD4ARQBqADsAMwA=</Token><CustomData></CustomData><ThreeDResponse><VerifyAuth3DResponse><Result></Result><ECI>5</ECI><CAVV>Vk83Y2t0cHRzRFZzRlZlR0JIQXo=</CAVV><WhitelistStatus></WhitelistStatus><XID>00000000000000000501</XID><ThreeDReason></ThreeDReason><ThreeDSVersion></ThreeDSVersion><ThreeDSServerTransID></ThreeDSServerTransID><AcsTransID></AcsTransID><DSTransID>c5b808e7-1de1-4069-a17b-f70d3b3b1645</DSTransID></VerifyAuth3DResponse></ThreeDResponse><AcquirerID>19</AcquirerID><IssuerBankName></IssuerBankName><IssuerBankCountry></IssuerBankCountry><Reference></Reference><AGVCode></AGVCode><AGVError></AGVError><UniqueCC>GyueFkuQqW+UL38d57fuA5/RqfQ=</UniqueCC><CustomData2></CustomData2><CreditCardInfo><IsPrepaid>0</IsPrepaid><CardType></CardType><CardProgram></CardProgram><CardProduct></CardProduct></CreditCardInfo><IsPartialApproval>0</IsPartialApproval><AmountInfo><RequestedAmount>1</RequestedAmount><RequestedCurrency>EUR</RequestedCurrency><ProcessedAmount>1</ProcessedAmount><ProcessedCurrency>EUR</ProcessedCurrency></AmountInfo><RRN></RRN><ICC></ICC><CVVReply></CVVReply><FraudResponse><FinalDecision>Accept</FinalDecision><Recommendations /><Rule /></FraudResponse></Response>
     )
   end
 end


### PR DESCRIPTION
This PR includes two commits, one from a contributor adding initial implementation, and one from me fixing up some conflicts in the logic and switching to the standardized 3DS fields.

    Pull MPI fields from the standard hash instead of top-level options.

    SafeCharge added 3DS support before the three_d_secure hash and its
    fields were standardized, and it utilizes the three_d_secure option as a
    boolean flag to request the 3DS flow from SafeCharge. This update checks
    if the option is a flag and assembles the correct request fields.

Remote (2 unrelated failures):
27 tests, 69 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.5926% passed

Unit:
22 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed