### PR TITLE
Redsys: Refactor XML character escape logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Worldpay: Only override cardholdername for 3ds tests [curiousepic] #3918
 * Orbital: Add support for general credit [meagabeth] #3922
 * Banco Sabadell: Ensure sca_exemption field is used #3923
+* Redsys: Refactor XML character escape logic #3925
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -470,6 +470,11 @@ module ActiveMerchant #:nodoc:
         xml.target!
       end
 
+      # Template Method to allow AM API clients to override decision to escape, based on their own criteria.
+      def escape_special_chars?(data, options = {})
+        data[:threeds]
+      end
+
       def build_merchant_data(xml, data, options = {})
         # See https://sis-t.redsys.es:25443/sis/services/SerClsWSEntradaV2/wsdl/SerClsWSEntradaV2.wsdl
         # (which results from calling #threeds_url + '?WSDL', https://sis-t.redsys.es:25443/sis/services/SerClsWSEntradaV2?WSDL)
@@ -480,7 +485,7 @@ module ActiveMerchant #:nodoc:
           xml.DS_MERCHANT_AMOUNT             data[:amount]
           xml.DS_MERCHANT_ORDER              data[:order_id]
           xml.DS_MERCHANT_TRANSACTIONTYPE    data[:action]
-          if data[:description] && data[:threeds]
+          if data[:description] && escape_special_chars?(data, options)
             xml.DS_MERCHANT_PRODUCTDESCRIPTION CGI.escape(data[:description])
           else
             xml.DS_MERCHANT_PRODUCTDESCRIPTION data[:description]
@@ -499,7 +504,7 @@ module ActiveMerchant #:nodoc:
 
           # Only when card is present
           if data[:card]
-            if data[:card][:name] && data[:threeds]
+            if data[:card][:name] && escape_special_chars?(data, options)
               xml.DS_MERCHANT_TITULAR    CGI.escape(data[:card][:name])
             else
               xml.DS_MERCHANT_TITULAR    data[:card][:name]

--- a/test/unit/gateways/redsys_sha256_test.rb
+++ b/test/unit/gateways/redsys_sha256_test.rb
@@ -155,8 +155,6 @@ class RedsysSHA256Test < Test::Unit::TestCase
     assert_equal '2.1.0', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
     assert_equal 'Y', response.params['ds_card_psd2']
     assert_equal 'CardConfiguration', response.message
-
-    p response.params['ds_emv3ds']
   end
 
   def test_3ds_data_passed


### PR DESCRIPTION
Enables AM API clients to override decision to escape in case different
criteria than default is needed

Local:
4682 tests, 73306 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
45 tests, 183 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
31 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed