### PR TITLE
Bin Range Update

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -61,6 +61,7 @@
 * Credorax: Add support for `echo` field [meagabeth] #3973
 * Worldpay: support cancelOrRefund via options [therufs] #3975
 * Payeezy: support general credit [cdmackeyfree] #3977
+* Ripley and Hipercard: Add BIN ranges [naashton] #3978
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -71,6 +71,12 @@ module ActiveMerchant #:nodoc:
       MASTERCARD_RANGES = [
         (222100..272099),
         (510000..559999),
+        [605272],
+        [606282],
+        [637095],
+        [637568],
+        (637599..637600),
+        [637609],
       ]
 
       MAESTRO_BINS = Set.new(
@@ -105,7 +111,7 @@ module ActiveMerchant #:nodoc:
             606126
             636380 636422 636502 636639
             637046 637756
-            639130
+            639130 639229
             690032]
       )
 
@@ -198,7 +204,7 @@ module ActiveMerchant #:nodoc:
       def self.in_bin_range?(number, ranges)
         bin = number.to_i
         ranges.any? do |range|
-          range.cover?(bin)
+          range.include?(bin)
         end
       end
 

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -40,7 +40,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
        596245 596289 596399 596405 596590 596608 596645 596646 596791 596808 596815 596846 597077 597094
        597143 597370 597410 597765 597855 597862 598053 598054 598395 598585 598793 598794 598815 598835
        598838 598880 598889 599000 599069 599089 599148 599191 599310 599741 599742 599867 601070 604983
-       606126 636380 636422 636502 636639 637046 637756 639130 690032]
+       606126 636380 636422 636502 636639 637046 637756 639130 639229 690032]
   end
 
   def test_should_be_able_to_identify_valid_expiry_months
@@ -148,6 +148,12 @@ class CreditCardMethodsTest < Test::Unit::TestCase
   def test_should_detect_mastercard
     assert_equal 'master', CreditCard.brand?('2720890000000000')
     assert_equal 'master', CreditCard.brand?('5413031000000000')
+    assert_equal 'master', CreditCard.brand?('6052721000000000')
+    assert_equal 'master', CreditCard.brand?('6062821000000000')
+    assert_equal 'master', CreditCard.brand?('6370951000000000')
+    assert_equal 'master', CreditCard.brand?('6375681000000000')
+    assert_equal 'master', CreditCard.brand?('6375991000000000')
+    assert_equal 'master', CreditCard.brand?('6376091000000000')
   end
 
   def test_should_detect_forbrugsforeningen


### PR DESCRIPTION
Adding several bins for MC and 1 for Maestro.

Change check on ln:207 from `range.cover?(bin)` to
`range.include?(bin)`.

The reason for this is, upon adding arrays of individual bins (following
existing convention in this file), `cover?` only applies to a range of
values. `include?` allows us to add single value arrays in existing bin
range sets and achieve same outcomes.

`include?` and `cover?` are both inclusive, so:
`(1..2).cover?(1)` returns `true`
`(1..2).include?(1)` returns `true`

CE-1593

Unit: 44 tests, 503 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: No Remote Tests