### PR TITLE
Add Support for Stored Credentials on HPS gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Orbital: Update remote 3DS tests [jessiagee] #3892
 * Mercado Pago: support Creditel card type [therufs] #3893
 * Payeezy: Update error mapping [meagabeth] #3896
+* HPS: Add support for stored_credential [cdmackeyfree] #3894
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
           add_descriptor_name(xml, options)
           add_card_or_token_payment(xml, card_or_token, options)
           add_three_d_secure(xml, card_or_token, options)
+          add_stored_credentials(xml, options)
         end
       end
 
@@ -52,6 +53,8 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment_method, options = {})
         if payment_method.is_a?(Check)
           commit_check_sale(money, payment_method, options)
+        elsif options.dig(:stored_credential, :reason_type) == 'recurring'
+          commit_recurring_billing_sale(money, payment_method, options)
         else
           commit_credit_sale(money, payment_method, options)
         end
@@ -131,6 +134,21 @@ module ActiveMerchant #:nodoc:
           add_descriptor_name(xml, options)
           add_card_or_token_payment(xml, card_or_token, options)
           add_three_d_secure(xml, card_or_token, options)
+          add_stored_credentials(xml, options)
+        end
+      end
+
+      def commit_recurring_billing_sale(money, card_or_token, options)
+        commit('RecurringBilling') do |xml|
+          add_amount(xml, money)
+          add_allow_dup(xml)
+          add_card_or_token_customer_data(xml, card_or_token, options)
+          add_details(xml, options)
+          add_descriptor_name(xml, options)
+          add_card_or_token_payment(xml, card_or_token, options)
+          add_three_d_secure(xml, card_or_token, options)
+          add_stored_credentials(xml, options)
+          add_stored_credentials_for_recurring_billing(xml, options)
         end
       end
 
@@ -262,6 +280,38 @@ module ActiveMerchant #:nodoc:
           # the gateway only allows a single character for the ECI
           xml.hps :ECommerceIndicator, strip_leading_zero(three_d_secure[:eci]) if three_d_secure[:eci]
           xml.hps :XID, three_d_secure[:xid] if three_d_secure[:xid]
+        end
+      end
+
+      # We do not currently support installments on this gateway.
+      # The HPS gateway treats recurring transactions as a seperate transaction type
+      def add_stored_credentials(xml, options)
+        return unless options[:stored_credential]
+
+        xml.hps :CardOnFileData do
+          if options[:stored_credential][:initiator] == 'customer'
+            xml.hps :CardOnFile, 'C'
+          elsif options[:stored_credential][:initiator] == 'merchant'
+            xml.hps :CardOnFile, 'M'
+          else
+            return
+          end
+
+          if options[:stored_credential][:network_transaction_id]
+            xml.hps :CardBrandTxnId, options[:stored_credential][:network_transaction_id]
+          else
+            return
+          end
+        end
+      end
+
+      def add_stored_credentials_for_recurring_billing(xml, options)
+        xml.hps :RecurringData do
+          if options[:stored_credential][:reason_type] = 'recurring'
+            xml.hps :OneTime, 'N'
+          else
+            xml.hps :OneTime, 'Y'
+          end
         end
       end
 


### PR DESCRIPTION
Heartland Payment System treats recurring purchases as a separate transaction type.

The initiator field (here referred to as 'CardOnFile') and the network_transaction_id are both nested under Transaction -> CreditSale -> Block1 -> CardonFileData

The reason_type (signified by the 'OneTime' indicator at HPS)is nested under Transaction -> RecurringBilling -> Block1 -> RecurringData

This structure required supporting the recurring transaction type so that stored credentials can be supported for this gateway.

Local:

4630 tests, 73050 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:

55 tests, 152 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:

57 tests, 283 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed