### PR TITLE
Worldpay: Add support for `statementNarrative` field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * HPS: Add support for stored_credential [cdmackeyfree] #3894
 * Orbital: Ensure payment_detail sends for ECP [jessiagee] #3899
 * Payeezy: Update `error_code_from` method [meagabeth] #3900
+* Worldpay: Add support for `statementNarrative` field [meagabeth] #3901
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -206,6 +206,7 @@ module ActiveMerchant #:nodoc:
               end
               add_payment_method(xml, money, payment_method, options)
               add_shopper(xml, options)
+              add_statement_narrative(xml, options)
               add_risk_data(xml, options[:risk_data]) if options[:risk_data]
               add_hcg_additional_data(xml, options) if options[:hcg_additional_data]
               add_instalments_data(xml, options) if options[:instalments]
@@ -483,6 +484,10 @@ module ActiveMerchant #:nodoc:
             xml.userAgentHeader options[:user_agent]
           end
         end
+      end
+
+      def add_statement_narrative(xml, options)
+        xml.statementNarrative truncate(options[:statement_narrative], 50) if options[:statement_narrative]
       end
 
       def add_authenticated_shopper_id(xml, options)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -577,6 +577,12 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_match @store_options[:customer], response.authorization
   end
 
+  def test_successful_purchase_with_statement_narrative
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(statement_narrative: 'Merchant Statement Narrative'))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_successful_authorize_using_token
     assert store = @gateway.store(@credit_card, @store_options)
     assert_success store

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -560,6 +560,15 @@ class WorldpayTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_statement_narrative_and_truncation
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(statement_narrative: 'Merchant Statement Narrative The Story Of Your Purchase'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<statementNarrative>Merchant Statement Narrative The Story Of Your Pur</statementNarrative>), data
+      assert_no_match %r(<statementNarrative>Merchant Statement Narrative The Story Of Your Purchase</statementNarrative>), data
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_instalments
     stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(instalments: 3))


### PR DESCRIPTION
CE-1341

Unit:
78 tests, 504 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
60 tests, 249 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.6667% passed
- 5 failing tests also fail on master branch