### PR TITLE
Orbital: Send ECP details with refund

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Payeezy: Update `error_code_from` method [meagabeth] #3900
 * Worldpay: Add support for `statementNarrative` field [meagabeth] #3901
 * Mercado Pago: Give ability to pass capture option in authorize txn field [naashton] #3897
+* Orbital: Ensure correct fields sent in refund [jessiagee] #3903
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -262,8 +262,13 @@ module ActiveMerchant #:nodoc:
 
       # R – Refund request
       def refund(money, authorization, options = {})
-        order = build_new_order_xml(REFUND, money, nil, options.merge(authorization: authorization)) do |xml|
-          add_refund(xml, options[:currency])
+        payment_method = options[:payment_method]
+        order = build_new_order_xml(REFUND, money, payment_method, options.merge(authorization: authorization)) do |xml|
+          if payment_method.is_a?(Check)
+            add_echeck(xml, payment_method, options)
+          else
+            add_refund(xml, options[:currency])
+          end
           xml.tag! :CustomerRefNum, options[:customer_ref_num] if @options[:customer_profiles] && options[:profile_txn]
         end
         commit(order, :refund, options[:retry_logic], options[:trace_number])


### PR DESCRIPTION
Loaded suite test/unit/gateways/orbital_test

110 tests, 649 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_orbital_test

61 tests, 295 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed