### PR TITLE
Forte: Send xdata fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Orbital: Send AVSname for all eCheck transactions [jessiagee] #3911
 * Litle: update support of customerId field [cdmackeyfree] #3913
 * Payment Express: fix signature for `verify` [therufs] #3914
+* Forte: Send xdata fields [dsmcclain] #3915
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -28,6 +28,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method, options)
         add_billing_address(post, payment_method, options)
         add_shipping_address(post, options)
+        add_xdata(post, options)
         post[:action] = 'sale'
 
         commit(:post, post)
@@ -41,6 +42,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method, options)
         add_billing_address(post, payment_method, options)
         add_shipping_address(post, options)
+        add_xdata(post, options)
         post[:action] = 'authorize'
 
         commit(:post, post)
@@ -120,6 +122,16 @@ module ActiveMerchant #:nodoc:
 
       def add_service_fee(post, options)
         post[:service_fee_amount] = options[:service_fee_amount] if options[:service_fee_amount]
+      end
+
+      def add_xdata(post, options)
+        post[:xdata] = {}
+        if xdata = options[:xdata]
+          (1..9).each do |n|
+            field = "xdata_#{n}".to_sym
+            post[:xdata][field] = xdata[field] if xdata[field]
+          end
+        end
       end
 
       def add_billing_address(post, payment, options)

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -46,6 +46,26 @@ class RemoteForteTest < Test::Unit::TestCase
     assert_equal 'PPD', response.params['echeck']['sec_code']
   end
 
+  def test_successful_purchase_with_xdata
+    @options = @options.merge({
+      xdata: {
+        xdata_1: 'some customer metadata',
+        xdata_2: 'some customer metadata',
+        xdata_3: 'some customer metadata',
+        xdata_4: 'some customer metadata',
+        xdata_5: 'some customer metadata',
+        xdata_6: 'some customer metadata',
+        xdata_7: 'some customer metadata',
+        xdata_8: 'some customer metadata',
+        xdata_9: 'some customer metadata'
+      }
+    })
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    (1..9).each { |n| assert_equal 'some customer metadata', response.params['xdata']["xdata_#{n}"] }
+  end
+
   def test_successful_purchase_with_echeck_with_more_options
     options = {
       sec_code: 'WEB'

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -71,6 +71,16 @@ class ForteTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_xdata
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(MockedResponse.new(successful_purchase_with_xdata_response))
+
+    assert_success response
+    (1..9).each { |n| assert_equal 'some customer metadata', response.params['xdata']["xdata_#{n}"] }
+    assert response.test?
+  end
+
   def test_successful_authorize
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.authorize(@amount, @credit_card, @options)
@@ -375,6 +385,57 @@ class ForteTest < Test::Unit::TestCase
         "billing_address":{
           "first_name":"Jim",
           "last_name":"Smith"
+        },
+        "card": {
+          "name_on_card":"Longbob Longsen",
+          "masked_account_number":"****2224",
+          "expire_month":9,
+          "expire_year":2016,
+          "card_verification_value":"***",
+          "card_type":"visa"
+        },
+        "response": {
+          "authorization_code":"123456",
+          "avs_result":"Y",
+          "cvv_code":"M",
+          "environment":"sandbox",
+          "response_type":"A",
+          "response_code":"A01",
+          "response_desc":"TEST APPROVAL"
+        },
+        "links": {
+          "self":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+          "settlements":"https://sandbox.forte.net/API/v2/transactions/trn_bb7687a7-3d3a-40c2-8fa9-90727a814249/settlements"
+        }
+      }
+    '
+  end
+
+  def successful_purchase_with_xdata_response
+    '
+      {
+        "transaction_id":"trn_bb7687a7-3d3a-40c2-8fa9-90727a814249",
+        "account_id":"act_300111",
+        "location_id":"loc_176008",
+        "action":"sale",
+        "authorization_amount": 1.0,
+        "service_fee_amount": ".5",
+        "subtotal_amount": ".5",
+        "authorization_code":"123456",
+        "billing_address":{
+          "first_name":"Jim",
+          "last_name":"Smith"
+        },
+        "xdata": {
+          "xdata_1": "some customer metadata",
+          "xdata_2": "some customer metadata",
+          "xdata_3": "some customer metadata",
+          "xdata_4": "some customer metadata",
+          "xdata_5": "some customer metadata",
+          "xdata_6": "some customer metadata",
+          "xdata_7": "some customer metadata",
+          "xdata_8": "some customer metadata",
+          "xdata_9": "some customer metadata"
         },
         "card": {
           "name_on_card":"Longbob Longsen",


### PR DESCRIPTION
Loaded suite test/unit/gateways/forte_test
22 tests, 85 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_forte_test
23 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed