### PR TITLE
Adyen: Set default card holder name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', platforms: :jruby
-gem 'rubocop', '~> 0.60.0', require: false
+gem 'rubocop', '~> 0.62.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -383,7 +383,7 @@ module ActiveMerchant #:nodoc:
         }
 
         card.delete_if { |_k, v| v.blank? }
-        card[:holderName] ||= 'Not Provided' if credit_card.is_a?(NetworkTokenizationCreditCard)
+        card[:holderName] ||= 'Not Provided'
         requires!(card, :expiryMonth, :expiryYear, :holderName, :number)
         post[:card] = card
       end

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -409,6 +409,20 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal 'Authorised', response.message
   end
 
+  def test_successful_authorize_with_credit_card_no_name
+    credit_card_no_name = ActiveMerchant::Billing::CreditCard.new({
+      number: '4111111111111111',
+      month: 3,
+      year: 2030,
+      verification_value: '737',
+      brand: 'visa'
+    })
+
+    response = @gateway.authorize(@amount, credit_card_no_name, @options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -815,6 +815,23 @@ class AdyenTest < Test::Unit::TestCase
     assert_equal @options[:shipping_address][:country], post[:deliveryAddress][:country]
   end
 
+  def test_authorize_with_credit_card_no_name
+    credit_card_no_name = ActiveMerchant::Billing::CreditCard.new({
+      number: '4111111111111111',
+      month: 3,
+      year: 2030,
+      verification_value: '737',
+      brand: 'visa'
+    })
+
+    response = stub_comms do
+      @gateway.authorize(@amount, credit_card_no_name, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'Not Provided', JSON.parse(data)['card']['holderName']
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_authorize_with_network_tokenization_credit_card_no_name
     @apple_pay_card.first_name = nil
     @apple_pay_card.last_name = nil


### PR DESCRIPTION
Apply default card holder name for credit cards as well, not just `NetworkTokenizationCreditCard`. Covers cards that are passed in without a name.

---

remote:
98 tests, 375 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

unit:
75 tests, 391 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

local:
4720 tests, 73455 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
699 files inspected, no offenses detected