### PR TITLE
Adyen: cancelOrRefund endpoint when passed as option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,6 +41,7 @@
 * Orbital: Add 'ND' ECPActionCode to $0 Prenote Check [jessiagee] #3935
 * Checkout: Add support for stored_credential [meagabeth] #3934
 * Credorax: Add support for 3ds_reqchallengeind [dsmcclain] #3936
+* Adyen: cancelOrRefund endpoint when passed as option [naashton] #3937
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -88,8 +88,9 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options = {})
         post = init_post(options)
+        endpoint = options[:cancel_or_refund] ? 'cancelOrRefund' : 'cancel'
         add_reference(post, authorization, options)
-        commit('cancel', post, options)
+        commit(endpoint, post, options)
       end
 
       def adjust(money, authorization, options = {})
@@ -564,11 +565,10 @@ module ActiveMerchant #:nodoc:
           response['refusalReason'] = 'Received unexpected 3DS authentication response. Use the execute_threed and/or threed_dynamic options to initiate a proper 3DS flow.'
           return false
         end
-
         case action.to_s
         when 'authorise', 'authorise3d'
           %w[Authorised Received RedirectShopper].include?(response['resultCode'])
-        when 'capture', 'refund', 'cancel'
+        when 'capture', 'refund', 'cancel', 'cancelOrRefund'
           response['response'] == "[#{action}-received]"
         when 'adjustAuthorisation'
           response['response'] == 'Authorised' || response['response'] == '[adjustAuthorisation-received]'

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -648,7 +648,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_failed_credit
     response = @gateway.credit(@amount, '')
     assert_failure response
-    assert_equal 'Reference Missing', response.message
+    assert_equal "Required field 'reference' is not provided.", response.message
   end
 
   def test_successful_void
@@ -973,7 +973,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     card = credit_card('4242424242424242', month: 16)
     assert response = @gateway.purchase(@amount, card, @options)
     assert_failure response
-    assert_equal 'Expiry Date Invalid: Expiry month should be between 1 and 12 inclusive', response.message
+    assert_equal 'The provided Expiry Date is not valid.: Expiry month should be between 1 and 12 inclusive', response.message
   end
 
   def test_invalid_expiry_year_for_purchase
@@ -1134,6 +1134,23 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert response.test?
     refute response.authorization.blank?
     assert_success response
+  end
+
+  def test_successful_cancel_or_refund
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert cancel = @gateway.void(auth.authorization)
+    assert_success cancel
+    assert_equal '[cancel-received]', cancel.message
+
+    capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+
+    @options[:cancel_or_refund] = true
+    assert void = @gateway.void(auth.authorization, @options)
+    assert_success void
+    assert_equal '[cancelOrRefund-received]', void.message
   end
 
   private

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -618,7 +618,7 @@ class AdyenTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(failed_credit_response)
     response = @gateway.refund(@amount, '')
     assert_nil response.authorization
-    assert_equal 'Reference Missing', response.message
+    assert_equal "Required field 'reference' is not provided.", response.message
     assert_failure response
   end
 
@@ -635,6 +635,14 @@ class AdyenTest < Test::Unit::TestCase
     response = @gateway.void('7914775043909934')
     assert_equal '7914775043909934#8614775821628806#', response.authorization
     assert_equal '[cancel-received]', response.message
+    assert response.test?
+  end
+
+  def test_successful_cancel_or_refund
+    @gateway.expects(:ssl_post).returns(successful_cancel_or_refund_response)
+    response = @gateway.void('7914775043909934')
+    assert_equal '7914775043909934#8614775821628806#', response.authorization
+    assert_equal '[cancelOrRefund-received]', response.message
     assert response.test?
   end
 
@@ -1233,7 +1241,7 @@ class AdyenTest < Test::Unit::TestCase
     {
       "status":422,
       "errorCode":"130",
-      "message":"Reference Missing",
+      "message":"Required field 'reference' is not provided.",
       "errorType":"validation"
     }
     RESPONSE
@@ -1244,6 +1252,15 @@ class AdyenTest < Test::Unit::TestCase
     {
       "pspReference":"8614775821628806",
       "response":"[cancel-received]"
+    }
+    RESPONSE
+  end
+
+  def successful_cancel_or_refund_response
+    <<-RESPONSE
+    {
+      "pspReference":"8614775821628806",
+      "response":"[cancelOrRefund-received]"
     }
     RESPONSE
   end


### PR DESCRIPTION
Support the cancelOrRefund endpoint when `cancel_or_refund` boolean
option is passed. Void transaction defaults to 'cancel' if the value is
false or non-existent.

Test were failing because of a change in the expected error message from
Adyen

CE-1408

Unit: 74 tests, 387 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 97 tests, 373 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed