### PR TITLE
Adyen: Pass Network Tx Reference for MIT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Worldpay: synchronous response changes [naashton] #3928
 * PaywayDotCom: Add more thorough scrubbing [tatsianaclifton] #3929
 * Remove CONTRIBUTING.md and update README.md to reflect new repository wiki [dsmcclain] #3930
+* Adyen: Pass Network Tx Reference for MIT [curiousepic] #3932
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1040,19 +1040,26 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  # The MIT tests may fail unless the test merchant has toggled on Network
+  # Transaction Reference in the Additional Data Settings of the API URLs
+  # section of the Adyen account dashboard
   def test_purchase_using_stored_credential_recurring_cit
     initial_options = stored_credential_options(:cardholder, :recurring, :initial)
     assert auth = @gateway.authorize(@amount, @credit_card, initial_options)
     assert_success auth
     assert_equal 'Subscription', auth.params['additionalData']['recurringProcessingModel']
+
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
     assert_equal '[capture-received]', capture.message
-    assert network_transaction_id = 'none'
 
-    used_options = stored_credential_options(:recurring, :cardholder, id: network_transaction_id)
-    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
-    assert_success purchase
+    cit_used_options = stored_credential_options(:recurring, :cardholder, id: auth.network_transaction_id)
+    assert cit_purchase = @gateway.purchase(@amount, @credit_card, cit_used_options)
+    assert_success cit_purchase
+
+    mit_used_options = stored_credential_options(:recurring, :merchant, id: auth.network_transaction_id)
+    assert mit_purchase = @gateway.purchase(@amount, @credit_card, mit_used_options)
+    assert_success mit_purchase
   end
 
   def test_purchase_using_stored_credential_recurring_mit
@@ -1060,14 +1067,18 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, initial_options)
     assert_success auth
     assert_equal 'Subscription', auth.params['additionalData']['recurringProcessingModel']
+
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
     assert_equal '[capture-received]', capture.message
-    assert network_transaction_id = 'none'
 
-    used_options = stored_credential_options(:recurring, :cardholder, id: network_transaction_id)
-    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
-    assert_success purchase
+    cit_used_options = stored_credential_options(:recurring, :cardholder, id: auth.network_transaction_id)
+    assert cit_purchase = @gateway.purchase(@amount, @credit_card, cit_used_options)
+    assert_success cit_purchase
+
+    mit_used_options = stored_credential_options(:recurring, :merchant, id: auth.network_transaction_id)
+    assert mit_purchase = @gateway.purchase(@amount, @credit_card, mit_used_options)
+    assert_success mit_purchase
   end
 
   def test_purchase_using_stored_credential_unscheduled_cit
@@ -1075,14 +1086,18 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, initial_options)
     assert_success auth
     assert_equal 'CardOnFile', auth.params['additionalData']['recurringProcessingModel']
+
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
     assert_equal '[capture-received]', capture.message
-    assert network_transaction_id = 'none'
 
-    used_options = stored_credential_options(:unscheduled, :cardholder, id: network_transaction_id)
-    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
-    assert_success purchase
+    cit_used_options = stored_credential_options(:unscheduled, :cardholder, id: auth.network_transaction_id)
+    assert cit_purchase = @gateway.purchase(@amount, @credit_card, cit_used_options)
+    assert_success cit_purchase
+
+    mit_used_options = stored_credential_options(:unscheduled, :merchant, id: auth.network_transaction_id)
+    assert mit_purchase = @gateway.purchase(@amount, @credit_card, mit_used_options)
+    assert_success mit_purchase
   end
 
   def test_purchase_using_stored_credential_unscheduled_mit
@@ -1090,14 +1105,18 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, initial_options)
     assert_success auth
     assert_equal 'UnscheduledCardOnFile', auth.params['additionalData']['recurringProcessingModel']
+
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
     assert_equal '[capture-received]', capture.message
-    assert network_transaction_id = 'none'
 
-    used_options = stored_credential_options(:unscheduled, :cardholder, id: network_transaction_id)
-    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
-    assert_success purchase
+    cit_used_options = stored_credential_options(:unscheduled, :cardholder, id: auth.network_transaction_id)
+    assert cit_purchase = @gateway.purchase(@amount, @credit_card, cit_used_options)
+    assert_success cit_purchase
+
+    mit_used_options = stored_credential_options(:unscheduled, :merchant, id: auth.network_transaction_id)
+    assert mit_purchase = @gateway.purchase(@amount, @credit_card, mit_used_options)
+    assert_success mit_purchase
   end
 
   def test_successful_authorize_with_sub_merchant_data

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -468,7 +468,7 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_stored_credential_recurring_cit_initial
-    options = stored_credential_options(:cardholder, :recurring, :initial)
+    options = options_with_stored_credentials(:cardholder, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -481,7 +481,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_stored_credential_recurring_cit_used
     @credit_card.verification_value = nil
-    options = stored_credential_options(:cardholder, :recurring, id: 'abc123')
+    options = options_with_stored_credentials(:cardholder, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -493,7 +493,7 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_stored_credential_recurring_mit_initial
-    options = stored_credential_options(:merchant, :recurring, :initial)
+    options = options_with_stored_credentials(:merchant, :recurring, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -506,19 +506,20 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_stored_credential_recurring_mit_used
     @credit_card.verification_value = nil
-    options = stored_credential_options(:merchant, :recurring, id: 'abc123')
+    options = options_with_stored_credentials(:merchant, :recurring, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"ContAuth"/, data)
       assert_match(/"recurringProcessingModel":"Subscription"/, data)
+      assert_match(/"additionalData":{"networkTxReference":"abc123"/, data)
     end.respond_with(successful_authorize_response)
 
     assert_success response
   end
 
   def test_stored_credential_unscheduled_cit_initial
-    options = stored_credential_options(:cardholder, :unscheduled, :initial)
+    options = options_with_stored_credentials(:cardholder, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -531,7 +532,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_stored_credential_unscheduled_cit_used
     @credit_card.verification_value = nil
-    options = stored_credential_options(:cardholder, :unscheduled, id: 'abc123')
+    options = options_with_stored_credentials(:cardholder, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -543,7 +544,7 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_stored_credential_unscheduled_mit_initial
-    options = stored_credential_options(:merchant, :unscheduled, :initial)
+    options = options_with_stored_credentials(:merchant, :unscheduled, :initial)
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -556,12 +557,13 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_stored_credential_unscheduled_mit_used
     @credit_card.verification_value = nil
-    options = stored_credential_options(:merchant, :unscheduled, id: 'abc123')
+    options = options_with_stored_credentials(:merchant, :unscheduled, id: 'abc123')
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/"shopperInteraction":"ContAuth"/, data)
       assert_match(/"recurringProcessingModel":"UnscheduledCardOnFile"/, data)
+      assert_match(/"additionalData":{"networkTxReference":"abc123"/, data)
     end.respond_with(successful_authorize_response)
 
     assert_success response
@@ -957,7 +959,7 @@ class AdyenTest < Test::Unit::TestCase
 
   private
 
-  def stored_credential_options(*args, id: nil)
+  def options_with_stored_credentials(*args, id: nil)
     {
       order_id: '#1001',
       description: 'AM test',


### PR DESCRIPTION
Add the Network Transaction Reference for MIT requests - see https://docs.adyen.com/api-explorer/#/Payout/v30/post/payout__reqParam_additionalData-AdditionalDataCommon-networkTxReference

The new tests assume the test merchant has toggled on Network
Transaction Reference in the Additional Data Settings of the API URLs
section of the Adyen account dashboard. Otherwise the value is not
returned in initial responses.

Also add this value as a param on the Response itself.

Remote (2 failures on master):
96 tests, 361 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.9167% passed

Unit:
73 tests, 384 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed