### PR TITLE
Credorax: Add support for `d2` field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -58,6 +58,7 @@
 * Windcave/Payment Express: Add support for AvsAction and EnableAVSData fields [meagabeth] #3967
 * CyberSource: Update XML tag for merchantDefinedData [meagabeth] #3969
 * Elavon: Send ssl_vendor_id field [dsmcclain] #3972
+* Credorax: Add support for `echo` field [meagabeth] #3973
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -523,6 +523,13 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_failure bad_response
   end
 
+  def test_purchase_passes_d2_field
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(echo: 'Echo Parameter'))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'Echo Parameter', response.params['D2']
+  end
+
   # #########################################################################
   # # CERTIFICATION SPECIFIC REMOTE TESTS
   # #########################################################################

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -712,6 +712,72 @@ class CredoraxTest < Test::Unit::TestCase
     end.respond_with(successful_credit_response)
   end
 
+  def test_purchase_adds_echo_field
+    @options[:echo] = 'Echo Parameter'
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/d2=Echo\+Parameter/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_authorize_adds_echo_field
+    @options[:echo] = 'Echo Parameter'
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/d2=Echo\+Parameter/, data)
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_capture_adds_echo_field
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(successful_authorize_response)
+
+    @options[:echo] = 'Echo Parameter'
+    stub_comms do
+      @gateway.capture(@amount, response.authorization, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/d2=Echo\+Parameter/, data)
+    end.respond_with(successful_capture_response)
+  end
+
+  def test_void_adds_echo_field
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_authorize_response)
+
+    @options[:echo] = 'Echo Parameter'
+    stub_comms do
+      @gateway.void(response.authorization, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/d2=Echo\+Parameter/, data)
+    end.respond_with(successful_void_response)
+  end
+
+  def test_refund_adds_echo_field
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    @options[:echo] = 'Echo Parameter'
+    stub_comms do
+      @gateway.refund(@amount, response.authorization, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/d2=Echo\+Parameter/, data)
+    end.respond_with(successful_refund_response)
+  end
+
+  def test_credit_adds_echo_field
+    @options[:echo] = 'Echo Parameter'
+    stub_comms do
+      @gateway.credit(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/d2=Echo\+Parameter/, data)
+    end.respond_with(successful_credit_response)
+  end
+
   def test_purchase_omits_phone_when_nil
     # purchase passes the phone number when provided
     @options[:billing_address][:phone] = '555-444-3333'


### PR DESCRIPTION
`d2` is known as an echo parameter, which will be returned in the transaction response if the respective parameter is sent in the request

CE-1078

Local:
4716 tests, 73439 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
76 tests, 365 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
44 tests, 161 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed