### PR TITLE
Orbital: Pass line_items on capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@
 * Credorax: Add support for 3ds_reqchallengeind [dsmcclain] #3936
 * Adyen: cancelOrRefund endpoint when passed as option [naashton] #3937
 * Qvalent: Add customer reference number FIX [fredo-] #3939
+* Orbital: Pass line_items in capture [jessiagee] #3941
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -388,9 +388,9 @@ module ActiveMerchant #:nodoc:
       def add_level3_tax(xml, options = {})
         if (level3 = options[:level_3_data])
           xml.tag! :PC3VATtaxAmt, byte_limit(level3[:vat_tax], 12) if level3[:vat_tax]
-          xml.tag! :PC3AltTaxAmt, byte_limit(level3[:alt_tax], 9) if level3[:alt_tax]
           xml.tag! :PC3VATtaxRate, byte_limit(level3[:vat_rate], 4) if level3[:vat_rate]
           xml.tag! :PC3AltTaxInd, byte_limit(level3[:alt_ind], 15) if level3[:alt_ind]
+          xml.tag! :PC3AltTaxAmt, byte_limit(level3[:alt_tax], 9) if level3[:alt_tax]
         end
       end
 
@@ -911,6 +911,7 @@ module ActiveMerchant #:nodoc:
             add_level2_advice_addendum(xml, parameters)
             add_level3_purchase(xml, parameters)
             add_level3_tax(xml, parameters)
+            add_line_items(xml, parameters) if parameters[:line_items]
           end
         end
         xml.target!

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -553,6 +553,15 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorize_and_capture_with_line_items
+    auth = @gateway.authorize(@amount, @credit_card, @options.merge(level_2_data: @level_2_options, level_3_data: @level_3_options_visa, line_items: @line_items_visa))
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    capture = @gateway.capture(@amount, auth.authorization, @options.merge(level_2_data: @level_2_options, level_3_data: @level_3_options_visa, line_items: @line_items_visa))
+    assert_success capture
+  end
+
   def test_failed_authorize_with_echeck_due_to_invalid_amount
     assert auth = @echeck_gateway.authorize(-1, @echeck, @options.merge(order_id: '2'))
     assert_failure auth


### PR DESCRIPTION
* Ensuring line_items are passed on capture
* Fixed a DTD issue with Level3 tax format

bundle exec rake test:local
Loaded suite /Users/jessiagee/.asdf/installs/ruby/2.5.7/lib/ruby/gems/2.5.0/gems/rake-13.0.3/lib/rake/rake_test_loader

4696 tests, 73364 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

696 files inspected, no offenses detected

Loaded suite test/unit/gateways/orbital_test

116 tests, 683 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_orbital_test

68 tests, 316 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed