### PR TITLE
Spreedly: Additional card types for Stripe, Worldpay, Checkout.com

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w[AD AE AR AT AU BE BG BH BR CH CL CN CO CY CZ DE DK EE EG ES FI FR GB GR HK HR HU IE IS IT JO JP KW LI LT LU LV MC MT MX MY NL NO NZ OM PE PL PT QA RO SA SE SG SI SK SM TR US]
       self.default_currency = 'USD'
       self.money_format = :cents
-      self.supported_cardtypes = %i[visa master american_express diners_club maestro discover]
+      self.supported_cardtypes = %i[visa master american_express diners_club maestro discover jcb]
       self.currencies_without_fractions = %w(BIF DJF GNF ISK KMF XAF CLF XPF JPY PYG RWF KRW VUV VND XOF)
       self.currencies_with_three_decimal_places = %w(BHD LYD JOD KWD OMR TND)
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w(AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MT MX NL NO NZ PL PT RO SE SG SI SK US)
       self.default_currency = 'USD'
       self.money_format = :cents
-      self.supported_cardtypes = %i[visa master american_express discover jcb diners_club maestro]
+      self.supported_cardtypes = %i[visa master american_express discover jcb diners_club maestro unionpay]
       self.currencies_without_fractions = %w(BIF CLP DJF GNF JPY KMF KRW MGA PYG RWF VND VUV XAF XOF XPF UGX)
 
       self.homepage_url = 'https://stripe.com/'

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'GBP'
       self.money_format = :cents
       self.supported_countries = %w(HK GB AU AD AR BE BR CA CH CN CO CR CY CZ DE DK ES FI FR GI GR HU IE IN IT JP LI LU MC MT MY MX NL NO NZ PA PE PL PT SE SG SI SM TR UM VA)
-      self.supported_cardtypes = %i[visa master american_express discover jcb maestro elo naranja cabal]
+      self.supported_cardtypes = %i[visa master american_express discover jcb maestro elo naranja cabal unionpay]
       self.currencies_without_fractions = %w(HUF IDR ISK JPY KRW)
       self.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
       self.homepage_url = 'http://www.worldpay.com/'
@@ -26,6 +26,7 @@ module ActiveMerchant #:nodoc:
         'elo'              => 'ELO-SSL',
         'naranja'          => 'NARANJA-SSL',
         'cabal'            => 'CABAL-SSL',
+        'unionpay'         => 'CHINAUNIONPAY-SSL',
         'unknown'          => 'CARD-SSL'
       }
 


### PR DESCRIPTION
## What has been done

Paddle are integrating with a number of payment gateways, via Spreedly. We have noted missing card types with the Stripe, Worldpay and Checkout.com gateways, which should be supported by active_merchant.

We have added the following card types to the relevant gateway class and its `supported_cardtypes` array.

1. StripeGateway: `unionpay` card type 

2. WorldpayGateway: `unionpay` card type

3. CheckoutV2Gateway: `jcb` card type 
