### PR TITLE
BlueSnap: Update handling of `transaction-fraud-info` fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * CyberSource: Update `billing_address` override [meagabeth] #3862
 * Paymentez: Add 3DS MPI field support [carrigan] #3856
 * BlueSnap: Add support `fraud-session-id` field [meagabeth] #3863
+* BlueSnap: Update handling of `transaction-fraud-info` fields [meagabeth] #3866
 
 == Version 1.117.0 (November 13th)
 * Checkout V2: Pass attempt_n3d along with 3ds enabled [naashton] #3805

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -318,9 +318,9 @@ module ActiveMerchant
 
       def add_fraud_info(doc, payment_method, options)
         doc.send('transaction-fraud-info') do
+          doc.send('shopper-ip-address', options[:ip]) if options[:ip]
           if fraud_info = options[:transaction_fraud_info]
             doc.send('fraud-session-id', fraud_info[:fraud_session_id]) if fraud_info[:fraud_session_id]
-            doc.send('shopper-ip-address', fraud_info[:shopper_ip_address]) if fraud_info[:shopper_ip_address]
           end
           unless payment_method.is_a? String
             doc.send('shipping-contact-info') do

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -306,12 +306,12 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_transaction_fraud_info
-    fraud_info_options = @options.merge(
+    fraud_info_options = @options.merge({
+      ip: '123.12.134.1',
       transaction_fraud_info: {
-        fraud_session_id: 'fbcc094208f54c0e974d56875c73af7a',
-        shopper_ip_address: '123.12.134.1'
+        fraud_session_id: 'fbcc094208f54c0e974d56875c73af7a'
       }
-    )
+    })
 
     response = @gateway.purchase(@amount, @credit_card, fraud_info_options)
     assert_success response

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -51,8 +51,7 @@ class BlueSnapTest < Test::Unit::TestCase
     }
     @option_fraud_info = @options.merge(
       transaction_fraud_info: {
-        fraud_session_id: 'fbcc094208f54c0e974d56875c73af7a',
-        shopper_ip_address: '123.12.134.1'
+        fraud_session_id: 'fbcc094208f54c0e974d56875c73af7a'
       }
     )
   end
@@ -240,8 +239,9 @@ class BlueSnapTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_fraud_info
+    fraud_info = @option_fraud_info.merge({ ip: '123.12.134.1' })
     response = stub_comms(@gateway, :raw_ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @option_fraud_info)
+      @gateway.purchase(@amount, @credit_card, fraud_info)
     end.check_request do |_method, _url, data|
       assert_match(/<fraud-session-id>fbcc094208f54c0e974d56875c73af7a<\/fraud-session-id>/, data)
       assert_match(/<shopper-ip-address>123.12.134.1<\/shopper-ip-address>/, data)


### PR DESCRIPTION
The `shopper-ip-address` field will now accept `ip` as a top level field within the received `options` hash rather than it needing to be nested within `transaction-fraud-info`

Local
4615 tests, 72965 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote
48 tests, 164 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit
39 tests, 229 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed