### PR TITLE
Paymentez: Add 3DS MPI field support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * Orbital: Update 3DS support for Mastercard [meagabeth] #3850
 * Payeezy: Support standardized stored credentials [therufs] #3861
 * CyberSource: Update `billing_address` override [meagabeth] #3862
+* Paymentez: Add 3DS MPI field support [carrigan] #3856
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -175,7 +175,27 @@ module ActiveMerchant #:nodoc:
         extra_params = {}
         extra_params.merge!(options[:extra_params]) if options[:extra_params]
 
+        add_external_mpi_fields(extra_params, options)
+
         post['extra_params'] = extra_params unless extra_params.empty?
+      end
+
+      def add_external_mpi_fields(extra_params, options)
+        three_d_secure_options = options[:three_d_secure]
+        return unless three_d_secure_options
+
+        auth_data = {
+          cavv: three_d_secure_options[:cavv],
+          xid: three_d_secure_options[:xid],
+          eci: three_d_secure_options[:eci],
+          version: three_d_secure_options[:version],
+          reference_id: three_d_secure_options[:three_ds_server_trans_id],
+          status: three_d_secure_options[:authentication_response_status] || three_d_secure_options[:directory_response_status]
+        }.compact
+
+        return if auth_data.empty?
+
+        extra_params[:auth_data] = auth_data
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -22,6 +22,29 @@ class RemotePaymentezTest < Test::Unit::TestCase
       vat: 0,
       dev_reference: 'Testing'
     }
+
+    @cavv = 'example-cavv-value'
+    @xid = 'three-ds-v1-trans-id'
+    @eci = '01'
+    @three_ds_v1_version = '1.0.2'
+    @three_ds_v2_version = '2.1.0'
+    @three_ds_server_trans_id = 'three-ds-v2-trans-id'
+    @authentication_response_status = 'Y'
+
+    @three_ds_v1_mpi = {
+      cavv: @cavv,
+      eci: @eci,
+      version: @three_ds_v1_version,
+      xid: @xid
+    }
+
+    @three_ds_v2_mpi = {
+      cavv: @cavv,
+      eci: @eci,
+      version: @three_ds_v2_version,
+      three_ds_server_trans_id: @three_ds_server_trans_id,
+      authentication_response_status: @authentication_response_status
+    }
   end
 
   def test_successful_purchase
@@ -90,6 +113,18 @@ class RemotePaymentezTest < Test::Unit::TestCase
     token = store_response.authorization
     purchase_response = @gateway.purchase(@amount, token, @options)
     assert_success purchase_response
+  end
+
+  def test_successful_purchase_with_3ds1_mpi_fields
+    @options[:three_d_secure] = @three_ds_v1_mpi
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_3ds2_mpi_fields
+    @options[:three_d_secure] = @three_ds_v2_mpi
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
   end
 
   def test_failed_purchase
@@ -175,6 +210,18 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert capture = @gateway.capture(amount, auth.authorization)
     assert_success capture
     assert_equal 'Response by mock', capture.message
+  end
+
+  def test_successful_authorize_with_3ds1_mpi_fields
+    @options[:three_d_secure] = @three_ds_v1_mpi
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_authorize_with_3ds2_mpi_fields
+    @options[:three_d_secure] = @three_ds_v2_mpi
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
   end
 
   def test_failed_authorize

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -22,6 +22,29 @@ class PaymentezTest < Test::Unit::TestCase
       description: 'Store Purchase',
       email: 'a@b.com'
     }
+
+    @cavv = 'example-cavv-value'
+    @xid = 'three-ds-v1-trans-id'
+    @eci = '01'
+    @three_ds_v1_version = '1.0.2'
+    @three_ds_v2_version = '2.1.0'
+    @three_ds_server_trans_id = 'three-ds-v2-trans-id'
+    @authentication_response_status = 'Y'
+
+    @three_ds_v1_mpi = {
+      cavv: @cavv,
+      eci: @eci,
+      version: @three_ds_v1_version,
+      xid: @xid
+    }
+
+    @three_ds_v2_mpi = {
+      cavv: @cavv,
+      eci: @eci,
+      version: @three_ds_v2_version,
+      three_ds_server_trans_id: @three_ds_server_trans_id,
+      authentication_response_status: @authentication_response_status
+    }
   end
 
   def test_successful_purchase
@@ -52,6 +75,41 @@ class PaymentezTest < Test::Unit::TestCase
 
     assert_equal 'PR-926', response.authorization
     assert response.test?
+  end
+
+  def test_purchase_3ds1_mpi_fields
+    @options[:three_d_secure] = @three_ds_v1_mpi
+
+    expected_auth_data = {
+      cavv: @cavv,
+      xid: @xid,
+      eci: @eci,
+      version: @three_ds_v1_version
+    }
+
+    @gateway.expects(:commit_transaction).with do |_, post_data|
+      post_data['extra_params'][:auth_data] == expected_auth_data
+    end
+
+    @gateway.purchase(@amount, @credit_card, @options)
+  end
+
+  def test_purchase_3ds2_mpi_fields
+    @options[:three_d_secure] = @three_ds_v2_mpi
+
+    expected_auth_data = {
+      cavv: @cavv,
+      eci: @eci,
+      version: @three_ds_v2_version,
+      reference_id: @three_ds_server_trans_id,
+      status: @authentication_response_status
+    }
+
+    @gateway.expects(:commit_transaction).with() do |_, post_data|
+      post_data['extra_params'][:auth_data] == expected_auth_data
+    end
+
+    @gateway.purchase(@amount, @credit_card, @options)
   end
 
   def test_failed_purchase
@@ -96,6 +154,41 @@ class PaymentezTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'CI-635', response.authorization
     assert response.test?
+  end
+
+  def test_authorize_3ds1_mpi_fields
+    @options[:three_d_secure] = @three_ds_v1_mpi
+
+    expected_auth_data = {
+      cavv: @cavv,
+      xid: @xid,
+      eci: @eci,
+      version: @three_ds_v1_version
+    }
+
+    @gateway.expects(:commit_transaction).with() do |_, post_data|
+      post_data['extra_params'][:auth_data] == expected_auth_data
+    end
+
+    @gateway.authorize(@amount, @credit_card, @options)
+  end
+
+  def test_authorize_3ds2_mpi_fields
+    @options[:three_d_secure] = @three_ds_v2_mpi
+
+    expected_auth_data = {
+      cavv: @cavv,
+      eci: @eci,
+      version: @three_ds_v2_version,
+      reference_id: @three_ds_server_trans_id,
+      status: @authentication_response_status
+    }
+
+    @gateway.expects(:commit_transaction).with() do |_, post_data|
+      post_data['extra_params'][:auth_data] == expected_auth_data
+    end
+
+    @gateway.authorize(@amount, @credit_card, @options)
   end
 
   def test_failed_authorize


### PR DESCRIPTION
## Why?

3DS MPI fields are not currently supported for Paymentez gateway (ECS-1608)

Source: https://paymentez.github.io/api-doc/#payment-methods-cards-debit-with-token-base-case

## What Changed?

Adds 3DS MPI field support to Paymentez gateway.

Remote tests are permissive and do not allow for failure cases due to invalid parameters, so only successful remote tests were added.

## Test Coverage

Unit Tests:
---
4608 tests, 72918 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100% passed

Rubocop:
---
693 files inspected, no offenses detected

Remote Tests:
---
30 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions,
0 notifications
100% passed