### PR TITLE
GlobalCollect: Truncate address fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Payment Express: support verify/validate [therufs] #3874
+* GlobalCollect: Truncate address fields [meagabeth] #3878
 
 == Version 1.118.0 (January 22nd, 2021)
 * Worldpay: Add support for challengeWindowSize [carrigan] #3823

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -201,21 +201,21 @@ module ActiveMerchant #:nodoc:
         shipping_address = options[:shipping_address]
         if billing_address = options[:billing_address] || options[:address]
           post['order']['customer']['billingAddress'] = {
-            'street' => billing_address[:address1],
-            'additionalInfo' => billing_address[:address2],
+            'street' => truncate(billing_address[:address1], 50),
+            'additionalInfo' => truncate(billing_address[:address2], 50),
             'zip' => billing_address[:zip],
             'city' => billing_address[:city],
-            'state' => billing_address[:state],
+            'state' => truncate(billing_address[:state], 35),
             'countryCode' => billing_address[:country]
           }
         end
         if shipping_address
           post['order']['customer']['shippingAddress'] = {
-            'street' => shipping_address[:address1],
-            'additionalInfo' => shipping_address[:address2],
+            'street' => truncate(shipping_address[:address1], 50),
+            'additionalInfo' => truncate(shipping_address[:address2], 50),
             'zip' => shipping_address[:zip],
             'city' => shipping_address[:city],
-            'state' => shipping_address[:state],
+            'state' => truncate(shipping_address[:state], 35),
             'countryCode' => shipping_address[:country]
           }
           post['order']['customer']['shippingAddress']['name'] = {

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -14,6 +14,15 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase'
     }
+    @long_address = {
+      billing_address: {
+        address1: '1234 Supercalifragilisticexpialidociousthiscantbemorethanfiftycharacters',
+        city: '‎Portland',
+        state: 'ME',
+        zip: '09901',
+        country: 'US'
+      }
+    }
   end
 
   def test_successful_purchase
@@ -161,6 +170,12 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     credit_card = credit_card('4567350000427977', { first_name: nil, last_name: nil })
 
     response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_truncated_address
+    response = @gateway.purchase(@amount, @credit_card, @long_address)
     assert_success response
     assert_equal 'Succeeded', response.message
   end

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -220,6 +220,24 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_truncates_address_fields
+    response = stub_comms do
+      @gateway.purchase(@accepted_amount, @credit_card, {
+        billing_address: {
+          address1: '1234 Supercalifragilisticexpialidociousthiscantbemorethanfiftycharacters',
+          address2: 'Unit 6',
+          city: '‎Portland',
+          state: 'ME',
+          zip: '09901',
+          country: 'US'
+        }
+      })
+    end.check_request do |_endpoint, data, _headers|
+      refute_match(/Supercalifragilisticexpialidociousthiscantbemorethanfiftycharacters/, data)
+    end.respond_with(successful_capture_response)
+    assert_success response
+  end
+
   def test_failed_authorize
     response = stub_comms do
       @gateway.authorize(@rejected_amount, @declined_card, @options)


### PR DESCRIPTION
The gateway has various character limits for a few of the `billingAddress` and `shippingAddress` fields. These character limits are now being enforced and include `street`, `state`, and `additionalInfo`.

CE-1016

Unit:
27 tests, 133 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
24 tests, 59 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.8333% passed
One unrelated failure, also failing on main branch