### PR TITLE
[Firstdatae427] Fixes some apple pay transaction issues

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -212,8 +212,8 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'Expiry_Date', expdate(credit_card)
           xml.tag! 'CardHoldersName', credit_card.name
           xml.tag! 'CardType', card_type(credit_card.brand)
-          xml.tag! 'WalletProviderID', options[:wallet_provider_id] if options[:wallet_provider_id]
 
+          add_wallet_provider_id(xml, credit_card, options)
           add_credit_card_eci(xml, credit_card, options)
           add_credit_card_verification_strings(xml, credit_card, options)
         end
@@ -221,10 +221,9 @@ module ActiveMerchant #:nodoc:
 
       def add_credit_card_eci(xml, credit_card, options)
         eci = if credit_card.is_a?(NetworkTokenizationCreditCard) && credit_card.source == :apple_pay && card_brand(credit_card) == 'discover'
-                # Discover requires any Apple Pay transaction, regardless of in-app
-                # or web, and regardless of the ECI contained in the PKPaymentToken,
-                # to have an ECI value explicitly of 04.
-                '04'
+                # Payeezy requires an ECI of 5 for apple pay transactions
+                # See: https://support.payeezy.com/hc/en-us/articles/203730589-Ecommerce-Flag-Values
+                '05'
               else
                 (credit_card.respond_to?(:eci) ? credit_card.eci : nil) || options[:eci] || DEFAULT_ECI
               end
@@ -276,8 +275,20 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'Expiry_Date', expdate(credit_card)
         xml.tag! 'CardHoldersName', credit_card.name
         xml.tag! 'CardType', card_type(credit_card.brand)
-        xml.tag! 'WalletProviderID', options[:wallet_provider_id] if options[:wallet_provider_id]
+
+        add_wallet_provider_id(xml, credit_card, options)
         add_card_authentication_data(xml, options)
+      end
+
+      def add_wallet_provider_id(xml, credit_card, options)
+        provider_id = if options[:wallet_provider_id]
+                        options[:wallet_provider_id]
+                      elsif credit_card.is_a?(NetworkTokenizationCreditCard) && credit_card.source == :apple_pay
+                        # See: https://support.payeezy.com/hc/en-us/articles/206601408-First-Data-Payeezy-Gateway-Web-Service-API-Reference-Guide#3.9
+                        4
+                      end
+
+        xml.tag! 'WalletProviderID', provider_id if provider_id
       end
 
       def add_customer_data(xml, options)

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -51,7 +51,20 @@ class FirstdataE4V27Test < Test::Unit::TestCase
 
   def test_successful_purchase_with_wallet
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge!({ wallet_provider_id: 4 }))
+      @gateway.purchase(@amount, @credit_card, @options.merge!({ wallet_provider_id: 3 }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/WalletProviderID>3</, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_wallet_provider_id_for_apple_pay
+    response = stub_comms do
+      credit_card = network_tokenization_credit_card
+
+      credit_card.source = :apple_pay
+      @gateway.purchase(@amount, credit_card, @options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/WalletProviderID>4</, data)
     end.respond_with(successful_purchase_response)
@@ -255,13 +268,13 @@ class FirstdataE4V27Test < Test::Unit::TestCase
         '6011111111111117',
         brand: 'discover',
         transaction_id: '123',
-        eci: '05',
+        eci: '04',
         payment_cryptogram: 'whatever_the_cryptogram_is'
       )
 
       @gateway.purchase(@amount, credit_card, @options)
     end.check_request do |_, data, _|
-      assert_match '<Ecommerce_Flag>04</Ecommerce_Flag>', data
+      assert_match '<Ecommerce_Flag>05</Ecommerce_Flag>', data
       assert_match '<XID>123</XID>', data
       assert_match '<CAVV>whatever_the_cryptogram_is</CAVV>', data
       assert_xml_valid_to_wsdl(data)


### PR DESCRIPTION
Firsdata/Payeezy contacted Shopify to let us know that they need
the ECI for applepay/discover to be set to 5 and not 4.
See: https://support.payeezy.com/hc/en-us/articles/203730589-Ecommerce-Flag-Values

We also need to pass a WalletProviderID of 4 when the card source
is apple pay.
See: https://support.payeezy.com/hc/en-us/articles/206601408-First-Data-Payeezy-Gateway-Web-Service-API-Reference-Guide#3.9