### PR TITLE
PaywayDotCom: make `source_id` a required field

### DIFF
--- a/lib/active_merchant/billing/gateways/payway_dot_com.rb
+++ b/lib/active_merchant/billing/gateways/payway_dot_com.rb
@@ -65,7 +65,7 @@ module ActiveMerchant #:nodoc:
       SCRUB_REPLACEMENT = '\1[FILTERED]'
 
       def initialize(options = {})
-        requires!(options, :login, :password, :company_id)
+        requires!(options, :login, :password, :company_id, :source_id)
         super
       end
 
@@ -73,7 +73,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_common(post, options)
         add_card_payment(post, payment, options)
-        add_card_transaction(post, money, options)
+        add_card_transaction_details(post, money, options)
         add_address(post, payment, options)
 
         commit('sale', post)
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_common(post, options)
         add_card_payment(post, payment, options)
-        add_card_transaction(post, money, options)
+        add_card_transaction_details(post, money, options)
         add_address(post, payment, options)
 
         commit('authorize', post)
@@ -92,7 +92,7 @@ module ActiveMerchant #:nodoc:
       def capture(money, authorization, options = {})
         post = {}
         add_common(post, options)
-        add_card_transaction_name_and_source(post, authorization, options)
+        add_card_transaction_name(post, authorization, options)
 
         commit('capture', post)
       end
@@ -101,7 +101,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_common(post, options)
         add_card_payment(post, payment, options)
-        add_card_transaction(post, money, options)
+        add_card_transaction_details(post, money, options)
         add_address(post, payment, options)
 
         commit('credit', post)
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
       def void(authorization, options = {})
         post = {}
         add_common(post, options)
-        add_card_transaction_name_and_source(post, authorization, options)
+        add_card_transaction_name(post, authorization, options)
 
         commit('void', post)
       end
@@ -131,12 +131,8 @@ module ActiveMerchant #:nodoc:
         post[:userName] = @options[:login]
         post[:password] = @options[:password]
         post[:companyId] = @options[:company_id]
-      end
-
-      def add_card_transaction_name_and_source(post, identifier, options)
-        post[:cardTransaction] ||= {}
-        post[:cardTransaction][:name] = identifier
-        post[:cardTransaction][:sourceId] = options[:source_id] if options[:source_id]
+        post[:cardTransaction] = {}
+        post[:cardTransaction][:sourceId] = @options[:source_id]
       end
 
       def add_address(post, payment, options)
@@ -155,14 +151,16 @@ module ActiveMerchant #:nodoc:
         post[:cardAccount][:phone]     = phone           if phone
       end
 
-      def add_card_transaction(post, money, options)
-        post[:cardTransaction] ||= {}
+      def add_card_transaction_details(post, money, options)
         post[:cardTransaction][:amount] = amount(money)
         eci_type = options[:eci_type].nil? ? '1' : options[:eci_type]
         post[:cardTransaction][:eciType] = eci_type
-        post[:cardTransaction][:sourceId] = options[:source_id] if options[:source_id]
         post[:cardTransaction][:processorSoftDescriptor] = options[:processor_soft_descriptor] if options[:processor_soft_descriptor]
         post[:cardTransaction][:tax] = options[:tax] if options[:tax]
+      end
+
+      def add_card_transaction_name(post, identifier, options)
+        post[:cardTransaction][:name] = identifier
       end
 
       def add_card_payment(post, payment, options)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -804,6 +804,7 @@ payway_dot_com:
   login:      "sprerestwsdev"
   password:   "sprerestwsdev1!"
   company_id: "3"
+  source_id: "67"
 
 pin:
   api_key: "I_mo9BUUUXIwXF-avcs3LA"

--- a/test/remote/gateways/remote_payway_dot_com_test.rb
+++ b/test/remote/gateways/remote_payway_dot_com_test.rb
@@ -10,9 +10,7 @@ class RemotePaywayDotComTest < Test::Unit::TestCase
     @invalid_luhn_card = credit_card('4000300011112221')
     @options = {
       billing_address: address,
-      description: 'Store Purchase',
-      # source_id must be provided, contact payway support for valid source_id(s)
-      source_id: '67'
+      description: 'Store Purchase'
     }
   end
 
@@ -27,7 +25,6 @@ class RemotePaywayDotComTest < Test::Unit::TestCase
       order_id: '1',
       ip: '127.0.0.1',
       email: 'joe@example.com',
-      source_id: '67',
       eci_type: '5',
       tax: '7',
       soft_descriptor: "Dan's Guitar Store"
@@ -117,7 +114,7 @@ class RemotePaywayDotComTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = PaywayDotComGateway.new(login: '', password: '', company_id: '')
+    gateway = PaywayDotComGateway.new(login: '', password: '', company_id: '', source_id: '')
 
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/payway_dot_com_test.rb
+++ b/test/unit/gateways/payway_dot_com_test.rb
@@ -5,7 +5,8 @@ class PaywayDotComTest < Test::Unit::TestCase
     @gateway = PaywayDotComGateway.new(
       login: 'sprerestwsdev',
       password: 'sprerestwsdev1!',
-      company_id: '3'
+      company_id: '3',
+      source_id: '67'
     )
     @credit_card = credit_card
     @amount = 100
@@ -13,8 +14,7 @@ class PaywayDotComTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase',
-      source_id: '67'
+      description: 'Store Purchase'
     }
   end
 
@@ -141,12 +141,17 @@ class PaywayDotComTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    @gateway2 = PaywayDotComGateway.new(login: '', password: '', company_id: '')
-    @gateway2.expects(:ssl_request).returns(failed_invalid_login_response)
+    gateway = PaywayDotComGateway.new(login: '', password: '', company_id: '', source_id: '')
+    gateway.expects(:ssl_request).returns(failed_invalid_login_response)
 
-    assert response = @gateway2.purchase(@amount, @credit_card, @options)
+    assert response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
     assert_match %r{5001}, response.message[0, 4]
+  end
+
+  def test_missing_source_id
+    error = assert_raises(ArgumentError) { PaywayDotComGateway.new(login: '', password: '', company_id: '') }
+    assert_equal 'Missing required parameter: source_id', error.message
   end
 
   def test_scrub


### PR DESCRIPTION
CE-1574

Local:
4719 tests, 73458 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_payway_dot_com_test
16 tests, 43 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
699 files inspected, no offenses detected