### PR TITLE
Qvalent: add `customer_reference_number`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * PaywayDotCom: Add more thorough scrubbing [tatsianaclifton] #3929
 * Remove CONTRIBUTING.md and update README.md to reflect new repository wiki [dsmcclain] #3930
 * Adyen: Pass Network Tx Reference for MIT [curiousepic] #3932
+* Qvalent: Add customer_reference_number [fredo-] #3931
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -30,6 +30,7 @@ module ActiveMerchant #:nodoc:
         add_stored_credential_data(post, payment_method, options)
         add_customer_data(post, options)
         add_soft_descriptors(post, options)
+        add_customer_reference(post)
 
         commit('capture', post)
       end
@@ -43,6 +44,7 @@ module ActiveMerchant #:nodoc:
         add_stored_credential_data(post, payment_method, options)
         add_customer_data(post, options)
         add_soft_descriptors(post, options)
+        add_customer_reference(post)
 
         commit('preauth', post)
       end
@@ -53,6 +55,7 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization, options)
         add_customer_data(post, options)
         add_soft_descriptors(post, options)
+        add_customer_reference(post)
 
         commit('captureWithoutAuth', post)
       end
@@ -64,6 +67,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_soft_descriptors(post, options)
         post['order.ECI'] = options[:eci] || 'SSL'
+        add_customer_reference(post)
 
         commit('refund', post)
       end
@@ -76,6 +80,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method)
         add_customer_data(post, options)
         add_soft_descriptors(post, options)
+        add_customer_reference(post)
 
         commit('refund', post)
       end
@@ -85,6 +90,7 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization, options)
         add_customer_data(post, options)
         add_soft_descriptors(post, options)
+        add_customer_reference(post)
 
         commit('reversal', post)
       end
@@ -149,12 +155,16 @@ module ActiveMerchant #:nodoc:
         return unless payment_method.brand == 'visa'
 
         stored_credential = options[:stored_credential]
-        if stored_credential[:initial_transaction]
-          post['card.storedCredentialUsage'] = 'INITIAL_STORAGE'
-        elsif stored_credential[:reason_type] == ('recurring' || 'installment')
+        if stored_credential[:reason_type] == 'unscheduled'
+          if stored_credential[:initiator] == 'merchant'
+            post['card.storedCredentialUsage'] = 'UNSCHEDULED_MIT'
+          elsif stored_credential[:initiator] == 'customer'
+            post['card.storedCredentialUsage'] = 'UNSCHEDULED_CIT'
+          end
+        elsif stored_credential[:reason_type] == 'recurring'
           post['card.storedCredentialUsage'] = 'RECURRING'
-        elsif stored_credential[:reason_type] == 'unscheduled'
-          post['card.storedCredentialUsage'] = 'UNSCHEDULED'
+        elsif stored_credential[:reason_type] == 'installment'
+          post['card.storedCredentialUsage'] = 'INSTALLMENT'
         end
       end
 
@@ -182,7 +192,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_card_reference(post)
-        post['customer.customerReferenceNumber'] = options[:order_id]
+        post['customer.customerReferenceNumber'] = options[:customer_reference_number] || options[:order_id]
+      end
+
+      def add_customer_reference(post)
+        post['customer.customerReferenceNumber'] = options[:customer_reference_number] if options[:customer_reference_number]
       end
 
       def add_reference(post, authorization, options)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -924,6 +924,11 @@ quickpay_with_api_key:
   apikey: "fB46983ZwR5dzy46A3r6ngDx7P37N5YTu1F4S9W2JKCs9v4t5L9m2Q8Mlbjpa2I1"
   version: 7
 
+# To get this credential, log into: https://quickstream.support.qvalent.com/->click Administration->Facility Settings->
+# Authentication and Credentials->update "Technology" to SOAP and save->create cert and download .pfx file->
+# use the following command to get the Bag Attributes:
+# $ openssl pkcs12 -in filename.pfx -out cert.pem -nodes
+# open cert.pem file in a text editor (e.g. TextEdit) and you'll see the Bag Attributes to add below under "pem:" field
 qvalent:
   username: "QRSL"
   password: "QRSLTEST"

--- a/test/remote/gateways/remote_qvalent_test.rb
+++ b/test/remote/gateways/remote_qvalent_test.rb
@@ -13,7 +13,8 @@ class RemoteQvalentTest < Test::Unit::TestCase
     @options = {
       order_id: generate_unique_id,
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      customer_reference_number: generate_unique_id
     }
   end
 
@@ -60,9 +61,9 @@ class RemoteQvalentTest < Test::Unit::TestCase
       order_id: generate_unique_id,
       billing_address: address,
       description: 'Store Purchase',
-      xid: '123',
-      cavv: '456',
-      eci: '5'
+      xid: 'sgf7h125tr8gh24abmah',
+      cavv: 'MTIzNDU2Nzg5MDEyMzQ1Njc4OTA=',
+      eci: 'INS'
     }
 
     response = @gateway.purchase(@amount, @credit_card, options)

--- a/test/unit/gateways/qvalent_test.rb
+++ b/test/unit/gateways/qvalent_test.rb
@@ -192,7 +192,7 @@ class QvalentTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, { stored_credential: { initial_transaction: true, reason_type: 'unscheduled', initiator: 'merchant' } })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/posEntryMode=MANUAL/, data)
-      assert_match(/storedCredentialUsage=INITIAL_STORAGE/, data)
+      assert_match(/storedCredentialUsage=UNSCHEDULED_MIT/, data)
       assert_match(/ECI=SSL/, data)
     end.respond_with(successful_purchase_response)
 
@@ -263,6 +263,34 @@ class QvalentTest < Test::Unit::TestCase
 
   def test_transcript_scrubbing
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
+  end
+
+  def test_default_add_card_reference_number
+    post = {}
+    @gateway.options[:order_id] = 1234534
+    @gateway.send(:add_card_reference, post)
+    assert_equal post['customer.customerReferenceNumber'], 1234534
+  end
+
+  def test_add_card_reference_number
+    post = {}
+    @gateway.options[:order_id] = 1234
+    @gateway.options[:customer_reference_number] = 4321
+    @gateway.send(:add_card_reference, post)
+    assert_equal post['customer.customerReferenceNumber'], 4321
+  end
+
+  def test_default_add_customer_reference_number
+    post = {}
+    @gateway.send(:add_customer_reference, post)
+    assert_nil post['customer.customerReferenceNumber']
+  end
+
+  def test_add_customer_reference_number
+    post = {}
+    @gateway.options[:customer_reference_number] = 4321
+    @gateway.send(:add_customer_reference, post)
+    assert_equal post['customer.customerReferenceNumber'], 4321
   end
 
   private


### PR DESCRIPTION
To all transactions in the normal payment flow
Update fixtures file to explain how to set up the appropriate credentials for testing
Update `card.storedCredentialUsage` field and 3DS `order.xid` and others
Update deprecated `INITIAL_STORAGE` to `UNSCHEDULED_MIT` in unit test and nest order object into 3DS options


[CE-1337](https://spreedly.atlassian.net/browse/CE-1337)

Unit:
27 tests, 128 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
22 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed