### PR TITLE
Correct capitalization for SubmerchantID field on Adyen

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Worldpay: Add support for challengeWindowSize [carrigan] #3823
+* Adyen: Update capitalization on subMerchantId field [cdmackeyfree] #3824
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -227,7 +227,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_merchant_data(post, options)
-        post[:additionalData][:subMerchantId] = options[:sub_merchant_id] if options[:sub_merchant_id]
+        post[:additionalData][:subMerchantID] = options[:sub_merchant_id] if options[:sub_merchant_id]
         post[:additionalData][:subMerchantName] = options[:sub_merchant_name] if options[:sub_merchant_name]
         post[:additionalData][:subMerchantStreet] = options[:sub_merchant_street] if options[:sub_merchant_street]
         post[:additionalData][:subMerchantCity] = options[:sub_merchant_city] if options[:sub_merchant_city]
@@ -235,7 +235,6 @@ module ActiveMerchant #:nodoc:
         post[:additionalData][:subMerchantPostalCode] = options[:sub_merchant_postal_code] if options[:sub_merchant_postal_code]
         post[:additionalData][:subMerchantCountry] = options[:sub_merchant_country] if options[:sub_merchant_country]
         post[:additionalData][:subMerchantTaxId] = options[:sub_merchant_tax_id] if options[:sub_merchant_tax_id]
-        post[:additionalData][:subMerchantId] = options[:sub_merchant_id] if options[:sub_merchant_id]
         post[:additionalData][:subMerchantMCC] = options[:sub_merchant_mcc] if options[:sub_merchant_mcc]
       end
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -830,7 +830,7 @@ class AdyenTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, @options.merge(sub_merchant_data))
     end.check_request do |_endpoint, data, _headers|
       parsed = JSON.parse(data)
-      assert parsed['additionalData']['subMerchantId']
+      assert parsed['additionalData']['subMerchantID']
       assert parsed['additionalData']['subMerchantName']
       assert parsed['additionalData']['subMerchantStreet']
       assert parsed['additionalData']['subMerchantCity']


### PR DESCRIPTION
Per Adyen's documentation it should be "ID" as opposed to "Id"

Unit Tests:
70 tests, 336 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
92 tests, 353 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Local Tests:
4589 tests, 72591 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed