### PR TITLE
Update fraud detection field: device_unique_id on Decidir gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * SafeCharge: 3DS external MPI data refinements [curiousepic] #3821
 * Credorax: Add support for 3DS Adviser [meagabeth] #3834
 * Adyen: Support subMerchant data [mymir][therufs] #3835
+* Decidir: add device_unique_identifier to card data #3839
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -170,6 +170,8 @@ module ActiveMerchant #:nodoc:
         card_data[:security_code] = credit_card.verification_value if credit_card.verification_value?
         card_data[:card_holder_name] = credit_card.name if credit_card.name
 
+        card_data[:device_unique_identifier] = options[:device_unique_id] if valid_fraud_detection_option?(options[:device_unique_id])
+
         # additional data used for Visa transactions
         card_data[:card_holder_door_number] = options[:card_holder_door_number].to_i if options[:card_holder_door_number]
         card_data[:card_holder_birthday] = options[:card_holder_birthday] if options[:card_holder_birthday]
@@ -210,7 +212,7 @@ module ActiveMerchant #:nodoc:
           hsh[:channel] = options[:channel] if valid_fraud_detection_option?(options[:channel])
           hsh[:dispatch_method] = options[:dispatch_method] if valid_fraud_detection_option?(options[:dispatch_method])
           hsh[:csmdds] = options[:csmdds] if valid_fraud_detection_option?(options[:csmdds])
-          hsh[:device_unique_identifier] = options[:device_unique_identifier] if valid_fraud_detection_option?(options[:device_unique_identifier])
+          hsh[:device_unique_id] = options[:device_unique_id] if valid_fraud_detection_option?(options[:device_unique_id])
           hsh[:bill_to] = options[:bill_to] if valid_fraud_detection_option?(options[:bill_to])
           hsh[:purchase_totals] = options[:purchase_totals] if valid_fraud_detection_option?(options[:purchase_totals])
           hsh[:customer_in_site] = options[:customer_in_site] if valid_fraud_detection_option?(options[:customer_in_site])

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -84,6 +84,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
             description: 'Campo MDD17'
           }
         ],
+        device_unique_id: '1',
         bill_to: {
           postal_code: '12345',
           last_name: 'Smith',

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -45,7 +45,8 @@ class DecidirTest < Test::Unit::TestCase
             code: 17,
             description: 'Campo MDD17'
           }
-        ]
+        ],
+        device_unique_id: '111'
       },
       installments: 12,
       site_id: '99999999'
@@ -60,7 +61,7 @@ class DecidirTest < Test::Unit::TestCase
       assert data =~ /"number":"123456"/
       assert data =~ /"establishment_name":"Heavenly Buffaloes"/
       assert data =~ /"site_id":"99999999"/
-      assert data =~ /"fraud_detection":{"send_to_cs":false,"channel":"Web","dispatch_method":"Store Pick Up","csmdds":\[{"code":17,"description":"Campo MDD17"}\]}/
+      assert data =~ /"fraud_detection":{"send_to_cs":false,"channel":"Web","dispatch_method":"Store Pick Up","csmdds":\[{"code":17,"description":"Campo MDD17"}\],"device_unique_id":"111"}/
     end.respond_with(successful_purchase_response)
 
     assert_equal 7719132, response.authorization


### PR DESCRIPTION
From talks between the customer and the gateway, the field needed to be sent in as`device_unique_id`
and then add fraud_detection > device_unique_identifier in the card_data object to work.

Local test:
4600 tests, 72884 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
34 tests, 165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
22 tests, 78 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed