### PR TITLE
Ensure `setup_future_usage` and `off_session` work 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Stripe PI: ensure `setup_future_sage` and `off_session` work when using SetupIntents.
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -30,6 +30,7 @@ module ActiveMerchant #:nodoc:
         add_shipping_address(post, options)
         setup_future_usage(post, options)
         add_exemption(post, options)
+        add_stored_credentials(post, options)
         add_error_on_requires_action(post, options)
         request_three_d_secure(post, options)
 
@@ -56,16 +57,22 @@ module ActiveMerchant #:nodoc:
       end
 
       def create_payment_method(payment_method, options = {})
-        post = {}
-        post[:type] = 'card'
-        post[:card] = {}
-        post[:card][:number] = payment_method.number
-        post[:card][:exp_month] = payment_method.month
-        post[:card][:exp_year] = payment_method.year
-        post[:card][:cvc] = payment_method.verification_value if payment_method.verification_value
-        add_billing_address(post, options)
+        post_data = create_payment_method_data(payment_method, options)
+
         options = format_idempotency_key(options, 'pm')
-        commit(:post, 'payment_methods', post, options)
+        commit(:post, 'payment_methods', post_data, options)
+      end
+
+      def create_payment_method_data(payment_method, options = {})
+        post_data = {}
+        post_data[:type] = 'card'
+        post_data[:card] = {}
+        post_data[:card][:number] = payment_method.number
+        post_data[:card][:exp_month] = payment_method.month
+        post_data[:card][:exp_year] = payment_method.year
+        post_data[:card][:cvc] = payment_method.verification_value if payment_method.verification_value
+        add_billing_address(post_data, options)
+        post_data
       end
 
       def update_intent(money, intent_id, payment_method, options = {})
@@ -100,6 +107,17 @@ module ActiveMerchant #:nodoc:
         post[:description] = options[:description] if options[:description]
 
         commit(:post, 'setup_intents', post, options)
+      end
+
+      def retrieve_setup_intent(setup_intent_id)
+        # Retrieving a setup_intent passing 'expand[]=latest_attempt' allows the caller to
+        # check for a network_transaction_id and ds_transaction_id
+        # eg (latest_attempt -> payment_method_details -> card -> network_transaction_id)
+        #
+        # Being able to retrieve these fields enables payment flows that rely on MIT exemptions, e.g: off_session
+        commit(:post, "setup_intents/#{setup_intent_id}", {
+          'expand[]': 'latest_attempt'
+        }, {})
       end
 
       def authorize(money, payment_method, options = {})
@@ -194,6 +212,10 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def off_session_request?(options = {})
+        (options[:off_session] || options[:setup_future_usage]) && options[:confirm] == true
+      end
+
       def add_connected_account(post, options = {})
         super(post, options)
         post[:application_fee_amount] = options[:application_fee] if options[:application_fee]
@@ -201,25 +223,21 @@ module ActiveMerchant #:nodoc:
 
       def add_whitelisted_attribute(post, options, attribute)
         post[attribute] = options[attribute] if options[attribute]
-        post
       end
 
       def add_capture_method(post, options)
         capture_method = options[:capture_method].to_s
         post[:capture_method] = capture_method if ALLOWED_METHOD_STATES.include?(capture_method)
-        post
       end
 
       def add_confirmation_method(post, options)
         confirmation_method = options[:confirmation_method].to_s
         post[:confirmation_method] = confirmation_method if ALLOWED_METHOD_STATES.include?(confirmation_method)
-        post
       end
 
       def add_customer(post, options)
         customer = options[:customer].to_s
         post[:customer] = customer if customer.start_with?('cus_')
-        post
       end
 
       def add_return_url(post, options)
@@ -227,22 +245,26 @@ module ActiveMerchant #:nodoc:
 
         post[:confirm] = options[:confirm]
         post[:return_url] = options[:return_url] if options[:return_url]
-        post
       end
 
       def add_payment_method_token(post, payment_method, options)
         return if payment_method.nil?
 
         if payment_method.is_a?(ActiveMerchant::Billing::CreditCard)
-          p = create_payment_method(payment_method, options)
-          return p unless p.success?
+          if off_session_request?(options)
+            post[:payment_method_data] = create_payment_method_data(payment_method, options)
+          else
+            p = create_payment_method(payment_method, options)
+            return p unless p.success?
 
-          payment_method = p.params['id']
+            payment_method = p.params['id']
+          end
         end
 
-        if payment_method.is_a?(StripePaymentToken)
+        case payment_method
+        when StripePaymentToken
           post[:payment_method] = payment_method.payment_data['id']
-        elsif payment_method.is_a?(String)
+        when String
           if payment_method.include?('|')
             customer_id, payment_method_id = payment_method.split('|')
             token = payment_method_id
@@ -252,6 +274,8 @@ module ActiveMerchant #:nodoc:
           end
           post[:payment_method] = token
         end
+
+        post
       end
 
       def add_payment_method_types(post, options)
@@ -259,7 +283,6 @@ module ActiveMerchant #:nodoc:
         return if payment_method_types.nil?
 
         post[:payment_method_types] = Array(payment_method_types)
-        post
       end
 
       def add_exemption(post, options = {})
@@ -268,6 +291,19 @@ module ActiveMerchant #:nodoc:
         post[:payment_method_options] ||= {}
         post[:payment_method_options][:card] ||= {}
         post[:payment_method_options][:card][:moto] = true if options[:moto]
+      end
+
+      def add_stored_credentials(post, options = {})
+        return unless options[:stored_credential] && !options[:stored_credential].values.all?(&:nil?)
+
+        stored_credential = options[:stored_credential]
+        post[:payment_method_options] ||= {}
+        post[:payment_method_options][:card] ||= {}
+        post[:payment_method_options][:card][:mit_exemption] = {}
+
+        # Stripe PI accepts network_transaction_id and ds_transaction_id via mit field under card.
+        post[:payment_method_options][:card][:mit_exemption][:network_transaction_id] = stored_credential[:network_transaction_id] if stored_credential[:network_transaction_id]
+        post[:payment_method_options][:card][:mit_exemption][:ds_transaction_id] = stored_credential[:ds_transaction_id] if stored_credential[:ds_transaction_id]
       end
 
       def add_error_on_requires_action(post, options = {})
@@ -299,8 +335,7 @@ module ActiveMerchant #:nodoc:
 
       def setup_future_usage(post, options = {})
         post[:setup_future_usage] = options[:setup_future_usage] if %w(on_session off_session).include?(options[:setup_future_usage])
-        post[:off_session] = options[:off_session] if options[:off_session] && options[:confirm] == true
-        post
+        post[:off_session] = options[:off_session] if off_session_request?(options)
       end
 
       def add_billing_address(post, options = {})
@@ -317,7 +352,6 @@ module ActiveMerchant #:nodoc:
         post[:billing_details][:email] = billing[:email] if billing[:email]
         post[:billing_details][:name] = billing[:name] if billing[:name]
         post[:billing_details][:phone] = billing[:phone] if billing[:phone]
-        post
       end
 
       def add_shipping_address(post, options = {})
@@ -336,7 +370,6 @@ module ActiveMerchant #:nodoc:
         post[:shipping][:carrier] = shipping[:carrier] if shipping[:carrier]
         post[:shipping][:phone] = shipping[:phone] if shipping[:phone]
         post[:shipping][:tracking_number] = shipping[:tracking_number] if shipping[:tracking_number]
-        post
       end
 
       def format_idempotency_key(options, suffix)

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -253,6 +253,7 @@ module ActiveMerchant #:nodoc:
         if payment_method.is_a?(ActiveMerchant::Billing::CreditCard)
           if off_session_request?(options)
             post[:payment_method_data] = create_payment_method_data(payment_method, options)
+            return
           else
             p = create_payment_method(payment_method, options)
             return p unless p.success?
@@ -336,6 +337,7 @@ module ActiveMerchant #:nodoc:
       def setup_future_usage(post, options = {})
         post[:setup_future_usage] = options[:setup_future_usage] if %w(on_session off_session).include?(options[:setup_future_usage])
         post[:off_session] = options[:off_session] if off_session_request?(options)
+        post
       end
 
       def add_billing_address(post, options = {})


### PR DESCRIPTION
Ensure `setup_future_sage` and `off_session` work when using SetupIntents and
PaymentIntents APIs

ECS-1512

Local:
4630 tests, 73058 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
52 tests, 244 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
20 tests, 132 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed