### PR TITLE
Credorax: Add support for 3DS Adviser

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Decidir: update fraud_detection field [cdmackeyfree] #3829
 * Paymentez: Add Olimpica cardtype [meagabeth] #3831
 * SafeCharge: 3DS external MPI data refinements [curiousepic] #3821
+* Credorax: Add support for 3DS Adviser [meagabeth] #3834
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -331,6 +331,7 @@ module ActiveMerchant #:nodoc:
           three_ds_2_options = options[:three_ds_2]
           browser_info = three_ds_2_options[:browser_info]
           post[:'3ds_initiate'] = options[:three_ds_initiate] || '01'
+          post[:f23] = options[:f23] if options[:f23]
           post[:'3ds_purchasedate'] = Time.now.utc.strftime('%Y%m%d%I%M%S')
           options.dig(:stored_credential, :initiator) == 'merchant' ? post[:'3ds_channel'] = '03' : post[:'3ds_channel'] = '02'
           post[:'3ds_redirect_url'] = three_ds_2_options[:notification_url]

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -5,10 +5,11 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     @gateway = CredoraxGateway.new(fixtures(:credorax))
 
     @amount = 100
+    @adviser_amount = 1000001
     @credit_card = credit_card('4176661000001015', verification_value: '281', month: '12', year: '2022')
     @fully_auth_card = credit_card('5223450000000007', brand: 'mastercard', verification_value: '090', month: '12', year: '2025')
     @declined_card = credit_card('4176661000001111', verification_value: '681', month: '12', year: '2022')
-    @three_ds_card = credit_card('5455330200000016', verification_value: '737', month: '12', year: '2022')
+    @three_ds_card = credit_card('4761739000060016', verification_value: '212', month: '12', year: '2027')
     @options = {
       order_id: '1',
       currency: 'EUR',
@@ -130,6 +131,15 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @three_ds_card, options)
     assert_success response
     assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_3ds_adviser
+    threeds_options = @options.merge(@normalized_3ds_2_options)
+    options = threeds_options.merge(three_ds_initiate: '03', f23: '1')
+    response = @gateway.purchase(@adviser_amount, @three_ds_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal '01', response.params['SMART_3DS_RESULT']
   end
 
   def test_successful_moto_purchase

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -22,6 +22,8 @@ class CredoraxTest < Test::Unit::TestCase
       shipping_address: address(),
       order_id: '123',
       execute_threed: true,
+      three_ds_initiate: '03',
+      f23: '1',
       three_ds_challenge_window_size: '01',
       stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
@@ -253,6 +255,8 @@ class CredoraxTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       assert_match(/3ds_channel=02/, data)
       assert_match(/3ds_transtype=01/, data)
+      assert_match(/3ds_initiate=03/, data)
+      assert_match(/f23=1/, data)
       assert_match(/3ds_redirect_url=www.example.com/, data)
       assert_match(/3ds_challengewindowsize=01/, data)
       assert_match(/d5=unknown/, data)


### PR DESCRIPTION
The Credorax 3DS Adviser module depends on the use of the `3ds_initiate` parameter and can be controlled more specifically with the use of the `f23` parameter. If the `3ds_initiate` parameter isn’t received in the original request, it will be sent with a value of ’01’ by default. The `f23` parameter is optional and has no default if it is not sent in the original request.

Unit:
69 tests, 331 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
42 tests, 155 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CE-1082