### PR TITLE
Run GitHub Actions CI on PRs

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -1,7 +1,12 @@
 name: CI
 
 on:
-  - push
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
This is a followup to the same PR in [activemerchant/payment_icons](https://github.com/activemerchant/payment_icons/pull/400), so we Github Actions behavior similar in other `activemerchant` repos.
