### PR TITLE
Enable General Credit on Payeezy gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,7 @@
 * Elavon: Send ssl_vendor_id field [dsmcclain] #3972
 * Credorax: Add support for `echo` field [meagabeth] #3973
 * Worldpay: support cancelOrRefund via options [therufs] #3975
+* Payeezy: support general credit [cdmackeyfree] #3977
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -79,6 +79,14 @@ module ActiveMerchant
         commit(params, options)
       end
 
+      def credit(amount, payment_method, options = {})
+        params = { transaction_type: 'refund' }
+
+        add_amount(params, amount, options)
+        add_payment_method(params, payment_method, options)
+        commit(params, options)
+      end
+
       def store(payment_method, options = {})
         params = { transaction_type: 'store' }
 

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -212,6 +212,14 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_general_credit
+    assert response = @gateway.credit(@amount, @credit_card, @options)
+    assert_match(/Transaction Normal/, response.message)
+    assert_equal '100', response.params['bank_resp_code']
+    assert_equal nil, response.error_code
+    assert_success response
+  end
+
   def test_successful_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -233,6 +233,12 @@ class PayeezyGateway < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_general_credit
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    assert response = @gateway.credit(@amount, @credit_card)
+    assert_success response
+  end
+
   def test_successful_void
     response = stub_comms do
       @gateway.void(@authorization, @options)


### PR DESCRIPTION
Adds the ability to credit a customer without a prior transaction id connected to the refund.

remote:
38 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

unit:
38 tests, 180 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

local:
4711 tests, 73422 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed