### PR TITLE
Worldpay: Add support for challengeWindowSize

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Worldpay: Add support for challengeWindowSize [carrigan] #3823
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -260,7 +260,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_additional_3ds_data(xml, options)
-        xml.additional3DSData 'dfReferenceId' => options[:session_id]
+        additional_data = { 'dfReferenceId' => options[:session_id] }
+        additional_data['challengeWindowSize'] = options[:browser_size] if options[:browser_size]
+
+        xml.additional3DSData additional_data
       end
 
       def add_3ds_exemption(xml, options)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -72,6 +72,13 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_3ds2_authorize_with_browser_size
+    options = @options.merge({ execute_threed: true, three_ds_version: '2.0', browser_size: '390x400' })
+    assert response = @gateway.authorize(@amount, @threeDS2_card, options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_successful_authorize_with_risk_data
     options = @options.merge({ execute_threed: true, three_ds_version: '2.0', risk_data: risk_data })
     assert response = @gateway.authorize(@amount, @threeDS2_card, options)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -726,6 +726,24 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_3ds_additional_information
+    browser_size = '390x400'
+    session_id = '0215ui8ib1'
+
+    options = @options.merge(
+      session_id: session_id,
+      browser_size: browser_size,
+      execute_threed: true,
+      three_ds_version: '2.0.1'
+    )
+
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_tag_with_attributes 'additional3DSData', { 'dfReferenceId' => session_id, 'challengeWindowSize' => browser_size }, data
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_transcript_scrubbing
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end


### PR DESCRIPTION
## Why?

ECS-1536

Worldpay currently does not have support for requesting different sizes for 3DS2 challenge content.

## What Changed?

Adds support for Worldpay's additional3DSData.challengeWindowSize field which lets merchants request different sizes for 3DS2 challenge content.

## Test Suite 

### Unit tests:

4590 tests, 72595 assertions, 0 failures, 0 errors, 0 pendings,
  0 omissions, 0 notifications
100% passed
693 files inspected, no offenses detected

### Remote tests:

Before:
57 tests, 239 assertions, 5 failures, 0 errors, 0 pendings,
  0 omissions, 0 notifications
91.2281% passed

After:
58 tests, 242 assertions, 5 failures, 0 errors, 0 pendings,
  0 omissions, 0 notifications
91.3793% passed