### PR TITLE
CyberSource: Update `billing_address` override

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Paypal: Update AuthStatus3ds MPI field [curiousepic] #3857
 * Orbital: Update 3DS support for Mastercard [meagabeth] #3850
 * Payeezy: Support standardized stored credentials [therufs] #3861
+* CyberSource: Update `billing_address` override [meagabeth] #3862
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -256,8 +256,9 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      # Create all address hash key value pairs so that we still function if we
-      # were only provided with one or two of them or even none
+      # Create all required address hash key value pairs
+      # If a value of nil is received, that value will be passed on to the gateway and will not be replaced with a default value
+      # Billing address fields received without an override value or with an empty string value will be replaced with the default_address values
       def setup_address_hash(options)
         default_address = {
           address1: 'Unspecified',
@@ -268,8 +269,18 @@ module ActiveMerchant #:nodoc:
         }
 
         submitted_address = options[:billing_address] || options[:address] || default_address
-        options[:billing_address] = default_address.merge(submitted_address.symbolize_keys) { |_k, default, submitted| submitted.blank? ? default : submitted }
+        options[:billing_address] = default_address.merge(submitted_address.symbolize_keys) { |_k, default, submitted| check_billing_field_value(default, submitted) }
         options[:shipping_address] = options[:shipping_address] || {}
+      end
+
+      def check_billing_field_value(default, submitted)
+        if submitted.nil?
+          nil
+        elsif submitted.blank?
+          default
+        else
+          submitted
+        end
       end
 
       def build_auth_request(money, creditcard_or_reference, options)

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -364,9 +364,16 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_billing_address_override
-    @options[:billing_address] = address
+    billing_address = {
+      address1: '111 North Pole Lane',
+      city: 'Santaland',
+      state: '',
+      phone: nil
+    }
+    @options[:billing_address] = billing_address
     @options[:email] = 'override@example.com'
     assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_equal true, response.success?
     assert_successful_response(response)
   end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -121,6 +121,27 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_allows_nil_values_in_billing_address
+    billing_address = {
+      address1: '123 Fourth St',
+      city: 'Fiveton',
+      state: '',
+      country: 'CA'
+    }
+
+    stub_comms do
+      @gateway.authorize(100, @credit_card, billing_address: billing_address)
+    end.check_request do |_endpoint, data, _headers|
+      assert_nil billing_address[:zip]
+      assert_nil billing_address[:phone]
+      assert_match(%r(<billTo>.*<street1>123 Fourth St</street1>.*</billTo>)m, data)
+      assert_match(%r(<billTo>.*<city>Fiveton</city>.*</billTo>)m, data)
+      assert_match(%r(<billTo>.*<state>NC</state>.*</billTo>)m, data)
+      assert_match(%r(<billTo>.*<postalCode>00000</postalCode>.*</billTo>)m, data)
+      assert_match(%r(<billTo>.*<country>CA</country>.*</billTo>)m, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_uses_names_from_billing_address_if_present
     name = 'Wesley Crusher'
 


### PR DESCRIPTION
CyberSource requires certain billing address fields be sent in with requests. The existing `setup_address_hash` method has been updated so that if it receives a value of `nil` for any of the `billing_address` subfields, it will send `nil` to the gateway. If a `billing_address` subfield is received without an override value or with an empty string value, it will be replaced with the default_address value found in the `setup_address_hash` method.

[CE-1281](https://spreedly.atlassian.net/browse/CE-1281)

Local tests:
4606 tests, 72931 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
102 tests, 499 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
95 tests, 491 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.7368% passed
The 5 remote tests failing are also failing on master branch:
test_successful_validate_pinless_debit_card
test_successful_tax_calculation
test_successful_pinless_debit_card_puchase
test_successful_3ds_validate_purchase_request
test_successful_3ds_validate_authorize_request