### PR TITLE
Payeezy: Update `error_code_from` method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Payeezy: Update error mapping [meagabeth] #3896
 * HPS: Add support for stored_credential [cdmackeyfree] #3894
 * Orbital: Ensure payment_detail sends for ECP [jessiagee] #3899
+* Payeezy: Update `error_code_from` method [meagabeth] #3900
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -355,10 +355,11 @@ module ActiveMerchant
 
       def error_code_from(response)
         error_code = nil
-        if response['bank_resp_code'] && response['bank_resp_code'] != '100'
+        if response['bank_resp_code'] == '100'
+          return
+        elsif response['bank_resp_code']
           error_code = response['bank_resp_code']
-        else
-          error_code = response['Error'].to_h['messages'].to_a.map { |e| e['code'] }.join(', ')
+        elsif error_code = response['Error'].to_h['messages'].to_a.map { |e| e['code'] }.join(', ')
         end
 
         error_code

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -67,6 +67,8 @@ class RemotePayeezyTest < Test::Unit::TestCase
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_match(/Transaction Normal/, response.message)
+    assert_equal '100', response.params['bank_resp_code']
+    assert_equal nil, response.error_code
     assert_success response
   end
 


### PR DESCRIPTION
CE-1303

Update `error_code_from` method to send `nil` if `bank_resp_code` is present and equal to '100', map the value of `bank_resp_code` to `error_code` if it is not equal to '100'

Unit:
36 tests, 172 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
36 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed