### PR TITLE
Elavon: Fix issue with encoding data sent in the request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Orbital: Update ECP details to use payment source [jessiagee] #3881
 * Alelo: Add additional BIN ranges [meagabeth] #3882
 * HPS: Update Add support for general credit [naashton] #3885
+* Elavon: Fix issue with encoding data sent in the request [naashton] #3865
 
 == Version 1.118.0 (January 22nd, 2021)
 * Worldpay: Add support for challengeWindowSize [carrigan] #3823

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -380,6 +380,7 @@ module ActiveMerchant #:nodoc:
 
       def commit(request)
         request = "xmldata=#{request}".delete('&')
+
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request, headers))
 
         Response.new(
@@ -415,6 +416,14 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(response)
         [response[:approval_code], response[:txn_id]].join(';')
+      end
+
+      def truncate(value, size)
+        return nil unless value
+
+        difference = value.force_encoding('iso-8859-1').length - value.length
+
+        return value.to_s[0, (size - difference)]
       end
     end
   end

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -413,6 +413,16 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_truncated_data
+    credit_card = @credit_card
+    credit_card.first_name = 'Ricky ™ Martínez įncogníto'
+    credit_card.last_name = 'Lesly Andrea Mart™nez estrada the last name'
+    @options[:billing_address][:address1] = 'Bats & Cats'
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -385,6 +385,19 @@ class ElavonTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_truncate_special_characters
+    first_name = 'Ricky ™ Martínez įncogníto'
+    credit_card = @credit_card
+    credit_card.first_name = first_name
+
+    stub_comms do
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      check = '<ssl_first_name>Ricky ™ Martínez </ssl_first_name>'
+      assert_match(/#{check}/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_level_3_fields_in_request
     level_3_data = {
       customer_code: 'bob',


### PR DESCRIPTION
Unicode characters greater than 1 byte appear to result in an increase
in length+1 for each character for each byte greater than 1.

`force_encoding('iso-8859-1')` on the individual piece of data and then
re-encoding the request data to `utf-8` seems to resolve the issue.

CE-1231

Unit: 41 tests, 226 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 35 tests, 165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed