### PR TITLE
Redsys: Add code 0195, fix typo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Netbanx: Add-customer-information(name,email,IP)-to-a-transaction [rockyhakjoong] #3754
 * Decidir: Improve error mapping [meagabeth] #3875
 * Worldpay: support `skip_capture` [therufs] #3879
+* Redsys: Add new response code text [britth] #3880
 
 == Version 1.118.0 (January 22nd, 2021)
 * Worldpay: Add support for challengeWindowSize [carrigan] #3823

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -126,6 +126,7 @@ module ActiveMerchant #:nodoc:
         184 => 'Authentication error',
         190 => 'Refusal with no specific reason',
         191 => 'Expiry date incorrect',
+        195 => 'Requires SCA authentication',
 
         201 => 'Card expired',
         202 => 'Card blocked temporarily or under suspicion of fraud',
@@ -622,7 +623,7 @@ module ActiveMerchant #:nodoc:
       def response_text(code)
         code = code.to_i
         code = 0 if code < 100
-        RESPONSE_TEXTS[code] || 'Unkown code, please check in manual'
+        RESPONSE_TEXTS[code] || 'Unknown code, please check in manual'
       end
 
       def response_text_3ds(xml, params)


### PR DESCRIPTION
Adds a new response code (195 - Requires SCA authentication), fixes a typo

Remote:
25 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
42 tests, 161 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed