### PR TITLE
RedSys: introduce Template Method Pattern (GoF) in `commit`

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -293,6 +293,10 @@ module ActiveMerchant #:nodoc:
           gsub(%r((<DS_MERCHANT_CVV2>)\s+(</DS_MERCHANT_CVV2>))i, '\1[BLANK]\2')
       end
 
+      def commit(data, options = {})
+        commit_internal data, options
+      end
+
       private
 
       def add_action(data, action, options = {})
@@ -382,7 +386,7 @@ module ActiveMerchant #:nodoc:
                                   threeds_hash[:threeDSInfo] == 'ChallengeResponse'
       end
 
-      def commit(data, options = {})
+      def commit_internal(data, options = {})
         if data[:threeds]
           action = determine_3ds_action(data[:threeds])
           request = <<-REQUEST

--- a/test/unit/gateways/redsys_sha256_test.rb
+++ b/test/unit/gateways/redsys_sha256_test.rb
@@ -155,8 +155,6 @@ class RedsysSHA256Test < Test::Unit::TestCase
     assert_equal '2.1.0', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
     assert_equal 'Y', response.params['ds_card_psd2']
     assert_equal 'CardConfiguration', response.message
-
-    p response.params['ds_emv3ds']
   end
 
   def test_3ds_data_passed


### PR DESCRIPTION
This commit enables AM API clients to more easily extend certain aspects
of standard operations.

As a PoC, the `commit` method is now public, but defers its
implementation to `commit_internal` which continues to be `private`.

Local
4682 tests, 73306 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
45 tests, 183 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
31 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed