### PR TITLE
Vantiv/Litle: Truncate address fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Payment Express: support verify/validate [therufs] #3874
 * GlobalCollect: Truncate address fields [meagabeth] #3878
+* Litle: Truncate address fields [meagabeth] #3877
 
 == Version 1.118.0 (January 22nd, 2021)
 * Worldpay: Add support for challengeWindowSize [carrigan] #3823

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -371,9 +371,9 @@ module ActiveMerchant #:nodoc:
         return unless address
 
         doc.companyName(address[:company]) unless address[:company].blank?
-        doc.addressLine1(address[:address1]) unless address[:address1].blank?
-        doc.addressLine2(address[:address2]) unless address[:address2].blank?
-        doc.city(address[:city]) unless address[:city].blank?
+        doc.addressLine1(truncate(address[:address1], 35)) unless address[:address1].blank?
+        doc.addressLine2(truncate(address[:address2], 35)) unless address[:address2].blank?
+        doc.city(truncate(address[:city], 35)) unless address[:city].blank?
         doc.state(address[:state]) unless address[:state].blank?
         doc.zip(address[:zip]) unless address[:zip].blank?
         doc.country(address[:country]) unless address[:country].blank?

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -148,6 +148,23 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_truncated_billing_address
+    assert response = @gateway.purchase(10010, @credit_card1, {
+      order_id: '1',
+      email: 'test@example.com',
+      billing_address: {
+        address1: '1234 Supercalifragilisticexpialidocious',
+        address2: 'Unit 6',
+        city: '‎Lake Chargoggagoggmanchauggagoggchaubunagungamaugg',
+        state: 'ME',
+        zip: '09901',
+        country: 'US'
+      }
+    })
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_purchase_with_debt_repayment_flag
     assert response = @gateway.purchase(10010, @credit_card1, @options.merge(debt_repayment: true))
     assert_success response

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -46,6 +46,15 @@ class LitleTest < Test::Unit::TestCase
       account_number: '1099999999',
       account_type: 'checking'
     )
+
+    @long_address = {
+      address1: '1234 Supercalifragilisticexpialidocious',
+      address2: 'Unit 6',
+      city: '‎Lake Chargoggagoggmanchauggagoggchaubunagungamaugg',
+      state: 'ME',
+      zip: '09901',
+      country: 'US'
+    }
   end
 
   def test_successful_purchase
@@ -148,6 +157,14 @@ class LitleTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, shipping_address: address)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<shipToAddress>.*Widgets.*456.*Apt 1.*Otta.*ON.*K1C.*CA.*555-5/m, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_truncating_billing_address
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, billing_address: @long_address)
+    end.check_request do |_endpoint, data, _headers|
+      refute_match(/<billToAddress>Supercalifragilisticexpialidocious/m, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
The gateway has a character limit of 35 for `address` fields. This is now being enforced on `address1`, `address2` and `city` fields.

CE-1017

Local:
4625 tests, 73027 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
50 tests, 218 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
46 tests, 196 assertions, 13 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
71.7391% passed
Tests failing are also failing on main branch