### PR TITLE
Braintree_Blue: Add support for account_type field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Credorax: Add support for 3DS Adviser [meagabeth] #3834
 * Adyen: Support subMerchant data [mymir][therufs] #3835
 * Decidir: add device_unique_identifier to card data #3839
+* BraintreeBlue: add support for account_type field #3840
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -583,6 +583,7 @@ module ActiveMerchant #:nodoc:
         parameters[:device_data] = options[:device_data] if options[:device_data]
         parameters[:service_fee_amount] = options[:service_fee_amount] if options[:service_fee_amount]
 
+        add_account_type(parameters, options) if options[:account_type]
         add_skip_options(parameters, options)
         add_merchant_account_id(parameters, options)
 
@@ -607,6 +608,11 @@ module ActiveMerchant #:nodoc:
         end
 
         parameters
+      end
+
+      def add_account_type(parameters, options)
+        parameters[:options][:credit_card] = {}
+        parameters[:options][:credit_card][:account_type] = options[:account_type]
       end
 
       def add_skip_options(parameters, options)

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -756,6 +756,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'B', response.cvv_result['code']
   end
 
+  def test_successful_purchase_with_account_type
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      params[:options][:credit_card][:account_type] == 'credit'
+    end.returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), account_type: 'credit')
+  end
+
   def test_configured_logger_has_a_default
     # The default is actually provided by the Braintree gem, but we
     # assert its presence in order to show ActiveMerchant need not


### PR DESCRIPTION
[CE-1132](https://spreedly.atlassian.net/browse/CE-1132)

Unit: 81 tests, 184 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 82 tests, 439 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Note: Have not included a remote test for the account_type field because currently Braintree does not support account_type parameter on sandbox environments