### PR TITLE
WorldPay: remove some defaults in billing address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * Worldpay: Add support for `statementNarrative` field [meagabeth] #3901
 * Mercado Pago: Give ability to pass capture option in authorize txn field [naashton] #3897
 * Orbital: Ensure correct fields sent in refund [jessiagee] #3903
+* WorldPay: remove some defaults in billing address [carrigan] #3902
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874
@@ -26,7 +27,7 @@
 * HPS: Update Add support for general credit [naashton] #3885
 * Elavon: Fix issue with encoding data sent in the request [naashton] #3865
 * Orbital: Update ECP to use EWS verification [jessiagee] #3886
-* Eway: Add 3ds field when do direct payment [GavinSun9527] #3860 
+* Eway: Add 3ds field when do direct payment [GavinSun9527] #3860
 * Support Creditel cardtype [therufs] #3883
 * Elavon: Remove ampersand char from fields [naashton] #3891
 

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -538,15 +538,23 @@ module ActiveMerchant #:nodoc:
       def address_with_defaults(address)
         address ||= {}
         address.delete_if { |_, v| v.blank? }
+        ensure_address1_and_city(address)
         address.reverse_merge!(default_address)
+      end
+
+      # `address1` and `city` are optional but if one is supplied, the other
+      # must also be present
+      def ensure_address1_and_city(address)
+        has_address1 = !address[:address1].nil? && !address[:address1].blank?
+        has_city = !address[:city].nil? && !address[:city].blank?
+
+        address[:city] = 'N/A' if !has_city && has_address1
+        address[:address1] = 'N/A' if !has_address1 && has_city
       end
 
       def default_address
         {
-          address1: 'N/A',
           zip: '0000',
-          city: 'N/A',
-          state: 'N/A',
           country: 'US'
         }
       end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -397,6 +397,12 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_success @gateway.authorize(@amount, @credit_card, @options.merge(billing_address: billing_address))
   end
 
+  def test_state_omitted
+    billing_address = address
+    billing_address.delete(:state)
+    assert_success @gateway.authorize(@amount, @credit_card, @options.merge(billing_address: billing_address))
+  end
+
   def test_ip_address
     assert_success @gateway.authorize(@amount, @credit_card, @options.merge(ip: '192.18.123.12'))
   end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -467,10 +467,10 @@ class WorldpayTest < Test::Unit::TestCase
       assert_no_match %r(firstName), data
       assert_no_match %r(lastName), data
       assert_no_match %r(address2), data
-      assert_match %r(<address1>N/A</address1>), data
-      assert_match %r(<city>N/A</city>), data
+      assert_match %r(<address1/>), data
+      assert_match %r(<city/>), data
       assert_match %r(<postalCode>0000</postalCode>), data
-      assert_match %r(<state>N/A</state>), data
+      assert_match %r(<state/>), data
       assert_match %r(<countryCode>US</countryCode>), data
       assert_match %r(<telephoneNumber>555-3323</telephoneNumber>), data
     end.respond_with(successful_authorize_response)
@@ -504,12 +504,36 @@ class WorldpayTest < Test::Unit::TestCase
       assert_no_match %r(firstName), data
       assert_no_match %r(lastName), data
       assert_no_match %r(address2), data
-      assert_match %r(<address1>N/A</address1>), data
-      assert_match %r(<city>N/A</city>), data
+      assert_match %r(<address1/>), data
+      assert_match %r(<city/>), data
       assert_match %r(<postalCode>0000</postalCode>), data
-      assert_match %r(<state>N/A</state>), data
+      assert_match %r(<state/>), data
       assert_match %r(<countryCode>US</countryCode>), data
       assert_match %r(<telephoneNumber>555-3323</telephoneNumber>), data
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_address_with_address1_no_city
+    city = 'Ontario'
+    address_with_nils = { address1: nil, city: city }
+
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(billing_address: address_with_nils))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<address1>N/A</address1>), data
+      assert_match %r(<city>#{city}</city>), data
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_address_with_city_no_address1
+    address1 = '456 My Street'
+    address_with_nils = { address1: address1, city: nil }
+
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(billing_address: address_with_nils))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<address1>#{address1}</address1>), data
+      assert_match %r(<city>N/A</city>), data
     end.respond_with(successful_authorize_response)
   end
 


### PR DESCRIPTION
## Why?

ECS-14244

ActiveMerchant sends default values to WorldPay for the billing address when no value is given. This can be problematic when the gateway needs to do address verification.

## What Changed?

This commit removes the defaults for billing address state, address1, and city. The WorldPay docs specify that if either field of address1 and city is given, the other must also be, so defaulting was added for these fields when only one or the other is given.

## Test Suite

Worldpay Remote Tests Before:
60 tests, 249 assertions, 5 failures, 0 errors, 0 pendings,
  0 omissions, 0 notifications

Worldpay Remote Tests After:
61 tests, 250 assertions, 5 failures, 0 errors, 0 pendings,
  0 omissions, 0 notifications

Unit Tests:
4652 tests, 73157 assertions, 0 failures, 0 errors, 0 pendings,
  0 omissions, 0 notifications
693 files inspected, no offenses detected