### PR TITLE
Paymentez: Revise Serfinanza to be Olimpica card type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@
 * Pass network_transaction_id attribute in Response [therufs] #3815
 * Elavon: support standardized stored credentials [therufs] #3816
 * Decidir: update fraud_detection field [cdmackeyfree] #3829
-* Paymentez: Add Serfinanza cardtype [meagabeth] #3830
+* Paymentez: Add Olimpica cardtype [meagabeth] #3831
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -24,7 +24,7 @@ module ActiveMerchant #:nodoc:
     # * Naranja
     # * UnionPay
     # * Alia
-    # * Serfinanza
+    # * Olimpica
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -101,7 +101,7 @@ module ActiveMerchant #:nodoc:
       # * +'naranja'+
       # * +'union_pay'+
       # * +'alia'+
-      # * +'serfinanza'+
+      # * +'olimpica'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -31,7 +31,7 @@ module ActiveMerchant #:nodoc:
             CARNET_BINS.any? { |bin| num.slice(0, bin.size) == bin }
           )
         },
-        'serfinanza' => ->(num) { num =~ /^636853\d{10}$/ }
+        'olimpica' => ->(num) { num =~ /^636853\d{10}$/ }
       }
 
       # http://www.barclaycard.co.uk/business/files/bin_rules.pdf

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w[MX EC CO BR CL PE]
       self.default_currency = 'USD'
-      self.supported_cardtypes = %i[visa master american_express diners_club elo alia serfinanza]
+      self.supported_cardtypes = %i[visa master american_express diners_club elo alia olimpica]
 
       self.homepage_url = 'https://secure.paymentez.com/'
       self.display_name = 'Paymentez'

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -149,8 +149,8 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     end
   end
 
-  def test_should_detect_serfinanza_card
-    assert_equal 'serfinanza', CreditCard.brand?('6368530000000000')
+  def test_should_detect_olimpica_card
+    assert_equal 'olimpica', CreditCard.brand?('6368530000000000')
   end
 
   def test_should_detect_vr_card


### PR DESCRIPTION
No Olimpica test card numbers are available, so no tests were written

CE-992

Unit:
4598 tests, 72632 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 66 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed