### PR TITLE
Orbital: Ensure payment_detail sends for ECP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Mercado Pago: support Creditel card type [therufs] #3893
 * Payeezy: Update error mapping [meagabeth] #3896
 * HPS: Add support for stored_credential [cdmackeyfree] #3894
+* Orbital: Ensure payment_detail sends for ECP [jessiagee] #3899
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -531,7 +531,12 @@ module ActiveMerchant #:nodoc:
           xml.tag! :CheckDDA, check.account_number if check.account_number
           xml.tag! :BankAccountType, ACCOUNT_TYPE[check.account_type] if ACCOUNT_TYPE[check.account_type]
           xml.tag! :ECPAuthMethod, options[:auth_method] if options[:auth_method] && ECP_AUTH_METHODS.include?(options[:auth_method])
-          xml.tag! :BankPmtDelv, options[:payment_delivery] if options[:payment_delivery] && ECP_BANK_PAYMENT.include?(options[:payment_delivery])
+
+          if options[:payment_delivery] && ECP_BANK_PAYMENT.include?(options[:payment_delivery])
+            xml.tag! :BankPmtDelv, options[:payment_delivery]
+          else
+            xml.tag! :BankPmtDelv, 'B'
+          end
         end
       end
 

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -604,6 +604,34 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_equal 'Approved', auth.message
   end
 
+  def test_authorize_sends_with_payment_delivery
+    assert auth = @echeck_gateway.authorize(@amount, @echeck, @options.merge(order_id: '4', payment_delivery: 'A'))
+    assert_success auth
+    assert_equal 'Approved', auth.message
+  end
+
+  def test_authorize_sends_with_incorrect_payment_delivery
+    transcript = capture_transcript(@echeck_gateway) do
+      @echeck_gateway.authorize(@amount, @echeck, @options.merge(order_id: '4', payment_delivery: 'X'))
+    end
+
+    assert_match(/<BankPmtDelv>B/, transcript)
+    assert_match(/<MessageType>A/, transcript)
+    assert_match(/<ApprovalStatus>1/, transcript)
+    assert_match(/<RespCode>00/, transcript)
+  end
+
+  def test_default_payment_delivery_with_no_payment_delivery_sent
+    transcript = capture_transcript(@echeck_gateway) do
+      @echeck_gateway.authorize(@amount, @echeck, @options.merge(order_id: '4'))
+    end
+
+    assert_match(/<BankPmtDelv>B/, transcript)
+    assert_match(/<MessageType>A/, transcript)
+    assert_match(/<ApprovalStatus>1/, transcript)
+    assert_match(/<RespCode>00/, transcript)
+  end
+
   # == Certification Tests
 
   # ==== Section A

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -1158,6 +1158,33 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_payment_delivery_when_param_correct
+    response = stub_comms do
+      @gateway.purchase(50, @echeck, order_id: 1, payment_delivery: 'A')
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<BankPmtDelv>A/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
+  def test_payment_delivery_when_param_incorrect
+    response = stub_comms do
+      @gateway.purchase(50, @echeck, order_id: 1, payment_delivery: 'Z')
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<BankPmtDelv>B/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
+  def test_payment_delivery_when_no_payment_delivery_param
+    response = stub_comms do
+      @gateway.purchase(50, @echeck, order_id: 1)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<BankPmtDelv>B/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
   ActiveMerchant::Billing::OrbitalGateway::APPROVED.each do |resp_code|
     define_method "test_approval_response_code_#{resp_code}" do
       @gateway.expects(:ssl_post).returns(successful_purchase_response(resp_code))


### PR DESCRIPTION
Loaded suite test/unit/gateways/orbital_test

110 tests, 649 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_orbital_test

59 tests, 281 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed