### PR TITLE
Orbital: Use billing_address name as fallback

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -454,7 +454,7 @@ module ActiveMerchant #:nodoc:
         # always send the AVSname if the payment is a check regardless
         # if there's an address or not
         if payment_source.is_a?(Check) && address.blank?
-          xml.tag! :AVSname, (payment_source&.name ? payment_source.name[0..29] : nil)
+          xml.tag! :AVSname, billing_name(payment_source, options)
 
           return
         end
@@ -471,11 +471,19 @@ module ActiveMerchant #:nodoc:
             xml.tag! :AVSphoneNum, (address[:phone] ? address[:phone].scan(/\d/).join.to_s[0..13] : nil)
           end
 
-          xml.tag! :AVSname, (payment_source&.name ? payment_source.name[0..29] : nil)
+          xml.tag! :AVSname, billing_name(payment_source, options)
           xml.tag! :AVScountryCode, (avs_supported ? byte_limit(format_address_field(address[:country]), 2) : '')
 
           # Needs to come after AVScountryCode
           add_destination_address(xml, address) if avs_supported
+        end
+      end
+
+      def billing_name(payment_source, options)
+        if !payment_source&.name.blank?
+          payment_source.name[0..29]
+        elsif !options[:billing_address][:name].blank?
+          options[:billing_address][:name][0..29]
         end
       end
 


### PR DESCRIPTION
When adding the AVSName element, if there is no name on the payment
method itself, look in the billing address hash for a name instead.

Remote:
68 tests, 316 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
118 tests, 691 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed