### PR TITLE
Worldpay: reintroduce address1 and city defaults

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Orbital: Ensure correct fields sent in refund [jessiagee] #3903
 * WorldPay: remove some defaults in billing address [carrigan] #3902
 * Adyen: Support for General Credit [naashton] #3904
+* Worldpay: reintroduce address1 and city defaults [carrigan] #3905
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -538,24 +538,15 @@ module ActiveMerchant #:nodoc:
       def address_with_defaults(address)
         address ||= {}
         address.delete_if { |_, v| v.blank? }
-        ensure_address1_and_city(address)
         address.reverse_merge!(default_address)
-      end
-
-      # `address1` and `city` are optional but if one is supplied, the other
-      # must also be present
-      def ensure_address1_and_city(address)
-        has_address1 = !address[:address1].nil? && !address[:address1].blank?
-        has_city = !address[:city].nil? && !address[:city].blank?
-
-        address[:city] = 'N/A' if !has_city && has_address1
-        address[:address1] = 'N/A' if !has_address1 && has_city
       end
 
       def default_address
         {
           zip: '0000',
-          country: 'US'
+          country: 'US',
+          city: 'N/A',
+          address1: 'N/A'
         }
       end
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -467,8 +467,8 @@ class WorldpayTest < Test::Unit::TestCase
       assert_no_match %r(firstName), data
       assert_no_match %r(lastName), data
       assert_no_match %r(address2), data
-      assert_match %r(<address1/>), data
-      assert_match %r(<city/>), data
+      assert_match %r(<address1>N/A</address1>), data
+      assert_match %r(<city>N/A</city>), data
       assert_match %r(<postalCode>0000</postalCode>), data
       assert_match %r(<state/>), data
       assert_match %r(<countryCode>US</countryCode>), data
@@ -504,36 +504,12 @@ class WorldpayTest < Test::Unit::TestCase
       assert_no_match %r(firstName), data
       assert_no_match %r(lastName), data
       assert_no_match %r(address2), data
-      assert_match %r(<address1/>), data
-      assert_match %r(<city/>), data
+      assert_match %r(<address1>N/A</address1>), data
+      assert_match %r(<city>N/A</city>), data
       assert_match %r(<postalCode>0000</postalCode>), data
       assert_match %r(<state/>), data
       assert_match %r(<countryCode>US</countryCode>), data
       assert_match %r(<telephoneNumber>555-3323</telephoneNumber>), data
-    end.respond_with(successful_authorize_response)
-  end
-
-  def test_address_with_address1_no_city
-    city = 'Ontario'
-    address_with_nils = { address1: nil, city: city }
-
-    stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(billing_address: address_with_nils))
-    end.check_request do |_endpoint, data, _headers|
-      assert_match %r(<address1>N/A</address1>), data
-      assert_match %r(<city>#{city}</city>), data
-    end.respond_with(successful_authorize_response)
-  end
-
-  def test_address_with_city_no_address1
-    address1 = '456 My Street'
-    address_with_nils = { address1: address1, city: nil }
-
-    stub_comms do
-      @gateway.authorize(100, @credit_card, @options.merge(billing_address: address_with_nils))
-    end.check_request do |_endpoint, data, _headers|
-      assert_match %r(<address1>#{address1}</address1>), data
-      assert_match %r(<city>N/A</city>), data
     end.respond_with(successful_authorize_response)
   end
 


### PR DESCRIPTION
## Why?

ECS-1706

PR #3902 removed some defaults per the Worldpay documentation. While the sandbox allowed these fields to be blank, the production gateway wants them filled in.

## What Changed

This commit reverts the address1 and city changes to always default to a non-null value.

## Test Suite

Worldpay remote tests (same pass rate as master):

61 tests, 250 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions,
  0 notifications
91.8033% passed

Unit tests:

4652 tests, 73159 assertions, 0 failures, 0 errors, 0 pendings,
  0 omissions, 0 notifications
100% passed