### PR TITLE
Payeezy: Update error mapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Orbital: Update commit to accept retry_logic in params [jessiagee] #3890
 * Orbital: Update remote 3DS tests [jessiagee] #3892
 * Mercado Pago: support Creditel card type [therufs] #3893
+* Payeezy: Update error mapping [meagabeth] #3896
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -102,6 +102,13 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failed_purchase_with_insufficient_funds
+    assert response = @gateway.purchase(530200, @credit_card, @options)
+    assert_failure response
+    assert_equal '302', response.error_code
+    assert_match(/Insufficient Funds/, response.message)
+  end
+
   def test_authorize_and_capture
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth


### PR DESCRIPTION
When a `bank_resp_code` is returned and is not equal to '100', it is mapped to `error_code`. If a transaction errors for a different reason and a `bank_resp_code` is not returned, the `error_code` will reflect its previous behavior, pulling the `code` from `messages` within the `Error` field in the response.

CE-1303

Remote:
36 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
36 tests, 172 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed