### PR TITLE
Decidir: Improve error mapping

### DIFF
--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -301,15 +301,21 @@ module ActiveMerchant #:nodoc:
         error_code = nil
         if error = response.dig('status_details', 'error')
           code = error.dig('reason', 'id')
-          error_code = STANDARD_ERROR_CODE_MAPPING[code]
+          standard_error_code = STANDARD_ERROR_CODE_MAPPING[code]
+          error_code = "#{code}, #{standard_error_code}"
           error_code ||= error['type']
         elsif response['error_type']
           error_code = response['error_type'] if response['validation_errors']
-        elsif error = response.dig('error')
+        elsif response.dig('error', 'validation_errors')
+          error = response.dig('error')
           validation_errors = error.dig('validation_errors', 0)
           code = validation_errors['code'] if validation_errors && validation_errors['code']
           param = validation_errors['param'] if validation_errors && validation_errors['param']
           error_code = "#{error['error_type']} | #{code} | #{param}" if error['error_type']
+        elsif error = response.dig('error')
+          code = error.dig('reason', 'id')
+          standard_error_code = STANDARD_ERROR_CODE_MAPPING[code]
+          error_code = "#{code}, #{standard_error_code}"
         end
 
         error_code || STANDARD_ERROR_CODE[:processing_error]

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -150,6 +150,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
     response = @gateway_for_purchase.purchase(@amount, @declined_card, @options)
     assert_failure response
     assert_equal 'COMERCIO INVALIDO | invalid_card', response.message
+    assert_equal '3, config_error', response.error_code
     assert_match Gateway::STANDARD_ERROR_CODE[:config_error], response.error_code
   end
 
@@ -157,7 +158,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
     response = @gateway_for_purchase.purchase(@amount, @declined_card, @options.merge(installments: -1))
     assert_failure response
     assert_equal 'invalid_param: installments', response.message
-    assert_match 'invalid_request_error', response.error_code
+    assert_equal 'invalid_request_error', response.error_code
   end
 
   def test_successful_authorize_and_capture
@@ -253,8 +254,16 @@ class RemoteDecidirTest < Test::Unit::TestCase
     assert_match %r{PEDIR AUTORIZACION | request_authorization_card}, response.message
   end
 
-  def test_invalid_login
+  def test_invalid_login_without_api_key
     gateway = DecidirGateway.new(api_key: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{No API key found in request}, response.message
+  end
+
+  def test_invalid_login
+    gateway = DecidirGateway.new(api_key: 'xxxxxxx')
 
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -153,6 +153,14 @@ class DecidirTest < Test::Unit::TestCase
     assert_match 'invalid_request_error | invalid_param | payment_type', response.error_code
   end
 
+  def test_failed_purchase_error_response_with_error_code
+    @gateway_for_purchase.expects(:ssl_request).returns(error_response_with_error_code)
+
+    response = @gateway_for_purchase.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match '14, invalid_number', response.error_code
+  end
+
   def test_successful_authorize
     @gateway_for_auth.expects(:ssl_request).returns(successful_authorize_response)
 
@@ -534,6 +542,12 @@ class DecidirTest < Test::Unit::TestCase
   def unique_error_response
     %{
       {\"error\":{\"error_type\":\"invalid_request_error\",\"validation_errors\":[{\"code\":\"invalid_param\",\"param\":\"payment_type\"}]}}
+    }
+  end
+
+  def error_response_with_error_code
+    %{
+      {\"error\":{\"type\":\"invalid_number\",\"reason\":{\"id\":14,\"description\":\"TARJETA INVALIDA\",\"additional_description\":\"\"}}}
     }
   end
 end


### PR DESCRIPTION
- Revise the `error_code` to include the numerical `id` associated with the `reason` that was included in the `error_code`, when available
- Update remote `test_invalid_login` tests based on updated response.message we receive back from Decidir gateway

CE-776

All Local:
4616 tests, 72969 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
35 tests, 170 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
23 tests, 80 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed