### PR TITLE
Decidir: Add addtitional fraud detection fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,7 @@
 * Checkout V2: Support for attempt_n3d 3DS field [naashton] #3790
 * Elavon: Strip ampersands [therufs] #3795
 * Paybox: Add support for 3DS 1.0 values [jcpaybox] #3335
+* Decidir: Add additional fraud_detection options [cdmackeyfree] #3812
 
 == Version 1.114.0
 * BlueSnap: Add address1,address2,phone,shipping_* support #3749

--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     # ==== Customer Information Manager (CIM)

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -210,6 +210,14 @@ module ActiveMerchant #:nodoc:
           hsh[:channel] = options[:channel] if valid_fraud_detection_option?(options[:channel])
           hsh[:dispatch_method] = options[:dispatch_method] if valid_fraud_detection_option?(options[:dispatch_method])
           hsh[:csmdds] = options[:csmdds] if valid_fraud_detection_option?(options[:csmdds])
+          hsh[:device_unique_id] = options[:device_unique_id] if valid_fraud_detection_option?(options[:device_unique_id])
+          hsh[:bill_to] = options[:bill_to] if valid_fraud_detection_option?(options[:bill_to])
+          hsh[:purchase_totals] = options[:purchase_totals] if valid_fraud_detection_option?(options[:purchase_totals])
+          hsh[:customer_in_site] = options[:customer_in_site] if valid_fraud_detection_option?(options[:customer_in_site])
+          hsh[:retail_transaction_data] = options[:retail_transaction_data] if valid_fraud_detection_option?(options[:retail_transaction_data])
+          hsh[:ship_to] = options[:ship_to] if valid_fraud_detection_option?(options[:ship_to])
+          hsh[:tax_voucher_required] = options[:tax_voucher_required] if valid_fraud_detection_option?(options[:tax_voucher_required])
+          hsh[:copy_paste_card_data] = options[:copy_paste_card_data] if valid_fraud_detection_option?(options[:copy_paste_card_data])
         end
       end
 

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -83,7 +83,32 @@ class RemoteDecidirTest < Test::Unit::TestCase
             code: 17,
             description: 'Campo MDD17'
           }
-        ]
+        ],
+        bill_to: {
+          postal_code: '12345',
+          last_name: 'Smith',
+          country: 'US',
+          street1: '123 Mockingbird Lane',
+          state: 'TN',
+          email: 'dootdoot@hotmail.com',
+          customer_id: '111111',
+          phone_number: '555-5555',
+          first_name: 'Joe',
+          city: 'Pantsville'
+        },
+        customer_in_site: {
+          password: '',
+          is_guest: false,
+          street: '123 Mockingbird Lane',
+          cellphone_number: '555-1212',
+          num_of_transactions: 48,
+          date_of_birth: '8-4-80',
+          days_in_site: 105
+        },
+        purchase_totals: {
+          currency: 'USD',
+          amount: 100
+        }
       },
       installments: '12',
       site_id: '99999999'
@@ -148,8 +173,8 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway_for_auth.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'TARJETA INVALIDA | invalid_number', response.message
-    assert_match Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
+    assert_equal 'PEDIR AUTORIZACION | request_authorization_card', response.message
+    assert_match 'call_issuer', response.error_code
   end
 
   def test_failed_partial_capture
@@ -223,7 +248,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway_for_auth.verify(@declined_card, @options)
     assert_failure response
-    assert_match %r{TARJETA INVALIDA | invalid_number}, response.message
+    assert_match %r{PEDIR AUTORIZACION | request_authorization_card}, response.message
   end
 
   def test_invalid_login


### PR DESCRIPTION
Adds bill_to, purchase_totals, customer_in_site, retail_transaction_data, ship_to, tax_voucher_required.

Updated an error message as Decidir had changed their messages for declined auth/verify to be more specific.

Unit test
34 tests, 165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests
22 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

local:
4586 tests, 72562 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed