### PR TITLE
Add Serfinanza cardtype

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Pass network_transaction_id attribute in Response [therufs] #3815
 * Elavon: support standardized stored credentials [therufs] #3816
 * Decidir: update fraud_detection field [cdmackeyfree] #3829
+* Paymentez: Add Serfinanza cardtype [meagabeth] #3830
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -24,6 +24,7 @@ module ActiveMerchant #:nodoc:
     # * Naranja
     # * UnionPay
     # * Alia
+    # * Serfinanza
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -100,6 +101,7 @@ module ActiveMerchant #:nodoc:
       # * +'naranja'+
       # * +'union_pay'+
       # * +'alia'+
+      # * +'serfinanza'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -30,7 +30,8 @@ module ActiveMerchant #:nodoc:
             in_bin_range?(num.slice(0, 6), CARNET_RANGES) ||
             CARNET_BINS.any? { |bin| num.slice(0, bin.size) == bin }
           )
-        }
+        },
+        'serfinanza' => ->(num) { num =~ /^636853\d{10}$/ }
       }
 
       # http://www.barclaycard.co.uk/business/files/bin_rules.pdf

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w[MX EC CO BR CL PE]
       self.default_currency = 'USD'
-      self.supported_cardtypes = %i[visa master american_express diners_club elo alia]
+      self.supported_cardtypes = %i[visa master american_express diners_club elo alia serfinanza]
 
       self.homepage_url = 'https://secure.paymentez.com/'
       self.display_name = 'Paymentez'

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -8,7 +8,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111', verification_value: '666')
     @elo_credit_card = credit_card('6362970000457013',
       month: 10,
-      year: 2020,
+      year: 2022,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
@@ -137,7 +137,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void('')
     assert_failure response
-    assert_equal 'Carrier not supported', response.message
+    assert_equal 'ValidationError', response.message
     assert_equal Gateway::STANDARD_ERROR_CODE[:config_error], response.error_code
   end
 
@@ -171,7 +171,8 @@ class RemotePaymentezTest < Test::Unit::TestCase
   def test_successful_authorize_and_capture_with_different_amount
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
-    assert capture = @gateway.capture(@amount + 100, auth.authorization)
+    amount = 99.0
+    assert capture = @gateway.capture(amount, auth.authorization)
     assert_success capture
     assert_equal 'Response by mock', capture.message
   end

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -149,6 +149,10 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     end
   end
 
+  def test_should_detect_serfinanza_card
+    assert_equal 'serfinanza', CreditCard.brand?('6368530000000000')
+  end
+
   def test_should_detect_vr_card
     assert_equal 'vr', CreditCard.brand?('6370364495764400')
   end


### PR DESCRIPTION
No Serfinanza card numbers are available, so no tests were written

Paymentez looks to have had a changed response so that was updated
Litle had a rubocop offense that was resolved

CE-992

Unit:
4598 tests, 72632 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 66 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed