### PR TITLE
HPS: Strip zip codes of non-alphanumeric characters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@
 * Orbital: Add support for general credit [meagabeth] #3922
 * Banco Sabadell: Ensure sca_exemption field is used #3923
 * Redsys: Refactor XML character escape logic #3925
+* HPS: Strip zip codes of non-alphanumeric characters [dsmcclain] #3926
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -175,7 +175,7 @@ module ActiveMerchant #:nodoc:
             xml.hps :CardHolderAddr, billing_address[:address1] if billing_address[:address1]
             xml.hps :CardHolderCity, billing_address[:city] if billing_address[:city]
             xml.hps :CardHolderState, billing_address[:state] if billing_address[:state]
-            xml.hps :CardHolderZip, billing_address[:zip] if billing_address[:zip]
+            xml.hps :CardHolderZip, alphanumeric_zip(billing_address[:zip]) if billing_address[:zip]
           end
         end
       end
@@ -437,6 +437,10 @@ module ActiveMerchant #:nodoc:
 
       def test?
         @options[:secret_api_key]&.include?('_cert_')
+      end
+
+      def alphanumeric_zip(zip)
+        zip.gsub(/[^0-9a-z]/i, '')
       end
 
       ISSUER_MESSAGES = {

--- a/test/remote/gateways/remote_hps_test.rb
+++ b/test/remote/gateways/remote_hps_test.rb
@@ -53,6 +53,13 @@ class RemoteHpsTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_hyphenated_zip
+    @options[:billing_address][:zip] = '12345-1234'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_successful_purchase_no_address
     options = {
       order_id: '1',

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -38,6 +38,18 @@ class HpsTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_zip_formatting
+    @options[:billing_address][:zip] = '12345-1234 '
+
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/<hps:CardHolderZip>123451234<\/hps:CardHolderZip>/, data)
+    end.respond_with(successful_swipe_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_check_purchase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@check_amount, @check, @options)


### PR DESCRIPTION
CE-1428

Local: 4682 tests, 73306 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit: 60 tests, 293 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote: 57 tests, 154 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.4912% passed

**Notice:** Tests relying on the `hps_echeck` credentials are currently failing with an `Authorization` error. As a result, reviewers should expect 2 failing remote tests. A message will be sent to the gateway in an effort to resolve this, but for the meantime we will move forward with the changes in this PR.