### PR TITLE
Paypal: Update AuthStatus3ds MPI field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Stripe Payment Intents: Add support for error_on_requires_action option [tatsianaclifton] #3846
 * Add 3DS 2.0 values to paypal [nebdil] #3285
 * Redsys: Update Mpi Fields [tatsianaclifton] #3855
+* Paypal: Update AuthStatus3ds MPI field [curiousepic] #3857
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -110,7 +110,9 @@ module ActiveMerchant #:nodoc:
         three_d_secure = options[:three_d_secure]
         xml.tag! 'ThreeDSecureRequest' do
           xml.tag! 'MpiVendor3ds', 'Y'
-          xml.tag! 'AuthStatus3ds', three_d_secure[:trans_status] unless three_d_secure[:trans_status].blank?
+          if three_d_secure[:authentication_response_status] || three_d_secure[:trans_status]
+            xml.tag! 'AuthStatus3ds', three_d_secure[:authentication_response_status] || three_d_secure[:trans_status]
+          end
           xml.tag! 'Cavv', three_d_secure[:cavv] unless three_d_secure[:cavv].blank?
           xml.tag! 'Eci3ds', three_d_secure[:eci] unless three_d_secure[:eci].blank?
           xml.tag! 'Xid', three_d_secure[:xid] unless three_d_secure[:xid].blank?

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -300,7 +300,7 @@ class PaypalTest < Test::Unit::TestCase
   def test_successful_purchase_with_3ds_version_2
     params = @params.merge!({
       three_d_secure: {
-        trans_status: 'Y',
+        authentication_response_status: 'Y',
         eci: '05',
         cavv: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
         ds_transaction_id: 'bDE9Aa1A-C5Ac-AD3a-4bBC-aC918ab1de3E',

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -1443,7 +1443,7 @@ class PaypalTest < Test::Unit::TestCase
   def three_d_secure_option(version:, xid: nil, ds_transaction_id: nil)
     {
       three_d_secure: {
-        trans_status: 'Y',
+        authentication_response_status: 'Y',
         eci: 'eci',
         cavv: 'cavv',
         xid: xid,


### PR DESCRIPTION
Update the AuthStatus3ds field to prefer pulling from the standardized
auth_response_status field.
https://developer.paypal.com/docs/paypal-payments-pro/integration-guide/3d-secure/#5-complete-direct-payment-integration-using-3-d-secure-fields

Unit:
68 tests, 279 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
30 tests, 83 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed