### PR TITLE
SecurePayAU: Send order ID for payments with stored card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -104,6 +104,7 @@
 * Worldpay: Fix stored credentials unscheduled reason type [Buitragox] #5352
 * Worldpay: Worldpay: Idempotency key fix [jherreraa] #5359
 * Hi Pay: Don't add 3ds when :three_ds_2 is missing [Buitragox] #5355
+* SecurePayAU: Send order ID for payments with stored card [dacook] #3979
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -181,7 +181,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def commit(action, request)
-        response = parse(ssl_post(test? ? self.test_url : self.live_url, build_request(action, request)))
+        response = parse(ssl_post(test? ? self.test_url : self.live_url, build_request(action, request), {"Content-Type" => "text/xml; charset=utf-8"}))
 
         Response.new(
           success?(response),
@@ -241,7 +241,7 @@ module ActiveMerchant # :nodoc:
 
       def commit_periodic(request)
         my_request = build_periodic_request(request)
-        response = parse(ssl_post(test? ? self.test_periodic_url : self.live_periodic_url, my_request))
+        response = parse(ssl_post(test? ? self.test_periodic_url : self.live_periodic_url, my_request, {"Content-Type" => "text/xml; charset=utf-8"}))
 
         Response.new(
           success?(response),

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -207,6 +207,7 @@ module ActiveMerchant # :nodoc:
         end
         xml.tag! 'amount', amount(money)
         xml.tag! 'periodicType', PERIODIC_TYPES[action] if PERIODIC_TYPES[action]
+        xml.tag! 'transactionReference', options[:order_id] if options[:order_id]
 
         xml.target!
       end

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -21,7 +21,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     @credit_card = credit_card('4242424242424242', { month: 9, year: 15 })
 
     @options = {
-      order_id: '2',
+      order_id: 'order123',
       billing_address: address,
       description: 'Store Purchase'
     }
@@ -166,6 +166,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     assert response = @gateway.purchase(12300, 'test1234', @options)
     assert_success response
     assert_equal response.params['amount'], '12300'
+    assert_equal response.params['ponum'], 'order123'
 
     assert_equal 'Approved', response.message
   end

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -5,6 +5,10 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     include ActiveMerchant::Billing::CreditCardMethods
     attr_accessor :number, :month, :year, :first_name, :last_name, :verification_value, :brand
 
+    def initialize(params)
+      params.each { |k,v| instance_variable_set("@#{k.to_s}".to_sym,v) }
+    end
+
     def verification_value?
       !@verification_value.blank?
     end
@@ -94,10 +98,11 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
 
     assert response = @gateway.refund(@amount + 1, authorization)
     assert_failure response
-    assert_equal 'Only $1.0 available for refund', response.message
+    assert_equal 'Only 1.00 AUD available for refund', response.message
   end
 
   def test_successful_void
+    omit("It appears that SecurePayAU no longer supports void")
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
 
@@ -110,6 +115,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
   end
 
   def test_failed_void
+    omit("It appears that SecurePayAU no longer supports void")
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     authorization = response.authorization

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -13,7 +13,7 @@ class SecurePayAuTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      order_id: '1',
+      order_id: 'order123',
       billing_address: address,
       description: 'Store Purchase'
     }
@@ -77,6 +77,14 @@ class SecurePayAuTest < Test::Unit::TestCase
     @gateway.expects(:commit_periodic)
 
     @gateway.purchase(@amount, '123', @options)
+  end
+
+  def test_periodic_payment_submits_order_id
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, '123', @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/<transactionReference>order123<\/transactionReference>/, data)
+    end.respond_with(successful_purchase_response)
   end
 
   def test_purchase_with_creditcard_calls_commit_with_purchase


### PR DESCRIPTION
**Changelog:** SecurePayAU: Send order ID for payments with stored cards

Order IDs were being sent for normal payments, but now they are also sent for payments triggered on stored cards as `transactionReference`.
As per XML spec (https://auspost.com.au/payments/docs/securepay/resources/API_Card_Storage_and_Scheduled_Payments.pdf )

Also:
- Fixed broken remote tests
- Send content-type headers for best practice

Unit test results:
test/unit/gateways/secure_pay_au_test.rb
24 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote test results: 
test/remote/gateways/remote_secure_pay_au_test.rb
18 tests, 57 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed