### PR TITLE
Transaction Hash is missing expiration date and 3ds info. Also, return transaction details if transaction failed

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -487,7 +487,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def transaction_hash(result)
-        return { 'processor_response_code' => response_code_from_result(result) } unless result.success?
+        unless result.transaction
+          return { 'processor_response_code' => response_code_from_result(result) }
+        end
 
         transaction = result.transaction
         if transaction.vault_customer

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -532,7 +532,8 @@ module ActiveMerchant #:nodoc:
           'bin'                 => transaction.credit_card_details.bin,
           'last_4'              => transaction.credit_card_details.last_4,
           'card_type'           => transaction.credit_card_details.card_type,
-          'token'               => transaction.credit_card_details.token
+          'token'               => transaction.credit_card_details.token,
+          'expiration_date'     => transaction.credit_card_details.expiration_date
         }
 
         if transaction.risk_data
@@ -544,6 +545,15 @@ module ActiveMerchant #:nodoc:
           }
         else
           risk_data = nil
+        end
+
+        if transaction.three_d_secure_info
+          three_d_secure_info = {
+            'enrolled'                   => transaction.three_d_secure_info.enrolled,
+            'liability_shifted'          => transaction.three_d_secure_info.liability_shifted,
+            'liability_shifted_possible' => transaction.three_d_secure_info.liability_shift_possible,
+            'status'                     => transaction.three_d_secure_info.status,
+          }
         end
 
         {
@@ -558,7 +568,8 @@ module ActiveMerchant #:nodoc:
           'merchant_account_id'     => transaction.merchant_account_id,
           'risk_data'               => risk_data,
           'network_transaction_id'  => transaction.network_transaction_id || nil,
-          'processor_response_code' => response_code_from_result(result)
+          'processor_response_code' => response_code_from_result(result),
+          'three_d_secure_info'     => three_d_secure_info,
         }
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -973,6 +973,21 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'authenticate_successful', response.params['braintree_transaction']['three_d_secure_info']['status']
   end
 
+  def test_unsuccessful_response_to_have_transaction_details
+    assert response = @gateway.authorize(
+      250000,
+      credit_card(
+        '4111111111111111',
+        first_name: 'Old First',
+        last_name: 'Old Last',
+        month: 12, year: 2030
+      ),
+    )
+    assert_failure response
+    assert_equal 'processor_declined', response.params['braintree_transaction']['status']
+    assert_not_nil response.params['braintree_transaction']['credit_card_details']
+  end
+
   private
 
   def stored_credential_options(*args, id: nil)

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -947,6 +947,32 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
   end
 
+  def test_successful_authorize_expiration_date_response
+    assert response = @gateway.authorize(
+      @amount,
+      credit_card('4111111111111111',
+        first_name: 'Old First', last_name: 'Old Last',
+        month: 12, year: 2030),
+      @options
+    )
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'authorized', response.params['braintree_transaction']['status']
+    assert_equal '12/2030', response.params['braintree_transaction']['credit_card_details']['expiration_date']
+  end
+
+  def test_successful_three_d_secure_info_response
+    assert response = @gateway.authorize(
+      @amount,
+      'fake-three-d-secure-visa-full-authentication-nonce',
+      @options.merge({ payment_method_nonce: true })
+    )
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'authorized', response.params['braintree_transaction']['status']
+    assert_equal 'authenticate_successful', response.params['braintree_transaction']['three_d_secure_info']['status']
+  end
+
   private
 
   def stored_credential_options(*args, id: nil)


### PR DESCRIPTION
The transaction hash is missing credit card expiration date and three d secure info, which I included into the hash, if available.
Also, I added transaction details to the transaction hash even if it fails.

# unit tests
4696 tests, 73364 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

# remote:
Expiration Date Test:
1 tests, 5 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

three d secure info test:
1 tests, 5 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed