### PR TITLE
CyberSource: Update XML tag for merchantDefinedData

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,6 +56,7 @@
 * Orbital: Add middle name to EWSMiddleName for ECP [jessiagee] #3962
 * Support Canadian Bank Accounts [naashton] #3964
 * Windcave/Payment Express: Add support for AvsAction and EnableAVSData fields [meagabeth] #3967
+* CyberSource: Update XML tag for merchantDefinedData [meagabeth] #3969
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -604,7 +604,7 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'merchantDefinedData' do
           (1..100).each do |each|
             key = "mdd_field_#{each}".to_sym
-            xml.tag!("field#{each}", options[key]) if options[key]
+            xml.tag!('mddField', options[key], 'id' => each) if options[key]
           end
         end
       end

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -99,7 +99,7 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(100, @credit_card, order_id: '1', mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
+      assert_match(/<mddField id=\"2\">CustomValue2</m, data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -195,7 +195,7 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.authorize(100, @credit_card, order_id: '1', mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
+      assert_match(/<mddField id=\"2\">CustomValue2</m, data)
     end.respond_with(successful_authorization_response)
   end
 
@@ -387,7 +387,7 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.capture(100, '1846925324700976124593', order_id: '1', mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
+      assert_match(/<mddField id=\"2\">CustomValue2</m, data)
     end.respond_with(successful_capture_response)
   end
 
@@ -528,7 +528,7 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.credit(@amount, @credit_card, mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
+      assert_match(/<mddField id=\"2\">CustomValue2</m, data)
     end.respond_with(successful_card_credit_response)
   end
 
@@ -578,7 +578,7 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.void(authorization, mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/field2>CustomValue2.*field3>CustomValue3</m, data)
+      assert_match(/<mddField id=\"2\">CustomValue2</m, data)
     end.respond_with(successful_void_response)
   end
 


### PR DESCRIPTION
This update does not change how mdd_field is passed in with a transaction, only how it is adjusted for proper xml formatting according to [CyberSource gateway documentation](https://support.cybersource.com/s/article/What-is-an-XML-example-of-merchant-defined-data-fields-mddField-in-an-SOAP-call). Based on this, it should not break existing customer's use of the field.

CE-258

Local:4710 tests, 73418 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit: 102 tests, 499 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote: 95 tests, 490 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.6842% passed
Failing remote tests are also failing on master branch:
test_successful_authorization_and_failed_capture
test_successful_validate_pinless_debit_card
test_successful_tax_calculation
test_successful_pinless_debit_card_puchase
test_successful_3ds_validate_purchase_request
test_successful_3ds_validate_authorize_request