### PR TITLE
Braintree: Add support for `risk_data` fields

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -622,6 +622,7 @@ module ActiveMerchant #:nodoc:
         add_addresses(parameters, options)
 
         add_descriptor(parameters, options)
+        add_risk_data(parameters, options)
         add_travel_data(parameters, options) if options[:travel_data]
         add_lodging_data(parameters, options) if options[:lodging_data]
         add_channel(parameters, options)
@@ -679,6 +680,15 @@ module ActiveMerchant #:nodoc:
           name: options[:descriptor_name],
           phone: options[:descriptor_phone],
           url: options[:descriptor_url]
+        }
+      end
+
+      def add_risk_data(parameters, options)
+        return unless options[:risk_data]
+
+        parameters[:risk_data] = {
+          customer_browser: options[:risk_data][:customer_browser],
+          customer_ip: options[:risk_data][:customer_ip]
         }
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -167,6 +167,17 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal '1000 Approved', response.message
   end
 
+  def test_successful_purchase_sending_risk_data
+    options = @options.merge(
+      risk_data: {
+        customer_browser: 'User-Agent Header',
+        customer_ip: '127.0.0.1'
+      }
+    )
+    assert response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+  end
+
   def test_successful_verify
     assert response = @gateway.verify(@credit_card, @options)
     assert_success response

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -195,6 +195,17 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.authorize(100, credit_card('41111111111111111111'), service_fee_amount: '2.31')
   end
 
+  def test_risk_data_can_be_specified
+    risk_data = {
+      customer_browser: 'User-Agent Header',
+      customer_ip: '127.0.0.1'
+    }
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(risk_data: risk_data)).returns(braintree_result)
+
+    @gateway.authorize(100, credit_card('4111111111111111'), risk_data: risk_data)
+  end
+
   def test_hold_in_escrow_can_be_specified
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:options][:hold_in_escrow] == true)


### PR DESCRIPTION
The `risk_data` information, [seen here in Braintree's documentation](https://developers.braintreepayments.com/reference/request/transaction/sale/ruby#risk_data), can be sent for fraud analysis

CE-1488

Local:
4705 tests, 73392 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
83 tests, 190 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
84 tests, 446 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed