### PR TITLE
Braintree: Return `cvv_code` and `avs_code` in response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@
 * JCB: Add additional BIN ranges [dsmcclain] #3946
 * vPOS: Support new gateway type [therufs] #3906
 * Braintree: Add support for AVS and CVV results in $0 credit card verification transactions [meagabeth] #3951
+* Braintree: Return cvv_code and avs_code in response [meagabeth] #3952
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -135,6 +135,8 @@ module ActiveMerchant #:nodoc:
             result = @braintree_gateway.verification.create(payload)
             response = Response.new(result.success?, message_from_transaction_result(result), response_options(result))
             response.cvv_result['message'] = ''
+            response.cvv_result['code'] = response.params['cvv_result']
+            response.avs_result['code'] = response.params['avs_result'][:code]
             response
           end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -184,8 +184,8 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.verify(card, @options.merge({ allow_card_verification: true }))
     assert_success response
     assert_match 'OK', response.message
-    assert_not_nil response.params['cvv_result']
-    assert_not_nil response.params['avs_result']
+    assert_equal 'M', response.cvv_result['code']
+    assert_equal 'P', response.avs_result['code']
   end
 
   def test_successful_verify_with_device_data

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -141,9 +141,8 @@ class BraintreeBlueTest < Test::Unit::TestCase
     response = @gateway.verify(card, options)
     assert_success response
     assert_equal 'transaction_id', response.params['authorization']
-    assert_equal true, response.params['test']
-    assert_equal 'M', response.params['cvv_result']
-    assert_equal 'P', response.params['avs_result'][:code]
+    assert_equal 'M', response.cvv_result['code']
+    assert_equal 'P', response.avs_result['code']
   end
 
   def test_user_agent_includes_activemerchant_version


### PR DESCRIPTION
Local:
4703 tests, 73388 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
82 tests, 189 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
83 tests, 444 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed