### PR TITLE
Orbital: Send AVSname for all eCheck transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Stripe PI: Send Validate on Payment Method Attach [tatsianaclifton] #3909
 * Adyen: Update handling of authorization returned from gateway [meagabeth] #3910
 * Update gateway templates for Rubocop compliance [therufs] #3912 #3895
+* Orbital: Send AVSname for all eCheck transactions [jessiagee] #3911
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -663,6 +663,47 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_success refund
   end
 
+  def test_echeck_purchase_with_address_responds_with_name
+    transcript = capture_transcript(@echeck_gateway) do
+      @echeck_gateway.authorize(@amount, @echeck, @options.merge(order_id: '2'))
+    end
+
+    assert_match(/<AVSname>Jim Smith/, transcript)
+    assert_match(/<RespCode>00/, transcript)
+    assert_match(/<StatusMsg>Approved/, transcript)
+  end
+
+  def test_echeck_purchase_with_no_address_responds_with_name
+    test_check_no_address = check(name: 'Test McTest')
+
+    transcript = capture_transcript(@echeck_gateway) do
+      @echeck_gateway.authorize(@amount, test_check_no_address, @options.merge(order_id: '2', address: nil, billing_address: nil))
+    end
+
+    assert_match(/<AVSname>Test McTest/, transcript)
+    assert_match(/<RespCode>00/, transcript)
+    assert_match(/<StatusMsg>Approved/, transcript)
+  end
+
+  def test_credit_purchase_with_address_responds_with_name
+    transcript = capture_transcript(@gateway) do
+      @gateway.authorize(@amount, @credit_card, @options.merge(order_id: '2'))
+    end
+
+    assert_match(/<AVSname>Longbob Longsen/, transcript)
+    assert_match(/<RespCode>00/, transcript)
+    assert_match(/<StatusMsg>Approved/, transcript)
+  end
+
+  def test_credit_purchase_with_no_address_responds_with_no_name
+    transcript = capture_transcript(@gateway) do
+      @gateway.authorize(@amount, @credit_card, @options.merge(order_id: '2', address: nil, billing_address: nil))
+    end
+
+    assert_match(/<RespCode>00/, transcript)
+    assert_match(/<StatusMsg>Approved/, transcript)
+  end
+
   # == Certification Tests
 
   # ==== Section A


### PR DESCRIPTION
Loaded suite test/unit/gateways/orbital_test

114 tests, 668 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_orbital_test

65 tests, 306 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed