### PR TITLE
Credorax: Add support for 3ds_reqchallengeind

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,7 @@
 * Qvalent: Add customer_reference_number [fredo-] #3931
 * Orbital: Add 'ND' ECPActionCode to $0 Prenote Check [jessiagee] #3935
 * Checkout: Add support for stored_credential [meagabeth] #3934
+* Credorax: Add support for 3ds_reqchallengeind [dsmcclain] #3936
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -334,6 +334,7 @@ module ActiveMerchant #:nodoc:
           post[:f23] = options[:f23] if options[:f23]
           post[:'3ds_purchasedate'] = Time.now.utc.strftime('%Y%m%d%I%M%S')
           options.dig(:stored_credential, :initiator) == 'merchant' ? post[:'3ds_channel'] = '03' : post[:'3ds_channel'] = '02'
+          post[:'3ds_reqchallengeind'] = options[:three_ds_reqchallengeind] if options[:three_ds_reqchallengeind]
           post[:'3ds_redirect_url'] = three_ds_2_options[:notification_url]
           post[:'3ds_challengewindowsize'] = options[:three_ds_challenge_window_size] || '03'
           post[:d5] = browser_info[:user_agent]

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -27,6 +27,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
       execute_threed: true,
       three_ds_version: '2',
       three_ds_challenge_window_size: '01',
+      three_ds_reqchallengeind: '04',
       stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
         channel: 'browser',

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'pry'
 
 class CredoraxTest < Test::Unit::TestCase
   include CommStub
@@ -24,6 +25,7 @@ class CredoraxTest < Test::Unit::TestCase
       execute_threed: true,
       three_ds_initiate: '03',
       f23: '1',
+      three_ds_reqchallengeind: '04',
       three_ds_challenge_window_size: '01',
       stored_credential: { reason_type: 'unscheduled' },
       three_ds_2: {
@@ -257,6 +259,7 @@ class CredoraxTest < Test::Unit::TestCase
       assert_match(/3ds_transtype=01/, data)
       assert_match(/3ds_initiate=03/, data)
       assert_match(/f23=1/, data)
+      assert_match(/3ds_reqchallengeind=04/, data)
       assert_match(/3ds_redirect_url=www.example.com/, data)
       assert_match(/3ds_challengewindowsize=01/, data)
       assert_match(/d5=unknown/, data)
@@ -551,15 +554,6 @@ class CredoraxTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       assert_match(/h3=12345/, data)
     end.respond_with(successful_credit_response)
-  end
-
-  def test_supports_billing_descriptor
-    @options[:billing_descriptor] = 'abcdefghijkl'
-    stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options)
-    end.check_request do |_endpoint, data, _headers|
-      assert_match(/i2=abcdefghijkl/, data)
-    end.respond_with(successful_purchase_response)
   end
 
   def test_purchase_adds_billing_descriptor


### PR DESCRIPTION
Unit:
69 tests, 333 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
43 tests, 158 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CE-1446