### PR TITLE
Mercado Pago: support Creditel card type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Stripe PI: ensure `setup_future_sage` and `off_session` work when using SetupIntents.
 * Orbital: Update commit to accept retry_logic in params [jessiagee] #3890
 * Orbital: Update remote 3DS tests [jessiagee] #3892
+* Mercado Pago: support Creditel card type [therufs] #3893
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.live_url = self.test_url = 'https://api.mercadopago.com/v1'
 
       self.supported_countries = %w[AR BR CL CO MX PE UY]
-      self.supported_cardtypes = %i[visa master american_express elo cabal naranja]
+      self.supported_cardtypes = %i[visa master american_express elo cabal naranja creditel]
 
       self.homepage_url = 'https://www.mercadopago.com/'
       self.display_name = 'Mercado Pago'

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -2,28 +2,30 @@ require 'test_helper'
 
 class RemoteMercadoPagoTest < Test::Unit::TestCase
   def setup
+    exp_year = Time.now.year + 1
     @gateway = MercadoPagoGateway.new(fixtures(:mercado_pago))
     @argentina_gateway = MercadoPagoGateway.new(fixtures(:mercado_pago_argentina))
     @colombian_gateway = MercadoPagoGateway.new(fixtures(:mercado_pago_colombia))
+    @uruguayan_gateway = MercadoPagoGateway.new(fixtures(:mercado_pago_uruguay))
 
     @amount = 500
     @credit_card = credit_card('5031433215406351')
     @colombian_card = credit_card('4013540682746260')
     @elo_credit_card = credit_card('5067268650517446',
       month: 10,
-      year: 2020,
+      year: exp_year,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737')
-    @cabal_credit_card = credit_card('6042012045809847',
+    @cabal_credit_card = credit_card('6035227716427021',
       month: 10,
-      year: 2020,
+      year: exp_year,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737')
     @naranja_credit_card = credit_card('5895627823453005',
       month: 10,
-      year: 2020,
+      year: exp_year,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '123')

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -6,7 +6,6 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     @gateway = MercadoPagoGateway.new(fixtures(:mercado_pago))
     @argentina_gateway = MercadoPagoGateway.new(fixtures(:mercado_pago_argentina))
     @colombian_gateway = MercadoPagoGateway.new(fixtures(:mercado_pago_colombia))
-    @uruguayan_gateway = MercadoPagoGateway.new(fixtures(:mercado_pago_uruguay))
 
     @amount = 500
     @credit_card = credit_card('5031433215406351')


### PR DESCRIPTION
No valid test card number is known for Creditel, so no tests were added.

Unit:
    38 tests, 175 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed
    
Remote:
    32 tests, 94 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    90.625% passed
    
Failing tests (also seen in #3741 ):
    - test_successful_purchase_with_taxes_and_net_amount
    - test_successful_purchase_with_processing_mode_gateway
    - test_partial_capture
    
CE-1295
