### PR TITLE
Adyen: Update handling of authorization returned from gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Worldpay: reintroduce address1 and city defaults [carrigan] #3905
 * Stripe: ensure potentially nested data is scrubbed #3907
 * Stripe PI: Send Validate on Payment Method Attach [tatsianaclifton] #3909
+* Adyen: Update handling of authorization returned from gateway [meagabeth] #3910
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -399,7 +399,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_original_reference(post, authorization, options = {})
-        original_psp_reference, = authorization.split('#')
+        if authorization.start_with?('#')
+          _, original_psp_reference, = authorization.split('#')
+        else
+          original_psp_reference, = authorization.split('#')
+        end
         post[:originalReference] = single_reference(authorization) || original_psp_reference
       end
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -6,12 +6,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
     @amount = 100
 
-    @credit_card = credit_card('3700 0000 0000 002',
+    @credit_card = credit_card('4111111111111111',
       month: 3,
       year: 2030,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '7373',
+      verification_value: '737',
       brand: 'visa')
 
     @avs_credit_card = credit_card('4400000000000008',
@@ -315,8 +315,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
   # with rule set in merchant account to skip 3DS for cards of this brand
   def test_successful_authorize_with_3ds_dynamic_rule_broken
     mastercard_threed = credit_card('5212345678901234',
-      month: 10,
-      year: 2020,
+      month: 3,
+      year: 2030,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
@@ -586,6 +586,16 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert refund = @gateway.refund(@amount, purchase.authorization)
     assert_success refund
     assert_equal '[refund-received]', refund.message
+  end
+
+  def test_successful_refund_with_auth_original_reference
+    auth_response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth_response
+    assert_equal 'Authorised', auth_response.message
+
+    refund_resp = @gateway.refund(@amount, auth_response.authorization)
+    assert_success refund_resp
+    assert_equal '[refund-received]', refund_resp.message
   end
 
   def test_successful_refund_with_elo_card


### PR DESCRIPTION
Add test to confirm successful refund possible using `pspReference` from an `authorize` transaction instead of a `capture` transaction. Update test cards that had expired.

CE-803

Local:
4650 tests, 73149 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
71 tests, 372 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
94 tests, 361 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed