### PR TITLE
Worldpay: support cancelOrRefund via options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,6 +59,7 @@
 * CyberSource: Update XML tag for merchantDefinedData [meagabeth] #3969
 * Elavon: Send ssl_vendor_id field [dsmcclain] #3972
 * Credorax: Add support for `echo` field [meagabeth] #3973
+* Worldpay: support cancelOrRefund via options [therufs] #3975
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -555,6 +555,28 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', refund.message
   end
 
+  def test_cancel_or_refund_non_captured_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(skip_capture: true))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+    assert response.authorization
+
+    refund = @gateway.refund(@amount, response.authorization, authorization_validated: true, cancel_or_refund: true)
+    assert_success refund
+    assert_equal 'SUCCESS', refund.message
+  end
+
+  def test_cancel_or_refund_captured_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+    assert response.authorization
+
+    refund = @gateway.refund(@amount, response.authorization, authorization_validated: true, cancel_or_refund: true)
+    assert_success refund
+    assert_equal 'SUCCESS', refund.message
+  end
+
   def test_multiple_refunds
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase


### PR DESCRIPTION
Note: Currently, the cancelOrRefund method behaves in a way opposite to what Worldpay docs claim.  See https://developer.worldpay.com/docs/wpg/manage/modificationrequests#xml-reference: `<cancelOrRefund> ... Must include the <amount> information`, but actually doing this causes an error.

CE-1208

Remote:
------
67 tests, 289 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.0149% passed
Failures: test_3ds_version_2_parameters_pass_thru, test_3ds_version_1_parameters_pass_thru

Unit:
----
85 tests, 530 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed