### PR TITLE
Moneris: Add authorization to `store` response

### DIFF
--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -304,13 +304,17 @@ module ActiveMerchant #:nodoc:
           test: test?,
           avs_result: { code: response[:avs_result_code] },
           cvv_result: response[:cvd_result_code] && response[:cvd_result_code][-1, 1],
-          authorization: authorization_from(response)
+          authorization: authorization_from(action, response)
         )
       end
 
       # Generates a Moneris authorization string of the form 'trans_id;receipt_id'.
-      def authorization_from(response = {})
-        "#{response[:trans_id]};#{response[:receipt_id]}" if response[:trans_id] && response[:receipt_id]
+      def authorization_from(action, response = {})
+        if %w[res_temp_add res_add_cc].include?(action)
+          response[:data_key]
+        else
+          "#{response[:trans_id]};#{response[:receipt_id]}" if response[:trans_id] && response[:receipt_id]
+        end
       end
 
       # Tests for a successful response from Moneris' servers

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -195,7 +195,8 @@ class MonerisRemoteTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card)
     assert_success response
     assert_equal 'Successfully registered cc details', response.message
-    assert response.params['data_key'].present?
+    assert response.authorization.present?
+    assert_equal response.params['data_key'], response.authorization
     @data_key = response.params['data_key']
   end
 
@@ -203,7 +204,8 @@ class MonerisRemoteTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, duration: 600)
     assert_success response
     assert_equal 'Successfully registered cc details', response.message
-    assert response.params['data_key'].present?
+    assert response.authorization.present?
+    assert_equal response.params['data_key'], response.authorization
   end
 
   # AVS result fields are stored in the vault and returned as part of the

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -196,8 +196,9 @@ class MonerisTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card)
     assert_success response
     assert_equal 'Successfully registered cc details', response.message
-    assert response.params['data_key'].present?
-    @data_key = response.params['data_key']
+    assert response.authorization.present?
+    assert_equal response.params['data_key'], response.authorization
+    @data_key = response.authorization
   end
 
   def test_successful_store_with_duration
@@ -205,8 +206,9 @@ class MonerisTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, duration: 600)
     assert_success response
     assert_equal 'Successfully registered cc details', response.message
-    assert response.params['data_key'].present?
-    @data_key = response.params['data_key']
+    assert response.authorization.present?
+    assert_equal response.params['data_key'], response.authorization
+    @data_key = response.authorization
   end
 
   def test_successful_unstore


### PR DESCRIPTION
Hello! First of all thanks everyone involved in the project support.

When using the `store` method with the Moneris gateway are currently always getting a `nil` authorization in the response. According to [the docs](https://github.com/activemerchant/active_merchant/wiki/Patterns-&-Standards#store), the token should be returned in `Response#authorization` instead. This commit adds that expected behavior to the Moneris gateway.

Remote:
40 tests, 219 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
51 tests, 281 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed