### PR TITLE
Orbital: Remove unnecessary requirements checks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Payment Express: fix signature for `verify` [therufs] #3914
 * Forte: Send xdata fields [dsmcclain] #3915
 * PaywayDotCom: Add New Gateway [DanAtPayway] #3898
+* Orbital: Remove unnecessary requirements [jessiagee] #3917
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -610,17 +610,6 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_equal 'Approved', auth.message
   end
 
-  def test_authorize_sends_with_incorrect_payment_delivery
-    transcript = capture_transcript(@echeck_gateway) do
-      @echeck_gateway.authorize(@amount, @echeck, @options.merge(order_id: '4', payment_delivery: 'X'))
-    end
-
-    assert_match(/<BankPmtDelv>B/, transcript)
-    assert_match(/<MessageType>A/, transcript)
-    assert_match(/<ApprovalStatus>1/, transcript)
-    assert_match(/<RespCode>00/, transcript)
-  end
-
   def test_default_payment_delivery_with_no_payment_delivery_sent
     transcript = capture_transcript(@echeck_gateway) do
       @echeck_gateway.authorize(@amount, @echeck, @options.merge(order_id: '4'))

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -1230,15 +1230,6 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_success response
   end
 
-  def test_payment_delivery_when_param_incorrect
-    response = stub_comms do
-      @gateway.purchase(50, @echeck, order_id: 1, payment_delivery: 'Z')
-    end.check_request do |_endpoint, data, _headers|
-      assert_match(/<BankPmtDelv>B/, data)
-    end.respond_with(successful_purchase_response)
-    assert_success response
-  end
-
   def test_payment_delivery_when_no_payment_delivery_param
     response = stub_comms do
       @gateway.purchase(50, @echeck, order_id: 1)


### PR DESCRIPTION
Loaded suite test/unit/gateways/orbital_test

113 tests, 664 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_orbital_test

64 tests, 302 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

rake test:local

4662 tests, 73206 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed