### PR TITLE
Authorize.Net: Stored Credential Support Improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,6 +65,7 @@
 * Adyen: Default card holder name for credit cards [shasum] #3980
 * PaywayDotCom: make `source_id` a required field [dsmcclain] # 3981 
 * Qvalent: remove `pem_password` from required credentials [dsmcclain] #3982
+* Authorize.net: Fix stored credentials [tatsianaclifton] #3971
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -708,9 +708,10 @@ module ActiveMerchant
         return unless options[:stored_credential]
 
         xml.processingOptions do
-          if options[:stored_credential][:initial_transaction]
+          if options[:stored_credential][:initial_transaction] && options[:stored_credential][:reason_type] == 'recurring'
+            xml.isFirstRecurringPayment 'true'
+          elsif options[:stored_credential][:initial_transaction]
             xml.isFirstSubsequentAuth 'true'
-            # xml.isFirstRecurringPayment 'true' if options[:stored_credential][:reason_type] == 'recurring'
           elsif options[:stored_credential][:initiator] == 'cardholder'
             xml.isStoredCredentials 'true'
           else
@@ -720,7 +721,7 @@ module ActiveMerchant
       end
 
       def add_subsequent_auth_information(xml, options)
-        return unless options.dig(:stored_credential, :reason_type) == 'unscheduled'
+        return unless options.dig(:stored_credential, :initiator) == 'merchant'
 
         xml.subsequentAuthInformation do
           xml.reason options[:stored_credential_reason_type_override] if options[:stored_credential_reason_type_override]
@@ -931,6 +932,11 @@ module ActiveMerchant
 
         response[:full_response_code] =
           if element = doc.at_xpath('//messages/message/code')
+            empty?(element.content) ? nil : element.content
+          end
+
+        response[:network_trans_id] =
+          if element = doc.at_xpath('//networkTransId')
             empty?(element.content) ? nil : element.content
           end
 

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -215,7 +215,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     stored_credential_params = {
       initial_transaction: true,
       reason_type: 'recurring',
-      initiator: 'merchant',
+      initiator: 'cardholder',
       network_transaction_id: nil
     }
     assert auth = @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
@@ -229,7 +229,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
       initial_transaction: false,
       reason_type: 'recurring',
       initiator: 'merchant',
-      network_transaction_id: auth.params['transaction_identifier']
+      network_transaction_id: auth.params['network_trans_id']
     }
 
     assert next_auth = @gateway.authorize(@amount, @credit_card, @options)
@@ -243,7 +243,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     stored_credential_params = {
       initial_transaction: true,
       reason_type: 'unscheduled',
-      initiator: 'merchant',
+      initiator: 'cardholder',
       network_transaction_id: nil
     }
     assert auth = @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
@@ -257,7 +257,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
       initial_transaction: false,
       reason_type: 'unscheduled',
       initiator: 'merchant',
-      network_transaction_id: auth.params['transaction_identifier']
+      network_transaction_id: auth.params['network_trans_id']
     }
 
     assert next_auth = @gateway.authorize(@amount, @credit_card, @options)
@@ -271,7 +271,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     stored_credential_params = {
       initial_transaction: true,
       reason_type: 'installment',
-      initiator: 'merchant',
+      initiator: 'cardholder',
       network_transaction_id: nil
     }
     assert auth = @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
@@ -285,7 +285,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
       initial_transaction: false,
       reason_type: 'installment',
       initiator: 'merchant',
-      network_transaction_id: auth.params['transaction_identifier']
+      network_transaction_id: auth.params['network_trans_id']
     }
 
     assert next_auth = @gateway.authorize(@amount, @credit_card, @options)
@@ -662,6 +662,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
       card_code
       cardholder_authentication_code
       full_response_code
+      network_trans_id
       response_code
       response_reason_code
       response_reason_text

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -539,11 +539,29 @@ class AuthorizeNetTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved.', capture.message
   end
 
-  def test_successful_auth_with_initial_stored_credential
+  def test_successful_auth_with_initial_reccuring_stored_credential
+    stored_credential_params = {
+      initial_transaction: true,
+      reason_type: 'recurring',
+      initiator: 'cardholder',
+      network_transaction_id: nil
+    }
+    auth = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+    end.check_request do |_endpoint, data, _headers|
+      doc = parse(data)
+      assert_equal 'true', doc.at_xpath('//processingOptions/isFirstRecurringPayment').content
+      assert_not_match(/isFirstSubsequentAuth/, doc)
+    end.respond_with(successful_authorize_response)
+    assert_success auth
+    assert auth.authorization
+  end
+
+  def test_successful_auth_with_initial_unscheduled_stored_credential
     stored_credential_params = {
       initial_transaction: true,
       reason_type: 'unscheduled',
-      initiator: 'merchant',
+      initiator: 'cardholder',
       network_transaction_id: nil
     }
     auth = stub_comms do
@@ -551,12 +569,31 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       doc = parse(data)
       assert_equal 'true', doc.at_xpath('//processingOptions/isFirstSubsequentAuth').content
+      assert_not_match(/isFirstRecurringPayment/, doc)
     end.respond_with(successful_authorize_response)
     assert_success auth
     assert auth.authorization
   end
 
-  def test_successful_auth_with_installment_stored_credential
+  def test_successful_auth_with_initial_installment_stored_credential
+    stored_credential_params = {
+      initial_transaction: true,
+      reason_type: 'installment',
+      initiator: 'cardholder',
+      network_transaction_id: nil
+    }
+    auth = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+    end.check_request do |_endpoint, data, _headers|
+      doc = parse(data)
+      assert_equal 'true', doc.at_xpath('//processingOptions/isFirstSubsequentAuth').content
+      assert_not_match(/isFirstRecurringPayment/, doc)
+    end.respond_with(successful_authorize_response)
+    assert_success auth
+    assert auth.authorization
+  end
+
+  def test_successful_auth_with_subsequent_installment_stored_credential
     stored_credential_params = {
       initial_transaction: false,
       reason_type: 'installment',
@@ -568,12 +605,31 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       doc = parse(data)
       assert_equal 'true', doc.at_xpath('//processingOptions/isSubsequentAuth').content
+      assert_equal '0123', doc.at_xpath('//subsequentAuthInformation/originalNetworkTransId').content
     end.respond_with(successful_authorize_response)
     assert_success auth
     assert auth.authorization
   end
 
-  def test_successful_auth_with_recurring_stored_credential
+  def test_successful_auth_with_subsequent_unscheduled_stored_credential
+    stored_credential_params = {
+      initial_transaction: false,
+      reason_type: 'unscheduled',
+      initiator: 'merchant',
+      network_transaction_id: '0123'
+    }
+    auth = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+    end.check_request do |_endpoint, data, _headers|
+      doc = parse(data)
+      assert_equal 'true', doc.at_xpath('//processingOptions/isSubsequentAuth').content
+      assert_equal '0123', doc.at_xpath('//subsequentAuthInformation/originalNetworkTransId').content
+    end.respond_with(successful_authorize_response)
+    assert_success auth
+    assert auth.authorization
+  end
+
+  def test_successful_auth_with_subsequent_recurring_stored_credential
     stored_credential_params = {
       initial_transaction: false,
       reason_type: 'recurring',
@@ -585,8 +641,60 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       doc = parse(data)
       assert_equal 'true', doc.at_xpath('//processingOptions/isSubsequentAuth').content
+      assert_equal '0123', doc.at_xpath('//subsequentAuthInformation/originalNetworkTransId').content
       assert_equal 'recurringBilling', doc.at_xpath('//transactionSettings/setting/settingName').content
       assert_equal 'true', doc.at_xpath('//transactionSettings/setting/settingValue').content
+    end.respond_with(successful_authorize_response)
+    assert_success auth
+    assert auth.authorization
+  end
+
+  def test_successful_auth_with_subsequent_installment_stored_credential_and_cardholder_initiator
+    stored_credential_params = {
+      initial_transaction: false,
+      reason_type: 'installment',
+      initiator: 'cardholder',
+      network_transaction_id: '0123'
+    }
+    auth = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+    end.check_request do |_endpoint, data, _headers|
+      doc = parse(data)
+      assert_equal 'true', doc.at_xpath('//processingOptions/isStoredCredentials').content
+    end.respond_with(successful_authorize_response)
+    assert_success auth
+    assert auth.authorization
+  end
+
+  def test_successful_auth_with_subsequent_unscheduled_stored_credential_and_cardholder_initiator
+    stored_credential_params = {
+      initial_transaction: false,
+      reason_type: 'unscheduled',
+      initiator: 'cardholder',
+      network_transaction_id: '0123'
+    }
+    auth = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+    end.check_request do |_endpoint, data, _headers|
+      doc = parse(data)
+      assert_equal 'true', doc.at_xpath('//processingOptions/isStoredCredentials').content
+    end.respond_with(successful_authorize_response)
+    assert_success auth
+    assert auth.authorization
+  end
+
+  def test_successful_auth_with_subsequent_recurring_stored_credential_and_cardholder_initiator
+    stored_credential_params = {
+      initial_transaction: false,
+      reason_type: 'recurring',
+      initiator: 'cardholder',
+      network_transaction_id: '0123'
+    }
+    auth = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+    end.check_request do |_endpoint, data, _headers|
+      doc = parse(data)
+      assert_equal 'true', doc.at_xpath('//processingOptions/isStoredCredentials').content
     end.respond_with(successful_authorize_response)
     assert_success auth
     assert auth.authorization


### PR DESCRIPTION
Add support for reccuring payment types. Extract networkTransId into response. Set originalNetworkTransId for all MIT transactions. Set isFirstRecurringPayment if it is a first recurring transaction.

ECS-1817

Unit:
107 tests, 637 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
73 tests, 269 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed