### PR TITLE
Stripe PI: Pass external 3DS auth data

### DIFF
--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -18,6 +18,10 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       verification_value: '737',
       month: 10,
       year: 2021)
+    @three_ds_external_data_card = credit_card('4000002760003184',
+      verification_value: '737',
+      month: 10,
+      year: 2021)
     @visa_card = credit_card('4242424242424242',
       verification_value: '737',
       month: 10,
@@ -123,6 +127,74 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
 
     assert_equal 'Your card was declined.', purchase.message
     refute purchase.params.dig('error', 'payment_intent', 'charges', 'data')[0]['captured']
+  end
+
+  def test_successful_purchase_with_external_auth_data_3ds_1
+    options = {
+      currency: 'GBP',
+      three_d_secure: {
+        eci: '05',
+        cavv: '4BQwsg4yuKt0S1LI1nDZTcO9vUM=',
+        xid: 'd+NEBKSpEMauwleRhdrDY06qj4A='
+      }
+    }
+
+    assert purchase = @gateway.purchase(@amount, @three_ds_external_data_card, options)
+
+    assert_equal 'succeeded', purchase.params['status']
+    assert purchase.params.dig('charges', 'data')[0]['captured']
+  end
+
+  def test_successful_purchase_with_external_auth_data_3ds_2
+    options = {
+      currency: 'GBP',
+      three_d_secure: {
+        version: '2.1.0',
+        eci: '02',
+        cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
+        ds_transaction_id: 'f879ea1c-aa2c-4441-806d-e30406466d79'
+      }
+    }
+
+    assert purchase = @gateway.purchase(@amount, @three_ds_external_data_card, options)
+
+    assert_equal 'succeeded', purchase.params['status']
+    assert purchase.params.dig('charges', 'data')[0]['captured']
+  end
+
+  def test_successful_purchase_with_customer_token_and_external_auth_data_3ds_2
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      three_d_secure: {
+        version: '2.1.0',
+        eci: '02',
+        cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
+        ds_transaction_id: 'f879ea1c-aa2c-4441-806d-e30406466d79'
+      }
+    }
+
+    assert purchase = @gateway.purchase(@amount, @three_ds_authentication_required, options)
+
+    assert_equal 'succeeded', purchase.params['status']
+    assert purchase.params.dig('charges', 'data')[0]['captured']
+  end
+
+  def test_successful_authorization_with_external_auth_data_3ds_2
+    options = {
+      currency: 'GBP',
+      three_d_secure: {
+        version: '2.1.0',
+        eci: '02',
+        cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
+        ds_transaction_id: 'f879ea1c-aa2c-4441-806d-e30406466d79'
+      }
+    }
+
+    assert authorization = @gateway.authorize(@amount, @three_ds_external_data_card, options)
+
+    assert_equal 'requires_capture', authorization.params['status']
+    refute authorization.params.dig('charges', 'data')[0]['captured']
   end
 
   def test_create_payment_intent_manual_capture_method


### PR DESCRIPTION
Support for passing through external 3DS 1 and 2 auth data. Reference:
https://stripe.com/docs/payments/payment-intents/three-d-secure-import

Remote (1 unrelated failure):
46 tests, 198 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.8261% passed

Unit:
16 tests, 104 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed