### PR TITLE
Updating add_ecp_details

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Decidir: Improve error mapping [meagabeth] #3875
 * Worldpay: support `skip_capture` [therufs] #3879
 * Redsys: Add new response code text [britth] #3880
+* Orbital: Update ECP details to use payment source [jessiagee] #3881
 
 == Version 1.118.0 (January 22nd, 2021)
 * Worldpay: Add support for challengeWindowSize [carrigan] #3823

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -251,7 +251,8 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_echeck_having_arc_authorization
-    assert response = @gateway.purchase(20, @echeck, @options.merge({ auth_method: 'A', check_serial_number: '000000000' }))
+    test_check = check(account_number: '000000000', account_type: 'checking', routing_number: '072403004')
+    assert response = @gateway.purchase(20, test_check, @options.merge({ auth_method: 'A' }))
     assert_success response
     assert_equal 'Approved', response.message
     assert_false response.authorization.blank?
@@ -259,12 +260,14 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
   def test_failed_missing_serial_for_arc_with_echeck
     assert_raise do
-      @gateway.purchase(20, @echeck, @options.merge({ auth_method: 'A' }))
+      test_check = { account_type: 'savings', routing_number: '072403004' }
+      @gateway.purchase(20, test_check, @options.merge({ auth_method: 'A' }))
     end
   end
 
   def test_successful_purchase_with_echeck_having_pop_authorization
-    assert response = @gateway.purchase(20, @echeck, @options.merge({ auth_method: 'P', check_serial_number: '000000000', terminal_city: 'CO', terminal_state: 'IL', image_reference_number: '00000' }))
+    test_check = check(account_number: '000000000', account_type: 'savings', routing_number: '072403004')
+    assert response = @gateway.purchase(20, test_check, @options.merge({ auth_method: 'P', terminal_city: 'CO', terminal_state: 'IL', image_reference_number: '00000' }))
     assert_success response
     assert_equal 'Approved', response.message
     assert_false response.authorization.blank?
@@ -272,7 +275,8 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
   def test_failed_missing_serial_for_pop_with_echeck
     assert_raise do
-      @gateway.purchase(20, @echeck, @options.merge({ auth_method: 'P' }))
+      test_check = { account_type: 'savings', routing_number: '072403004' }
+      @gateway.purchase(20, test_check, @options.merge({ auth_method: 'P' }))
     end
   end
 


### PR DESCRIPTION
Gateway Name: Orbital (Chase Paymentech)
Short Summary: Updating ECP details to look at the payment source for account information instead of options, fixed tests to reflect that

# Unit test output
Unit:
Loaded suite test/unit/gateways/orbital_test
Started
.......................................................................................................
Finished in 0.343716 seconds.
----------------------------------------------------------------------------------------------------------
103 tests, 617 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------
299.67 tests/s, 1795.09 assertions/s

# Remote test output
Remote:
Loaded suite test/remote/gateways/remote_orbital_test
Started
..................................................../Users/jessiagee/dev/active_merchant/lib/active_merchant/billing/gateways/orbital.rb:309:in `add_customer_profile': Customer Profile support in Orbital is non-conformant to the ActiveMerchant API and will be removed in its current form in a future version. Please contact the ActiveMerchant maintainers if you have an interest in modifying it to conform to the store/unstore/update API.
...
Finished in 30.080167 seconds.
----------------------------------------------------------------------------------------------------------
55 tests, 267 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------
1.83 tests/s, 8.88 assertions/s