### PR TITLE
Updating remote_orbital_test to use three_ds_gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Stripe PI: ensure `setup_future_sage` and `off_session` work when using SetupIntents.
 * Orbital: Update commit to accept retry_logic in params [jessiagee] #3890
+* Orbital: Update remote 3DS tests [jessiagee] #3892
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -5,6 +5,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     Base.mode = :test
     @gateway = ActiveMerchant::Billing::OrbitalGateway.new(fixtures(:orbital_gateway))
     @echeck_gateway = ActiveMerchant::Billing::OrbitalGateway.new(fixtures(:orbital_asv_aoa_gateway))
+    @three_ds_gateway = ActiveMerchant::Billing::OrbitalGateway.new(fixtures(:orbital_3ds_gateway))
 
     @amount = 100
     @credit_card = credit_card('4556761029983886')
@@ -378,7 +379,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
           merchant_email: 'email@example'
         }
       )
-      assert response = @gateway.authorize(100, cc, options)
+      assert response = @three_ds_gateway.authorize(100, cc, options)
 
       assert_success response
       assert_equal 'Approved', response.message
@@ -396,7 +397,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
         three_d_secure: fixture[:three_d_secure],
         address: fixture[:address]
       )
-      assert response = @gateway.purchase(100, cc, options)
+      assert response = @three_ds_gateway.purchase(100, cc, options)
 
       assert_success response
       assert_equal 'Approved', response.message


### PR DESCRIPTION
Includes use of a new MID for 3DS remote tests

Loaded suite test/remote/gateways/remote_orbital_test

56 tests, 270 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/orbital_test

107 tests, 637 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed