### PR TITLE
authorize.net: add settings section to refund xml

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -362,6 +362,7 @@ module ActiveMerchant
             add_shipping_fields(xml, options)
             add_tax_exempt_status(xml, options)
             add_po_number(xml, options)
+            add_settings(xml, nil, options)
             add_customer_data(xml, nil, options)
             add_user_fields(xml, amount, options)
           end

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -362,8 +362,8 @@ module ActiveMerchant
             add_shipping_fields(xml, options)
             add_tax_exempt_status(xml, options)
             add_po_number(xml, options)
-            add_settings(xml, nil, options)
             add_customer_data(xml, nil, options)
+            add_settings(xml, nil, options)
             add_user_fields(xml, amount, options)
           end
         end


### PR DESCRIPTION
the xml created by the credit method already has a section called settings (duplicate window, email customer etc). This is missing from the xml created by the refund method