### PR TITLE
Stripe PI: Enhance testing of SetupIntents API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * PaywayDotCom: Add New Gateway [DanAtPayway] #3898
 * Orbital: Remove unnecessary requirements [jessiagee] #3917
 * SafeCharge (Nuvei): Add network tokenization support [DStoyanoff] #3847
+* Stripe PI: Enhance testing of SetupIntents API #3908
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874


### PR DESCRIPTION
Ensure the responses expected from /setup_intents/ endpoint match the
expected shape.

Local:
4652 tests, 73160 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
53 tests, 251 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
20 tests, 132 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed