### PR TITLE
Qvalent: remove `pem_password` from required creds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -64,6 +64,7 @@
 * Ripley and Hipercard: Add BIN ranges [naashton] #3978
 * Adyen: Default card holder name for credit cards [shasum] #3980
 * PaywayDotCom: make `source_id` a required field [dsmcclain] # 3981 
+* Qvalent: remove `pem_password` from required credentials [dsmcclain] #3982
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/qvalent.rb
+++ b/lib/active_merchant/billing/gateways/qvalent.rb
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options = {})
-        requires!(options, :username, :password, :merchant, :pem, :pem_password)
+        requires!(options, :username, :password, :merchant, :pem)
         super
       end
 

--- a/test/unit/gateways/qvalent_test.rb
+++ b/test/unit/gateways/qvalent_test.rb
@@ -16,6 +16,12 @@ class QvalentTest < Test::Unit::TestCase
     @amount = 100
   end
 
+  def test_successful_gateway_creation_without_pem_password
+    gateway = QvalentGateway.new(username: 'username', password: 'password', merchant: 'merchant', pem: 'pem')
+
+    assert_instance_of QvalentGateway, gateway
+  end
+
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)


### PR DESCRIPTION
CE-1176

Local:
4720 tests, 73460 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_qvalent_test
22 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
699 files inspected, no offenses detected