### PR TITLE
Payeezy: Send `customer_ref` field

### DIFF
--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -39,6 +39,7 @@ module ActiveMerchant
         add_address(params, options)
         add_amount(params, amount, options)
         add_soft_descriptors(params, options)
+        add_level2_data(params, options)
         add_stored_credentials(params, options)
 
         commit(params, options)
@@ -53,6 +54,7 @@ module ActiveMerchant
         add_address(params, options)
         add_amount(params, amount, options)
         add_soft_descriptors(params, options)
+        add_level2_data(params, options)
         add_stored_credentials(params, options)
 
         commit(params, options)
@@ -244,6 +246,13 @@ module ActiveMerchant
 
       def add_soft_descriptors(params, options)
         params[:soft_descriptors] = options[:soft_descriptors] if options[:soft_descriptors]
+      end
+
+      def add_level2_data(params, options)
+        return unless level2_data = options[:level2]
+
+        params[:level2] = {}
+        params[:level2][:customer_ref] = level2_data[:customer_ref]
       end
 
       def add_stored_credentials(params, options)

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -85,6 +85,12 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_customer_ref
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(level2: { customer_ref: 'An important customer' }))
+    assert_match(/Transaction Normal/, response.message)
+    assert_success response
+  end
+
   def test_successful_purchase_with_stored_credentials
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@options_stored_credentials))
     assert_match(/Transaction Normal/, response.message)

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -131,6 +131,17 @@ class PayeezyGateway < Test::Unit::TestCase
     assert_equal 'Transaction Normal - Approved', response.message
   end
 
+  def test_successful_purchase_with_customer_ref
+    options = @options.merge(level2: { customer_ref: 'An important customer' })
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/"level2":{"customer_ref":"An important customer"}/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_stored_credentials
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(@options_stored_credentials))


### PR DESCRIPTION
The `customer_ref` field is nested inside a `level2` object.

CE-1485

Running RuboCop...
Inspecting 699 files
699 files inspected, no offenses detected

unit:
Loaded suite test/unit/gateways/payeezy_test
37 tests, 176 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

remote:
Loaded suite test/remote/gateways/remote_payeezy_test
37 tests, 146 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed