### PR TITLE
Added PAYARC gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,22 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-
+* Element: Add duplicate_override_flag [almalee24] #4012
+* PayTrace: Support gateway [meagabeth] #3985
+* vPOS: Support credit + refund [therufs] #3998
+* PayArc: Support gateway [senthil-code] #3974
+* NMI: Support cardholder_auth field for 3DS2 [cdmackeyfree] #4002
+* Confiable: Support cardtype [therufs] #4004
+* Maestro: Add BIN [therufs] #4003
+* PayULatam: Ensure phone number is pulled from shipping_address correctly [dsmcclain] #4005
+* SafeCharge: Add challenge_preference for 3DS [klaiv] #3999
+* Adyen: Pass networkTxReference in all transactions [naashton] #4006
+* Adyen: Ensure correct transaction reference is selected [dsmcclain] #4007
+* PayTrace: Support level_3_data fields [meagabeth] #4008
+* BluePay: Add support for Stored Credentials [dsmcclain] #4009
+* Orbital: Add support for SCARecurringPayment [jessiagee] #4010
+* Braintree: Support recurring_first and moto reasons [curiousepic] #4013
+* PayTrace: Adjust capture method [meagabeth] #4015
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993
@@ -11,7 +26,6 @@
 * Checkout v2: Support metadata field [saschakala] #3992
 * Adyen: Support networkTxReference field [naashton] #3997
 * Paypal Express: Enable PayPal express reference transaction request to send merchant session id [janees-e] #3994
-* PayTrace: Support gateway [meagabeth] #3985
 
 == Version 1.120.0 (May 28th, 2021)
 * Braintree: Bump required braintree gem version to 3.0.1

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -84,6 +84,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_rebill(post, options) if options[:rebill]
         add_duplicate_override(post, options)
+        add_stored_credential(post, options)
         post[:TRANS_TYPE] = 'AUTH'
         commit('AUTH_ONLY', money, post, options)
       end
@@ -107,6 +108,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_rebill(post, options) if options[:rebill]
         add_duplicate_override(post, options)
+        add_stored_credential(post, options)
         post[:TRANS_TYPE] = 'SALE'
         commit('AUTH_CAPTURE', money, post, options)
       end
@@ -459,6 +461,33 @@ module ActiveMerchant #:nodoc:
         post[:REB_FIRST_DATE]  = options[:rebill_start_date]
         post[:REB_EXPR]        = options[:rebill_expression]
         post[:REB_CYCLES]      = options[:rebill_cycles]
+      end
+
+      def add_stored_credential(post, options)
+        post[:cof] = initiator(options)
+        post[:cofscheduled] = scheduled(options)
+      end
+
+      def initiator(options)
+        return unless initiator = options.dig(:stored_credential, :initiator)
+
+        case initiator
+        when 'merchant'
+          'M'
+        when 'cardholder'
+          'C'
+        end
+      end
+
+      def scheduled(options)
+        return unless reason_type = options.dig(:stored_credential, :reason_type)
+
+        case reason_type
+        when 'recurring' || 'installment'
+          'Y'
+        when 'unscheduled'
+          'N'
+        end
       end
 
       def post_data(action, parameters = {})

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -588,7 +588,8 @@ module ActiveMerchant #:nodoc:
           'merchant_account_id'     => transaction.merchant_account_id,
           'risk_data'               => risk_data,
           'network_transaction_id'  => transaction.network_transaction_id || nil,
-          'processor_response_code' => response_code_from_result(result)
+          'processor_response_code' => response_code_from_result(result),
+          'recurring'               => transaction.recurring
         }
       end
 
@@ -770,6 +771,8 @@ module ActiveMerchant #:nodoc:
           else
             parameters[:transaction_source] = stored_credential[:reason_type]
           end
+        elsif %w(recurring_first moto).include?(stored_credential[:reason_type])
+          parameters[:transaction_source] = stored_credential[:reason_type]
         else
           parameters[:transaction_source] = ''
         end

--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -192,6 +192,7 @@ module ActiveMerchant #:nodoc:
           xml.PaymentType options[:payment_type] if options[:payment_type]
           xml.SubmissionType options[:submission_type] if options[:submission_type]
           xml.DuplicateCheckDisableFlag options[:duplicate_check_disable_flag].to_s == 'true' ? 'True' : 'False' unless options[:duplicate_check_disable_flag].nil?
+          xml.DuplicateOverrideFlag options[:duplicate_override_flag].to_s == 'true' ? 'True' : 'False' unless options[:duplicate_override_flag].nil?
         end
       end
 

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -612,10 +612,18 @@ module ActiveMerchant #:nodoc:
         xml.tag!(:MCDirectoryTransID, three_d_secure[:ds_transaction_id]) if three_d_secure[:ds_transaction_id]
       end
 
-      def add_ucafind(xml, creditcard, three_d_secure)
+      def add_mc_ucafind(xml, creditcard, three_d_secure)
         return unless three_d_secure && creditcard.brand == 'master'
 
         xml.tag! :UCAFInd, '4'
+      end
+
+      def add_mc_scarecurring(xml, creditcard, parameters, three_d_secure)
+        return unless parameters && parameters[:sca_recurring] && creditcard.brand == 'master'
+
+        valid_eci = three_d_secure && three_d_secure[:eci] && three_d_secure[:eci] == '7'
+
+        xml.tag!(:SCARecurringPayment, parameters[:sca_recurring]) if valid_eci
       end
 
       def add_dpanind(xml, creditcard)
@@ -884,9 +892,10 @@ module ActiveMerchant #:nodoc:
             add_card_indicators(xml, parameters)
             add_stored_credentials(xml, parameters)
             add_pymt_brand_program_code(xml, payment_source, three_d_secure)
+            add_mc_scarecurring(xml, payment_source, parameters, three_d_secure)
             add_mc_program_protocol(xml, payment_source, three_d_secure)
             add_mc_directory_trans_id(xml, payment_source, three_d_secure)
-            add_ucafind(xml, payment_source, three_d_secure)
+            add_mc_ucafind(xml, payment_source, three_d_secure)
           end
         end
         xml.target!

--- a/lib/active_merchant/billing/gateways/pay_arc.rb
+++ b/lib/active_merchant/billing/gateways/pay_arc.rb
@@ -1,0 +1,386 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PayArcGateway < Gateway
+      self.test_url = 'https://testapi.payarc.net/v1'
+      self.live_url = 'https://api.payarc.net/v1'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'usd'
+      self.supported_cardtypes = %i[visa master american_express discover jcb]
+
+      self.homepage_url = 'https://www.payarc.net/'
+      self.display_name = 'PAYARC Gateway'
+
+      STANDARD_ERROR_CODE_MAPPING = {}
+      STANDARD_ACTIONS = {
+        token:
+          { end_point: 'tokens',
+            allowed_fields: %i[card_source card_number exp_month exp_year cvv card_holder_name
+                               address_line1 address_line2 city state zip country] },
+        capture:
+          { end_point: 'charges',
+            allowed_fields: %i[amount statement_description card_id currency customer_id token_id card_source tip_amount
+                               card_level sales_tax purchase_order supplier_reference_number customer_ref_id ship_to_zip
+                               amex_descriptor customer_vat_number summary_commodity_code shipping_charges duty_charges
+                               ship_from_zip destination_country_code vat_invoice order_date tax_category tax_type
+                               tax_amount address_line1 zip terminal_id surcharge description email receipt_phone
+                               statement_descriptor ] },
+        void:
+          { end_point: 'charges/{{chargeID}}/void',
+            allowed_fields: %i[reason void_description] },
+        refund:
+          { end_point: 'charges/{{charge_id}}/refunds',
+            allowed_fields: %i[amount reason description] },
+        credit:
+          { end_point: 'refunds/wo_reference',
+            allowed_fields: %i[amount charge_description statement_description terminal_id card_source card_number
+                               exp_month exp_year cvv card_holder_name address_line1 address_line2 city state zip
+                               country currency reason receipt_phone receipt_email  ] }
+      }
+
+      SUCCESS_STATUS = %w[
+        submitted_for_settlement authorized partially_submitted_for_settlement
+        credit partial_refund void refunded settled
+      ]
+
+      FAILURE_STATUS = %w[not_processed failed_by_gateway invalid_track_data authorization_expired]
+
+      # The gateway must be configured with Bearer token.
+      #
+      # <tt>:api_key</tt>     PAYARC's Bearer token must be passsed to initialise the gateway.
+
+      def initialize(options = {})
+        requires!(options, :api_key)
+        super
+      end
+
+      #
+      # Purchase API through PAYARC.
+      #
+      # <tt>:money</tt>       A positive integer in cents representing how much to charge. The minimum amount is 50c USD.
+      #
+      # <tt>:creditcard</tt>     <tt>CreditCard</tt> object with card details.
+      #
+      # <tt>:options</tt>     Other information like address, card source etc can be passed in options
+      #
+      # ==== Options
+      #
+      # * <tt>:card_source </tt> -- Source of payment (REQUIRED) ( INTERNET, SWIPE, PHONE, MAIL, MANUAL )
+      # * <tt>:currency </tt> -- Three-letter ISO currency code, in lowercase (REQUIRED)
+      # * <tt>:card_holder_name</tt> --Name of the Card Holder (OPTIONAL)
+      # * <tt>:address_line1</tt> -- Address Line 1 (OPTIONAL)
+      # * <tt>:address_line2</tt> -- Address Line 2 (OPTIONAL)
+      # * <tt>:state </tt> -- State (OPTIONAL)
+      # * <tt>:country </tt> -- Country (OPTIONAL)
+      # * <tt>:statement_description </tt> -- An arbitrary string to be displayed on your costomer's credit card statement. This may be up to 22 characters. (OPTIONAL)
+      # * <tt> :card_level </tt> -- Commercial card level - "LEVEL2" OR "LEVEL3" (OPTIONAL)
+      # * <tt> :sales_tax  </tt> -- A positive integer in cents representing sales tax. (OPTIONAL)
+      # * <tt> :terminal_id </tt> -- Optional terminal id. (OPTIONAL)
+      # * <tt> :tip_amount </tt> -- A positive integer in cents representing tip amount. (OPTIONAL)
+      # * <tt> :sales_tax </tt> -- Applicable for LEVEL2 or LEVEL3 Charge. A positive integer in cents representing sales tax. (REQUIRED for LEVEL2 0r LEVEL3)
+      # * <tt> :purchase_order </tt> -- Applicable for Level2 or Level3 Charge. The value used by the customer to identify an order. Issued by the buyer to the seller. (REQUIRED for LEVEL2 0r LEVEL3)
+      # * <tt> :order_date </tt> -- Applicable for Level2 Charge for AMEX card only or Level3 Charge. The date the order was processed. Format: Alphanumeric and Special Character |Min Length=0 Max Length=10|Allowed format: MM/DD/YYYY For example: 12/01/2016
+      # * <tt> :customer_ref_id </tt> -- Applicable for Level2 Charge for AMEX card only or Level3 Charge. The reference identifier supplied by the Commercial Card cardholder. Format: Alphanumeric and Special Character |Min Length=0 Max Length=17| a-z A-Z 0-9 Space <>
+      # * <tt> :ship_to_zip </tt> -- Applicable for Level2 Charge for AMEX card only or Level3 Charge. The postal code for the address to which the goods are being shipped. Format: Alphanumeric |Min Length=2 Max Length=10
+      # * <tt> :amex_descriptor </tt> -- Applicable for Level2 Charge for AMEX card only. The value of the Transaction Advice Addendum field, displays descriptive information about a transactions on a customer's AMEX card statement. Format: Alphanumeric and Special Character |Min Length=0 Max Length=40|a-z A-Z 0-9 Space <>
+      # * <tt> :supplier_reference_number </tt> --  Applicable for Level2 Charge for AMEX card only or Level3 charge. The value used by the customer to identify an order. Issued by the buyer to the seller.
+      # * <tt> :tax_amount </tt> -- Applicable for Level3 Charge. The tax amount. Format: Numeric|Max Length=12|Allowed characters: 0-9 .(dot) Note: If a decimal point is included, the amount reflects a dollar value. If a decimal point is not included, the amount reflects a cent value.
+      # * <tt> :tax_category </tt> -- Applicable for Level3 Charge. The type of tax. Formerly established through TaxCategory messages. Allowed values: SERVICE, DUTY, VAT, ALTERNATE, NATIONAL, TAX_EXEMPT
+      # * <tt> :customer_vat_number </tt> -- Applicable for Level3 Charge. Indicates the customer's government assigned tax identification number or the identification number assigned to their purchasing company by the tax authorities. Format: Alphanumeric and Special Character|Min Length=0 Max Length=13| a-z A-Z 0-9 Space <>
+      # * <tt> :summary_commodity_code </tt> -- Applicable for Level3 Charge. The international description code of the overall goods or services being supplied. Format: Alphanumeric and Special Character |Min Length=0 Max Length=4|Allowed character: a-z A-Z 0-9 Space <>
+      # * <tt> :shipping_charges </tt> -- Applicable for Level3 Charge. The dollar amount for shipping or freight charges applied to a product or transaction. Format: Numeric |Max Length=12|Allowed characters: 0-9 .(dot) Note: If a decimal point is included, the amount reflects a dollar value. If a decimal point is not included, the amount reflects a cent value.
+      # * <tt> :duty_charges </tt> -- Applicable for Level3 Charge. Indicates the total charges for any import or export duties included in the order. Format: Numeric |Max Length=12|Allowed characters: 0-9 . (dot) Note: If a decimal point is included, the amount reflects a dollar value. If a decimal point is not included, the amount reflects a cent value.
+      # * <tt> :ship_from_zip </tt> -- Applicable for Level3 Charge. The postal code for the address to which the goods are being shipped. Format: Alphanumeric |Min Length=2 Max Length=10
+      # * <tt> :destination_country_code </tt> -- Applicable for Level3 Charge. The destination country code indicator. Format: Alphanumeric.
+      # * <tt> :tax_type  </tt> -- Applicable for Level3 Charge. The type of tax. For example, VAT, NATIONAL, Service Tax. Format: Alphanumeric and Special Character
+      # * <tt> :vat_invoice </tt> -- Applicable for Level3 Charge. The Value Added Tax (VAT) invoice number associated with the transaction. Format: Alphanumeric and Special Character |Min Length=0 Max Length=15|Allowed character: a-z A-Z 0-9 Space <>
+      # * <tt> :tax_rate </tt> -- Applicable for Level3 Charge. The type of tax rate. This field is used if taxCategory is not used. Default sale tax rate in percentage Must be between 0.1% - 22% ,Applicable only Level 2 AutoFill. Format: Decimal Number |Max Length=4|Allowed characters: 0-9 .(dot) Allowed range: 0.01 - 100
+      # * <tt> :email </tt> -- Customer's email address.
+      # * <tt> :phone_number </tt> -- Customer's contact phone number.
+
+      def purchase(money, creditcard, options = {})
+        options[:capture] = 1
+        MultiResponse.run do |r|
+          r.process { token(creditcard, options) }
+          r.process { charge(money, r.authorization, options) }
+        end
+      end
+
+      #
+      # Authorize the payment API through PAYARC.
+      #
+      # <tt>:money</tt>       A positive integer in cents representing how much to charge. The minimum amount is 50c USD.
+      #
+      # <tt>:creditcard</tt>     <tt>CreditCard</tt> object with card details.
+      #
+      # <tt>:options</tt>     Other information like address, card source etc can be passed in options
+      #
+      # ==== Options
+      #
+      # * <tt>:card_source </tt> -- Source of payment (REQUIRED) ( INTERNET, SWIPE, PHONE, MAIL, MANUAL )
+      # * <tt>:currency </tt> -- Three-letter ISO currency code, in lowercase (REQUIRED)
+      # * <tt>:card_holder_name</tt> --Name of the Card Holder (OPTIONAL)
+      # * <tt>:address_line1</tt> -- Address Line 1 (OPTIONAL)
+      # * <tt>:address_line2</tt> -- Address Line 2 (OPTIONAL)
+      # * <tt>:state </tt> -- State (OPTIONAL)
+      # * <tt>:country </tt> -- Country (OPTIONAL)
+      # * <tt>:statement_description </tt> -- An arbitrary string to be displayed on your costomer's credit card statement. This may be up to 22 characters. (OPTIONAL)
+      # * <tt> :card_level </tt> -- Commercial card level - "LEVEL2" OR "LEVEL3" (OPTIONAL)
+      # * <tt> :sales_tax  </tt> -- A positive integer in cents representing sales tax. (OPTIONAL)
+      # * <tt> :terminal_id </tt> -- Optional terminal id. (OPTIONAL)
+      # * <tt> :tip_amount </tt> -- A positive integer in cents representing tip amount. (OPTIONAL)
+      # * <tt> :sales_tax </tt> -- Applicable for LEVEL2 or LEVEL3 Charge. A positive integer in cents representing sales tax. (REQUIRED for LEVEL2 0r LEVEL3)
+      # * <tt> :purchase_order </tt> -- Applicable for Level2 or Level3 Charge. The value used by the customer to identify an order. Issued by the buyer to the seller. (REQUIRED for LEVEL2 0r LEVEL3)
+      # * <tt> :order_date </tt> -- Applicable for Level2 Charge for AMEX card only or Level3 Charge. The date the order was processed. Format: Alphanumeric and Special Character |Min Length=0 Max Length=10|Allowed format: MM/DD/YYYY For example: 12/01/2016
+      # * <tt> :customer_ref_id </tt> -- Applicable for Level2 Charge for AMEX card only or Level3 Charge. The reference identifier supplied by the Commercial Card cardholder. Format: Alphanumeric and Special Character |Min Length=0 Max Length=17| a-z A-Z 0-9 Space <>
+      # * <tt> :ship_to_zip </tt> -- Applicable for Level2 Charge for AMEX card only or Level3 Charge. The postal code for the address to which the goods are being shipped. Format: Alphanumeric |Min Length=2 Max Length=10
+      # * <tt> :amex_descriptor </tt> -- Applicable for Level2 Charge for AMEX card only. The value of the Transaction Advice Addendum field, displays descriptive information about a transactions on a customer's AMEX card statement. Format: Alphanumeric and Special Character |Min Length=0 Max Length=40|a-z A-Z 0-9 Space <>
+      # * <tt> :supplier_reference_number </tt> --  Applicable for Level2 Charge for AMEX card only or Level3 charge. The value used by the customer to identify an order. Issued by the buyer to the seller.
+      # * <tt> :tax_amount </tt> -- Applicable for Level3 Charge. The tax amount. Format: Numeric|Max Length=12|Allowed characters: 0-9 .(dot) Note: If a decimal point is included, the amount reflects a dollar value. If a decimal point is not included, the amount reflects a cent value.
+      # * <tt> :tax_category </tt> -- Applicable for Level3 Charge. The type of tax. Formerly established through TaxCategory messages. Allowed values: SERVICE, DUTY, VAT, ALTERNATE, NATIONAL, TAX_EXEMPT
+      # * <tt> :customer_vat_number </tt> -- Applicable for Level3 Charge. Indicates the customer's government assigned tax identification number or the identification number assigned to their purchasing company by the tax authorities. Format: Alphanumeric and Special Character|Min Length=0 Max Length=13| a-z A-Z 0-9 Space <>
+      # * <tt> :summary_commodity_code </tt> -- Applicable for Level3 Charge. The international description code of the overall goods or services being supplied. Format: Alphanumeric and Special Character |Min Length=0 Max Length=4|Allowed character: a-z A-Z 0-9 Space <>
+      # * <tt> :shipping_charges </tt> -- Applicable for Level3 Charge. The dollar amount for shipping or freight charges applied to a product or transaction. Format: Numeric |Max Length=12|Allowed characters: 0-9 .(dot) Note: If a decimal point is included, the amount reflects a dollar value. If a decimal point is not included, the amount reflects a cent value.
+      # * <tt> :duty_charges </tt> -- Applicable for Level3 Charge. Indicates the total charges for any import or export duties included in the order. Format: Numeric |Max Length=12|Allowed characters: 0-9 . (dot) Note: If a decimal point is included, the amount reflects a dollar value. If a decimal point is not included, the amount reflects a cent value.
+      # * <tt> :ship_from_zip </tt> -- Applicable for Level3 Charge. The postal code for the address to which the goods are being shipped. Format: Alphanumeric |Min Length=2 Max Length=10
+      # * <tt> :destination_country_code </tt> -- Applicable for Level3 Charge. The destination country code indicator. Format: Alphanumeric.
+      # * <tt> :tax_type  </tt> -- Applicable for Level3 Charge. The type of tax. For example, VAT, NATIONAL, Service Tax. Format: Alphanumeric and Special Character
+      # * <tt> :vat_invoice </tt> -- Applicable for Level3 Charge. The Value Added Tax (VAT) invoice number associated with the transaction. Format: Alphanumeric and Special Character |Min Length=0 Max Length=15|Allowed character: a-z A-Z 0-9 Space <>
+      # * <tt> :tax_rate </tt> -- Applicable for Level3 Charge. The type of tax rate. This field is used if taxCategory is not used. Default sale tax rate in percentage Must be between 0.1% - 22% ,Applicable only Level 2 AutoFill. Format: Decimal Number |Max Length=4|Allowed characters: 0-9 .(dot) Allowed range: 0.01 - 100
+      # * <tt> :email </tt> -- Customer's email address.
+      # * <tt> :phone_number </tt> -- Customer's contact phone number.
+
+      def authorize(money, creditcard, options = {})
+        options[:capture] = '0'
+        MultiResponse.run do |r|
+          r.process { token(creditcard, options) }
+          r.process { charge(money, r.authorization, options) }
+        end
+      end
+
+      #
+      # Capture the payment of an existing, uncaptured, charge.
+      # This is the second half of the two-step payment flow, where first you created / authorized a charge
+      # with the capture option set to false.
+      #
+      # <tt>:money</tt>         A positive integer in cents representing how much to charge. The minimum amount is 50c USD.
+      #
+      # <tt>:tx_reference</tt>  charge_id from previously created / authorized a charge
+      #
+      # <tt>:options</tt>       Other information like address, card source etc can be passed in options
+
+      def capture(money, tx_reference, options = {})
+        post = {}
+        add_money(post, money, options)
+        action = "#{STANDARD_ACTIONS[:capture][:end_point]}/#{tx_reference}/capture"
+        post = filter_gateway_fields(post, options, STANDARD_ACTIONS[:capture][:allowed_fields])
+        commit(action, post)
+      end
+
+      #
+      # Voids the transaction / charge.
+      #
+      # <tt>:tx_reference</tt>  charge_id from previously created  charge
+      #
+      # <tt>:options</tt>       Other information like address, card source etc can be passed in options
+      #
+      # ==== Options
+      #
+      # * <tt> :reason </tt> -- Reason for voiding transaction (REQUIRED) ( requested_by_customer, duplicate, fraudulent, other )
+
+      def void(tx_reference, options = {})
+        post = {}
+        post['reason'] = options[:reason] || 'duplicate'
+        action = STANDARD_ACTIONS[:void][:end_point].gsub(/{{chargeID}}/, tx_reference)
+        post = filter_gateway_fields(post, options, STANDARD_ACTIONS[:void][:allowed_fields])
+        commit(action, post)
+      end
+
+      #
+      # Refund full / partial  payment of an successful charge / capture / purchase.
+      #
+      # <tt>:money</tt>         A positive integer in cents representing how much to charge. The minimum amount is 50c USD.
+      #
+      # <tt>:tx_reference</tt>  charge_id from previously created / authorized a charge
+      #
+      # <tt>:options</tt>       Other information like address, card source etc can be passed in options
+
+      def refund(money, tx_reference, options = {})
+        post = {}
+        add_money(post, money, options)
+        action = STANDARD_ACTIONS[:refund][:end_point].gsub(/{{charge_id}}/, tx_reference)
+        post = filter_gateway_fields(post, options, STANDARD_ACTIONS[:refund][:allowed_fields])
+        commit(action, post)
+      end
+
+      def credit(money, creditcard, options = {})
+        post = {}
+        add_money(post, money, options)
+        add_creditcard(post, creditcard, options)
+        add_address(post, creditcard, options)
+        action = STANDARD_ACTIONS[:credit][:end_point]
+        post = filter_gateway_fields(post, options, STANDARD_ACTIONS[:credit][:allowed_fields])
+        commit(action, post)
+      end
+
+      #
+      # Verify the creditcard API through PAYARC.
+      #
+      # <tt>:creditcard</tt>     <tt>CreditCard</tt> object with card details.
+      #
+      # <tt>:options</tt>     Other information like address, card source etc can be passed in options
+      #
+      # ==== Options
+      #
+      # * <tt>:card_source </tt> -- Source of payment (REQUIRED) ( INTERNET, SWIPE, PHONE, MAIL, MANUAL )
+      # * <tt>:card_holder_name</tt> --Name of the Card Holder (OPTIONAL)
+      # * <tt>:address_line1</tt> -- Address Line 1 (OPTIONAL)
+      # * <tt>:address_line2</tt> -- Address Line 2 (OPTIONAL)
+      # * <tt>:state </tt> -- State (OPTIONAL)
+      # * <tt>:country </tt> -- Country (OPTIONAL)
+
+      def verify(creditcard, options = {})
+        token(creditcard, options)
+      end
+
+      #:nodoc:
+      def token(creditcard, options = {})
+        post = {}
+        post['authorize_card'] = 1
+        post['card_source'] = options[:card_source]
+        add_creditcard(post, creditcard, options)
+        add_address(post, creditcard, options)
+        post = filter_gateway_fields(post, options, STANDARD_ACTIONS[:token][:allowed_fields])
+        commit(STANDARD_ACTIONS[:token][:end_point], post)
+      end
+
+      def supports_scrubbing? #:nodoc:
+        true
+      end
+
+      def scrub(transcript)
+        #:nodoc:
+        transcript.
+          gsub(%r((Authorization: Bearer )[^\s]+\s)i, '\1[FILTERED]\2').
+          gsub(%r((&?card_number=)[^&]*)i, '\1[FILTERED]').
+          gsub(%r((&?cvv=)[^&]*)i, '\1[BLANK]')
+      end
+
+      private
+
+      def charge(money, authorization, options = {})
+        post = {}
+        post['token_id'] = authorization
+        post['capture'] = options[:capture] || 1
+        add_money(post, money, options)
+        post = filter_gateway_fields(post, options, STANDARD_ACTIONS[:capture][:allowed_fields])
+        commit(STANDARD_ACTIONS[:capture][:end_point], post)
+      end
+
+      def add_creditcard(post, creditcard, options)
+        post['card_number'] = creditcard.number
+        post['exp_month'] = creditcard.month
+        post['exp_year'] = creditcard.year
+        post['cvv'] = creditcard.verification_value unless creditcard.verification_value.nil?
+        post['card_holder_name'] = options[:card_holder_name] || "#{creditcard.first_name} #{creditcard.last_name}"
+      end
+
+      def add_address(post, creditcard, options)
+        post['address_line1'] = options[:address_line1]
+        post['address_line2'] = options[:address_line2]
+        post['city'] = options[:city]
+        post['state'] = options[:state]
+        post['zip'] = options[:zip]
+        post['country'] = options[:country]
+      end
+
+      def add_money(post, money, options)
+        post['amount'] = money
+        post['currency'] = (options[:currency] || currency(money))
+        post['statement_description'] = options[:statement_description]
+      end
+
+      def headers(api_key)
+        {
+          'Authorization' => 'Bearer ' + api_key.strip,
+          'Accept' => 'application/json',
+          'User-Agent' => "PayArc ActiveMerchantBindings/#{ActiveMerchant::VERSION}"
+        }
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      rescue JSON::ParserError
+        body
+      end
+
+      def filter_gateway_fields(post, options, gateway_fields)
+        filtered_options = options.slice(*gateway_fields)
+        post.update(filtered_options)
+        post
+      end
+
+      def commit(action, parameters)
+        url = (test? ? test_url : live_url)
+        headers = headers(@options[:api_key])
+        end_point = "#{url}/#{action}"
+        begin
+          response = ssl_post(end_point, post_data(parameters), headers)
+          parsed_response = parse(response)
+
+          Response.new(
+            success_from(parsed_response, action),
+            message_from(parsed_response, action),
+            parsed_response,
+            test: test?,
+            authorization: parse_response_id(parsed_response),
+            error_code: error_code_from(parsed_response, action)
+          )
+        rescue ResponseError => e
+          parsed_response = parse(e.response.body)
+          Response.new(
+            false,
+            message_from(parsed_response, action),
+            parsed_response,
+            test: test?,
+            authorization: nil,
+            error_code: error_code_from(parsed_response, action)
+          )
+        end
+      end
+
+      def success_from(response, action)
+        if action == STANDARD_ACTIONS[:token][:end_point]
+          token = parse_response_id(response)
+          (!token.nil? && !token.empty?)
+        elsif response
+          return SUCCESS_STATUS.include? response['data']['status'] if response['data']
+        end
+      end
+
+      def message_from(response, action)
+        if success_from(response, action)
+          if action == STANDARD_ACTIONS[:token][:end_point]
+            return response['data']['id']
+          else
+            return response['data']['status']
+          end
+        else
+          return response['message']
+        end
+      end
+
+      def parse_response_id(response)
+        response['data']['id'] if response && response['data']
+      end
+
+      def post_data(params)
+        params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+      end
+
+      def error_code_from(response, action)
+        response['status_code'] unless success_from(response, action)
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/pay_trace.rb
+++ b/lib/active_merchant/billing/gateways/pay_trace.rb
@@ -31,7 +31,9 @@ module ActiveMerchant #:nodoc:
         transaction_refund: 'transactions/refund/for_transaction',
         transaction_void: 'transactions/void',
         store: 'customer/create',
-        redact: 'customer/delete'
+        redact: 'customer/delete',
+        level_3_visa: 'level_three/visa',
+        level_3_mastercard: 'level_three/mastercard'
       }
 
       def initialize(options = {})
@@ -40,48 +42,52 @@ module ActiveMerchant #:nodoc:
         acquire_access_token
       end
 
-      def purchase(money, payment_or_customerid, options = {})
+      def purchase(money, payment_or_customer_id, options = {})
         post = {}
-        add_invoice(post, money, options)
-        if payment_or_customerid.class == String
-          post[:customer_id] = payment_or_customerid
-
-          response = commit(ENDPOINTS[:customer_id_sale], post)
-          check_token_response(response, ENDPOINTS[:customer_id_sale], post, options)
+        add_amount(post, money, options)
+        if customer_id?(payment_or_customer_id)
+          post[:customer_id] = payment_or_customer_id
+          endpoint = ENDPOINTS[:customer_id_sale]
         else
-          add_payment(post, payment_or_customerid)
-          add_address(post, payment_or_customerid, options)
+          add_payment(post, payment_or_customer_id)
+          add_address(post, payment_or_customer_id, options)
           add_customer_data(post, options)
-
-          response = commit(ENDPOINTS[:keyed_sale], post)
-          check_token_response(response, ENDPOINTS[:keyed_sale], post, options)
+          endpoint = ENDPOINTS[:keyed_sale]
         end
+        response = commit(endpoint, post)
+        check_token_response(response, endpoint, post, options)
+
+        return response unless visa_or_mastercard?(options)
+
+        send_level_3_data(response, options)
       end
 
-      def authorize(money, payment_or_customerid, options = {})
+      def authorize(money, payment_or_customer_id, options = {})
         post = {}
-        add_invoice(post, money, options)
-        if payment_or_customerid.class == String
-          post[:customer_id] = payment_or_customerid
-
-          response = commit(ENDPOINTS[:customer_id_auth], post)
-          check_token_response(response, ENDPOINTS[:customer_id_auth], post, options)
+        add_amount(post, money, options)
+        if customer_id?(payment_or_customer_id)
+          post[:customer_id] = payment_or_customer_id
+          endpoint = ENDPOINTS[:customer_id_auth]
         else
-          add_payment(post, payment_or_customerid)
-          add_address(post, payment_or_customerid, options)
+          add_payment(post, payment_or_customer_id)
+          add_address(post, payment_or_customer_id, options)
           add_customer_data(post, options)
-
-          response = commit(ENDPOINTS[:keyed_auth], post)
-          check_token_response(response, ENDPOINTS[:keyed_auth], post, options)
+          endpoint = ENDPOINTS[:keyed_auth]
         end
+        response = commit(endpoint, post)
+        check_token_response(response, endpoint, post, options)
       end
 
-      def capture(authorization, options = {})
+      def capture(money, authorization, options = {})
         post = {}
-        post[:amount] = amount(options[:amount]) if options[:amount]
         post[:transaction_id] = authorization
+        add_amount(post, money, options) if options[:include_capture_amount] == true
         response = commit(ENDPOINTS[:capture], post)
         check_token_response(response, ENDPOINTS[:capture], post, options)
+
+        return response unless visa_or_mastercard?(options)
+
+        send_level_3_data(response, options)
       end
 
       def refund(authorization, options = {})
@@ -159,6 +165,27 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      # method can only be used to add level 3 data to any approved and unsettled sale transaction so it is built into the standard purchase workflow above
+      def send_level_3_data(response, options)
+        post = {}
+        post[:transaction_id] = response.authorization
+        endpoint = ENDPOINTS[:"level_3_#{options[:visa_or_mastercard]}"]
+
+        add_level_3_data(post, options)
+        adjust = commit(endpoint, post)
+        check_token_response(adjust, endpoint, post, options)
+      end
+
+      def visa_or_mastercard?(options)
+        return false unless options[:visa_or_mastercard]
+
+        options[:visa_or_mastercard] == 'visa' || options[:visa_or_mastercard] == 'mastercard'
+      end
+
+      def customer_id?(payment_or_customer_id)
+        payment_or_customer_id.class == String
+      end
+
       def add_customer_data(post, options)
         return unless options[:email]
 
@@ -177,7 +204,7 @@ module ActiveMerchant #:nodoc:
         post[:billing_address][:zip] = address[:zip]
       end
 
-      def add_invoice(post, money, options)
+      def add_amount(post, money, options)
         post[:amount] = amount(money)
       end
 
@@ -186,6 +213,77 @@ module ActiveMerchant #:nodoc:
         post[:credit_card][:number] = payment.number
         post[:credit_card][:expiration_month] = payment.month
         post[:credit_card][:expiration_year] = payment.year
+      end
+
+      def add_level_3_data(post, options)
+        post[:invoice_id] = options[:invoice_id] if options[:invoice_id]
+        post[:customer_reference_id] = options[:customer_reference_id] if options[:customer_reference_id]
+        post[:tax_amount] = amount(options[:tax_amount]) if options[:tax_amount]
+        post[:national_tax_amount] = amount(options[:national_tax_amount]) if options[:national_tax_amount]
+        post[:merchant_tax_id] = options[:merchant_tax_id] if options[:merchant_tax_id]
+        post[:customer_tax_id] = options[:customer_tax_id] if options[:customer_tax_id]
+        post[:commodity_code] = options[:commodity_code] if options[:commodity_code]
+        post[:discount_amount] = amount(options[:discount_amount]) if options[:discount_amount]
+        post[:freight_amount] = amount(options[:freight_amount]) if options[:freight_amount]
+        post[:duty_amount] = amount(options[:duty_amount]) if options[:duty_amount]
+        post[:additional_tax_amount] = amount(options[:additional_tax_amount]) if options[:additional_tax_amount]
+        post[:additional_tax_rate] = amount(options[:additional_tax_rate]) if options[:additional_tax_rate]
+
+        add_source_address(post, options)
+        add_shipping_address(post, options)
+        add_line_items(post, options)
+      end
+
+      def add_source_address(post, options)
+        return unless source_address =  options[:source_address] ||
+                                        options[:billing_address] ||
+                                        options[:address]
+
+        post[:source_address] = {}
+        post[:source_address][:zip] = source_address[:zip] if source_address[:zip]
+      end
+
+      def add_shipping_address(post, options)
+        return unless shipping_address = options[:shipping_address]
+
+        post[:shipping_address] = {}
+        post[:shipping_address][:name] = shipping_address[:name] if shipping_address[:name]
+        post[:shipping_address][:street_address] = shipping_address[:address1] if shipping_address[:address1]
+        post[:shipping_address][:street_address2] = shipping_address[:address2] if shipping_address[:address2]
+        post[:shipping_address][:city] = shipping_address[:city] if shipping_address[:city]
+        post[:shipping_address][:state] = shipping_address[:state] if shipping_address[:state]
+        post[:shipping_address][:zip] = shipping_address[:zip] if shipping_address[:zip]
+        post[:shipping_address][:country] = shipping_address[:country] if shipping_address[:country]
+      end
+
+      def add_line_items(post, options)
+        return unless options[:line_items]
+
+        line_items = []
+        options[:line_items].each do |li|
+          obj = {}
+
+          obj[:additional_tax_amount] = amount(li[:additional_tax_amount]) if li[:additional_tax_amount]
+          obj[:additional_tax_included] = li[:additional_tax_included] if li[:additional_tax_included]
+          obj[:additional_tax_rate] = amount(li[:additional_tax_rate]) if li[:additional_tax_rate]
+          obj[:amount] = amount(li[:amount]) if li[:amount]
+          obj[:commodity_code] = li[:commodity_code] if li[:commodity_code]
+          obj[:debit_or_credit] = li[:debit_or_credit] if li[:debit_or_credit]
+          obj[:description] = li[:description] if li[:description]
+          obj[:discount_amount] = amount(li[:discount_amount]) if li[:discount_amount]
+          obj[:discount_rate] = amount(li[:discount_rate]) if li[:discount_rate]
+          obj[:discount_included] = li[:discount_included] if li[:discount_included]
+          obj[:merchant_tax_id] = li[:merchant_tax_id] if li[:merchant_tax_id]
+          obj[:product_id] = li[:product_id] if li[:product_id]
+          obj[:quantity] = li[:quantity] if li[:quantity]
+          obj[:transaction_id] = li[:transaction_id] if li[:transaction_id]
+          obj[:tax_included] = li[:tax_included] if li[:tax_included]
+          obj[:unit_of_measure] = li[:unit_of_measure] if li[:unit_of_measure]
+          obj[:unit_cost] = amount(li[:unit_cost]) if li[:unit_cost]
+
+          line_items << obj
+        end
+        post[:line_items] = line_items
       end
 
       def check_token_response(response, endpoint, body = {}, options = {})

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -657,6 +657,10 @@ pago_facil:
   service_id: 3
 
 # Working credentials, no need to replace
+pay_arc:
+  api_key: APIKEY
+
+# Working credentials, no need to replace
 pay_conex:
   account_id: '220614968961'
   api_accesskey: '69e9c4dd6b8ab9ab47da4e288df78315'

--- a/test/remote/gateways/remote_blue_pay_test.rb
+++ b/test/remote/gateways/remote_blue_pay_test.rb
@@ -41,6 +41,15 @@ class BluePayTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_stored_credential
+    options = @options.merge(stored_credential: { initiator: 'cardholder', reason_type: 'recurring' })
+    assert response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert response.test?
+    assert_equal 'This transaction has been approved', response.message
+    assert response.authorization
+  end
+
   def test_expired_credit_card
     @credit_card.year = 2004
     assert response = @gateway.purchase(@amount, @credit_card, @options)

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -967,6 +967,25 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
   end
 
+  def test_successful_cardholder_purchase_initial_setup
+    creds_options = { initiator: 'merchant', reason_type: 'recurring_first', initial_transaction: true }
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_not_nil response.params['braintree_transaction']['network_transaction_id']
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+    assert_equal true, response.params['braintree_transaction']['recurring']
+  end
+
+  def test_successful_cardholder_purchase_initial_moto
+    creds_options = { initiator: 'merchant', reason_type: 'moto', initial_transaction: true }
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_not_nil response.params['braintree_transaction']['network_transaction_id']
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
   private
 
   def stored_credential_options(*args, id: nil)

--- a/test/remote/gateways/remote_element_test.rb
+++ b/test/remote/gateways/remote_element_test.rb
@@ -86,6 +86,24 @@ class RemoteElementTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_duplicate_override_flag
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_override_flag: true))
+    assert_success response
+    assert_equal 'Approved', response.message
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_override_flag: false))
+    assert_success response
+    assert_equal 'Approved', response.message
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_overrride_flag: 'true'))
+    assert_success response
+    assert_equal 'Approved', response.message
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_override_flag: 'xxx'))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_purchase_with_terminal_id
     response = @gateway.purchase(@amount, @credit_card, @options.merge(terminal_id: '02'))
     assert_success response

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -197,6 +197,27 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_false response.authorization.blank?
   end
 
+  def test_successful_purchase_with_sca_recurring_master_card
+    cc = credit_card('5555555555554444', first_name: 'Joe', last_name: 'Smith',
+                     month: '12', year: '2022', brand: 'master', verification_value: '999')
+    options_local = {
+      three_d_secure: {
+        eci: '7',
+        xid: 'TESTXID',
+        cavv: 'AAAEEEDDDSSSAAA2243234',
+        ds_transaction_id: '97267598FAE648F28083C23433990FBC',
+        version: 2
+      },
+      sca_recurring: 'Y'
+    }
+
+    assert response = @three_ds_gateway.purchase(100, cc, @options.merge(options_local))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
   def test_successful_purchase_with_american_express_network_tokenization_credit_card
     network_card = network_tokenization_credit_card('4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
@@ -693,7 +714,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
     assert_match(/<AVSname>Jim Smith/, transcript)
     assert_match(/<RespCode>00/, transcript)
-    assert_match(/<StatusMsg>Approved/, transcript)
+    assert_match(/atusMsg>Approved</, transcript)
   end
 
   def test_echeck_purchase_with_no_address_responds_with_name
@@ -705,7 +726,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
     assert_match(/<AVSname>Test McTest/, transcript)
     assert_match(/<RespCode>00/, transcript)
-    assert_match(/<StatusMsg>Approved/, transcript)
+    assert_match(/atusMsg>Approved</, transcript)
   end
 
   def test_credit_purchase_with_address_responds_with_name

--- a/test/remote/gateways/remote_pay_arc_test.rb
+++ b/test/remote/gateways/remote_pay_arc_test.rb
@@ -1,0 +1,189 @@
+require 'test_helper'
+
+class RemotePayArcTest < Test::Unit::TestCase
+  def setup
+    @gateway = PayArcGateway.new(fixtures(:pay_arc))
+    credit_card_options = {
+      month: '12',
+      year: '2022',
+      first_name: 'Rex Joseph',
+      last_name: '',
+      verification_value: '999'
+    }
+    @credit_card = credit_card('4111111111111111', credit_card_options)
+    @invalid_credit_card = credit_card('3111111111111111', credit_card_options)
+    @invalid_cvv_card = credit_card('4111111111111111', credit_card_options.update(verification_value: '123'))
+
+    @amount = 100
+
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase',
+      card_source: 'INTERNET',
+      address_line1: '920 Sunnyslope Ave',
+      address_line2: 'Bronx',
+      city: 'New York',
+      state: 'New York',
+      zip: '10469',
+      country: 'USA'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+  end
+
+  def test_successful_purchase_with_more_options
+    extra_options = {
+      order_id: '1',
+      ip: '127.0.0.1',
+      email: 'joe@example.com',
+      tip_amount: 10
+    }
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(extra_options))
+    assert_success response
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @invalid_credit_card, @options)
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  def test_successful_authorize
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'authorized', response.message
+  end
+
+  # Failed due to invalid CVV
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @invalid_cvv_card, @options)
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  def test_successful_authorize_and_capture
+    authorize_response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize_response
+    response = @gateway.capture(@amount, authorize_response.authorization, @options)
+    assert_success response
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, 'invalid_txn_refernece', @options)
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  def test_successful_void
+    charge_response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success charge_response
+
+    assert void = @gateway.void(charge_response.authorization, @options)
+    assert_success void
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? void.message
+    end
+  end
+
+  def test_failed_void
+    response = @gateway.void('invalid_txn_reference', @options)
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  def test_partial_capture
+    authorize_response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize_response
+
+    response = @gateway.capture(@amount - 1, authorize_response.authorization, @options)
+    assert_success response
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? refund.message
+    end
+    assert_equal 'refunded', refund.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount - 1, purchase.authorization)
+    assert_success refund
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? refund.message
+    end
+    assert_equal 'partial_refund', refund.message
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  def test_successful_credit
+    response = @gateway.credit(@amount, @credit_card, @options)
+    assert_success response
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+    assert_equal 'refunded', response.message
+  end
+
+  def test_failed_credit
+    response = @gateway.credit('', @invalid_credit_card, @options)
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+  end
+
+  def test_failed_verify
+    response = @gateway.verify(@invalid_credit_card, @options)
+    assert_failure response
+  end
+
+  def test_invalid_login
+    gateway = PayArcGateway.new(api_key: '<invalid bearer token>')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+    assert_scrubbed(fixtures(:pay_arc), transcript)
+    assert_scrubbed(/card_number=#{@credit_card.number}/, transcript)
+    assert_scrubbed(/cvv=#{@credit_card.verification_value}/, transcript)
+  end
+end

--- a/test/remote/gateways/remote_pay_trace_test.rb
+++ b/test/remote/gateways/remote_pay_trace_test.rb
@@ -61,6 +61,104 @@ class RemotePayTraceTest < Test::Unit::TestCase
     assert_equal 'Your transaction was successfully approved.', response.message
   end
 
+  def test_successful_purchase_with_level_3_data_visa
+    options = {
+      visa_or_mastercard: 'visa',
+      invoice_id: 'inv12345',
+      customer_reference_id: '123abcd',
+      tax_amount: 499,
+      national_tax_amount: 172,
+      merchant_tax_id: '3456defg',
+      customer_tax_id: '3456test',
+      commodity_code: '4321',
+      discount_amount: 99,
+      freight_amount: 75,
+      duty_amount: 32,
+      source_address: {
+        zip: '94947'
+      },
+      shipping_address: {
+        zip: '94948',
+        country: 'US'
+      },
+      additional_tax_amount: 4,
+      additional_tax_rate: 1,
+      line_items: [
+        {
+          additional_tax_amount: 0,
+            additional_tax_rate: 8,
+            amount: 1999,
+            commodity_code: '123commodity',
+            description: 'plumbing',
+            discount_amount: 327,
+            product_id: 'skucode123',
+            quantity: 4,
+            unit_of_measure: 'EACH',
+            unit_cost: 424
+        }
+      ]
+    }
+
+    response = @gateway.purchase(250, @credit_card, options)
+    assert_success response
+    assert_equal 170, response.params['response_code']
+  end
+
+  def test_successful_purchase_with_level_3_data_mastercard
+    options = {
+      visa_or_mastercard: 'mastercard',
+      invoice_id: 'inv1234',
+      customer_reference_id: 'PO123456',
+      tax_amount: 810,
+      source_address: {
+        zip: '99201'
+      },
+      shipping_address: {
+        zip: '85284',
+        country: 'US'
+      },
+      additional_tax_amount: 40,
+      additional_tax_included: true,
+      line_items: [
+        {
+          additional_tax_amount: 40,
+          additional_tax_included: true,
+          additional_tax_rate: 8,
+          amount: 1999,
+          debit_or_credit: 'D',
+          description: 'business services',
+          discount_amount: 327,
+          discount_rate: 1,
+          discount_included: true,
+          merchant_tax_id: '12-123456',
+          product_id: 'sku1245',
+          quantity: 4,
+          tax_included: true,
+          unit_of_measure: 'EACH',
+          unit_cost: 524
+        }
+      ]
+    }
+
+    response = @gateway.purchase(250, @mastercard, options)
+    assert_success response
+    assert_equal 170, response.params['response_code']
+  end
+
+  # Level three data can only be added to approved sale transactions done with visa or mastercard.
+  # This test is to show that if a transaction were to come through with a different card type,
+  # the gateway integration would ignore the attempt to add level three data, but could still approve the sale transaction.
+  def test_successful_purchase_with_attempted_level_3
+    options = {
+      visa_or_mastercard: 'discover',
+      invoice_id: 'inv1234',
+      customer_reference_id: 'PO123456'
+    }
+
+    response = @gateway.purchase(300, @discover, @options.merge(options))
+    assert_success response
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(29, @amex, @options)
     assert_failure response
@@ -71,7 +169,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
     auth = @gateway.authorize(300, @credit_card, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(auth.authorization, @options.merge(amount: 300))
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
     assert_success capture
     assert_equal 'Your transaction was successfully captured.', capture.message
   end
@@ -86,6 +184,37 @@ class RemotePayTraceTest < Test::Unit::TestCase
     assert_equal 'Your transaction was successfully approved.', response.message
   end
 
+  def test_successful_authorize_and_capture_with_level_3_data
+    options = {
+      visa_or_mastercard: 'mastercard',
+      address: {
+        zip: '99201'
+      },
+      shipping_address: {
+        zip: '85284',
+        country: 'US'
+      },
+      line_items: [
+        {
+          description: 'office supplies',
+          product_id: 'sku9876'
+        },
+        {
+          description: 'business services',
+          product_id: 'sku3456'
+        }
+      ]
+    }
+    auth = @gateway.authorize(100, @mastercard, options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization, options)
+    assert_success capture
+
+    transaction_id = auth.authorization
+    assert_equal "Visa/MasterCard enhanced data was successfully added to Transaction ID #{transaction_id}. 2 line item records were created.", capture.message
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(29, @mastercard, @options)
     assert_failure response
@@ -96,12 +225,12 @@ class RemotePayTraceTest < Test::Unit::TestCase
     auth = @gateway.authorize(500, @amex, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(auth.authorization, @options.merge(amount: 300))
+    assert capture = @gateway.capture(200, auth.authorization, @options.merge(include_capture_amount: true))
     assert_success capture
   end
 
   def test_failed_capture
-    response = @gateway.capture('')
+    response = @gateway.capture(@amount, '')
     assert_failure response
     assert_equal 'One or more errors has occurred.', response.message
   end

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -224,6 +224,36 @@ class BluePayTest < Test::Unit::TestCase
       @gateway.send(:parse, 'STATUS=2&CVV2=M&AVS=A&MESSAGE=FAILURE').message
   end
 
+  def test_passing_stored_credentials_data_for_mit_transaction
+    options = @options.merge({ stored_credential: { initiator: 'merchant', reason_type: 'recurring' } })
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/cof=M/, data)
+      assert_match(/cofscheduled=Y/, data)
+    end.respond_with(RSP[:approved_auth])
+  end
+
+  def test_passing_stored_credentials_for_cit_transaction
+    options = @options.merge({ stored_credential: { initiator: 'cardholder', reason_type: 'unscheduled' } })
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/cof=C/, data)
+      assert_match(/cofscheduled=N/, data)
+    end.respond_with(RSP[:approved_auth])
+  end
+
+  def test_passes_nothing_for_unrecognized_stored_credentials_values
+    options = @options.merge({ stored_credential: { initiator: 'unknown', reason_type: 'something weird' } })
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/cof=&/, data)
+      assert_match(/cofscheduled=&/, data)
+    end.respond_with(RSP[:approved_auth])
+  end
+
   # Recurring Billing Unit Tests
   def test_successful_recurring
     @gateway.expects(:ssl_post).returns(successful_recurring_response)

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1255,6 +1255,36 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, id: '123ABC') })
   end
 
+  def test_stored_credential_recurring_first_cit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'will_vault'
+          },
+          transaction_source: 'recurring_first'
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: { initiator: 'merchant', reason_type: 'recurring_first', initial_transaction: true } })
+  end
+
+  def test_stored_credential_moto_cit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'will_vault'
+          },
+          transaction_source: 'moto'
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: { initiator: 'merchant', reason_type: 'moto', initial_transaction: true } })
+  end
+
   private
 
   def braintree_result(options = {})

--- a/test/unit/gateways/element_test.rb
+++ b/test/unit/gateways/element_test.rb
@@ -225,6 +225,57 @@ class ElementTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_duplicate_override_flag
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_override_flag: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<DuplicateOverrideFlag>True</DuplicateOverrideFlag>', data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_override_flag: 'true'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<DuplicateOverrideFlag>True</DuplicateOverrideFlag>', data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_override_flag: false))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<DuplicateOverrideFlag>False</DuplicateOverrideFlag>', data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_override_flag: 'xxx'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<DuplicateOverrideFlag>False</DuplicateOverrideFlag>', data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(duplicate_override_flag: 'False'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<DuplicateOverrideFlag>False</DuplicateOverrideFlag>', data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    # when duplicate_override_flag is NOT passed, should not be in XML at all
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      assert_no_match %r(<DuplicateOverrideFlag>False</DuplicateOverrideFlag>), data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_terminal_id
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(terminal_id: '02'))

--- a/test/unit/gateways/pay_arc_test.rb
+++ b/test/unit/gateways/pay_arc_test.rb
@@ -1,0 +1,792 @@
+require 'test_helper'
+
+class PayArcTest < Test::Unit::TestCase
+  def setup
+    @gateway = PayArcGateway.new(fixtures(:pay_arc))
+    credit_card_options = {
+      month: '12',
+      year: '2022',
+      first_name: 'Rex Joseph',
+      last_name: '',
+      verification_value: '999'
+    }
+    @credit_card = credit_card('4111111111111111', credit_card_options)
+    @invalid_credit_card = credit_card('3111111111111111', credit_card_options)
+    @invalid_cvv_card = credit_card('3111111111111111', credit_card_options.update(verification_value: '123'))
+    @amount = 100
+
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase',
+      card_source: 'INTERNET',
+      address_line1: '920 Sunnyslope Ave',
+      address_line2: 'Bronx',
+      city: 'New York',
+      state: 'New York',
+      zip: '10469',
+      country: 'USA'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).times(2).returns(
+      successful_token_response
+    ).then.returns(
+      successful_charge_response
+    )
+    response = @gateway.purchase(1022, @credit_card, @options)
+    assert_success response
+
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+    assert response.test?
+  end
+
+  # Failed due to already used / invalid token
+  def test_failure_purchase
+    @gateway.expects(:ssl_post).times(2).returns(
+      successful_token_response
+    ).then.returns(
+      failed_charge_response
+    )
+    response = @gateway.purchase(1022, @credit_card, @options)
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  # Failed due to invalid credit card
+  def test_failed_token
+    @gateway.expects(:ssl_post).returns(failed_token_response)
+    response = @gateway.token(@invalid_credit_card, @options)
+    assert_failure response
+  end
+
+  # Failed due to invalid cvv
+  def test_invalid_cvv
+    @gateway.expects(:ssl_post).returns(failed_token_response)
+    response = @gateway.token(@invalid_cvv_card, @options)
+    assert_failure response
+  end
+
+  def test_successful_verify
+    @gateway.expects(:ssl_post).returns(successful_token_response)
+    response = @gateway.verify(@invalid_cvv_card, @options)
+    assert_success response
+  end
+
+  def test_failed_verify
+    @gateway.expects(:ssl_post).returns(failed_token_response)
+    response = @gateway.verify(@invalid_credit_card, @options)
+    assert_failure response
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+    response = @gateway.void('FHBDKH123DFKG', @options)
+    assert_success response
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_post).returns(failed_void_response)
+    response = @gateway.void('12345', @options)
+    assert_failure response
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).times(2).returns(
+      successful_token_response
+    ).then.returns(
+      successful_authorize_response
+    )
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'authorized', response.message
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_post).times(2).returns(
+      successful_token_response
+    ).then.returns(
+      failed_authorize_response
+    )
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    response = @gateway.refund(@amount, 'WSHDHEHKDH')
+    assert_success response
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+    assert_equal 'refunded', response.message
+  end
+
+  def test_successful_partial_refund
+    @gateway.expects(:ssl_post).returns(successful_partial_refund_response)
+    response = @gateway.refund(@amount - 1, 'WSHDHEHKDH')
+    assert_success response
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+    assert_equal 'partial_refund', response.message
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+    response = @gateway.refund(@amount, 'WSHDHEHKDH')
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    transcript = @gateway.scrub(pre_scrubbed)
+    assert_scrubbed('quaslad-test.123.token-for-scrub', transcript)
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_equal transcript, post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    %{
+      <- "POST /v1/tokens HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Bearer token-fortesting\nAccept: application/json\r\nUser-Agent: PayArc ActiveMerchantBindings/1.119.0\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nHost: testapi.payarc.net\r\nContent-Length: 253\r\n\r\n"
+      <- "card_source=INTERNET&amount=100&currency=usd&statement_description=&card_number=23445123456&exp_month=12&exp_year=2022&cvv=983&address_line1=920+Sunnyslope+Ave&address_line2=Bronx&city=New+York&state=New+York&zip=10469&country=USA&card_holder_name="
+
+      -> "{\"data\":{\"object\":\"Token\",\"id\":\"0q8lLw88mlqEwYNE\",\"used\":false,\"ip\":null,\"tokenization_method\":null,\"created_at\":1620645488,\"updated_at\":1620645488,\"card\":{\"data\":{\"object\":\"Card\",\"id\":\"PMyLv0m5v151095m\",\"address1\":\"920 Sunnyslope Ave\",\"address2\":\"Bronx\",\"card_source\":\"INTERNET\",\"card_holder_name\":\"\",\"is_default\":0,\"exp_month\":\"12\",\"exp_year\":\"2022\",\"is_verified\":0,\"fingerprint\":\"1Lv0NL11yvy5yL05\",\"city\":\"New York\",\"state\":\"New York\",\"zip\":\"10469\",\"brand\":\"V\",\"last4digit\":\"1111\",\"first6digi"
+      -> "t\":411111,\"country\":\"USA\",\"avs_status\":null,\"cvc_status\":null,\"address_check_passed\":0,\"zip_check_passed\":0,\"customer_id\":null,\"created_at\":1620645488,\"updated_at\":1620645488}}},\"meta\":{\"include\":[],\"custom\":[]}}"
+      }
+  end
+
+  def post_scrubbed
+    %{
+      <- "POST /v1/tokens HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Bearer [FILTERED]Accept: application/json\r\nUser-Agent: PayArc ActiveMerchantBindings/1.119.0\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nHost: testapi.payarc.net\r\nContent-Length: 253\r\n\r\n"
+      <- "card_source=INTERNET&amount=100&currency=usd&statement_description=&card_number=[FILTERED]&exp_month=12&exp_year=2022&cvv=[BLANK]&address_line1=920+Sunnyslope+Ave&address_line2=Bronx&city=New+York&state=New+York&zip=10469&country=USA&card_holder_name="
+
+      -> "{\"data\":{\"object\":\"Token\",\"id\":\"0q8lLw88mlqEwYNE\",\"used\":false,\"ip\":null,\"tokenization_method\":null,\"created_at\":1620645488,\"updated_at\":1620645488,\"card\":{\"data\":{\"object\":\"Card\",\"id\":\"PMyLv0m5v151095m\",\"address1\":\"920 Sunnyslope Ave\",\"address2\":\"Bronx\",\"card_source\":\"INTERNET\",\"card_holder_name\":\"\",\"is_default\":0,\"exp_month\":\"12\",\"exp_year\":\"2022\",\"is_verified\":0,\"fingerprint\":\"1Lv0NL11yvy5yL05\",\"city\":\"New York\",\"state\":\"New York\",\"zip\":\"10469\",\"brand\":\"V\",\"last4digit\":\"1111\",\"first6digi"
+      -> "t\":411111,\"country\":\"USA\",\"avs_status\":null,\"cvc_status\":null,\"address_check_passed\":0,\"zip_check_passed\":0,\"customer_id\":null,\"created_at\":1620645488,\"updated_at\":1620645488}}},\"meta\":{\"include\":[],\"custom\":[]}}"
+      }
+  end
+
+  def successful_purchase_response
+    %(
+        {
+          "data": {
+              "object": "Charge",
+              "id": "LDoBnOnRnRWLOyWX",
+              "amount": 1010,
+              "amount_approved": 0,
+              "amount_refunded": 0,
+              "amount_captured": 1010,
+              "amount_voided": 0,
+              "application_fee_amount": 0,
+              "tip_amount": 0,
+              "payarc_fees": 0,
+              "type": "Sale",
+              "net_amount": 0,
+              "captured": 1,
+              "is_refunded": 0,
+              "status": "Bad Request - Try Again",
+              "auth_code": null,
+              "failure_code": "E0911",
+              "failure_message": "SystemError",
+              "charge_description": null,
+              "statement_description": "Bubbles Shop",
+              "invoice": null,
+              "under_review": 0,
+              "created_at": 1622000885,
+              "updated_at": 1622000896,
+              "email": null,
+              "phone_number": null,
+              "card_level": "LEVEL2",
+              "sales_tax": 10,
+              "purchase_order": "ABCD",
+              "supplier_reference_number": null,
+              "customer_ref_id": null,
+              "ship_to_zip": null,
+              "amex_descriptor": null,
+              "customer_vat_number": null,
+              "summary_commodity_code": null,
+              "shipping_charges": null,
+              "duty_charges": null,
+              "ship_from_zip": null,
+              "destination_country_code": null,
+              "vat_invoice": null,
+              "order_date": null,
+              "tax_category": null,
+              "tax_type": null,
+              "tax_rate": null,
+              "tax_amount": null,
+              "created_by": "bubbles@eyepaste.com",
+              "terminal_register": null,
+              "tip_amount_refunded": null,
+              "sales_tax_refunded": null,
+              "shipping_charges_refunded": null,
+              "duty_charges_refunded": null,
+              "pax_reference_number": null,
+              "refund_reason": null,
+              "refund_description": null,
+              "surcharge": 0,
+              "toll_amount": null,
+              "refund": {
+                  "data": []
+              },
+              "card": {
+                  "data": {
+                      "object": "Card",
+                      "id": "15y2901NPMP90MLv",
+                      "address1": "920 Sunnyslope Ave",
+                      "address2": "Bronx",
+                      "card_source": "INTERNET",
+                      "card_holder_name": "Rex Joseph",
+                      "is_default": 0,
+                      "exp_month": "12",
+                      "exp_year": "2022",
+                      "is_verified": 0,
+                      "fingerprint": "1Lv0NN9LyN5Pm105",
+                      "city": "New York",
+                      "state": "New York",
+                      "zip": "10469",
+                      "brand": "V",
+                      "last4digit": "1111",
+                      "first6digit": 411111,
+                      "country": "USA",
+                      "avs_status": null,
+                      "cvc_status": null,
+                      "address_check_passed": 0,
+                      "zip_check_passed": 0,
+                      "customer_id": null,
+                      "created_at": 1622000879,
+                      "updated_at": 1622000896
+                  }
+              }
+          },
+          "meta": {
+              "include": [
+                  "review"
+              ],
+              "custom": []
+          }
+      }
+    )
+  end
+
+  def successful_token_response
+    %{
+      {
+          "data": {
+              "object": "Token",
+              "id": "0mYL8wllq08YwlNE",
+              "used": false,
+              "ip": null,
+              "tokenization_method": null,
+              "created_at": 1620412546,
+              "updated_at": 1620412546,
+              "card": {
+                  "data": {
+                      "object": "Card",
+                      "id": "59P1y0PL1M9L0vML",
+                      "address1": "920 Sunnyslope Ave",
+                      "address2": "Bronx",
+                      "card_source": "INTERNET",
+                      "card_holder_name": "Rex Joseph",
+                      "is_default": 0,
+                      "exp_month": "12",
+                      "exp_year": "2022",
+                      "is_verified": 0,
+                      "fingerprint": "1Lv0NN9LyN5Pm105",
+                      "city": "New York",
+                      "state": "New York",
+                      "zip": "10469",
+                      "brand": "V",
+                      "last4digit": "1111",
+                      "first6digit": 411111,
+                      "country": "USA",
+                      "avs_status": null,
+                      "cvc_status": null,
+                      "address_check_passed": 0,
+                      "zip_check_passed": 0,
+                      "customer_id": null,
+                      "created_at": 1620412546,
+                      "updated_at": 1620412546
+                  }
+              }
+          },
+          "meta": {
+              "include": [],
+              "custom": []
+          }
+      }
+    }
+  end
+
+  def failed_token_response
+    %{
+      {
+    "status": "error",
+    "code": 0,
+    "message": "Invalid Card",
+    "status_code": 409,
+    "exception": "App\\Containers\\Card\\Exceptions\\InvalidCardDetailsException",
+    "file": "/home/deploy/payarc.com/app/Containers/Token/Actions/CreateTokenAction.php",
+    "line": 45
+    }
+   }
+  end
+
+  def successful_charge_response
+    %{
+      {
+          "data": {
+              "object": "Charge",
+              "id": "LDoBnOnRnyLyOyWX",
+              "amount": 1010,
+              "amount_approved": "1010",
+              "amount_refunded": 0,
+              "amount_captured": "1010",
+              "amount_voided": 0,
+              "application_fee_amount": 0,
+              "tip_amount": 0,
+              "payarc_fees": 29,
+              "type": "Sale",
+              "net_amount": 981,
+              "captured": "1",
+              "is_refunded": 0,
+              "status": "submitted_for_settlement",
+              "auth_code": "TAS353",
+              "failure_code": null,
+              "failure_message": null,
+              "charge_description": null,
+              "statement_description": "Testing",
+              "invoice": null,
+              "under_review": false,
+              "created_at": 1620473990,
+              "updated_at": 1620473992,
+              "email": null,
+              "phone_number": null,
+              "card_level": "LEVEL1",
+              "sales_tax": null,
+              "purchase_order": null,
+              "supplier_reference_number": null,
+              "customer_ref_id": null,
+              "ship_to_zip": null,
+              "amex_descriptor": null,
+              "customer_vat_number": null,
+              "summary_commodity_code": null,
+              "shipping_charges": null,
+              "duty_charges": null,
+              "ship_from_zip": null,
+              "destination_country_code": null,
+              "vat_invoice": null,
+              "order_date": null,
+              "tax_category": null,
+              "tax_type": null,
+              "tax_rate": null,
+              "tax_amount": null,
+              "created_by": "bubbles@eyepaste.com",
+              "terminal_register": null,
+              "tip_amount_refunded": null,
+              "sales_tax_refunded": null,
+              "shipping_charges_refunded": null,
+              "duty_charges_refunded": null,
+              "pax_reference_number": null,
+              "refund_reason": null,
+              "refund_description": null,
+              "surcharge": 0,
+              "toll_amount": null,
+              "refund": {
+                  "data": []
+              },
+              "card": {
+                  "data": {
+                      "object": "Card",
+                      "id": "mP1Lv0NP19mN05MN",
+                      "address1": "920 Sunnyslope Ave",
+                      "address2": "Bronx",
+                      "card_source": "INTERNET",
+                      "card_holder_name": "Rex Joseph",
+                      "is_default": 0,
+                      "exp_month": "12",
+                      "exp_year": "2022",
+                      "is_verified": 0,
+                      "fingerprint": "1Lv0NN9LyN5Pm105",
+                      "city": "New York",
+                      "state": "New York",
+                      "zip": "10469",
+                      "brand": "V",
+                      "last4digit": "1111",
+                      "first6digit": 411111,
+                      "country": "USA",
+                      "avs_status": null,
+                      "cvc_status": null,
+                      "address_check_passed": 0,
+                      "zip_check_passed": 0,
+                      "customer_id": null,
+                      "created_at": 1620473969,
+                      "updated_at": 1620473992
+                  }
+              }
+          },
+          "meta": {
+              "include": [
+                  "review"
+              ],
+              "custom": []
+          }
+      }
+    }
+  end
+
+  def failed_capture_response
+    %{
+      {
+          "status": "error",
+          "code": 0,
+          "message": "The given data was invalid.",
+          "errors": {
+              "currency": [
+                  "The selected currency is invalid."
+              ],
+              "customer_id": [
+                  "The customer id field is required when none of token id / cvv / exp year / exp month / card number are present."
+              ],
+              "token_id": [
+                  "The token id field is required when none of customer id / cvv / exp year / exp month / card number are present."
+              ],
+              "card_number": [
+                  "The card number field is required when none of token id / customer id are present."
+              ],
+              "exp_month": [
+                  "The exp month field is required when none of token id / customer id are present."
+              ],
+              "exp_year": [
+                  "The exp year field is required when none of token id / customer id are present."
+              ]
+          },
+          "status_code": 422,
+          "exception": "Illuminate\\Validation\\ValidationException",
+          "file": "/home/deploy/payarc.com/vendor/laravel/framework/src/Illuminate/Foundation/Http/FormRequest.php",
+          "line": 130
+      }
+    }
+  end
+
+  def successful_void_response
+    %{
+        {
+        "data": {
+            "object": "Charge",
+            "id": "LDoBnOnRnyLyOyWX",
+            "amount": 1010,
+            "amount_approved": 1010,
+            "amount_refunded": 0,
+            "amount_captured": 1010,
+            "amount_voided": 1010,
+            "application_fee_amount": 0,
+            "tip_amount": 0,
+            "payarc_fees": 29,
+            "type": "Sale",
+            "net_amount": 0,
+            "captured": 1,
+            "is_refunded": 0,
+            "status": "void",
+            "auth_code": "TAS353",
+            "failure_code": null,
+            "failure_message": null,
+            "charge_description": null,
+            "statement_description": "Testing",
+            "invoice": null,
+            "under_review": 0,
+            "created_at": 1620473990,
+            "updated_at": 1620495791,
+            "email": null,
+            "phone_number": null,
+            "card_level": "LEVEL1",
+            "sales_tax": null,
+            "purchase_order": null,
+            "supplier_reference_number": null,
+            "customer_ref_id": null,
+            "ship_to_zip": null,
+            "amex_descriptor": null,
+            "customer_vat_number": null,
+            "summary_commodity_code": null,
+            "shipping_charges": null,
+            "duty_charges": null,
+            "ship_from_zip": null,
+            "destination_country_code": null,
+            "vat_invoice": null,
+            "order_date": null,
+            "tax_category": null,
+            "tax_type": null,
+            "tax_rate": null,
+            "tax_amount": null,
+            "created_by": "bubbles@eyepaste.com",
+            "terminal_register": null,
+            "tip_amount_refunded": null,
+            "sales_tax_refunded": null,
+            "shipping_charges_refunded": null,
+            "duty_charges_refunded": null,
+            "pax_reference_number": null,
+            "refund_reason": null,
+            "refund_description": null,
+            "surcharge": 0,
+            "toll_amount": null,
+            "refund": {
+                "data": []
+            },
+            "card": {
+                "data": {
+                    "object": "Card",
+                    "id": "mP1Lv0NP19mN05MN",
+                    "address1": "920 Sunnyslope Ave",
+                    "address2": "Bronx",
+                    "card_source": "INTERNET",
+                    "card_holder_name": "Rex Joseph",
+                    "is_default": 0,
+                    "exp_month": "12",
+                    "exp_year": "2022",
+                    "is_verified": 0,
+                    "fingerprint": "1Lv0NN9LyN5Pm105",
+                    "city": "New York",
+                    "state": "New York",
+                    "zip": "10469",
+                    "brand": "V",
+                    "last4digit": "1111",
+                    "first6digit": 411111,
+                    "country": "USA",
+                    "avs_status": null,
+                    "cvc_status": null,
+                    "address_check_passed": 0,
+                    "zip_check_passed": 0,
+                    "customer_id": null,
+                    "created_at": 1620473969,
+                    "updated_at": 1620473992
+                }
+            }
+        },
+        "meta": {
+            "include": [
+                "review"
+            ],
+            "custom": []
+        }
+       }
+    }
+  end
+
+  def failed_void_response
+    %{
+      {
+        "status": "error",
+        "code": 0,
+        "message": "Property [is_under_review] does not exist on this collection instance.",
+        "status_code": 500,
+        "exception": "Exception",
+        "file": "/home/deploy/payarc.com/vendor/laravel/framework/src/Illuminate/Support/Collection.php",
+        "line": 2160
+      }
+    }
+  end
+
+  def successful_authorize_response
+    %{
+        {
+          "data": {
+              "object": "Charge",
+              "id": "BXMbnObLnoDMORoD",
+              "amount": 1010,
+              "amount_approved": "1010",
+              "amount_refunded": 0,
+              "amount_captured": 0,
+              "amount_voided": 0,
+              "application_fee_amount": 0,
+              "tip_amount": 0,
+              "payarc_fees": 0,
+              "type": "Sale",
+              "net_amount": 0,
+              "captured": "0",
+              "is_refunded": 0,
+              "status": "authorized",
+              "auth_code": "TAS363",
+              "failure_code": null,
+              "failure_message": null,
+              "charge_description": null,
+              "statement_description": "Testing",
+              "invoice": null,
+              "under_review": false,
+              "created_at": 1620651112,
+              "updated_at": 1620651115,
+              "email": null,
+              "phone_number": null,
+              "card_level": "LEVEL1",
+              "sales_tax": null,
+              "purchase_order": null,
+              "supplier_reference_number": null,
+              "customer_ref_id": null,
+              "ship_to_zip": null,
+              "amex_descriptor": null,
+              "customer_vat_number": null,
+              "summary_commodity_code": null,
+              "shipping_charges": null,
+              "duty_charges": null,
+              "ship_from_zip": null,
+              "destination_country_code": null,
+              "vat_invoice": null,
+              "order_date": null,
+              "tax_category": null,
+              "tax_type": null,
+              "tax_rate": null,
+              "tax_amount": null,
+              "created_by": "bubbles@eyepaste.com",
+              "terminal_register": null,
+              "tip_amount_refunded": null,
+              "sales_tax_refunded": null,
+              "shipping_charges_refunded": null,
+              "duty_charges_refunded": null,
+              "pax_reference_number": null,
+              "refund_reason": null,
+              "refund_description": null,
+              "surcharge": 0,
+              "toll_amount": null,
+              "refund": {
+                  "data": []
+              },
+              "card": {
+                  "data": {
+                      "object": "Card",
+                      "id": "mP1Lv0NP19y105MN",
+                      "address1": "920 Sunnyslope Ave",
+                      "address2": "Bronx",
+                      "card_source": "INTERNET",
+                      "card_holder_name": "Rex Joseph",
+                      "is_default": 0,
+                      "exp_month": "12",
+                      "exp_year": "2022",
+                      "is_verified": 0,
+                      "fingerprint": "1Lv0NN9LyN5Pm105",
+                      "city": "New York",
+                      "state": "New York",
+                      "zip": "10469",
+                      "brand": "V",
+                      "last4digit": "1111",
+                      "first6digit": 411111,
+                      "country": "USA",
+                      "avs_status": null,
+                      "cvc_status": null,
+                      "address_check_passed": 0,
+                      "zip_check_passed": 0,
+                      "customer_id": null,
+                      "created_at": 1620651066,
+                      "updated_at": 1620651115
+                  }
+              }
+          },
+          "meta": {
+              "include": [
+                  "review"
+              ],
+              "custom": []
+          }
+      }
+    }
+  end
+
+  def failed_authorize_response
+    %{
+       {
+          "status": "error",
+          "code": 0,
+          "message": "The requested token is not valid or already used",
+          "status_code": 400,
+          "exception": "App\\Containers\\Customer\\Exceptions\\InvalidTokenException",
+          "file": "/home/deploy/payarc.com/app/Containers/Charge/Actions/CreateSaleAction.php",
+          "line": 260
+      }
+    }
+  end
+
+  def failed_charge_response
+    %{
+       {
+          "status": "error",
+          "code": 0,
+          "message": "The requested token is not valid or already used",
+          "status_code": 400,
+          "exception": "App\\Containers\\Customer\\Exceptions\\InvalidTokenException",
+          "file": "/home/deploy/payarc.com/app/Containers/Charge/Actions/CreateSaleAction.php",
+          "line": 260
+      }
+    }
+  end
+
+  def successful_refund_response
+    %{
+          {
+          "data": {
+              "object": "Refund",
+              "id": "x9bQvpYvxBOYOqyB",
+              "refund_amount": "1010",
+              "currency": "usd",
+              "status": "refunded",
+              "reason": "requested_by_customer",
+              "description": "",
+              "email": null,
+              "receipt_number": null,
+              "charge_id": "LnbDBOMMbWXyORXM",
+              "created_at": 1620734715,
+              "updated_at": 1620734715
+          },
+          "meta": {
+              "include": [],
+              "custom": []
+          }
+      }
+    }
+  end
+
+  def successful_partial_refund_response
+    %{
+          {
+          "data": {
+              "object": "Refund",
+              "id": "Pqy8QxY8vb9YvB1O",
+              "refund_amount": "500",
+              "currency": "usd",
+              "status": "partial_refund",
+              "reason": "requested_by_customer",
+              "description": "",
+              "email": null,
+              "receipt_number": null,
+              "charge_id": "RbWLnOyBbyWBODBX",
+              "created_at": 1620734893,
+              "updated_at": 1620734893
+          },
+          "meta": {
+              "include": [],
+              "custom": []
+          }
+      }
+    }
+  end
+
+  def failed_refund_response
+    %{
+        {
+        "status": "error",
+        "code": 0,
+        "message": "Amount requested is not available for Refund  ",
+        "status_code": 409,
+        "exception": "Symfony\\Component\\HttpKernel\\Exception\\ConflictHttpException",
+        "file": "/home/deploy/payarc.com/app/Containers/Refund/Tasks/CheckAmountTask.php",
+        "line": 39    }
+    }
+  end
+end


### PR DESCRIPTION
Hi,

On behalf of PAYARC gateway ( https://www.payarc.com/ ), I have extended ActiveMerchant to support PAYARC. 
One of the main reasons for this is that we are planning to integrate with Spreedly.

Below methods have been added with the unit and remote test cases. 

purchase(money, creditcard, options = {})
authorize(money, creditcard, options = {})
capture(money, tx_reference, options = {})
void(tx_reference, options = {})
refund(money, tx_reference, options = {})
verify(creditcard, options = {})

Code has passed rubucop checks.

**Unit Test case results** 

```
bundle exec rake test:units TEST=test/unit/gateways/pay_arc_test.rb
Started
..............
Finished in 0.013748811 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
14 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1018.27 tests/s, 3054.81 assertions/s
```

**Remote Test case results** 

bundle exec rake test:remote TEST=test/remote/gateways/remote_pay_arc_test.rb

```
Started
.................
Finished in 104.064004411 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
17 tests, 43 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.16 tests/s, 0.41 assertions/s
```

Please check and let us if any changes are needed. 

Thanks & Regards,
Senthil
