### PR TITLE
Redsys: Update Mpi Fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Redsys: add_payment method solution [meagabeth] #3845
 * Stripe Payment Intents: Add support for error_on_requires_action option [tatsianaclifton] #3846
 * Add 3DS 2.0 values to paypal [nebdil] #3285
+* Redsys: Update Mpi Fields [tatsianaclifton] #3855
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -75,6 +75,7 @@ module ActiveMerchant #:nodoc:
 
       def api_version(options)
         return API_VERSION_3DS2 if options.dig(:three_d_secure, :version) =~ /^2/
+
         API_VERSION
       end
 

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -333,18 +333,18 @@ module ActiveMerchant #:nodoc:
         return unless options[:three_d_secure]
 
         if options[:three_d_secure][:version] == THREE_DS_V2
-          data[:threeDSServerTransID] = options[:three_d_secure][:xid] if options[:three_d_secure][:xid]
+          data[:threeDSServerTransID] = options[:three_d_secure][:three_ds_server_trans_id] if options[:three_d_secure][:three_ds_server_trans_id]
           data[:dsTransID] = options[:three_d_secure][:ds_transaction_id] if options[:three_d_secure][:ds_transaction_id]
           data[:authenticacionValue] = options[:three_d_secure][:cavv] if options[:three_d_secure][:cavv]
           data[:protocolVersion] = options[:three_d_secure][:version] if options[:three_d_secure][:version]
-
           data[:authenticacionMethod] = options[:authentication_method] if options[:authentication_method]
           data[:authenticacionType] = options[:authentication_type] if options[:authentication_type]
           data[:authenticacionFlow] = options[:authentication_flow] if options[:authentication_flow]
+          data[:eci_v2] = options[:three_d_secure][:eci] if options[:three_d_secure][:eci]
         elsif options[:three_d_secure][:version] == THREE_DS_V1
           data[:txid] = options[:three_d_secure][:xid] if options[:three_d_secure][:xid]
           data[:cavv] = options[:three_d_secure][:cavv] if options[:three_d_secure][:cavv]
-          data[:eci] = options[:three_d_secure][:eci] if options[:three_d_secure][:eci]
+          data[:eci_v1] = options[:three_d_secure][:eci] if options[:three_d_secure][:eci]
         end
       end
 
@@ -525,13 +525,13 @@ module ActiveMerchant #:nodoc:
         ds_merchant_mpi_external = {}
         ds_merchant_mpi_external[:TXID] = data[:txid] if data[:txid]
         ds_merchant_mpi_external[:CAVV] = data[:cavv] if data[:cavv]
-        ds_merchant_mpi_external[:ECI] = data[:eci] if data[:eci]
+        ds_merchant_mpi_external[:ECI] = data[:eci_v1] if data[:eci_v1]
 
         ds_merchant_mpi_external[:threeDSServerTransID] = data[:threeDSServerTransID] if data[:threeDSServerTransID]
         ds_merchant_mpi_external[:dsTransID] = data[:dsTransID] if data[:dsTransID]
         ds_merchant_mpi_external[:authenticacionValue] = data[:authenticacionValue] if data[:authenticacionValue]
         ds_merchant_mpi_external[:protocolVersion] = data[:protocolVersion] if data[:protocolVersion]
-
+        ds_merchant_mpi_external[:Eci] = data[:eci_v2] if data[:eci_v2]
         ds_merchant_mpi_external[:authenticacionMethod] = data[:authenticacionMethod] if data[:authenticacionMethod]
         ds_merchant_mpi_external[:authenticacionType] = data[:authenticacionType] if data[:authenticacionType]
         ds_merchant_mpi_external[:authenticacionFlow] = data[:authenticacionFlow] if data[:authenticacionFlow]

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -300,11 +300,11 @@ class PaypalTest < Test::Unit::TestCase
   def test_successful_purchase_with_3ds_version_2
     params = @params.merge!({
       three_d_secure: {
-          trans_status: 'Y',
-          eci: '05',
-          cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
-          ds_transaction_id: 'bDE9Aa1A-C5Ac-AD3a-4bBC-aC918ab1de3E',
-          version: '2.1.0'
+        trans_status: 'Y',
+        eci: '05',
+        cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+        ds_transaction_id: 'bDE9Aa1A-C5Ac-AD3a-4bBC-aC918ab1de3E',
+        version: '2.1.0'
       }
     })
     response = @gateway.purchase(@amount, @credit_card, params)

--- a/test/remote/gateways/remote_redsys_sha256_test.rb
+++ b/test/remote/gateways/remote_redsys_sha256_test.rb
@@ -72,8 +72,9 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_threeds2_as_mpi
-    xid = '97267598-FAE6-48F2-8083-C23433990FBC'
+    three_ds_server_trans_id = '97267598-FAE6-48F2-8083-C23433990FBC'
     ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'
+    eci = '01'
     version = '2.1.0'
 
     response = @gateway.purchase(
@@ -83,7 +84,8 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
         three_d_secure: {
           version: version,
           ds_transaction_id: ds_transaction_id,
-          xid: xid
+          three_ds_server_trans_id: three_ds_server_trans_id,
+          eci: eci
         },
         description: 'description',
         store: 'store',

--- a/test/remote/gateways/remote_redsys_test.rb
+++ b/test/remote/gateways/remote_redsys_test.rb
@@ -19,9 +19,10 @@ class RemoteRedsysTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_threeds2
-    xid = '97267598-FAE6-48F2-8083-C23433990FBC'
+    three_ds_server_trans_id = '97267598-FAE6-48F2-8083-C23433990FBC'
     ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'
     version = '2.1.0'
+    eci = '02'
 
     response = @gateway.purchase(
       100,
@@ -30,7 +31,8 @@ class RemoteRedsysTest < Test::Unit::TestCase
         three_d_secure: {
           version: version,
           ds_transaction_id: ds_transaction_id,
-          xid: xid
+          three_ds_server_trans_id: three_ds_server_trans_id,
+          eci: eci
         }
       )
     )

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -612,7 +612,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_3ds_version_1_request
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure_option(version: '1.0.2', xid: 'xid')))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<n2:Version>124</n2:Version>}, data
       assert_match %r{<AuthStatus3ds>Y</AuthStatus3ds>}, data
       assert_match %r{<Cavv>cavv</Cavv>}, data
@@ -624,7 +624,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_3ds_version_2_request
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure_option(version: '2.1.0', ds_transaction_id: 'ds_transaction_id')))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_match %r{<n2:Version>214.0</n2:Version>}, data
       assert_match %r{<AuthStatus3ds>Y</AuthStatus3ds>}, data
       assert_match %r{<Cavv>cavv</Cavv>}, data
@@ -1442,14 +1442,14 @@ class PaypalTest < Test::Unit::TestCase
 
   def three_d_secure_option(version:, xid: nil, ds_transaction_id: nil)
     {
-        three_d_secure: {
-            trans_status: 'Y',
-            eci: 'eci',
-            cavv: 'cavv',
-            xid: xid,
-            ds_transaction_id: ds_transaction_id,
-            version: version
-        }
+      three_d_secure: {
+        trans_status: 'Y',
+        eci: 'eci',
+        cavv: 'cavv',
+        xid: xid,
+        ds_transaction_id: ds_transaction_id,
+        version: version
+      }
     }
   end
 end

--- a/test/unit/gateways/redsys_sha256_test.rb
+++ b/test/unit/gateways/redsys_sha256_test.rb
@@ -169,13 +169,14 @@ class RedsysSHA256Test < Test::Unit::TestCase
 
   def test_3ds2_data_passed_as_mpi
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(100, credit_card, { order_id: '156270437866', description: 'esta es la descripción', three_d_secure: { version: '2.1.0', xid: 'xid', ds_transaction_id: 'ds_transaction_id', cavv: 'cavv' } })
+      @gateway.authorize(100, credit_card, { order_id: '156270437866', description: 'esta es la descripción', three_d_secure: { version: '2.1.0', three_ds_server_trans_id: 'three_ds_server_trans_id', ds_transaction_id: 'ds_transaction_id', cavv: 'cavv', eci: '02' } })
     end.check_request do |_method, _endpoint, encdata, _headers|
       data = CGI.unescape(encdata)
       assert_match(/<DS_MERCHANT_MPIEXTERNAL>/, data)
-      assert_match(%r("threeDSServerTransID":"xid"), data)
+      assert_match(%r("threeDSServerTransID":"three_ds_server_trans_id"), data)
       assert_match(%r("dsTransID":"ds_transaction_id"), data)
       assert_match(%r("authenticacionValue":"cavv"), data)
+      assert_match(%r("Eci":"02"), data)
 
       assert_not_match(%r("authenticacionMethod"), data)
       assert_not_match(%r("authenticacionType"), data)
@@ -188,16 +189,17 @@ class RedsysSHA256Test < Test::Unit::TestCase
 
   def test_3ds2_data_passed_as_mpi_with_optional_values
     stub_comms(@gateway, :ssl_request) do
-      @gateway.authorize(100, credit_card, { order_id: '156270437866', description: 'esta es la descripción', three_d_secure: { version: '2.1.0', xid: 'xid', ds_transaction_id: 'ds_transaction_id', cavv: 'cavv' },
+      @gateway.authorize(100, credit_card, { order_id: '156270437866', description: 'esta es la descripción', three_d_secure: { version: '2.1.0', three_ds_server_trans_id: 'three_ds_server_trans_id', ds_transaction_id: 'ds_transaction_id', cavv: 'cavv', eci: '02' },
         authentication_method: '01',
         authentication_type: 'anything',
         authentication_flow: 'F' })
     end.check_request do |_method, _endpoint, encdata, _headers|
       data = CGI.unescape(encdata)
       assert_match(/<DS_MERCHANT_MPIEXTERNAL>/, data)
-      assert_match(%r("threeDSServerTransID":"xid"), data)
+      assert_match(%r("threeDSServerTransID":"three_ds_server_trans_id"), data)
       assert_match(%r("dsTransID":"ds_transaction_id"), data)
       assert_match(%r("authenticacionValue":"cavv"), data)
+      assert_match(%r("Eci":"02"), data)
 
       assert_match(%r("authenticacionMethod":"01"), data)
       assert_match(%r("authenticacionType":"anything"), data)


### PR DESCRIPTION
Added support for using three_ds_server_trans_id as threeDSServerTransID if provided
Added support to set Eci when 3ds version 2

ECS-1599

Unit:
33 tests, 104 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Remote
21 tests, 60 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90.4762% passed

The following tests failed on master:
test_successful_authorise_using_vault_id
test_successful_purchase_using_vault_id