### PR TITLE
Elavon: Remove ampersand char from fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Orbital: Update ECP to use EWS verification [jessiagee] #3886
 * Eway: Add 3ds field when do direct payment [GavinSun9527] #3860 
 * Support Creditel cardtype [therufs] #3883
+* Elavon: Remove ampersand char from fields [naashton] #3891
 
 == Version 1.118.0 (January 22nd, 2021)
 * Worldpay: Add support for challengeWindowSize [carrigan] #3823

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -423,7 +423,7 @@ module ActiveMerchant #:nodoc:
 
         difference = value.force_encoding('iso-8859-1').length - value.length
 
-        return value.to_s[0, (size - difference)]
+        return value.delete('&"<>').to_s[0, (size - difference)]
       end
     end
   end

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -415,8 +415,9 @@ class RemoteElavonTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_truncated_data
     credit_card = @credit_card
-    credit_card.first_name = 'Ricky ™ Martínez įncogníto'
+    credit_card.first_name = 'Rick & ™ \" < > Martínez įncogníto'
     credit_card.last_name = 'Lesly Andrea Mart™nez estrada the last name'
+    @options[:billing_address][:city] = 'Saint-François-Xavier-de-Brompton'
     @options[:billing_address][:address1] = 'Bats & Cats'
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
The `&` char converts to the longer html encoding AFTER truncated,
resulting in the request being rejected for strings that are too long.
Easiest solution is to just remove the `&` from any value added to the
xml.

CE-1231

Unit: 42 tests, 229 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 35 tests, 165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed