### PR TITLE
passthrough 3DS for Pin Payments

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -30,6 +30,7 @@ module ActiveMerchant #:nodoc:
         add_address(post, creditcard, options)
         add_capture(post, options)
         add_metadata(post, options)
+        add_3ds(post, options)
 
         commit(:post, 'charges', post, options)
       end
@@ -156,6 +157,16 @@ module ActiveMerchant #:nodoc:
 
       def add_metadata(post, options)
         post[:metadata] = options[:metadata] if options[:metadata]
+      end
+
+      def add_3ds(post, options)
+        if options[:three_d_secure]
+          post[:three_d_secure] = {}
+          post[:three_d_secure][:version] = options[:three_d_secure][:version] if options[:three_d_secure][:version]
+          post[:three_d_secure][:eci] = options[:three_d_secure][:eci] if options[:three_d_secure][:eci]
+          post[:three_d_secure][:cavv] = options[:three_d_secure][:cavv] if options[:three_d_secure][:cavv]
+          post[:three_d_secure][:transaction_id] = options[:three_d_secure][:ds_transaction_id] || options[:three_d_secure][:xid]
+        end
       end
 
       def headers(params = {})


### PR DESCRIPTION
The Pin Payments API does support 3DS passthrough and therefore the Pin Payments active_merchant gateway is being expanded to allow for this capability in active_merchant.

The Pin Payments API Documentation describing the 3DS fields is [here](https://pinpayments.com/developers/api-reference/charges#post-charges)

Test Cards for the Pin Payments platform are [here](https://pinpayments.com/developers/api-reference/test-cards)

## Remote Test Run

```
Chris.Kruger@hostname active_merchant % rake test:remote TEST=test/remote/gateways/remote_pin_test.rb
The dependency jruby-openssl (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform java`.
/Users/Chris.Kruger/.rbenv/versions/2.6.6/bin/ruby -w -I"lib:test" /Users/Chris.Kruger/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb "test/remote/gateways/remote_pin_test.rb" 
Loaded suite /Users/Chris.Kruger/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.3/lib/rake/rake_test_loader
Started
/Users/Chris.Kruger/Development/active_merchant/test/test_helper.rb:284: Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.
/Users/Chris.Kruger/Development/active_merchant/test/test_helper.rb:284: Passing permitted_symbols with the 3rd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_symbols: ...) instead.
/Users/Chris.Kruger/Development/active_merchant/test/test_helper.rb:284: Passing aliases with the 4th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, aliases: ...) instead.
.................
Finished in 15.108185 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
17 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1.13 tests/s, 3.31 assertions/s
```