### PR TITLE
Banco Sabadell: Ensure sca_exemption field is used

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@
 * SafeCharge (Nuvei): Fix NT related bug [jimilpatel24] #3921
 * Worldpay: Only override cardholdername for 3ds tests [curiousepic] #3918
 * Orbital: Add support for general credit [meagabeth] #3922
+* Banco Sabadell: Ensure sca_exemption field is used #3923
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_redsys_sha256_test.rb
+++ b/test/remote/gateways/remote_redsys_sha256_test.rb
@@ -7,6 +7,9 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
     @credit_card = credit_card('4548812049400004')
     @declined_card = credit_card
     @threeds2_credit_card = credit_card('4918019199883839')
+
+    @threeds2_credit_card_frictionless = credit_card('4548814479727229')
+    @threeds2_credit_card_alt = credit_card('4548817212493017')
     @options = {
       order_id: generate_order_id
     }
@@ -131,6 +134,126 @@ class RemoteRedsysSHA256Test < Test::Unit::TestCase
     assert response.params['ds_emv3ds']
     assert_equal 'NO_3DS_v2', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
     assert_equal 'CardConfiguration', response.message
+  end
+
+  def test_successful_3ds_purchase_with_exemption
+    options = @options.merge(execute_threed: true, terminal: 12)
+    response = @gateway.purchase(@amount, @credit_card, options.merge(sca_exemption: 'LWV'))
+    assert_success response
+    assert response.params['ds_emv3ds']
+    assert_equal 'NO_3DS_v2', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
+    assert_equal 'CardConfiguration', response.message
+  end
+
+  def test_successful_purchase_with_stored_credentials
+    initial_options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring'
+      }
+    )
+    initial_response = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success initial_response
+    assert_equal 'Transaction Approved', initial_response.message
+    assert_not_nil initial_response.params['ds_merchant_cof_txnid']
+    network_transaction_id = initial_response.params['ds_merchant_cof_txnid']
+
+    used_options = @options.merge(
+      order_id: generate_order_id,
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled',
+        network_transaction_id: network_transaction_id
+      }
+    )
+    response = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_success response
+    assert_equal 'Transaction Approved', response.message
+  end
+
+  def test_successful_auth_purchase_with_stored_credentials
+    initial_options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring'
+      }
+    )
+    initial_response = @gateway.authorize(@amount, @credit_card, initial_options)
+    assert_success initial_response
+    assert_equal 'Transaction Approved', initial_response.message
+    assert_not_nil initial_response.params['ds_merchant_cof_txnid']
+    network_transaction_id = initial_response.params['ds_merchant_cof_txnid']
+
+    used_options = @options.merge(
+      order_id: generate_order_id,
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'recurring',
+        network_transaction_id: network_transaction_id
+      }
+    )
+    response = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_success response
+    assert_equal 'Transaction Approved', response.message
+  end
+
+  def test_successful_3ds2_purchase_with_mit_exemption
+    options = @options.merge(execute_threed: true, terminal: 12)
+    response = @gateway.purchase(@amount, @threeds2_credit_card, options.merge(sca_exemption: 'MIT', sca_exemption_direct_payment_enabled: true))
+    assert_success response
+    assert response.params['ds_emv3ds']
+    assert response.params['ds_card_psd2']
+    assert_equal '2.1.0', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
+    assert_equal 'Y', response.params['ds_card_psd2']
+    assert_equal 'CardConfiguration', response.message
+
+    # ensure MIT is supported
+    assert response.params['ds_excep_sca']
+    assert_match 'MIT', response.params['ds_excep_sca']
+  end
+
+  def test_failed_3ds2_purchase_with_mit_exemption_but_missing_direct_payment_enabled
+    options = @options.merge(execute_threed: true, terminal: 12)
+    response = @gateway.purchase(@amount, @threeds2_credit_card, options.merge(sca_exemption: 'MIT'))
+    assert_success response
+    assert response.params['ds_emv3ds']
+    assert response.params['ds_card_psd2']
+    assert_equal '2.1.0', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
+    assert_equal 'Y', response.params['ds_card_psd2']
+    assert_equal 'CardConfiguration', response.message
+
+    # ensure MIT is supported
+    assert response.params['ds_excep_sca']
+    assert_match 'MIT', response.params['ds_excep_sca']
+  end
+
+  def test_successful_purchase_with_mit_exemption
+    initial_options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring'
+      }
+    )
+    initial_response = @gateway.authorize(@amount, @credit_card, initial_options)
+    assert_success initial_response
+    assert_equal 'Transaction Approved', initial_response.message
+    assert_not_nil initial_response.params['ds_merchant_cof_txnid']
+    network_transaction_id = initial_response.params['ds_merchant_cof_txnid']
+
+    used_options = @options.merge(
+      order_id: generate_order_id,
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'recurring',
+        network_transaction_id: network_transaction_id
+      },
+      sca_exemption: 'MIT',
+      sca_exemption_direct_payment_enabled: true
+    )
+
+    response = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_success response
+    assert_equal response.message, 'Transaction Approved'
   end
 
   def test_purchase_with_invalid_order_id


### PR DESCRIPTION
The use of `sca_exemption` requires passing
`DS_MERCHANT_DIRECTPAYMENT=true` for those terminals where 3DS2 is
enabled.

This commit introduces a new option
`sca_exemption_direct_payment_enabled` that can be used to pass this
value, when needed

ECS-1747

Local:
45 tests, 183 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
30 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
4681 tests, 73300 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Note:

`test/remote/gateways/remote_redsys_test.rb`:
- failing same as current HEAD, 3633283fa2606321f87f94bdecacc2307b91ed16