### PR TITLE
HPS: Add support for general credit

### DIFF
--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -67,6 +67,15 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def credit(money, payment_method, options = {})
+        commit('CreditReturn') do |xml|
+          add_amount(xml, money)
+          add_allow_dup(xml)
+          add_card_or_token_payment(xml, payment_method, options)
+          add_details(xml, options)
+        end
+      end
+
       def verify(card_or_token, options = {})
         commit('CreditAccountVerify') do |xml|
           add_card_or_token_customer_data(xml, card_or_token, options)

--- a/test/remote/gateways/remote_hps_test.rb
+++ b/test/remote/gateways/remote_hps_test.rb
@@ -167,6 +167,17 @@ class RemoteHpsTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_credit
+    credit = @gateway.credit(@amount, @credit_card, @options)
+    assert_success credit
+    assert_equal 'Success', credit.params['GatewayRspMsg']
+  end
+
+  def test_failed_credit
+    credit = @gateway.credit(nil, @credit_card)
+    assert_failure credit
+  end
+
   def test_successful_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -142,6 +142,20 @@ class HpsTest < Test::Unit::TestCase
     assert_failure refund
   end
 
+  def test_successful_credit
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+
+    credit = @gateway.credit(@amount, @credit_card)
+    assert_success credit
+  end
+
+  def test_failed_credit
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+
+    credit = @gateway.refund(@amount, @credit_card)
+    assert_failure credit
+  end
+
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_void_response)
 


### PR DESCRIPTION
General credit transactions utilize the same endpoint as refund, but
take a `payment_method` instead and do not require a `transaction_id`
from a preceding transaction.

Tests that fail are due to some incorrect configurations for account.

CE-1305

Unit: 57 tests, 278 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 55 tests, 146 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.3636% passed