### PR TITLE
Elavon: Send `ssl_vendor_id` field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,7 @@
 * Support Canadian Bank Accounts [naashton] #3964
 * Windcave/Payment Express: Add support for AvsAction and EnableAVSData fields [meagabeth] #3967
 * CyberSource: Update XML tag for merchantDefinedData [meagabeth] #3969
+* Elavon: Send ssl_vendor_id field [dsmcclain] #3972
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment_method, options = {})
         request = build_xml_request do |xml|
+          xml.ssl_vendor_id         options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:purchase]
           xml.ssl_amount            amount(money)
 
@@ -63,6 +64,7 @@ module ActiveMerchant #:nodoc:
 
       def authorize(money, creditcard, options = {})
         request = build_xml_request do |xml|
+          xml.ssl_vendor_id         options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:authorize]
           xml.ssl_amount            amount(money)
 
@@ -82,6 +84,8 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options = {})
         request = build_xml_request do |xml|
+          xml.ssl_vendor_id         options[:ssl_vendor_id]
+
           if options[:credit_card]
             xml.ssl_transaction_type self.actions[:capture]
             xml.ssl_amount amount(money)
@@ -107,6 +111,7 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, identification, options = {})
         request = build_xml_request do |xml|
+          xml.ssl_vendor_id         options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:refund]
           xml.ssl_amount            amount(money)
           add_txn_id(xml, identification)
@@ -117,6 +122,7 @@ module ActiveMerchant #:nodoc:
 
       def void(identification, options = {})
         request = build_xml_request do |xml|
+          xml.ssl_vendor_id         options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:void]
 
           add_txn_id(xml, identification)
@@ -129,6 +135,7 @@ module ActiveMerchant #:nodoc:
         raise ArgumentError, 'Reference credits are not supported. Please supply the original credit card or use the #refund method.' if creditcard.is_a?(String)
 
         request = build_xml_request do |xml|
+          xml.ssl_vendor_id         options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:credit]
           xml.ssl_amount            amount(money)
           add_invoice(xml, options)
@@ -143,6 +150,7 @@ module ActiveMerchant #:nodoc:
 
       def verify(credit_card, options = {})
         request = build_xml_request do |xml|
+          xml.ssl_vendor_id         options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:verify]
           add_creditcard(xml, credit_card)
           add_address(xml, options)
@@ -154,6 +162,7 @@ module ActiveMerchant #:nodoc:
 
       def store(creditcard, options = {})
         request = build_xml_request do |xml|
+          xml.ssl_vendor_id         options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:store]
           xml.ssl_add_token 'Y'
           add_creditcard(xml, creditcard)
@@ -167,6 +176,7 @@ module ActiveMerchant #:nodoc:
 
       def update(token, creditcard, options = {})
         request = build_xml_request do |xml|
+          xml.ssl_vendor_id         options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:update]
           add_token(xml, token)
           add_creditcard(xml, creditcard)

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class RemoteElavonTest < Test::Unit::TestCase
   def setup
     @gateway = ElavonGateway.new(fixtures(:elavon))
-    @tokenization_gateway = fixtures(:elavon_tokenization) ? ElavonGateway.new(fixtures(:elavon_tokenization)) : ElavonGateway.new(fixtures(:elavon))
+    @tokenization_gateway = all_fixtures[:elavon_tokenization] ? ElavonGateway.new(fixtures(:elavon_tokenization)) : ElavonGateway.new(fixtures(:elavon))
     @bad_creds_gateway = ElavonGateway.new(login: 'foo', password: 'bar', user: 'me')
     @multi_currency_gateway = ElavonGateway.new(fixtures(:elavon_multi_currency))
 

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -385,6 +385,14 @@ class ElavonTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_ssl_vendor_id_in_request
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(ssl_vendor_id: 'ABC123'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_vendor_id>ABC123<\/ssl_vendor_id/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_truncate_special_characters
     first_name = 'Ricky ™ Martínez įncogníto'
     credit_card = @credit_card


### PR DESCRIPTION
CE-1525

Remote tests currently failing on my machine due to unresolved credentialing issues. Any reviewer should run `test/remote/gateways/remote_elavon_test.rb` and verify that all remote tests are passing.

rubocop:
699 files inspected, no offenses detected

local:
4711 tests, 73421 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed