### PR TITLE
SafeCharge: Fix nil error for NT flow

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@
 * Orbital: Remove unnecessary requirements [jessiagee] #3917
 * SafeCharge (Nuvei): Add network tokenization support [DStoyanoff] #3847
 * Stripe PI: Enhance testing of SetupIntents API #3908
+* SafeCharge (Nuvei): Fix NT related bug [jimilpatel24] #3921
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -152,7 +152,7 @@ module ActiveMerchant #:nodoc:
 
         if payment.is_a?(NetworkTokenizationCreditCard) && payment.source == :network_token
           post[:sg_CAVV] = payment.payment_cryptogram
-          post[:sg_ECI] = options[:three_d_secure][:eci] || '05'
+          post[:sg_ECI] = options[:three_d_secure] && options[:three_d_secure][:eci] || '05'
           post[:sg_IsExternalMPI] = 1
           post[:sg_ExternalTokenProvider] = 5
         else


### PR DESCRIPTION
The NT transaction fails if one of the 3DS params is not passed in the request. The change sets a default value correctly if the param is not passed in the request.

Unit:
24 tests, 130 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
28 tests, 71 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.8571% passed

The two tests that failed (test_successful_3ds_purchase and test_successful_regular_purchase_through_3ds_flow_with_invalid_pa_res) were failing before as well.

Local:
4677 tests, 73271 assertions, 4 failures, 3 errors, 0 pendings, 0 omissions, 0 notifications
99.8503% passed

None of the failures/errors are related to Safecharge gateway