### PR TITLE
SafeCharge: Block xid for 3DS2 external MPI data

### DIFF
--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -170,11 +170,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_external_mpi_data(post, options)
+        version = options[:three_d_secure][:ds_transaction_id] ? '2' : '1'
+
         post[:sg_eci] = options[:three_d_secure][:eci] if options[:three_d_secure][:eci]
         post[:sg_cavv] = options[:three_d_secure][:cavv] if options[:three_d_secure][:cavv]
-        post[:sg_dsTransID] = options[:three_d_secure][:ds_transaction_id] if options[:three_d_secure][:ds_transaction_id]
-        post[:sg_threeDSProtocolVersion] = options[:three_d_secure][:version] || (options[:three_d_secure][:ds_transaction_id] ? '2' : '1')
-        post[:sg_xid] = options[:three_d_secure][:xid]
+        post[:sg_dsTransID] = options[:three_d_secure][:ds_transaction_id] if version == '2'
+        post[:sg_threeDSProtocolVersion] = version
+        post[:sg_xid] = options[:three_d_secure][:xid] if version == '1'
         post[:sg_IsExternalMPI] = 1
       end
 

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -75,7 +75,6 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
       three_d_secure: {
         version: '2.1.0',
         ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
-        xid: '00000000000000000501',
         eci: '05',
         cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo='
       }
@@ -91,7 +90,6 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
       three_d_secure: {
         version: '2.1.0',
         ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
-        xid: '00000000000000000501',
         eci: '05',
         cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo='
       }
@@ -107,7 +105,6 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
       three_d_secure: {
         version: '2.1.0',
         ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
-        xid: '00000000000000000501',
         eci: '05',
         cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo='
       }

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -23,11 +23,21 @@ class SafeChargeTest < Test::Unit::TestCase
 
     @three_ds_options = @options.merge(three_d_secure: true)
 
-    @mpi_options = @options.merge({
+    @mpi_options_3ds1 = @options.merge({
       three_d_secure: {
-        ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
         eci: '05',
-        cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo='
+        cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo=',
+        xid: '00000000000000000501'
+      }
+    })
+
+    @mpi_options_3ds2 = @options.merge({
+      three_d_secure: {
+        version: '2.1.0',
+        eci: '05',
+        cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo=',
+        xid: '00000000000000000501',
+        ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645'
       }
     })
   end
@@ -236,27 +246,52 @@ class SafeChargeTest < Test::Unit::TestCase
   end
 
   def test_mpi_response_fail
+
     purchase = stub_comms do
-      @gateway.purchase(@amount, @three_ds_enrolled_card, @mpi_options)
+      @gateway.purchase(@amount, @three_ds_enrolled_card, @mpi_options_3ds1)
     end.check_request do |_, data, _|
       assert_match(/sg_eci/, data)
       assert_match(/sg_cavv/, data)
       assert_match(/sg_IsExternalMPI/, data)
-      assert_match(/sg_dsTransID/, data)
     end.respond_with(failed_mpi_response)
 
     assert_failure purchase
     assert_equal 'DECLINED', purchase.params['status']
   end
 
-  def test_mpi_response_success
+  def test_mpi_response_success_3ds1
+    mpi_options_3ds1 = @options.merge({
+      three_d_secure: {
+        eci: '05',
+        cavv: 'Vk83Y2t0cHRzRFZzRlZlR0JIQXo=',
+        xid: '00000000000000000501'
+      }
+    })
+
     purchase = stub_comms do
-      @gateway.purchase(@amount, @three_ds_enrolled_card, @mpi_options)
+      @gateway.purchase(@amount, @three_ds_enrolled_card, @mpi_options_3ds1)
+    end.check_request do |_, data, _|
+      assert_match(/sg_eci/, data)
+      assert_match(/sg_cavv/, data)
+      assert_match(/sg_IsExternalMPI/, data)
+      assert_match(/sg_threeDSProtocolVersion=1/, data)
+      assert_match(/sg_xid/, data)
+    end.respond_with(successful_mpi_response)
+
+    assert_success purchase
+    assert_equal 'APPROVED', purchase.params['status']
+  end
+
+  def test_mpi_response_success_3ds2
+    purchase = stub_comms do
+      @gateway.purchase(@amount, @three_ds_enrolled_card, @mpi_options_3ds2)
     end.check_request do |_, data, _|
       assert_match(/sg_eci/, data)
       assert_match(/sg_cavv/, data)
       assert_match(/sg_IsExternalMPI/, data)
       assert_match(/sg_dsTransID/, data)
+      assert_match(/sg_threeDSProtocolVersion=2/, data)
+      refute_match(/sg_xid/, data)
     end.respond_with(successful_mpi_response)
 
     assert_success purchase


### PR DESCRIPTION
Prevent xid field from being sent when external MPI data is provided for
3DS version 2.

Remote (2 unrelated failures):
27 tests, 69 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.5926% passed

Unit:
23 tests, 120 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed