### PR TITLE
Worldpay synchronous response changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@
 * Redsys: Refactor XML character escape logic #3925
 * HPS: Strip zip codes of non-alphanumeric characters [dsmcclain] #3926
 * Orbital: $0 PreNote using authorize for eCheck force_capture [jessiagee] #3927
+* Worldpay: synchronous response changes [naashton] #3928
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874


### PR DESCRIPTION
Most of the changes include test coverage for the updated configuration
for the Worldpay merchant, where responses now reflect a synchronous
workflow. The primary change is in the response message and in some
cases the structure of the response that is returned.

In the case of a `capture` transaction, the previous criteria for
success would expect to find an XML tag `<ok>`. For the changes in the
response, we can now more consistently look for the value in the
`<lastEvent>` tag. See difference in the response methods on line 1252 and 1269.

Refer to the new `synchronous_response` methods and compare them to
their counterparts to see the difference in what we expect from the
current implementation versus the new changes.

Refund remote test: Worldpay does not appear to `settle` a `capture`
transaction immediately leading to an instantaneous `refund` transaction
to fail. The unit test for a successful refund should be sufficient.

Unit: 84 tests, 525 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 65 tests, 279 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.9231% passed