### PR TITLE
Correct customer_id field on Litle/Vantiv Gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * Adyen: Update handling of authorization returned from gateway [meagabeth] #3910
 * Update gateway templates for Rubocop compliance [therufs] #3912 #3895
 * Orbital: Send AVSname for all eCheck transactions [jessiagee] #3911
+* Litle: update support of customerId field [cdmackeyfree] #3913
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -494,7 +494,7 @@ module ActiveMerchant #:nodoc:
         attributes = {}
         attributes[:id] = truncate(options[:id] || options[:order_id], 24)
         attributes[:reportGroup] = options[:merchant] || 'Default Report Group'
-        attributes[:customerId] = options[:customer]
+        attributes[:customerId] = options[:customer_id]
         attributes.delete_if { |_key, value| value == nil }
         attributes
       end

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -98,6 +98,30 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert @gateway.authorize(10010, @credit_card1, options)
   end
 
+  def test_successful_capture_with_customer_id
+    options = @options.merge(customer_id: '8675309')
+    assert response = @gateway.authorize(1000, @credit_card1, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_succesful_purchase_with_customer_id
+    options = @options.merge(customer_id: '8675309')
+    assert response = @gateway.purchase(1000, @credit_card1, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_refund_with_customer_id
+    options = @options.merge(customer_id: '8675309')
+
+    assert purchase = @gateway.purchase(100, @credit_card1, options)
+
+    assert refund = @gateway.refund(444, purchase.authorization, options)
+    assert_success refund
+    assert_equal 'Approved', refund.message
+  end
+
   def test_successful_authorization_with_echeck
     options = @options.merge({
       order_id: '38',

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -144,6 +144,30 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_passing_customer_id_on_purchase
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, customer_id: '8675309')
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(customerId=\"8675309\">\n), data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_customer_id_on_capture
+    stub_comms do
+      @gateway.capture(@amount, @credit_card, customer_id: '8675309')
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(customerId=\"8675309\">\n), data)
+    end.respond_with(successful_capture_response)
+  end
+
+  def test_passing_customer_id_on_refund
+    stub_comms do
+      @gateway.credit(@amount, @credit_card, customer_id: '8675309')
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(customerId=\"8675309\">\n), data)
+    end.respond_with(successful_credit_response)
+  end
+
   def test_passing_billing_address
     stub_comms do
       @gateway.purchase(@amount, @credit_card, billing_address: address)


### PR DESCRIPTION
Went to expand the use of customer_id field for use on capture and refund per request. Discovered that AM was not sending the field to the gateway correctly. The field `customer` should have been `customer_id` to work properly. Added tests for the field and confirmed that it is now being sent correctly.

Failing tests match the tests failing on master:
test_authorize_and_capture_with_stored_credential_recurring(RemoteLitleTest)
test_avs_and_cvv_result(RemoteLitleTest)
test_capture_unsuccessful(RemoteLitleTest)
test_echeck_store_and_purchase(RemoteLitleTest)
test_purchase_with_token_and_date_successful(RemoteLitleTest)
test_refund_unsuccessful(RemoteLitleTest)
test_store_and_purchase_with_token_successful(RemoteLitleTest)
test_store_successful(RemoteLitleTest)
test_store_unsuccessful(RemoteLitleTest)
test_successful_purchase_with_apple_pay(RemoteLitleTest)
test_unsuccessful_authorization(RemoteLitleTest)
test_unsuccessful_purchase(RemoteLitleTest)
test_unsuccessful_void(RemoteLitleTest)

Unit test
53 tests, 227 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote test:
49 tests, 205 assertions, 14 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
71.4286% passed

Local:
4662 tests, 73197 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed