### PR TITLE
Orbital: Add support for general credit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@
 * Stripe PI: Enhance testing of SetupIntents API #3908
 * SafeCharge (Nuvei): Fix NT related bug [jimilpatel24] #3921
 * Worldpay: Only override cardholdername for 3ds tests [curiousepic] #3918
+* Orbital: Add support for general credit [meagabeth] #3922
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -559,7 +559,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_success void
   end
 
-  def test_refund
+  def test_successful_refund
     amount = @amount
     assert response = @gateway.purchase(amount, @credit_card, @options)
     assert_success response
@@ -590,6 +590,12 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert response.authorization
     assert refund = @gateway.refund(amount, response.authorization, @options.merge(level_2_data: @level_2_options))
     assert_success refund
+  end
+
+  def test_successful_credit
+    payment_method = credit_card('5454545454545454')
+    assert response = @gateway.credit(@amount, payment_method, @options)
+    assert_success response
   end
 
   def test_failed_capture

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -1024,6 +1024,15 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_equal '9806', response.params['proc_status']
   end
 
+  def test_successful_credit
+    @gateway.expects(:ssl_post).returns(successful_credit_response)
+
+    assert response = @gateway.credit(100, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '1', response.params['approval_status']
+  end
+
   def test_send_address_details_for_united_states
     response = stub_comms do
       @gateway.purchase(50, credit_card, order_id: 1, billing_address: address)
@@ -1376,6 +1385,10 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def failed_refund_with_echeck_response
     '<?xml version="1.0" encoding="UTF-8"?><Response><QuickResp><ProcStatus>9806</ProcStatus><StatusMsg>Refund Transactions By TxRefNum Are Only Valid When The Original Transaction Was An AUTH Or AUTH CAPTURE.</StatusMsg></QuickResp></Response>'
+  end
+
+  def successful_credit_response
+    '<?xml version="1.0" encoding="UTF-8"?><Response><NewOrderResp><IndustryType></IndustryType><MessageType>R</MessageType><MerchantID>253997</MerchantID><TerminalID>001</TerminalID><CardBrand>MC</CardBrand><AccountNum>XXXXX5454</AccountNum><OrderID>6102f8d4ca9d5c08d6ea02</OrderID><TxRefNum>605266890AF5BA833E6190D89256B892981C531D</TxRefNum><TxRefIdx>1</TxRefIdx><ProcStatus>0</ProcStatus><ApprovalStatus>1</ApprovalStatus><RespCode>00</RespCode><AVSRespCode>3</AVSRespCode><CVV2RespCode>M</CVV2RespCode><AuthCode>tst627</AuthCode><RecurringAdviceCd></RecurringAdviceCd><CAVVRespCode></CAVVRespCode><StatusMsg>Approved</StatusMsg><RespMsg></RespMsg><HostRespCode>100</HostRespCode><HostAVSRespCode></HostAVSRespCode><HostCVV2RespCode></HostCVV2RespCode><CustomerRefNum></CustomerRefNum><CustomerName></CustomerName><ProfileProcStatus></ProfileProcStatus><CustomerProfileMessage></CustomerProfileMessage><RespTime>162857</RespTime><PartialAuthOccurred></PartialAuthOccurred><RequestedAmount></RequestedAmount><RedeemedAmount></RedeemedAmount><RemainingBalance></RemainingBalance><CountryFraudFilterStatus></CountryFraudFilterStatus><IsoCountryCode></IsoCountryCode></NewOrderResp></Response>'
   end
 
   def pre_scrubbed

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -748,7 +748,7 @@ class WorldpayTest < Test::Unit::TestCase
 
     @options[:execute_threed] = true
 
-    response = stub_comms do
+    stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_endpoint, data, _headers|
       assert_not_match %r{<cardHolderName>3D</cardHolderName>}, data


### PR DESCRIPTION
General credit transactions utilize the same endpoint as `refund`, but do not require a `tx_ref_num` and should be passed a payment method

CE-1312

Local: 4677 tests, 73272 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit: 114 tests, 670 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote: 65 tests, 304 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed