### PR TITLE
Stripe Payment Intents: Add error_on_requires_action Support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * BraintreeBlue: add support for account_type field [jimilpatel24] #3840
 * Redsys: Add support for stored_credential [meagabeth] #3844
 * Redsys: add_payment method solution [meagabeth] #3845
+* Stripe Payment Intents: Add support for error_on_requires_action option [tatsianaclifton] #3846
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -30,6 +30,7 @@ module ActiveMerchant #:nodoc:
         add_shipping_address(post, options)
         setup_future_usage(post, options)
         add_exemption(post, options)
+        add_error_on_requires_action(post, options)
         request_three_d_secure(post, options)
 
         CREATE_INTENT_ATTRIBUTES.each do |attribute|
@@ -267,6 +268,12 @@ module ActiveMerchant #:nodoc:
         post[:payment_method_options] ||= {}
         post[:payment_method_options][:card] ||= {}
         post[:payment_method_options][:card][:moto] = true if options[:moto]
+      end
+
+      def add_error_on_requires_action(post, options = {})
+        return unless options[:confirm]
+
+        post[:error_on_requires_action] = true if options[:error_on_requires_action]
       end
 
       def request_three_d_secure(post, options = {})


### PR DESCRIPTION
CE-1220

Unit:
17 tests, 109 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
48 tests, 208 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Note: Some tests failed for different gateway with rake test:local