### PR TITLE
Braintree: Add support for $0 auth verification

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@
 * Adyen: cancelOrRefund endpoint when passed as option [naashton] #3937
 * Qvalent: Add customer reference number FIX [fredo-] #3939
 * Orbital: Pass line_items in capture [jessiagee] #3941
+* BraintreeBlue: Add support for $0 auth verification [meagabeth] #3944
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -179,6 +179,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_match %r{number is not an accepted test number}, response.message
   end
 
+  def test_successful_credit_card_verification
+    card = credit_card('4111111111111111')
+    assert response = @gateway.verify(card, @options.merge({ allow_card_verification: true }))
+    assert_success response
+    assert_match 'OK', response.message
+  end
+
   def test_successful_verify_with_device_data
     # Requires Advanced Fraud Tools to be enabled
     assert response = @gateway.verify(@credit_card, @options.merge({ device_data: 'device data for verify' }))

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -127,6 +127,23 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert !@gateway.verify_credentials
   end
 
+  def test_zero_dollar_verification_transaction
+    Braintree::CreditCardVerificationGateway.any_instance.expects(:create).
+      returns(braintree_result)
+
+    card = credit_card('4111111111111111')
+    options = {
+      allow_card_verification: true,
+      billing_address: {
+        zip: '10000'
+      }
+    }
+    response = @gateway.verify(card, options)
+    assert_success response
+    assert_equal 'transaction_id', response.params['authorization']
+    assert_equal true, response.params['test']
+  end
+
   def test_user_agent_includes_activemerchant_version
     assert @internal_gateway.config.user_agent.include?("(ActiveMerchant #{ActiveMerchant::VERSION})")
   end


### PR DESCRIPTION
If a merchant sends the field `allow_card_verification` as `true`, the `verify` method will utilize Braintree's credit-card-verification endpoint. If `allow_card_verification` is sent as `false` or not sent at all, it will execute the `verify` with the existing authorize/void transaction flow as it has in the past. To note: `allow_card_verification` is not a gateway supported field so it is not passed on to Braintree during the `verify` process. The purpose of the field is to direct which flow the `verify` method should use.

CE-555

Local:
4697 tests, 73368 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
82 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
83 tests, 442 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed