### PR TITLE
Response: add network_transaction_id attribute

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Adyen: Update capitalization on subMerchantId field [cdmackeyfree] #3824
 * Maestro and Elo: Update BIN ranges [meagabeth] #3822
 * HPS: Truncate invoice numbers that are too long [curiousepic] #3825
+* Pass network_transaction_id attribute in Response [therufs] #3815
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805
@@ -21,6 +22,7 @@
 * Credorax: Allow 3DS1 normalized pass-through, ease version matching [britth] #3812
 * Redsys: Redsys: Harden 3DS v1/v2 check for External MPI [esmitperez] #3814
 * Add card types for Stripe, Worldpay, Checkout.com [LinTrieu] #3810
+* ActiveMerchant::Billing::Response: Include `network_transaction_id` attribute [therufs] #3815
 
 == Version 1.116.0 (October 28th)
 * Remove Braintree specific version dependency [pi3r] #3800

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
     end
 
     class Response
-      attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result, :error_code, :emv_authorization
+      attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result, :error_code, :emv_authorization, :network_transaction_id
 
       def success?
         @success
@@ -25,6 +25,7 @@ module ActiveMerchant #:nodoc:
         @fraud_review = options[:fraud_review]
         @error_code = options[:error_code]
         @emv_authorization = options[:emv_authorization]
+        @network_transaction_id = options[:network_transaction_id]
 
         @avs_result = if options[:avs_result].kind_of?(AVSResult)
                         options[:avs_result].to_hash


### PR DESCRIPTION
What: Add `network_transaction_id` as an attribute to Response

Why: Elavon (and possibly other gateways) require two different fields for a stored credential network_transaction_id (see #3816). Rather than dividing management duties between the host library and AM, provide a unified interface so that concatenation and division can occur within a single codebase. 