### PR TITLE
dLocal: Add supported cardtypes

### DIFF
--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w[AR BR CL CO MX PE UY TR]
       self.default_currency = 'USD'
-      self.supported_cardtypes = %i[visa master american_express discover jcb diners_club maestro naranja cabal]
+      self.supported_cardtypes = %i[visa master american_express discover jcb diners_club maestro naranja cabal elo alia carnet]
 
       self.homepage_url = 'https://dlocal.com/'
       self.display_name = 'dLocal'

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -8,12 +8,11 @@ class RemoteDLocalTest < Test::Unit::TestCase
     @credit_card = credit_card('4111111111111111')
     @credit_card_naranja = credit_card('5895627823453005')
     @cabal_credit_card = credit_card('5896 5700 0000 0004')
-    @invalid_cabal_card = credit_card('6035 2277 0000 0000')
     # No test card numbers, all txns are approved by default,
     # but errors can be invoked directly with the `description` field
     @options = {
       billing_address: address(country: 'Brazil'),
-      document: '42243309114',
+      document: '71575743221',
       currency: 'BRL'
     }
     @options_colombia = {
@@ -122,12 +121,6 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_match 'The payment was rejected', response.message
   end
 
-  def test_failed_purchase_with_cabal
-    response = @gateway.purchase(@amount, @invalid_cabal_card, @options)
-    assert_failure response
-    assert_match 'Payment not found', response.message
-  end
-
   def test_failed_document_format
     response = @gateway.purchase(@amount, @credit_card, @options.merge(document: 'bad_document'))
     assert_failure response
@@ -198,7 +191,7 @@ class RemoteDLocalTest < Test::Unit::TestCase
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
-    response = @gateway.refund(@amount + 1, purchase.authorization, @options.merge(notification_url: 'http://example.com'))
+    response = @gateway.refund(@amount + 100, purchase.authorization, @options.merge(notification_url: 'http://example.com'))
     assert_failure response
     assert_match 'Amount exceeded', response.message
   end


### PR DESCRIPTION
CE-1511

This PR adds `elo`, `alia`, and `carnet` to the list of cardtypes supported by the dLocal gateway.

It also adds fixes for the remote dLocal tests, most of which were failing. A new `payer.document` was required to get most of the tests passing again.

The test `test_failed_purchase_with_cabal` was removed because dLocal's sandbox does not validate cards and simply returns a success unless a failure is stimulated in the `description` field of the request (see https://docs.dlocal.com/guides/getting-started/sandbox-testing#testing-payments). 

I am seeing two failing remote tests, `test_successful_refund` and `test_partial_refund`, both of which fail with an `insufficient funds` error. This is because the sandbox merchant account has a (fake) funds balance that is currently in the negative, so the refund is rejected when it tries to assess a $20 refund fee to the account. If you are using the same sandbox account as I am when you review this PR, you should expect to see the same failures.

Rubocop:
699 files inspected, no offenses detected

Local:
4710 tests, 73418 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
27 tests, 70 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.5926% passed