### PR TITLE
Stripe PI: Send Validate on Payment Method Attach

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Adyen: Support for General Credit [naashton] #3904
 * Worldpay: reintroduce address1 and city defaults [carrigan] #3905
 * Stripe: ensure potentially nested data is scrubbed #3907
+* Stripe PI: Send Validate on Payment Method Attach [tatsianaclifton] #3909
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -183,7 +183,6 @@ module ActiveMerchant #:nodoc:
           if options[:customer]
             customer_id = options[:customer]
           else
-            post[:validate] = options[:validate] unless options[:validate].nil?
             post[:description] = options[:description] if options[:description]
             post[:email] = options[:email] if options[:email]
             options = format_idempotency_key(options, 'customer')
@@ -191,7 +190,9 @@ module ActiveMerchant #:nodoc:
             customer_id = customer.params['id']
           end
           options = format_idempotency_key(options, 'attach')
-          commit(:post, "payment_methods/#{params[:payment_method]}/attach", { customer: customer_id }, options)
+          attach_parameters = { customer: customer_id }
+          attach_parameters[:validate] = options[:validate] unless options[:validate].nil?
+          commit(:post, "payment_methods/#{params[:payment_method]}/attach", attach_parameters, options)
         else
           super(payment_method, options)
         end

--- a/test/remote/gateways/remote_netbanx_test.rb
+++ b/test/remote/gateways/remote_netbanx_test.rb
@@ -40,7 +40,7 @@ class RemoteNetbanxTest < Test::Unit::TestCase
     assert_equal 'X', response.avs_result['code']
     assert_equal 'N', response.cvv_result['code']
   end
-  
+
   def split_names(full_name)
     names = (full_name || '').split
     return [nil, nil] if names.size == 0

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -791,6 +791,26 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal store1.params['id'], store2.params['id']
   end
 
+  def test_successful_store_with_false_validate_option
+    options = {
+      currency: 'GBP',
+      validate: false
+    }
+    assert store = @gateway.store(@visa_card, options)
+    assert store.params['customer'].start_with?('cus_')
+    assert_equal 'unchecked', store.params['card']['checks']['cvc_check']
+  end
+
+  def test_successful_store_with_true_validate_option
+    options = {
+      currency: 'GBP',
+      validate: true
+    }
+    assert store = @gateway.store(@visa_card, options)
+    assert store.params['customer'].start_with?('cus_')
+    assert_equal 'pass', store.params['card']['checks']['cvc_check']
+  end
+
   def test_successful_verify
     options = {
       customer: @customer


### PR DESCRIPTION
Currently we are passing the validate field to Stripe PI’s /customers endpoint rather than the /payment_methods endpoint. This field is essentially ignored by the /customers endpoint, and all payment methods are being validated, even if the request was sent with ”validate”: false. This commit includes updates to instead pass "validate": false during the attachment step (POST /v1/payment_methods/:id/attach), rather than when the customer is being created. This will guarantee that Stripe does not validate cards when users do not want to do so.

ECS-1681

Unit:
23 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
54 tests, 250 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Local:
4655 tests, 73169 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed