### PR TITLE
Redsys: Add support for stored_credential

### DIFF
--- a/test/unit/gateways/redsys_test.rb
+++ b/test/unit/gateways/redsys_test.rb
@@ -47,6 +47,35 @@ class RedsysTest < Test::Unit::TestCase
     assert_equal '77bff3a969d6f97b2ec815448cdcff453971f573', res.params['ds_merchant_identifier']
   end
 
+  def test_successful_purchase_with_stored_credentials
+    @gateway.expects(:ssl_post).returns(successful_purchase_initial_stored_credential_response)
+    initial_options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring'
+      }
+    )
+    initial_res = @gateway.purchase(123, credit_card, initial_options)
+    assert_success initial_res
+    assert_equal 'Transaction Approved', initial_res.message
+    assert_equal '2012102122020', initial_res.params['ds_merchant_cof_txnid']
+    network_transaction_id = initial_res.params['Ds_Merchant_Cof_Txnid']
+
+    @gateway.expects(:ssl_post).returns(successful_purchase_used_stored_credential_response)
+    used_options = {
+      order_id: '1002',
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled',
+        network_transaction_id: network_transaction_id
+      }
+    }
+    res = @gateway.purchase(123, credit_card, used_options)
+    assert_success res
+    assert_equal 'Transaction Approved', res.message
+    assert_equal '561350', res.params['ds_authorisationcode']
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
     res = @gateway.purchase(123, credit_card, @options)
@@ -269,6 +298,14 @@ class RedsysTest < Test::Unit::TestCase
 
   def successful_purchase_response_with_credit_card_token
     "<?xml version='1.0' encoding=\"ISO-8859-1\" ?><RETORNOXML><CODIGO>0</CODIGO><Ds_Version>0.1</Ds_Version><OPERACION><Ds_Amount>100</Ds_Amount><Ds_Currency>978</Ds_Currency><Ds_Order>141661632759</Ds_Order><Ds_Signature>C65E11D80534B432042ABAA47DCA54F5AFEC23ED</Ds_Signature><Ds_MerchantCode>327234688</Ds_MerchantCode><Ds_Terminal>2</Ds_Terminal><Ds_Response>0000</Ds_Response><Ds_AuthorisationCode>341129</Ds_AuthorisationCode><Ds_TransactionType>A</Ds_TransactionType><Ds_SecurePayment>0</Ds_SecurePayment><Ds_Language>1</Ds_Language><Ds_Merchant_Identifier>77bff3a969d6f97b2ec815448cdcff453971f573</Ds_Merchant_Identifier><Ds_MerchantData></Ds_MerchantData><Ds_Card_Country>724</Ds_Card_Country></OPERACION></RETORNOXML>"
+  end
+
+  def successful_purchase_initial_stored_credential_response
+    "<?xml version='1.0' encoding=\"ISO-8859-1\" ?><RETORNOXML><CODIGO>0</CODIGO><Ds_Version>0.1</Ds_Version><OPERACION><Ds_Amount>123</Ds_Amount><Ds_Currency>978</Ds_Currency><Ds_Order>1001</Ds_Order><Ds_Signature>989D357BCC9EF0962A456C51422C4FAF4BF4399F</Ds_Signature><Ds_MerchantCode>91952713</Ds_MerchantCode><Ds_Terminal>1</Ds_Terminal><Ds_Response>0000</Ds_Response><Ds_AuthorisationCode>561350</Ds_AuthorisationCode><Ds_TransactionType>A</Ds_TransactionType><Ds_SecurePayment>0</Ds_SecurePayment><Ds_Language>1</Ds_Language><Ds_MerchantData></Ds_MerchantData><Ds_Card_Country>724</Ds_Card_Country><Ds_Merchant_Cof_Txnid>2012102122020</Ds_Merchant_Cof_Txnid><Ds_Card_Brand>1</Ds_Card_Brand><Ds_ProcessedPayMethod>3</Ds_ProcessedPayMethod></OPERACION></RETORNOXML>"
+  end
+
+  def successful_purchase_used_stored_credential_response
+    "<?xml version='1.0' encoding=\"ISO-8859-1\" ?><RETORNOXML><CODIGO>0</CODIGO><Ds_Version>0.1</Ds_Version><OPERACION><Ds_Amount>123</Ds_Amount><Ds_Currency>978</Ds_Currency><Ds_Order>1001</Ds_Order><Ds_Signature>989D357BCC9EF0962A456C51422C4FAF4BF4399F</Ds_Signature><Ds_MerchantCode>91952713</Ds_MerchantCode><Ds_Terminal>1</Ds_Terminal><Ds_Response>0000</Ds_Response><Ds_AuthorisationCode>561350</Ds_AuthorisationCode><Ds_TransactionType>A</Ds_TransactionType><Ds_SecurePayment>0</Ds_SecurePayment><Ds_Language>1</Ds_Language><Ds_MerchantData></Ds_MerchantData><Ds_Card_Country>724</Ds_Card_Country><Ds_Card_Brand>1</Ds_Card_Brand><Ds_ProcessedPayMethod>3</Ds_ProcessedPayMethod></OPERACION></RETORNOXML>"
   end
 
   def failed_purchase_response


### PR DESCRIPTION
CE-1184

Remote tests failing on master:
test_successful_authorise_using_vault_id
test_successful_purchase_using_vault_id

Remote:
21 tests, 60 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90.4762% passed

Unit
33 tests, 104 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed