### PR TITLE
Orbital: Add 'ND' ECPActionCode to $0 Prenote Check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@
 * Remove CONTRIBUTING.md and update README.md to reflect new repository wiki [dsmcclain] #3930
 * Adyen: Pass Network Tx Reference for MIT [curiousepic] #3932
 * Qvalent: Add customer_reference_number [fredo-] #3931
+* Orbital: Add 'ND' ECPActionCode to $0 Prenote Check [jessiagee] #3935
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -320,7 +320,7 @@ module ActiveMerchant #:nodoc:
       def add_network_tx_reference(post, options)
         return if options.dig(:stored_credential, :initial_transaction)
         return unless post.dig(:shopperInteraction) == 'ContAuth'
-        return unless ('Subscription' 'UnscheduledCardOnFile').include?(post.dig(:recurringProcessingModel))
+        return unless %w[Subscription UnscheduledCardOnFile].include?(post.dig(:recurringProcessingModel))
 
         post[:additionalData] ||= {}
         post[:additionalData][:networkTxReference] = options[:stored_credential][:network_transaction_id]

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -203,7 +203,7 @@ module ActiveMerchant #:nodoc:
         # if we are doing a force capture with a check, that
         # we do a purchase here
         if options[:force_capture] && payment_source.is_a?(Check) &&
-           (options[:action_code].include?('W8') || options[:action_code].include?('W9'))
+           (options[:action_code].include?('W8') || options[:action_code].include?('W9') || options[:action_code].include?('ND'))
           return purchase(money, payment_source, options)
         end
 


### PR DESCRIPTION
Loaded suite test/unit/gateways/orbital_test

116 tests, 683 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_orbital_test

67 tests, 313 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

bundle exec rake test:local

4691 tests, 73342 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed