### PR TITLE
BlueSnap: Add support `fraud-session-id` field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Payeezy: Support standardized stored credentials [therufs] #3861
 * CyberSource: Update `billing_address` override [meagabeth] #3862
 * Paymentez: Add 3DS MPI field support [carrigan] #3856
+* BlueSnap: Add support `fraud-session-id` field [meagabeth] #3863
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -318,8 +318,10 @@ module ActiveMerchant
 
       def add_fraud_info(doc, payment_method, options)
         doc.send('transaction-fraud-info') do
-          doc.send('shopper-ip-address', options[:ip]) if options[:ip]
-
+          if fraud_info = options[:transaction_fraud_info]
+            doc.send('fraud-session-id', fraud_info[:fraud_session_id]) if fraud_info[:fraud_session_id]
+            doc.send('shopper-ip-address', fraud_info[:shopper_ip_address]) if fraud_info[:shopper_ip_address]
+          end
           unless payment_method.is_a? String
             doc.send('shipping-contact-info') do
               add_shipping_contact_info(doc, payment_method, options)

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -305,6 +305,19 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_transaction_fraud_info
+    fraud_info_options = @options.merge(
+      transaction_fraud_info: {
+        fraud_session_id: 'fbcc094208f54c0e974d56875c73af7a',
+        shopper_ip_address: '123.12.134.1'
+      }
+    )
+
+    response = @gateway.purchase(@amount, @credit_card, fraud_info_options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_successful_echeck_purchase
     response = @gateway.purchase(@amount, @check, @options.merge(@valid_check_options))
     assert_success response


### PR DESCRIPTION
Add support for the `fraud-session-id` field within the `transaction-fraud-info` object. Update the previously used `ip` field to be `shopper_ip_address` within the `transaction_fraud-info` object. Additional details can be found via [BlueSnap's Documentation](https://developers.bluesnap.com/v8976-XML/docs/transaction-fraud-info). Sample request and response content can be found in [BlueSnap's Auth Capture documentation](https://developers.bluesnap.com/v8976-XML/docs/auth-capture)

Local:
4611 tests, 72957 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
39 tests, 229 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
48 tests, 164 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CE-1145