### PR TITLE
Worldpay: Only override cardholdername for 3ds tests

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -430,7 +430,7 @@ module ActiveMerchant #:nodoc:
           )
         end
 
-        card_holder_name = options[:execute_threed] && !options[:three_ds_version]&.start_with?('2') ? '3D' : payment_method.name
+        card_holder_name = test? && options[:execute_threed] && !options[:three_ds_version]&.start_with?('2') ? '3D' : payment_method.name
         xml.cardHolderName card_holder_name
         xml.cvc payment_method.verification_value
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -18,7 +18,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     @naranja_card = credit_card('5895620000000002')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
     @declined_card = credit_card('4111111111111111', first_name: nil, last_name: 'REFUSED')
-    @threeDS_card = credit_card('4111111111111111', first_name: nil, last_name: '3D')
+    @threeDS_card = credit_card('4111111111111111', first_name: nil, last_name: 'doot')
     @threeDS2_card = credit_card('4111111111111111', first_name: nil, last_name: '3DS_V2_FRICTIONLESS_IDENTIFIED')
     @threeDS_card_external_MPI = credit_card('4444333322221111', first_name: 'AA', last_name: 'BD')
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -706,7 +706,7 @@ class WorldpayTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
-  def test_3ds_name_coersion
+  def test_3ds_name_coersion_for_testing
     @options[:execute_threed] = true
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
@@ -716,7 +716,7 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
-  def test_3ds_name_coersion_based_on_version
+  def test_3ds_name_coersion_based_on_version_for_testing
     @options[:execute_threed] = true
     @options[:three_ds_version] = '2.0'
     response = stub_comms do
@@ -741,6 +741,20 @@ class WorldpayTest < Test::Unit::TestCase
       assert_match %r{<cardHolderName>3D</cardHolderName>}, data if /<submit>/.match?(data)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
+  end
+
+  def test_3ds_name_not_coerced_in_production
+    ActiveMerchant::Billing::Base.mode = :production
+
+    @options[:execute_threed] = true
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_not_match %r{<cardHolderName>3D</cardHolderName>}, data
+    end.respond_with(successful_authorize_response, successful_capture_response)
+  ensure
+    ActiveMerchant::Billing::Base.mode = :test
   end
 
   def test_3ds_additional_information


### PR DESCRIPTION
After confirming with Worldpay, the cardholder name should only be "3D"
for tests. This adds a check for whether it's a test request, but
retains the override logic for user sandbox testing.

Remote (2 unrelates failures also on master):
61 tests, 254 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.7213% passed

Unit:
78 tests, 504 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed