### PR TITLE
Support Canadian Bank Accounts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@
 * Credorax: adjust logic for sending 3ds shipping address fields [dsmcclain] #3959
 * Orbital: Ensure ECP always sends AVSName [jessiagee] #3963
 * Orbital: Add middle name to EWSMiddleName for ECP [jessiagee] #3962
+* Support Canadian Bank Accounts [naashton] #3964
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -13,6 +13,14 @@ module ActiveMerchant #:nodoc:
       # Used for Canadian bank accounts
       attr_accessor :institution_number, :transit_number
 
+      # Canadian Institution Numbers
+      # Found here: https://en.wikipedia.org/wiki/Routing_number_(Canada)
+      INSTITUTION_NUMBERS = %w(
+        001 002 003 004	006 010 016 030 039 117 127 177 219 245 260 269 270 308
+        309 310 315 320	338 340 509 540 608 614 623 809 815 819 828 829 837 839
+        865 879 889 899
+      )
+
       def name
         @name ||= "#{first_name} #{last_name}".strip
       end
@@ -67,6 +75,8 @@ module ActiveMerchant #:nodoc:
           else
             false
           end
+        when 8
+          true if INSTITUTION_NUMBERS.include?(routing_number[0..2].to_s)
         else
           false
         end

--- a/test/unit/check_test.rb
+++ b/test/unit/check_test.rb
@@ -4,6 +4,7 @@ class CheckTest < Test::Unit::TestCase
   VALID_ABA     = '111000025'
   INVALID_ABA   = '999999999'
   MALFORMED_ABA = 'I like fish'
+  VALID_CBA = '00194611'
 
   ACCOUNT_NUMBER = '123456789012'
 
@@ -77,5 +78,15 @@ class CheckTest < Test::Unit::TestCase
 
     c.account_type = nil
     assert !c.validate[:account_type]
+  end
+
+  def test_valid_canada_routing_number
+    assert_valid Check.new(
+      name: 'Tim Horton',
+      routing_number: VALID_CBA,
+      account_number: ACCOUNT_NUMBER,
+      account_holder_type: 'personal',
+      account_type: 'checking'
+    )
   end
 end


### PR DESCRIPTION
Add support for Canadian bank accounts, specifically validate routing
numbers. Validation is performed against the first 3 digits of the
routing number and a list financial institution numbers.

CE-1468

Unit: 10 tests, 22 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: