### PR TITLE
Braintree: Add support for AVS and CVV results in $0 credit card veri…

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -392,7 +392,11 @@ module ActiveMerchant #:nodoc:
 
       def response_options(result)
         options = {}
-        if result.transaction
+        if result.credit_card_verification
+          options[:authorization] = result.credit_card_verification.id
+          options[:avs_result] = { code: avs_code_from(result.credit_card_verification) }
+          options[:cvv_result] = result.credit_card_verification.cvv_response_code
+        elsif result.transaction
           options[:authorization] = result.transaction.id
           options[:avs_result] = { code: avs_code_from(result.transaction) }
           options[:cvv_result] = result.transaction.cvv_response_code

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -184,6 +184,8 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.verify(card, @options.merge({ allow_card_verification: true }))
     assert_success response
     assert_match 'OK', response.message
+    assert_not_nil response.params['cvv_result']
+    assert_not_nil response.params['avs_result']
   end
 
   def test_successful_verify_with_device_data
@@ -197,7 +199,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert transaction['risk_data']['id']
     assert_equal 'Approve', transaction['risk_data']['decision']
     assert_equal false, transaction['risk_data']['device_data_captured']
-    assert_equal 'kount', transaction['risk_data']['fraud_service_provider']
+    assert_equal 'fraud_protection', transaction['risk_data']['fraud_service_provider']
   end
 
   def test_successful_validate_on_store
@@ -449,7 +451,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert transaction['risk_data']['id']
     assert_equal 'Approve', transaction['risk_data']['decision']
     assert_equal false, transaction['risk_data']['device_data_captured']
-    assert_equal 'kount', transaction['risk_data']['fraud_service_provider']
+    assert_equal 'fraud_protection', transaction['risk_data']['fraud_service_provider']
   end
 
   def test_purchase_with_store_using_random_customer_id

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -129,7 +129,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_zero_dollar_verification_transaction
     Braintree::CreditCardVerificationGateway.any_instance.expects(:create).
-      returns(braintree_result)
+      returns(braintree_result(cvv_response_code: 'M', avs_error_response_code: 'P'))
 
     card = credit_card('4111111111111111')
     options = {
@@ -142,6 +142,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'transaction_id', response.params['authorization']
     assert_equal true, response.params['test']
+    assert_equal 'M', response.params['cvv_result']
+    assert_equal 'P', response.params['avs_result'][:code]
   end
 
   def test_user_agent_includes_activemerchant_version


### PR DESCRIPTION
…fication transactions

Edit device data related remote tests. The ['risk_data']['fraud_service_provider'] is no longer returning 'kount' and is now returning 'fraud_protection' in the remote tests.

CE-1518

Local:
4697 tests, 73370 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
82 tests, 190 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
83 tests, 444 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed