### PR TITLE
Credorax: Allow 3DS1 normalized pass-through, ease version matching

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * SafeCharge: Standardize MPI fields [curiousepic] #3809
 * Credorax: Adds AMEX to supported cards and adds 1A error code [LinTrieu] #3792
 * Stripe PI: Pass external 3DS auth data [curiousepic] #3811
+* Credorax: Allow 3DS1 normalized pass-through, ease version matching [britth] #3812
 
 == Version 1.116.0 (October 28th)
 * Remove Braintree specific version dependency [pi3r] #3800

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -325,7 +325,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_3d_secure(post, options)
-        if options[:eci] && options[:xid]
+        if (options[:eci] && options[:xid]) || (options[:three_d_secure] && options[:three_d_secure][:version]&.start_with?('1'))
           add_3d_secure_1_data(post, options)
         elsif options[:execute_threed] && options[:three_ds_2]
           three_ds_2_options = options[:three_ds_2]
@@ -358,8 +358,17 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_3d_secure_1_data(post, options)
-        post[:i8] = build_i8(options[:eci], options[:cavv], options[:xid])
-        post[:'3ds_version'] = options[:three_ds_version].nil? || options[:three_ds_version] == '1' ? '1.0' : options[:three_ds_version]
+        if three_d_secure_options = options[:three_d_secure]
+          post[:i8] = build_i8(
+            three_d_secure_options[:eci],
+            three_d_secure_options[:cavv],
+            three_d_secure_options[:xid]
+          )
+          post[:'3ds_version'] = three_d_secure_options[:version]&.start_with?('1') ? '1.0' : three_d_secure_options[:version]
+        else
+          post[:i8] = build_i8(options[:eci], options[:cavv], options[:xid])
+          post[:'3ds_version'] = options[:three_ds_version].nil? || options[:three_ds_version]&.start_with?('1') ? '1.0' : options[:three_ds_version]
+        end
       end
 
       def add_normalized_3d_secure_2_data(post, options)
@@ -369,7 +378,7 @@ module ActiveMerchant #:nodoc:
           three_d_secure_options[:eci],
           three_d_secure_options[:cavv]
         )
-        post[:'3ds_version'] = three_d_secure_options[:version] == '2' ? '2.0' : three_d_secure_options[:version]
+        post[:'3ds_version'] = three_d_secure_options[:version]&.start_with?('2') ? '2.0' : three_d_secure_options[:version]
         post[:'3ds_dstrxid'] = three_d_secure_options[:ds_transaction_id]
       end
 

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -93,7 +93,30 @@ class RemoteCredoraxTest < Test::Unit::TestCase
       xid: '00000000000000000501',
       # Having processor-specification enabled in Credorax test account causes 3DS tests to fail without a r1 (processor) parameter.
       processor: 'CREDORAX',
-      three_ds_version: '1.0'
+      three_ds_version: '1.0.2'
+    )
+
+    response = @gateway.purchase(@amount, @fully_auth_card, options)
+    assert_success response
+    assert_equal '1', response.params['H9']
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_auth_data_via_normalized_3ds1_options
+    version = '1.0.2'
+    eci = '02'
+    cavv = 'jJ81HADVRtXfCBATEp01CJUAAAA='
+    xid = '00000000000000000501'
+
+    options = @options.merge(
+      three_d_secure: {
+        version: version,
+        eci: eci,
+        cavv: cavv,
+        xid: xid
+      },
+      # Having processor-specification enabled in Credorax test account causes 3DS tests to fail without a r1 (processor) parameter.
+      processor: 'CREDORAX'
     )
 
     response = @gateway.purchase(@amount, @fully_auth_card, options)
@@ -118,7 +141,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_auth_data_via_normalized_3ds2_options
-    version = '2.0'
+    version = '2.2.0'
     eci = '02'
     cavv = 'jJ81HADVRtXfCBATEp01CJUAAAA='
     ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'


### PR DESCRIPTION
Allow use of normalized three_d_secure hash with v1 auth data as
with v2. Also use `start_with?` to check the version so that the
request doesn't error on that parameter when passing a specific
minor version.

Remote
42 tests, 155 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
70 tests, 333 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed