### PR TITLE
Payeezy: support standardized stored credentials

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,6 @@ Layout/CaseIndentation:
 Layout/IndentHash:
   EnforcedStyle: consistent
 
+Naming/PredicateName:
+  Exclude:
+    - "lib/active_merchant/billing/gateways/payeezy.rb"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 * Redsys: Update Mpi Fields [tatsianaclifton] #3855
 * Paypal: Update AuthStatus3ds MPI field [curiousepic] #3857
 * Orbital: Update 3DS support for Mastercard [meagabeth] #3850
+* Payeezy: Support standardized stored credentials [therufs] #3861
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -247,14 +247,32 @@ module ActiveMerchant
       end
 
       def add_stored_credentials(params, options)
-        if options[:sequence]
+        if options[:sequence] || options[:stored_credential]
           params[:stored_credentials] = {}
-          params[:stored_credentials][:cardbrand_original_transaction_id] = options[:cardbrand_original_transaction_id] if options[:cardbrand_original_transaction_id]
-          params[:stored_credentials][:sequence] = options[:sequence]
-          params[:stored_credentials][:initiator] = options[:initiator] if options[:initiator]
-          params[:stored_credentials][:is_scheduled] = options[:is_scheduled]
+          params[:stored_credentials][:cardbrand_original_transaction_id] = original_transaction_id(options) if original_transaction_id(options)
+          params[:stored_credentials][:initiator] = initiator(options) if initiator(options)
+          params[:stored_credentials][:sequence] = options[:sequence] || sequence(options[:stored_credential][:initial_transaction])
+          params[:stored_credentials][:is_scheduled] = options[:is_scheduled] || is_scheduled(options[:stored_credential][:reason_type])
           params[:stored_credentials][:auth_type_override] = options[:auth_type_override] if options[:auth_type_override]
         end
+      end
+
+      def original_transaction_id(options)
+        return options[:cardbrand_original_transaction_id] if options[:cardbrand_original_transaction_id]
+        return options[:stored_credential][:network_transaction_id] if options[:stored_credential][:network_transaction_id]
+      end
+
+      def initiator(options)
+        return options[:initiator] if options[:initiator]
+        return options[:stored_credential][:initiator].upcase if options[:stored_credential][:initiator]
+      end
+
+      def sequence(initial_transaction)
+        initial_transaction ? 'FIRST' : 'SUBSEQUENT'
+      end
+
+      def is_scheduled(reason_type)
+        reason_type == 'recurring' ? 'true' : 'false'
       end
 
       def commit(params, options)

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -33,6 +33,14 @@ class RemotePayeezyTest < Test::Unit::TestCase
       initiator: 'MERCHANT',
       auth_type_override: 'A'
     }
+    @options_standardized_stored_credentials = {
+      stored_credential: {
+        network_transaction_id: 'abc123', # Not checked if initial_transaction == true; not valid if initial_transaction == false.
+        initial_transaction: true,
+        reason_type: 'recurring',
+        initiator: 'cardholder'
+      }
+    }
   end
 
   def test_successful_store
@@ -77,6 +85,12 @@ class RemotePayeezyTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_stored_credentials
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@options_stored_credentials))
+    assert_match(/Transaction Normal/, response.message)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_standardized_stored_credentials
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@options_standardized_stored_credentials))
     assert_match(/Transaction Normal/, response.message)
     assert_success response
   end

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -22,6 +22,14 @@ class PayeezyGateway < Test::Unit::TestCase
       initiator: 'MERCHANT',
       auth_type_override: 'A'
     }
+    @options_standardized_stored_credentials = {
+      stored_credential: {
+        network_transaction_id: 'abc123',
+        initial_transaction: false,
+        reason_type: 'recurring',
+        initiator: 'cardholder'
+      }
+    }
     @authorization = 'ET1700|106625152|credit_card|4738'
     @reversal_id = SecureRandom.random_number(1000000).to_s
   end
@@ -126,6 +134,18 @@ class PayeezyGateway < Test::Unit::TestCase
   def test_successful_purchase_with_stored_credentials
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(@options_stored_credentials))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/stored_credentials/, data)
+    end.respond_with(successful_purchase_stored_credentials_response)
+
+    assert_success response
+    assert response.test?
+    assert_equal 'Transaction Normal - Approved', response.message
+  end
+
+  def test_successful_purchase_with_standardized_stored_credentials
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(@options_standardized_stored_credentials))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/stored_credentials/, data)
     end.respond_with(successful_purchase_stored_credentials_response)


### PR DESCRIPTION
Unit: 35 tests, 168 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 35 tests, 137 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed 

On the addition to rubocop.yml: 
Previously, rubocop generated the following error: `Naming/PredicateName: Rename is_scheduled to scheduled?. (https://github.com/rubocop-hq/ruby-style-guide#bool-methods-qmark)`. Since the term we send to the gateway is literally `is_scheduled`, I've added a permanent exception for this cop on this gateway.