### PR TITLE
Redsys: Add support for DS_MERCHANT_MERCHANTURL

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -511,6 +511,9 @@ module ActiveMerchant #:nodoc:
 
           xml.DS_MERCHANT_EMV3DS data[:threeds].to_json if data[:threeds]
 
+          merchant_url = options[:merchant_url] || @options[:merchant_url]
+          xml.DS_MERCHANT_MERCHANTURL merchant_url if merchant_url
+
           if options[:stored_credential]
             xml.DS_MERCHANT_COF_INI data[:DS_MERCHANT_COF_INI]
             xml.DS_MERCHANT_COF_TYPE data[:DS_MERCHANT_COF_TYPE]


### PR DESCRIPTION
When a purchase is completed, Redsys calls the merchant URL with transaction results. 

This pull request adds support for setting `DS_MERCHANT_MERCHANTURL`.

[On the official documentation]( https://pagosonline.redsys.es/conexion-redireccion.html#notificacion-online), it is called "Online Notifications".


> DS_MERCHANT_MERCHANTURL
> URL del comercio para la notificación "on-line"
> Si el comercio tiene configurada notificación online "HTTP" en el módulo de administración, se enviará una petición post con el resultado de la transacción a la URL especificada.
> https://pagosonline.redsys.es/parametros-entrada-salida.html#entradaTable