### PR TITLE
Decidir: correct field name for fraud prevention

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * HPS: Truncate invoice numbers that are too long [curiousepic] #3825
 * Pass network_transaction_id attribute in Response [therufs] #3815
 * Elavon: support standardized stored credentials [therufs] #3816
+* Decidir: update fraud_detection field [cdmackeyfree] #3829
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -210,7 +210,7 @@ module ActiveMerchant #:nodoc:
           hsh[:channel] = options[:channel] if valid_fraud_detection_option?(options[:channel])
           hsh[:dispatch_method] = options[:dispatch_method] if valid_fraud_detection_option?(options[:dispatch_method])
           hsh[:csmdds] = options[:csmdds] if valid_fraud_detection_option?(options[:csmdds])
-          hsh[:device_unique_id] = options[:device_unique_id] if valid_fraud_detection_option?(options[:device_unique_id])
+          hsh[:device_unique_identifier] = options[:device_unique_identifier] if valid_fraud_detection_option?(options[:device_unique_identifier])
           hsh[:bill_to] = options[:bill_to] if valid_fraud_detection_option?(options[:bill_to])
           hsh[:purchase_totals] = options[:purchase_totals] if valid_fraud_detection_option?(options[:purchase_totals])
           hsh[:customer_in_site] = options[:customer_in_site] if valid_fraud_detection_option?(options[:customer_in_site])

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -516,7 +516,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def url
-        return postlive_url if @options[:url_override].to_s == "postlive"
+        return postlive_url if @options[:url_override].to_s == 'postlive'
 
         test? ? test_url : live_url
       end


### PR DESCRIPTION
Decidir documentation shows that the field name is `device_unique_identifier` rather than `device_unique_id` as used in their error messaging.

Also includes a Rubocop correction for the litle gateway

Unit Tests:
34 tests, 165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
22 tests, 78 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Local Tests:
4597 tests, 72631 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed