### PR TITLE
Add 'unmaskExpirationDate' and 'includeIssuerInfo' to customer profile call

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -563,6 +563,8 @@ module ActiveMerchant #:nodoc:
 
       def build_get_customer_profile_request(xml, options)
         xml.tag!('customerProfileId', options[:customer_profile_id])
+        xml.tag!('unmaskExpirationDate', options[:unmask_expiration_date]) if options[:unmask_expiration_date]
+        xml.tag!('includeIssuerInfo', options[:include_issuer_info]) if options[:include_issuer_info]
         xml.target!
       end
 
@@ -574,6 +576,7 @@ module ActiveMerchant #:nodoc:
         xml.tag!('customerProfileId', options[:customer_profile_id])
         xml.tag!('customerPaymentProfileId', options[:customer_payment_profile_id])
         xml.tag!('unmaskExpirationDate', options[:unmask_expiration_date]) if options[:unmask_expiration_date]
+        xml.tag!('includeIssuerInfo', options[:include_issuer_info]) if options[:include_issuer_info]
         xml.target!
       end
 

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -267,7 +267,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
       customer_type: 'individual',
       bill_to: @address,
       payment: {
-        credit_card: credit_card('1234123412341234')
+        credit_card: credit_card('4111111111111111')
       }
     }
     assert response = @gateway.create_customer_profile(@options)
@@ -288,8 +288,8 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_equal 2, response.params['profile']['payment_profiles'].size
-    assert_equal 'XXXX1234', response.params['profile']['payment_profiles'][0]['payment']['credit_card']['card_number']
-    assert_equal 'XXXX4242', response.params['profile']['payment_profiles'][1]['payment']['credit_card']['card_number']
+    assert(response.params['profile']['payment_profiles'].one? { |payment| payment['payment']['credit_card']['card_number'] == 'XXXX4242' })
+    assert(response.params['profile']['payment_profiles'].one? { |payment| payment['payment']['credit_card']['card_number'] == 'XXXX1111' })
   end
 
   def test_successful_delete_customer_payment_profile_request

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -73,9 +73,28 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_success response
     assert_nil response.authorization
     assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
-    assert_nil response.params['profile']['merchant_customer_id']
-    assert_nil response.params['profile']['description']
     assert_equal 'new email address', response.params['profile']['email']
+  end
+
+  def test_get_customer_profile_with_unmasked_exp_date_and_issuer_info
+    assert response = @gateway.create_customer_profile(@options)
+    @customer_profile_id = response.authorization
+
+    assert_success response
+    assert response.test?
+
+    assert response = @gateway.get_customer_profile(
+      customer_profile_id: @customer_profile_id,
+      unmask_expiration_date: true,
+      include_issuer_info: true,
+    )
+    assert response.test?
+    assert_success response
+    assert_equal @customer_profile_id, response.authorization
+    assert_equal 'Successful.', response.message
+    assert_equal "XXXX#{@credit_card.last_digits}", response.params['profile']['payment_profiles']['payment']['credit_card']['card_number'], "The card number should contain the last 4 digits of the card we passed in #{@credit_card.last_digits}"
+    assert_equal formatted_expiration_date(@credit_card), response.params['profile']['payment_profiles']['payment']['credit_card']['expiration_date']
+    assert_equal @credit_card.first_digits, response.params['profile']['payment_profiles']['payment']['credit_card']['issuer_number']
   end
 
   # NOTE - prior_auth_capture should be used to complete an auth_only request
@@ -179,7 +198,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal @customer_profile_id, response.authorization
     assert customer_payment_profile_id = response.params['customer_payment_profile_id']
     assert customer_payment_profile_id =~ /\d+/, "The customerPaymentProfileId should be numeric. It was #{customer_payment_profile_id}"
   end
@@ -218,7 +237,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal @customer_profile_id, response.authorization
     assert customer_payment_profile_id = response.params['customer_payment_profile_id']
     assert customer_payment_profile_id =~ /\d+/, "The customerPaymentProfileId should be numeric. It was #{customer_payment_profile_id}"
   end
@@ -238,7 +257,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal @customer_profile_id, response.authorization
     assert customer_address_id = response.params['customer_address_id']
     assert customer_address_id =~ /\d+/, "The customerAddressId should be numeric. It was #{customer_address_id}"
   end
@@ -263,14 +282,14 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal @customer_profile_id, response.authorization
     assert customer_payment_profile_id = response.params['customer_payment_profile_id']
     assert customer_payment_profile_id =~ /\d+/, "The customerPaymentProfileId should be numeric. It was #{customer_payment_profile_id}"
 
     assert response = @gateway.get_customer_profile(customer_profile_id: @customer_profile_id)
     assert_equal 2, response.params['profile']['payment_profiles'].size
-    assert_equal 'XXXX4242', response.params['profile']['payment_profiles'][0]['payment']['credit_card']['card_number']
-    assert_equal 'XXXX1234', response.params['profile']['payment_profiles'][1]['payment']['credit_card']['card_number']
+    assert_equal 'XXXX1234', response.params['profile']['payment_profiles'][0]['payment']['credit_card']['card_number']
+    assert_equal 'XXXX4242', response.params['profile']['payment_profiles'][1]['payment']['credit_card']['card_number']
   end
 
   def test_successful_delete_customer_payment_profile_request
@@ -344,16 +363,19 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.get_customer_payment_profile(
       customer_profile_id: @customer_profile_id,
       customer_payment_profile_id: customer_payment_profile_id,
-      unmask_expiration_date: true
+      unmask_expiration_date: true,
+      include_issuer_info: true
     )
 
     assert response.test?
     assert_success response
     assert_nil response.authorization
+
     assert response.params['payment_profile']['customer_payment_profile_id'] =~ /\d+/, 'The customer_payment_profile_id should be a number'
     assert_equal "XXXX#{@credit_card.last_digits}", response.params['payment_profile']['payment']['credit_card']['card_number'], "The card number should contain the last 4 digits of the card we passed in #{@credit_card.last_digits}"
     assert_equal @profile[:payment_profiles][:customer_type], response.params['payment_profile']['customer_type']
     assert_equal formatted_expiration_date(@credit_card), response.params['payment_profile']['payment']['credit_card']['expiration_date']
+    assert_equal @credit_card.first_digits, response.params['payment_profile']['payment']['credit_card']['issuer_number']
   end
 
   def test_successful_get_customer_shipping_address_request
@@ -799,7 +821,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     assert response.test?
     assert_success response
-    assert_nil response.authorization
+    assert_equal @customer_profile_id, response.authorization
     assert @customer_payment_profile_id = response.params['customer_payment_profile_id']
     assert @customer_payment_profile_id =~ /\d+/, "The customerPaymentProfileId should be numeric. It was #{@customer_payment_profile_id}"
     return response

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -369,13 +369,15 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.get_customer_payment_profile(
       customer_profile_id: @customer_profile_id,
       customer_payment_profile_id: @customer_payment_profile_id,
-      unmask_expiration_date: true
+      unmask_expiration_date: true,
+      include_issuer_info: true
     )
     assert_instance_of Response, response
     assert_success response
     assert_nil response.authorization
     assert_equal @customer_payment_profile_id, response.params['profile']['payment_profiles']['customer_payment_profile_id']
     assert_equal formatted_expiration_date(@credit_card), response.params['profile']['payment_profiles']['payment']['credit_card']['expiration_date']
+    assert_equal @credit_card.first_digits, response.params['profile']['payment_profiles']['payment']['credit_card']['issuer_number']
   end
 
   def test_should_get_customer_shipping_address_request
@@ -823,6 +825,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
               <creditCard>
                   <cardNumber>#{@credit_card.number}</cardNumber>
                   <expirationDate>#{@gateway.send(:expdate, @credit_card)}</expirationDate>
+                  <issuerNumber>#{@credit_card.first_digits}</issuerNumber>
               </creditCard>
             </payment>
           </paymentProfiles>
@@ -874,6 +877,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
               <creditCard>
                 <cardNumber>#{@credit_card.number}</cardNumber>
                 <expirationDate>#{@gateway.send(:expdate, @credit_card)}</expirationDate>
+                <issuerNumber>#{@credit_card.first_digits}</issuerNumber>
               </creditCard>
             </payment>
           </paymentProfiles>
@@ -884,6 +888,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
               <creditCard>
                 <cardNumber>XXXX1234</cardNumber>
                 <expirationDate>XXXX</expirationDate>
+                <issuerNumber>424242</issuerNumber>
               </creditCard>
             </payment>
           </paymentProfiles>
@@ -914,6 +919,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
               <creditCard>
                   <cardNumber>#{@credit_card.number}</cardNumber>
                   <expirationDate>#{@gateway.send(:expdate, @credit_card)}</expirationDate>
+                  <issuerNumber>#{@credit_card.first_digits}</issuerNumber>
               </creditCard>
             </payment>
           </paymentProfiles>


### PR DESCRIPTION
Currently the 'unmaskExpirationDate' option only exists when getting a
customer payment profile. If you get a customer profile, which in turn
includes connected customer payment profiles, this option is not
available.

That would mean in cases where you may be trying to get a default card,
or just a list of cards, you need to make 2..n calls in order to get the
expiration date.

Additionally, the Auth.net CIM api allows for getting the issuer info:

- The Issuer Identification Number (IIN)
- Also sometimes known as the Bank Identification Number (BIN)
- Not all issuers are banks

This adds the issuer info option as well to both the customer profile call
and the customer payment profile call.