### PR TITLE
Worldpay: allow purchase without capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * GlobalCollect: Truncate address fields [meagabeth] #3878
 * Litle: Truncate address fields [meagabeth] #3877
 * Decidir: Improve error mapping [meagabeth] #3875
+* Worldpay: support `skip_capture` [therufs] #3879
 
 == Version 1.118.0 (January 22nd, 2021)
 * Worldpay: Add support for challengeWindowSize [carrigan] #3823

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -58,7 +58,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment_method, options = {})
         MultiResponse.run do |r|
           r.process { authorize(money, payment_method, options) }
-          r.process { capture(money, r.authorization, options.merge(authorization_validated: true)) }
+          r.process { capture(money, r.authorization, options.merge(authorization_validated: true)) } unless options[:skip_capture]
         end
       end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -56,6 +56,13 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_purchase_skipping_capture
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(skip_capture: true))
+    assert_success response
+    assert response.responses.length == 1
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_successful_authorize_avs_and_cvv
     card = credit_card('4111111111111111', verification_value: 555)
     assert response = @gateway.authorize(@amount, card, @options.merge(billing_address: address.update(zip: 'CCCC')))

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -164,6 +164,14 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_skipping_capture
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(skip_capture: true))
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert response.responses.length == 1
+    assert_success response
+  end
+
   def test_successful_purchase_with_elo
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'BRL'))


### PR DESCRIPTION
Unit:
77 tests, 500 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote (before changes):
58 tests, 242 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.3793% passed

Remote (after changes):
59 tests, 246 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.5254% passed

CE-1301