### PR TITLE
CyberSource: Support multiple new fields

### DIFF
--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -204,10 +204,29 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
-  def test_successful_authorization_with_installment_total_count
-    assert response = @gateway.authorize(@amount, @credit_card, installment_total_count: 5)
+  def test_successful_authorization_with_installment_data
+    options = @options.merge(installment_total_count: 5, installment_plan_type: 1, first_installment_date: '300101')
+    assert response = @gateway.authorize(@amount, @credit_card, options)
     assert_successful_response(response)
     assert !response.authorization.blank?
+  end
+
+  def test_successful_authorization_with_merchant_tax_id
+    options = @options.merge(merchant_tax_id: '123')
+    assert response = @gateway.authorize(@amount, @credit_card, options)
+    assert_successful_response(response)
+  end
+
+  def test_successful_authorization_with_sales_slip_number
+    options = @options.merge(sales_slip_number: '456')
+    assert response = @gateway.authorize(@amount, @credit_card, options)
+    assert_successful_response(response)
+  end
+
+  def test_successful_authorization_with_airline_agent_code
+    options = @options.merge(airline_agent_code: '7Q')
+    assert response = @gateway.authorize(@amount, @credit_card, options)
+    assert_successful_response(response)
   end
 
   def test_unsuccessful_authorization
@@ -396,7 +415,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
   end
 
-  def test_successful_pinless_debit_card_puchase
+  def test_successful_pinless_debit_card_purchase
     assert response = @gateway.purchase(@amount, @pinless_debit_card, @options.merge(pinless_debit_card: true))
     assert_successful_response(response)
   end

--- a/test/schema/cyber_source/CyberSourceTransaction_1.181.xsd
+++ b/test/schema/cyber_source/CyberSourceTransaction_1.181.xsd
@@ -1,0 +1,5290 @@
+
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="urn:schemas-cybersource-com:transaction-data-1.181" targetNamespace="urn:schemas-cybersource-com:transaction-data-1.181" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xsd:simpleType name="amount">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="boolean">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="dateTime">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:complexType name="Item">
+        <xsd:sequence>
+            <xsd:element name="unitPrice" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="quantity" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="productCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productSKU" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productRisk" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="cityOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="cityOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countyOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countyOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="districtOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="districtOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="stateOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="stateOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countryOverrideAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countryOverrideRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptancePostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipFromPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="export" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="noExport" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="nationalTax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="vatRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="sellerRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration5" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration6" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration7" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration8" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration9" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="buyerRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middlemanRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pointOfTitleTransfer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="giftCategory" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="timeCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="hostHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="timeHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="velocityHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="nonsensicalHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="obscenitiesHedge" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="unitOfMeasure" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="totalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="discountAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="discountRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="commodityCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grossNetIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxTypeApplied" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="alternateTaxTypeApplied" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateTaxRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="alternateTaxType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="localTax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="zeroCostToCustomerIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerPhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerNationality" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productDescription" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxStatusIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountManagementIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="typeOfSupply" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="unitTaxAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="weightAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="weightID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="weightUnitMeasurement" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="otherTax_1_type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_1_amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_1_rate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_1_statusIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_2_type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_2_amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_2_rate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_2_statusIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_3_type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_3_amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_3_rate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_3_statusIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_4_type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_4_amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_4_rate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_4_statusIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_5_type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_5_amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_5_rate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_5_statusIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_6_type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_6_amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_6_rate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_6_statusIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_7_type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otherTax_7_amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_7_rate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="otherTax_7_statusIndicator" type="xsd:string" minOccurs="0"/>
+
+
+            <xsd:element name="referenceData_1_number" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceData_1_code" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="referenceData_2_number" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceData_2_code" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="referenceData_3_number" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceData_3_code" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="referenceData_4_number" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceData_4_code" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="referenceData_5_number" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceData_5_code" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="referenceData_6_number" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceData_6_code" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="referenceData_7_number" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceData_7_code" type="xsd:string" minOccurs="0"/>
+
+
+            <xsd:element name="shippingDestinationTypes" type="xsd:string" minOccurs="0"/>
+
+
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCAuthService">
+        <xsd:sequence>
+            <xsd:element name="cavv" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavvAlgorithm" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkTokenCryptogram" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paSpecificationVersion" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directoryServerTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="acsServerTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eciRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="xid" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsLevel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fxQuoteID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="returnAuthRecord" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="authType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verbalAuthCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billPayment" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="authenticationXID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationXID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="industryDatatype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="traceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checksumKey" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="splitTenderIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="veresEnrolled" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paresStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialAuthIndicator" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="captureDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstRecurringPayment" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="duration" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mobileRemotePaymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardholderVerificationMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dccRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentDetails" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardholderAuthenticationMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="leastCostRouting" type="tns:boolean" minOccurs="0"/>
+			<xsd:element name="verificationType" type="xsd:string" minOccurs="0" />
+			<xsd:element name="cryptocurrencyPurchase" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lowValueExemptionIndicator" type="xsd:string" minOccurs="0"/>
+        	<xsd:element name="riskAnalysisExemptionIndicator" type="xsd:string" minOccurs="0"/>
+        	<xsd:element name="trustedMerchantExemptionIndicator" type="xsd:string" minOccurs="0"/>
+        	<xsd:element name="secureCorporatePaymentIndicator" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="deferredAuthIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatedAuthIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="debtRecoveryIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="delegatedAuthenticationExemptionIndicator" type="xsd:string" minOccurs="0" />
+            <xsd:element name="transitTransactionType" type="xsd:string" minOccurs="0" />
+			<xsd:element name="transportationMode" type="xsd:string" minOccurs="0" />
+			<xsd:element name="totaloffersCount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="effectiveAuthenticationType" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paChallengeCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paresStatusReason" type="xsd:string" minOccurs="0" />
+            <xsd:element name="challengeCancelCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paNetworkScore" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paAuthenticationDate" type="xsd:string" minOccurs="0" />
+            <xsd:element name="authenticationOutageExemptionIndicator" type="xsd:string" minOccurs="0" />
+
+
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="OCTService">
+        <xsd:sequence>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkOrder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="VerificationService">
+        <xsd:sequence>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="CCSaleService">
+        <xsd:sequence>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialAuthIndicator" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="cavv" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="xid" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="industryDatatype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkTokenCryptogram" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paSpecificationVersion" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directoryServerTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cryptocurrencyPurchase" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lowValueExemptionIndicator" type="xsd:string" minOccurs="0"/>
+        	<xsd:element name="riskAnalysisExemptionIndicator" type="xsd:string" minOccurs="0"/>
+        	<xsd:element name="trustedMerchantExemptionIndicator" type="xsd:string" minOccurs="0"/>
+        	<xsd:element name="secureCorporatePaymentIndicator" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="deferredAuthIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="delegatedAuthenticationExemptionIndicator" type="xsd:string" minOccurs="0" />
+			<xsd:element name="transitTransactionType" type="xsd:string" minOccurs="0" />
+			<xsd:element name="transportationMode" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCSaleCreditService">
+        <xsd:sequence>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="refundReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="saleRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCSaleReversalService">
+        <xsd:sequence>
+            <xsd:element name="saleRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCIncrementalAuthService">
+        <xsd:sequence>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="duration" type="xsd:integer" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required" />
+    </xsd:complexType>
+    <xsd:complexType name="CCCaptureService">
+        <xsd:sequence>
+            <xsd:element name="authType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verbalAuthCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialPaymentID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchasingLevel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="industryDatatype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantReceiptNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="posData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checksumKey" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="gratuityAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="duration" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="dpdeBillingMonth" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="sequence" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalCount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationIDAlternate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorName" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCCreditService">
+        <xsd:sequence>
+            <xsd:element name="captureRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialPaymentID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchasingLevel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="industryDatatype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billPayment" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="authorizationXID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="occurrenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="captureRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantReceiptNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checksumKey" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="duration" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="dpdeBillingMonth" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="reconciliationIDAlternate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="refundReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentDetails" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCAuthReversalService">
+        <xsd:sequence>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reversalReason" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCAutoAuthReversalService">
+        <xsd:sequence>
+            <xsd:element name="authPaymentServiceData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billPayment" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="dateAdded" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCDCCService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ServiceFeeCalculateService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ECDebitService">
+        <xsd:sequence>
+            <xsd:element name="paymentMode" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="settlementMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verificationLevel" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="partialPaymentID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="debitRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="effectiveDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ECCreditService">
+        <xsd:sequence>
+            <xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="settlementMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="debitRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialPaymentID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="debitRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="effectiveDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ECAuthenticateService">
+        <xsd:sequence>
+            <xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayerAuthEnrollService">
+        <xsd:sequence>
+            <xsd:element name="httpAccept" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpUserAgent" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaseDescription" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaseTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="countryCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="acquirerBin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="loginID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="password" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mobilePhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="MCC" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="marketingOptIn" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="marketingSource" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="defaultCard" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="shipAddressUsageDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionCountDay" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionCountYear" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addCardAttempts" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountPurchases" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fraudActivity" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="paymentAccountDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateAuthenticationMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateAuthenticationDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateAuthenticationData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="challengeRequired" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="challengeCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="preorder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reorder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="preorderDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="giftCardAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="giftCardCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="giftCardCount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="messageCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="npaCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recurringOriginalPurchaseDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="returnURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionMode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recurringEndDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recurringFrequency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantNewCustomer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerCCAlias" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="installmentTotalCount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpUserAccept" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mobilePhoneDomestic" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pareqChannel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shoppingChannel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationChannel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantTTPCredential" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestorID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestorName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="acsWindowSize" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="decoupledAuthenticationIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="decoupledAuthenticationMaxTime" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="deviceChannel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="priorAuthenticationReferenceID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="priorAuthenticationData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="priorAuthenticationMethod" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="priorAuthenticationTime" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="requestorInitiatedAuthenticationIndicator" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="sdkMaxTimeout" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationIndicator" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="whiteListStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalOffersCount" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="merchantScore" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantFraudRate" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="acquirerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="secureCorporatePaymentIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="resendCount" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayerAuthValidateService">
+        <xsd:sequence>
+            <xsd:element name="signedPARes" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="authenticationTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="responseAccessToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="otpToken" type="xsd:string" minOccurs="0"/>
+
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayerAuthSetupService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="TaxService">
+        <xsd:sequence>
+            <xsd:element name="nexus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="noNexus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptanceState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderAcceptancePostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderOriginPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration5" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration6" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration7" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration8" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerRegistration9" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="buyerRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middlemanRegistration" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pointOfTitleTransfer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commitIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="refundIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateOverrideReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reportingDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- DME -->
+    <xsd:complexType name="DMEService">
+        <xsd:sequence>
+            <xsd:element name="eventType" type="xsd:string" minOccurs="0" />
+            <xsd:element name="eventPolicy" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required" />
+    </xsd:complexType>
+    <xsd:complexType name="AFSService">
+        <xsd:sequence>
+            <xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cvCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="disableAVSScoring" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customRiskModel" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DAVService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="ExportService">
+        <xsd:sequence>
+            <xsd:element name="addressOperator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressWeight" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyWeight" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="nameWeight" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sanctionsLists" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="FXRatesService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="BankTransferService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="BankTransferRefundService">
+        <xsd:sequence>
+            <xsd:element name="bankTransferRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransferRealTimeRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransferRealTimeReconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransferRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransferRealTimeRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="BankTransferRealTimeService">
+        <xsd:sequence>
+            <xsd:element name="bankTransferRealTimeType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitMandateService">
+        <xsd:sequence>
+            <xsd:element name="mandateDescriptor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstDebitDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitService">
+        <xsd:sequence>
+            <xsd:element name="dateCollect" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directDebitText" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directDebitType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="validateRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recurringType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="validateRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateAuthenticationDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitRefundService">
+        <xsd:sequence>
+            <xsd:element name="directDebitRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directDebitRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directDebitType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recurringType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateAuthenticationDate" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitValidateService">
+        <xsd:sequence>
+            <xsd:element name="directDebitValidateText" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="DeviceFingerprintData">
+        <xsd:sequence>
+            <xsd:element name="data" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="provider" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionCreateService">
+        <xsd:sequence>
+            <xsd:element name="paymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="disableAutoAuth" type="tns:boolean" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionUpdateService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionEventUpdateService">
+        <xsd:sequence>
+            <xsd:element name="action" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionRetrieveService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionDeleteService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalPaymentService">
+        <xsd:sequence>
+            <xsd:element name="cancelURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="successURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalCreditService">
+        <xsd:sequence>
+            <xsd:element name="payPalPaymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payPalPaymentRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalEcSet-->
+    <xsd:complexType name="PayPalEcSetService">
+        <xsd:sequence>
+            <xsd:element name="paypalReturn" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCancelReturn" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalMaxamt" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReqconfirmshipping" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalNoshipping" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAddressOverride" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalLc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPagestyle" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalHdrimg" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalHdrbordercolor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalHdrbackcolor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPayflowcolor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promoCode0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestBillingAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementCustom" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalLogoimg" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalEcGetDetails-->
+    <xsd:complexType name="PayPalEcGetDetailsService">
+        <xsd:sequence>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalEcDoPayment-->
+    <xsd:complexType name="PayPalEcDoPaymentService">
+        <xsd:sequence>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPayerId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promoCode0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalDoCapture-->
+    <xsd:complexType name="PayPalDoCaptureService">
+        <xsd:sequence>
+            <xsd:element name="paypalAuthorizationId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="completeType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcDoPaymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcDoPaymentRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAuthorizationRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAuthorizationRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalAuthReversal-->
+    <xsd:complexType name="PayPalAuthReversalService">
+        <xsd:sequence>
+            <xsd:element name="paypalAuthorizationId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcDoPaymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcDoPaymentRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAuthorizationRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAuthorizationRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcOrderSetupRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcOrderSetupRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalRefund-->
+    <xsd:complexType name="PayPalRefundService">
+        <xsd:sequence>
+            <xsd:element name="paypalDoCaptureRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDoCaptureRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCaptureId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalNote" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalEcOrderSetup-->
+    <xsd:complexType name="PayPalEcOrderSetupService">
+        <xsd:sequence>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPayerId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promoCode0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalAuthorization-->
+    <xsd:complexType name="PayPalAuthorizationService">
+        <xsd:sequence>
+            <xsd:element name="paypalOrderId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcOrderSetupRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcOrderSetupRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDoRefTransactionRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDoRefTransactionRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalUpdateAgreement-->
+    <xsd:complexType name="PayPalUpdateAgreementService">
+        <xsd:sequence>
+            <xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementCustom" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalCreateAgreement-->
+    <xsd:complexType name="PayPalCreateAgreementService">
+        <xsd:sequence>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcSetRequestToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--PayPalDoRefTransaction-->
+    <xsd:complexType name="PayPalDoRefTransactionService">
+        <xsd:sequence>
+            <xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReqconfirmshipping" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReturnFmfDetails" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalSoftDescriptor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalShippingdiscount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalEcNotifyUrl" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="VoidService">
+        <xsd:sequence>
+            <xsd:element name="voidRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="voidRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="voidReason" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PinlessDebitService">
+        <xsd:sequence>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PinlessDebitValidateService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PinlessDebitReversalService">
+        <xsd:sequence>
+            <xsd:element name="pinlessDebitRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pinlessDebitRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <!--PinDebitPurchaseService-->
+    <xsd:complexType name="PinDebitPurchaseService">
+        <xsd:sequence>
+            <xsd:element name="networkOrder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="partialAuthIndicator" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ebtCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ebtVoucherSerialNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--End of PinDebitPurchaseService-->
+    <!--PinDebitCreditService-->
+    <xsd:complexType name="PinDebitCreditService">
+        <xsd:sequence>
+            <xsd:element name="networkOrder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ebtCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--End of PinDebitCreditService-->
+    <!--PinDebitReversalService-->
+    <xsd:complexType name="PinDebitReversalService">
+        <xsd:sequence>
+            <xsd:element name="pinDebitRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--End of PinDebitReversalService-->
+
+    <!--PayPal upgrade services -->
+    <xsd:complexType name="PayPalButtonCreateService">
+        <xsd:sequence>
+            <xsd:element name="buttonType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalPreapprovedPaymentService">
+        <xsd:sequence>
+            <xsd:element name="mpID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalPreapprovedUpdateService">
+        <xsd:sequence>
+            <xsd:element name="mpID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- China Payment -->
+    <xsd:complexType name="ChinaPaymentService">
+        <xsd:sequence>
+            <xsd:element name="paymentMode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="returnURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pickUpAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pickUpPhoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pickUpPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pickUpName" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- China Refund -->
+    <xsd:complexType name="ChinaRefundService">
+        <xsd:sequence>
+            <xsd:element name="chinaPaymentRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="chinaPaymentRequestToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="refundReason" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--Boleto Payment -->
+    <xsd:complexType name="BoletoPaymentService">
+        <xsd:sequence>
+            <xsd:element name="instruction" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expirationDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="PersonalID">
+        <xsd:sequence>
+            <xsd:element name="number" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="address" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="issuedBy" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Routing">
+        <xsd:sequence>
+            <xsd:element name="networkType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkLabel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="signatureCVMRequired" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Address">
+        <xsd:sequence>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="APInitiateService">
+        <xsd:sequence>
+            <xsd:element name="returnURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productDescription" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="countryCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="escrowAgreement" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="languageInterface" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="intent" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="successURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cancelURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="failureURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="APCheckStatusService">
+        <xsd:sequence>
+            <xsd:element name="apInitiateRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkStatusRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sessionsRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="RiskUpdateService">
+        <xsd:sequence>
+            <xsd:element name="actionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recordID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recordName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="negativeAddress" type="tns:Address" minOccurs="0"/>
+            <xsd:element name="markingReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingNotes" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceFingerprintSmartID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceFingerprintTrueIPAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceFingerprintProxyIPAddress" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="FraudUpdateService">
+        <xsd:sequence>
+            <xsd:element name="actionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markedData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingNotes" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingTransactionDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="markingCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="markingIndicator" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CaseManagementActionService">
+        <xsd:sequence>
+            <xsd:element name="actionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="comments" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="EncryptPaymentDataService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="InvoiceHeader">
+        <xsd:sequence>
+            <xsd:element name="merchantDescriptor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorContact" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorAlternate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorStreet" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="isGift" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="returnsAccepted" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="tenderType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantVATRegistrationNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaserOrderDate" type="xsd:string" minOccurs="0"/>
+            <!-- xsd:date -->
+            <xsd:element name="purchaserVATRegistrationNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="vatInvoiceReferenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="summaryCommodityCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="supplierOrderReference" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="userPO" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="costCenter" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaserCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxable" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="amexDataTAA1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amexDataTAA2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amexDataTAA3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amexDataTAA4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalTaxTypeCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardAcceptorRefNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizedContactName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessApplicationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="salesOrganizationID" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="submerchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantStreet" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantTelephoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantRegion" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="submerchantMerchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceDataCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceDataNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorStoreID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="clerkID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customData_1" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BusinessRules">
+        <xsd:sequence>
+            <xsd:element name="ignoreAVSResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ignoreCVResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ignoreDAVResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ignoreExportResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ignoreValidateResult" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="declineAVSFlags" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="scoreThreshold" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BillTo">
+        <xsd:sequence>
+            <xsd:element name="title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="buildingNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street5" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="district" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="county" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="company" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="email" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerUserName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerPassword" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipNetworkAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="hostname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="domainName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateOfBirth" type="xsd:string" minOccurs="0"/>
+            <!-- xsd:date -->
+            <xsd:element name="driversLicenseNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="driversLicenseState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ssn" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserCookiesAccepted" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="nif" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="personalID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="language" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="gender" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantTaxID" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="passportNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passportCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerAccountCreateDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerAccountChangeDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerAccountPasswordChangeDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pointOfReference" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="defaultIndicator" type="tns:boolean" minOccurs="0"/>
+
+            <xsd:element name="companyStreet1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyStreet2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="prefix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyPhoneNumber" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="httpBrowserColorDepth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserJavaEnabled" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="httpBrowserJavaScriptEnabled" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="httpBrowserLanguage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserScreenHeight" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserScreenWidth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="httpBrowserTimeDifference" type="xsd:string" minOccurs="0"/>
+
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ShipTo">
+        <xsd:sequence>
+            <xsd:element name="title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street5" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="county" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="buildingNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="district" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="company" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="email" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shippingMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="id" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressVerificationStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="notApplicable" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="immutable" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="destinationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pointOfReference" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="default" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="destinationTypes" type="xsd:string" minOccurs="0"/>
+
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ShipFrom">
+        <xsd:sequence>
+            <xsd:element name="title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="county" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="company" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="email" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Card">
+        <xsd:sequence>
+            <xsd:element name="fullName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expirationMonth" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="expirationYear" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="cvIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cvNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="issueNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="startMonth" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="startYear" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="pin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountEncoderID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="encryptedData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="virtual" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="prefix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardTypeName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardSubType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="level2Eligible" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="level3Eligible" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billingCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billingCurrencyNumericCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billingCurrencyMinorDigits" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="usage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="prepaidReloadable" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="prepaidType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="brands" type="tns:Brands" minOccurs="0" maxOccurs="5"/>
+            <xsd:element name="fastFundsBusinessFundedTransferDomestic" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fastFundsBusinessFundedTransferCrossBorder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fastFundsConsumerFundedTransferDomestic" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fastFundsConsumerFundedTransferCrossBorder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="octBusinessFundedTransferDomestic" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="octBusinessFundedTransferCrossBorder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="octConsumerFundedTransferDomestic" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="octConsumerFundedTransferCrossBorder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="octGamblingDomestic" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="octGamblingCrossBorder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fastFundsGamblingDomestic" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fastFundsGamblingCrossBorder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="octGeoRestrictionIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="comboCardType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="prepaidIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passPhrase" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="personalData" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Check">
+        <xsd:sequence>
+            <xsd:element name="fullName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankTransitNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="secCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountEncoderID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="imageReferenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="terminalCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="terminalState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerPresent" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkTransactionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="disableAccountValidation" type="tns:boolean" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BML">
+        <xsd:sequence>
+            <xsd:element name="customerBillingAddressChange" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerEmailChange" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerHasCheckingAccount" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerHasSavingsAccount" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerPasswordChange" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerPhoneChange" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="customerRegistrationDate" type="xsd:string" minOccurs="0"/>
+            <!-- xsd:date -->
+            <xsd:element name="customerTypeFlag" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grossHouseholdIncome" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="householdIncomeCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="itemCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantPromotionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="preapprovalNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productDeliveryTypeIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="residenceStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="tcVersion" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="yearsAtCurrentResidence" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="yearsWithCurrentEmployer" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="employerStreet1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerStreet2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerCompanyName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerPhoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerPhoneType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="employerPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToPhoneType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToPhoneType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="methodOfPayment" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerAuthenticatedByMerchant" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="backOfficeIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToEqualsBillToNameIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToEqualsBillToAddressIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateIPAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessLegalName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dbaName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessAddress1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessAddress2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessMainPhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="userID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminPhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminFax" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminEmailAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="adminTitle" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="supervisorLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="supervisorFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="supervisorEmailAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessDAndBNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessNAICSCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessYearsInBusiness" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessNumberOfEmployees" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessPONumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessLoanType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessApplicationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessProductCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgSSN" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgDateOfBirth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgAnnualIncome" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgIncomeCurrencyType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgResidenceStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgCheckingAccountIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgSavingsAccountIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgYearsAtEmployer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgYearsAtResidence" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeAddress1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeAddress2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomePostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomeCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgEmailAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgHomePhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pgTitle" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="OtherTax">
+        <xsd:sequence>
+            <xsd:element name="vatTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="vatTaxRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="vatTaxAmountSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="alternateTaxIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="alternateTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="localTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="localTaxIndicator" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="nationalTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="nationalTaxIndicator" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Aft">
+        <xsd:sequence>
+            <xsd:element name="indicator" type="xsd:string" minOccurs="0" />
+            <xsd:element name="serviceFee" type="xsd:string" minOccurs="0" />
+            <xsd:element name="foreignExchangeFee" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Wallet">
+        <xsd:sequence>
+            <xsd:element name="type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantReferenceID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="userPhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avv" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eciRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticatonMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardEnrollmentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paresStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="veresEnrolled" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="xid" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalPurchaseAmount" type="xsd:string" minOccurs="0" />
+	 		<xsd:element name="subtotalAmount" type="xsd:string" minOccurs="0" />
+	 		<xsd:element name="discountAmount" type="xsd:string" minOccurs="0" />
+	 		<xsd:element name="giftWrapAmount" type="xsd:string" minOccurs="0" />
+			<xsd:element name="eventType" type="xsd:string" minOccurs="0" />
+		    <xsd:element name="promotionCode" type="xsd:string" minOccurs="0" />
+			<xsd:element name="enrollmentID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="staySignedInIndicator" type="xsd:string" minOccurs="0" />
+            <xsd:element name="authenticationData" type="xsd:string" minOccurs="0" />
+            <xsd:element name="deviceID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="httpResponse" type="xsd:string" minOccurs="0" />
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="errorDescription" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pinURL" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+
+    <xsd:complexType name="PurchaseTotals">
+        <xsd:sequence>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="discountAmountSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountManagementIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dutyAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dutyAmountSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grandTotalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="freightAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="freightAmountSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="foreignAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="foreignCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="originalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="originalCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="exchangeRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="exchangeRateTimeStamp" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="exchangeRateType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount0" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmountType4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="serviceFeeAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="subtotalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="shippingAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="handlingAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="shippingHandlingAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="shippingDiscountAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="giftWrapAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="insuranceAmount" type="tns:amount" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="FundingTotals">
+        <xsd:sequence>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grandTotalAmount" type="tns:amount" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="GECC">
+        <xsd:sequence>
+            <xsd:element name="saleType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="planNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sequenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promotionEndDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promotionPlan" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="line" type="xsd:string" minOccurs="0" maxOccurs="7"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="UCAF">
+        <xsd:sequence>
+            <xsd:element name="authenticationData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="collectionIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="downgradeReasonCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Network">
+        <xsd:all>
+            <xsd:element name="octDomesticIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="octCrossBorderIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aftDomesticIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aftCrossBorderIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkOrder" type="xsd:string" minOccurs="0"/>
+        </xsd:all>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="Brands">
+        <xsd:all>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="type" type="xsd:string" minOccurs="0"/>
+        </xsd:all>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="FundTransfer">
+        <xsd:sequence>
+            <xsd:element name="accountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankCheckDigit" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BankInfo">
+        <xsd:sequence>
+            <xsd:element name="bankCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="address" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="branchCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="swiftCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sortCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="issuerID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="RecurringSubscriptionInfo">
+        <xsd:sequence>
+            <xsd:element name="subscriptionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="numberOfPayments" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="numberOfPaymentsToAdd" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="sequenceNumber" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="automaticRenew" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="frequency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="startDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="endDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="approvalRequired" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="event" type="tns:PaySubscriptionEvent" minOccurs="0"/>
+            <xsd:element name="billPayment" type="tns:boolean" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionEvent">
+        <xsd:sequence>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="approvedBy" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="number" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Subscription">
+        <xsd:sequence>
+            <xsd:element name="title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentMethod" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="TokenSource">
+        <xsd:sequence>
+            <xsd:element name="transientToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkTokenOption" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PaymentNetworkToken">
+        <xsd:sequence>
+            <xsd:element name="requestorID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="assuranceLevel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="originalCardCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceTechType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DecisionManager">
+        <xsd:sequence>
+            <xsd:element name="enabled" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="profile" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pausedRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authentication" type="tns:Authentication" minOccurs="0"/>
+            <xsd:element name="travelData" type="tns:DecisionManagerTravelData" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Authentication">
+        <xsd:sequence>
+            <xsd:element name="outOfScope" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="exemption" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DecisionManagerTravelData">
+        <xsd:sequence>
+            <xsd:element name="leg" type="tns:DecisionManagerTravelLeg" minOccurs="0" maxOccurs="100"/>
+            <xsd:element name="departureDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="completeRoute" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="journeyType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="actualFinalDestination" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DecisionManagerTravelLeg">
+        <xsd:sequence>
+            <xsd:element name="origin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="destination" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="departureDateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+    <xsd:complexType name="Batch">
+        <xsd:sequence>
+            <xsd:element name="batchID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recordID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PayPal">
+        <xsd:sequence>
+            <xsd:any processContents="skip" minOccurs="0" maxOccurs="999"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="JPO">
+        <xsd:sequence>
+            <xsd:element name="paymentMethod" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="bonusAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="bonuses" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="installments" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="firstBillingMonth" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="jccaTerminalID" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="issuerMessage" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="jis2TrackData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessNameAlphanumeric" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessNameJapanese" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="businessNameKatakana" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Token">
+        <xsd:sequence>
+            <xsd:element name="prefix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expirationMonth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expirationYear" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- Vme Reseller Service-->
+    <xsd:complexType name="AP">
+        <xsd:sequence>
+            <xsd:element name="orderID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pspBarcodeID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerRepresentativeID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="productDescription" type="xsd:string" minOccurs="0" />
+            <xsd:element name="settlementCurrency" type="xsd:string" minOccurs="0" />
+            <xsd:element name="subtotalAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="shippingAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="handlingAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="shippingHandlingAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="additionalAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="taxAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="giftWrapAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="discountAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="purchaseID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="productID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="device" type="tns:APDevice" minOccurs="0" />
+            <xsd:element name="apiKey" type="xsd:string" minOccurs="0" />
+            <xsd:element name="insuranceAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billingAgreementIndicator" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="billingAgreementID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="billingAgreementDescription" type="xsd:string" minOccurs="0" />
+            <xsd:element name="payerID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="fundingSource" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shippingAddressImmutable" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APDevice">
+        <xsd:sequence>
+            <xsd:element name="id" type="xsd:string" minOccurs="0" />
+            <xsd:element name="type" type="xsd:string" minOccurs="0" />
+            <xsd:element name="userAgent" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!--  apAuthService -->
+    <xsd:complexType name="APAuthService">
+        <xsd:sequence>
+            <xsd:element name="cancelURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="successURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="failureURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="preapprovalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of apAuthService -->
+
+    <!-- Start of AP Import Mandate Service -->
+
+
+    <xsd:complexType name="APImportMandateService">
+        <xsd:sequence>
+            <xsd:element name="dateSigned" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <!-- End of of AP Import Mandate Service -->
+
+    <!--  apAuthReversalService -->
+    <xsd:complexType name="APAuthReversalService">
+        <xsd:sequence>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of apAuthReversalService -->
+    <!--  apCaptureService -->
+    <xsd:complexType name="APCaptureService">
+        <xsd:sequence>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="isFinal" type="tns:boolean" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of apCaptureService -->
+    <!--  apOptionsService -->
+    <xsd:complexType name="APOptionsService">
+        <xsd:sequence>
+            <xsd:element name="limit" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="offset" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of apOptionsService -->
+    <!--  apRefundService -->
+    <xsd:complexType name="APRefundService">
+        <xsd:sequence>
+            <xsd:element name="captureRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="refundRequestID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="reason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instant" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="note" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="apInitiateRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="returnRef" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="saleRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of apRefundService -->
+    <!--  apSaleService -->
+    <xsd:complexType name="APSaleService">
+        <xsd:sequence>
+            <xsd:element name="cancelURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="successURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="failureURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentOptionID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="transactionTimeout" type="xsd:string" minOccurs="0" />
+            <xsd:element name="orderRequestID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="billingAgreementID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="mandateID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="dateCollect" type="xsd:string" minOccurs="0" />
+            <xsd:element name="preapprovalToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of apAuthService -->
+
+    <xsd:complexType name="APCheckOutDetailsService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of apCheckoutDetailsService -->
+    <xsd:complexType name="APTransactionDetailsService">
+        <xsd:sequence>
+            <xsd:element name="transactionDetailsRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!--  APConfirmPurchaseService -->
+    <xsd:complexType name="APConfirmPurchaseService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of APConfirmPurchaseService -->
+    <xsd:complexType name="APSessionsService">
+        <xsd:sequence>
+            <xsd:element name="cancelURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="successURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="failureURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overridePaymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentOptionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sessionsType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sessionsRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- APUIStyle -->
+    <xsd:complexType name="APUI">
+        <xsd:sequence>
+            <xsd:element name="colorBorder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="colorBorderSelected" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="colorButton" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="colorButtonText" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="colorCheckbox" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="colorCheckboxCheckMark" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="colorHeader" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="colorLink" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="colorText" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="borderRadius" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="theme" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- End of APUIStyle -->
+    <!--PayPalGetTxnDetails-->
+    <xsd:complexType name="PayPalGetTxnDetailsService">
+        <xsd:sequence>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of PayPalGetTxnDetails -->
+    <!--PayPalTransactionSearch-->
+    <xsd:complexType name="PayPalTransactionSearchService">
+        <xsd:sequence>
+            <xsd:element name="startDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="endDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalCustomerEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReceiptId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grandTotalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerSalutation" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerFirstname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerMiddlename" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerLastname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerSuffix" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- End of PayPalTransactionSearch -->
+    <!-- Credit card recipient data -->
+    <xsd:complexType name="Recipient">
+        <xsd:sequence>
+            <xsd:element name="dateOfBirth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billingAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="billingCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billingConversionRate" type="tns:amount" minOccurs="0"/>
+
+            <xsd:element name="firstName"  type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleName"  type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleInitial"  type="xsd:string" minOccurs="0"/>
+            <xsd:element name="address"  type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city"  type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state"  type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country"  type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber"  type="xsd:string" minOccurs="0"/>
+
+
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- End of Credit card recipient data -->
+    <xsd:complexType name="Sender">
+        <xsd:sequence>
+            <xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sourceOfFunds" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="address" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateOfBirth" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="middleInitial" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CCCheckStatusService">
+        <xsd:sequence>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="RequestMessage">
+        <xsd:sequence>
+            <xsd:element name="merchantID" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="merchantReferenceCode" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="debtIndicator" type="tns:boolean"
+                         minOccurs="0" />
+            <xsd:element name="clientLibrary" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="clientLibraryVersion" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="clientEnvironment" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="clientSecurityLibraryVersion"
+                         type="xsd:string" minOccurs="0" />
+            <xsd:element name="clientApplication" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="clientApplicationVersion"
+                         type="xsd:string" minOccurs="0" />
+            <xsd:element name="clientApplicationUser" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="routingCode" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="comments" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="returnURL" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="invoiceHeader" type="tns:InvoiceHeader"
+                         minOccurs="0" />
+            <xsd:element name="paymentScheme" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aggregatorMerchantIdentifier" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billTo" type="tns:BillTo" minOccurs="0" />
+            <xsd:element name="shipTo" type="tns:ShipTo" minOccurs="0" />
+            <xsd:element name="personalID" type="tns:PersonalID" minOccurs="0" />
+            <xsd:element name="shipFrom" type="tns:ShipFrom"
+                         minOccurs="0" />
+            <xsd:element name="item" type="tns:Item" minOccurs="0"
+                         maxOccurs="1000" />
+            <xsd:element name="purchaseTotals" type="tns:PurchaseTotals"
+                         minOccurs="0" />
+            <xsd:element name="fundingTotals" type="tns:FundingTotals"
+                         minOccurs="0" />
+            <xsd:element name="dcc" type="tns:DCC" minOccurs="0" />
+            <xsd:element name="pos" type="tns:Pos" minOccurs="0" />
+            <xsd:element name="pin" type="tns:Pin" minOccurs="0" />
+            <xsd:element name="encryptedPayment" type="tns:EncryptedPayment" minOccurs="0" />
+            <xsd:element name="installment" type="tns:Installment"
+                         minOccurs="0" />
+            <xsd:element name="card" type="tns:Card" minOccurs="0" />
+            <xsd:element name="category" type="tns:Category" minOccurs="0" />
+            <xsd:element name="check" type="tns:Check" minOccurs="0" />
+            <xsd:element name="bml" type="tns:BML" minOccurs="0" />
+            <xsd:element name="gecc" type="tns:GECC" minOccurs="0" />
+            <xsd:element name="ucaf" type="tns:UCAF" minOccurs="0" />
+            <xsd:element name="fundTransfer" type="tns:FundTransfer"
+                         minOccurs="0" />
+            <xsd:element name="bankInfo" type="tns:BankInfo"
+                         minOccurs="0" />
+            <xsd:element name="subscription" type="tns:Subscription"
+                         minOccurs="0" />
+            <xsd:element name="recurringSubscriptionInfo"
+                         type="tns:RecurringSubscriptionInfo" minOccurs="0" />
+            <xsd:element name="tokenSource"
+                         type="tns:TokenSource" minOccurs="0" />
+            <xsd:element name="decisionManager"
+                         type="tns:DecisionManager" minOccurs="0" />
+            <xsd:element name="otherTax" type="tns:OtherTax"
+                         minOccurs="0" />
+            <xsd:element name="paypal" type="tns:PayPal" minOccurs="0" />
+            <xsd:element name="merchantDefinedData"
+                         type="tns:MerchantDefinedData" minOccurs="0" />
+            <xsd:element name="auxiliaryData"
+                         type="tns:AuxiliaryData" minOccurs="0" />
+            <xsd:element name="merchantSecureData"
+                         type="tns:MerchantSecureData" minOccurs="0" />
+            <xsd:element name="jpo" type="tns:JPO" minOccurs="0" />
+            <xsd:element name="orderRequestToken" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="linkToRequest" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="serviceFee" type="tns:ServiceFee" minOccurs="0" />
+            <xsd:element name="giftCard" type="tns:GiftCard" minOccurs="0" />
+            <xsd:element name="ccAuthService" type="tns:CCAuthService"
+                         minOccurs="0" />
+            <xsd:element name="octService" type="tns:OCTService"
+                         minOccurs="0" />
+            <xsd:element name="ecAVSService" type="tns:ECAVSService"
+                         minOccurs="0" />
+
+            <xsd:element name="giftCardActivationService" type="tns:GiftCardActivationService"
+                         minOccurs="0" />
+            <xsd:element name="giftCardBalanceInquiryService" type="tns:GiftCardBalanceInquiryService"
+                         minOccurs="0" />
+            <xsd:element name="giftCardRedemptionService" type="tns:GiftCardRedemptionService"
+                         minOccurs="0" />
+            <xsd:element name="giftCardVoidService" type="tns:GiftCardVoidService"
+                         minOccurs="0" />
+            <xsd:element name="giftCardReversalService" type="tns:GiftCardReversalService"
+                         minOccurs="0" />
+            <xsd:element name="giftCardReloadService" type="tns:GiftCardReloadService"
+                         minOccurs="0" />
+            <xsd:element name="giftCardRefundService" type="tns:GiftCardRefundService"
+                         minOccurs="0" />
+
+            <xsd:element name="verificationService" type="tns:VerificationService" minOccurs="0" />
+            <xsd:element name="ccSaleService" type="tns:CCSaleService" minOccurs="0" />
+
+            <xsd:element name="ccSaleCreditService" type="tns:CCSaleCreditService" minOccurs="0" />
+
+            <xsd:element name="ccSaleReversalService" type="tns:CCSaleReversalService" minOccurs="0" />
+            <xsd:element name="ccIncrementalAuthService" type="tns:CCIncrementalAuthService" minOccurs="0" />
+            <xsd:element name="ccCaptureService"
+                         type="tns:CCCaptureService" minOccurs="0" />
+            <xsd:element name="ccCreditService"
+                         type="tns:CCCreditService" minOccurs="0" />
+            <xsd:element name="ccAuthReversalService"
+                         type="tns:CCAuthReversalService" minOccurs="0" />
+            <xsd:element name="ccAutoAuthReversalService"
+                         type="tns:CCAutoAuthReversalService" minOccurs="0" />
+            <xsd:element name="ccDCCService" type="tns:CCDCCService"
+                         minOccurs="0" />
+            <xsd:element name="serviceFeeCalculateService" type="tns:ServiceFeeCalculateService"
+                         minOccurs="0" />
+            <xsd:element name="ecDebitService" type="tns:ECDebitService"
+                         minOccurs="0" />
+            <xsd:element name="ecCreditService"
+                         type="tns:ECCreditService" minOccurs="0" />
+            <xsd:element name="ecAuthenticateService"
+                         type="tns:ECAuthenticateService" minOccurs="0" />
+            <xsd:element name="payerAuthSetupService"
+                         type="tns:PayerAuthSetupService" minOccurs="0" />
+            <xsd:element name="payerAuthEnrollService"
+                         type="tns:PayerAuthEnrollService" minOccurs="0" />
+            <xsd:element name="payerAuthValidateService"
+                         type="tns:PayerAuthValidateService" minOccurs="0" />
+            <xsd:element name="taxService" type="tns:TaxService"
+                         minOccurs="0" />
+            <xsd:element name="dmeService" type="tns:DMEService"
+                         minOccurs="0" />
+            <xsd:element name="afsService" type="tns:AFSService"
+                         minOccurs="0" />
+            <xsd:element name="davService" type="tns:DAVService"
+                         minOccurs="0" />
+            <xsd:element name="exportService" type="tns:ExportService"
+                         minOccurs="0" />
+            <xsd:element name="fxRatesService" type="tns:FXRatesService"
+                         minOccurs="0" />
+            <xsd:element name="bankTransferService"
+                         type="tns:BankTransferService" minOccurs="0" />
+            <xsd:element name="bankTransferRefundService"
+                         type="tns:BankTransferRefundService" minOccurs="0" />
+            <xsd:element name="bankTransferRealTimeService"
+                         type="tns:BankTransferRealTimeService" minOccurs="0" />
+            <xsd:element name="directDebitMandateService"
+                         type="tns:DirectDebitMandateService" minOccurs="0" />
+            <xsd:element name="directDebitService"
+                         type="tns:DirectDebitService" minOccurs="0" />
+            <xsd:element name="directDebitRefundService"
+                         type="tns:DirectDebitRefundService" minOccurs="0" />
+            <xsd:element name="directDebitValidateService"
+                         type="tns:DirectDebitValidateService" minOccurs="0" />
+            <xsd:element name="deviceFingerprintData"
+                         type="tns:DeviceFingerprintData" minOccurs="0"  maxOccurs="10" />
+            <xsd:element name="paySubscriptionCreateService"
+                         type="tns:PaySubscriptionCreateService" minOccurs="0" />
+            <xsd:element name="paySubscriptionUpdateService"
+                         type="tns:PaySubscriptionUpdateService" minOccurs="0" />
+            <xsd:element name="paySubscriptionEventUpdateService"
+                         type="tns:PaySubscriptionEventUpdateService" minOccurs="0" />
+            <xsd:element name="paySubscriptionRetrieveService"
+                         type="tns:PaySubscriptionRetrieveService" minOccurs="0" />
+            <xsd:element name="paySubscriptionDeleteService"
+                         type="tns:PaySubscriptionDeleteService" minOccurs="0" />
+            <xsd:element name="payPalPaymentService"
+                         type="tns:PayPalPaymentService" minOccurs="0" />
+            <xsd:element name="payPalCreditService"
+                         type="tns:PayPalCreditService" minOccurs="0" />
+            <xsd:element name="voidService" type="tns:VoidService"
+                         minOccurs="0" />
+            <xsd:element name="businessRules" type="tns:BusinessRules"
+                         minOccurs="0" />
+            <xsd:element name="pinlessDebitService"
+                         type="tns:PinlessDebitService" minOccurs="0" />
+            <xsd:element name="pinlessDebitValidateService"
+                         type="tns:PinlessDebitValidateService" minOccurs="0" />
+            <xsd:element name="pinlessDebitReversalService"
+                         type="tns:PinlessDebitReversalService" minOccurs="0" />
+            <xsd:element name="batch" type="tns:Batch" minOccurs="0" />
+            <xsd:element name="airlineData" type="tns:AirlineData"
+                         minOccurs="0" />
+            <xsd:element name="ancillaryData" type="tns:AncillaryData"
+                         minOccurs="0" />
+            <xsd:element name="lodgingData" type="tns:LodgingData" minOccurs="0" />
+            <xsd:element name="payPalButtonCreateService"
+                         type="tns:PayPalButtonCreateService" minOccurs="0" />
+            <xsd:element name="payPalPreapprovedPaymentService"
+                         type="tns:PayPalPreapprovedPaymentService" minOccurs="0" />
+            <xsd:element name="payPalPreapprovedUpdateService"
+                         type="tns:PayPalPreapprovedUpdateService" minOccurs="0" />
+            <xsd:element name="riskUpdateService"
+                         type="tns:RiskUpdateService" minOccurs="0" />
+            <xsd:element name="fraudUpdateService"
+                         type="tns:FraudUpdateService" minOccurs="0" />
+            <xsd:element name="caseManagementActionService"
+                         type="tns:CaseManagementActionService" minOccurs="0" />
+            <xsd:element name="reserved" type="tns:RequestReserved"
+                         minOccurs="0" maxOccurs="999" />
+            <xsd:element name="deviceFingerprintID" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="deviceFingerprintRaw" type="tns:boolean"
+                         minOccurs="0" />
+            <xsd:element name="deviceFingerprintHash" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="payPalRefundService"
+                         type="tns:PayPalRefundService" minOccurs="0" />
+            <xsd:element name="payPalAuthReversalService"
+                         type="tns:PayPalAuthReversalService" minOccurs="0" />
+            <xsd:element name="payPalDoCaptureService"
+                         type="tns:PayPalDoCaptureService" minOccurs="0" />
+            <xsd:element name="payPalEcDoPaymentService"
+                         type="tns:PayPalEcDoPaymentService" minOccurs="0" />
+            <xsd:element name="payPalEcGetDetailsService"
+                         type="tns:PayPalEcGetDetailsService" minOccurs="0" />
+            <xsd:element name="payPalEcSetService"
+                         type="tns:PayPalEcSetService" minOccurs="0" />
+            <xsd:element name="payPalEcOrderSetupService"
+                         type="tns:PayPalEcOrderSetupService" minOccurs="0" />
+            <xsd:element name="payPalAuthorizationService"
+                         type="tns:PayPalAuthorizationService" minOccurs="0" />
+            <xsd:element name="payPalUpdateAgreementService"
+                         type="tns:PayPalUpdateAgreementService" minOccurs="0" />
+            <xsd:element name="payPalCreateAgreementService"
+                         type="tns:PayPalCreateAgreementService" minOccurs="0" />
+            <xsd:element name="payPalDoRefTransactionService"
+                         type="tns:PayPalDoRefTransactionService" minOccurs="0" />
+            <xsd:element name="chinaPaymentService"
+                         type="tns:ChinaPaymentService" minOccurs="0" />
+            <xsd:element name="chinaRefundService"
+                         type="tns:ChinaRefundService" minOccurs="0" />
+            <xsd:element name="boletoPaymentService"
+                         type="tns:BoletoPaymentService" minOccurs="0" />
+            <xsd:element name="apPaymentType" type="xsd:string"
+                         minOccurs="0"/>
+            <xsd:element name="apInitiateService"
+                         type="tns:APInitiateService" minOccurs="0" />
+            <xsd:element name="apCheckStatusService"
+                         type="tns:APCheckStatusService" minOccurs="0" />
+            <xsd:element name="ignoreCardExpiration" type="tns:boolean"
+                         minOccurs="0" />
+            <xsd:element name="reportGroup" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="processorID" type="xsd:string"
+                         minOccurs="0" />
+            <xsd:element name="thirdPartyCertificationNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionLocalDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="solutionProviderTransactionID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="surchargeAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="surchargeSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pinDataEncryptedPIN" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pinDataKeySerialNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pinDataPinBlockEncodingFormat" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="cashbackAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="pinDebitPurchaseService" type="tns:PinDebitPurchaseService" minOccurs="0"/>
+            <xsd:element name="pinDebitCreditService" type="tns:PinDebitCreditService" minOccurs="0"/>
+            <xsd:element name="pinDebitReversalService" type="tns:PinDebitReversalService" minOccurs="0"/>
+            <xsd:element name="ap" type="tns:AP" minOccurs="0" />
+            <xsd:element name="apAuthService" type="tns:APAuthService" minOccurs="0" />
+            <xsd:element name="apAuthReversalService" type="tns:APAuthReversalService" minOccurs="0" />
+            <xsd:element name="apCaptureService" type="tns:APCaptureService" minOccurs="0" />
+            <xsd:element name="apOptionsService" type="tns:APOptionsService" minOccurs="0" />
+            <xsd:element name="apRefundService" type="tns:APRefundService" minOccurs="0" />
+            <xsd:element name="apSaleService" type="tns:APSaleService" minOccurs="0" />
+            <xsd:element name="apCheckoutDetailsService" type="tns:APCheckOutDetailsService" minOccurs="0" />
+            <xsd:element name="apSessionsService" type="tns:APSessionsService" minOccurs="0" />
+            <xsd:element name="apUI" type="tns:APUI" minOccurs="0" />
+            <xsd:element name="apTransactionDetailsService" type="tns:APTransactionDetailsService" minOccurs="0" />
+            <xsd:element name="apConfirmPurchaseService" type="tns:APConfirmPurchaseService" minOccurs="0" />
+            <xsd:element name="payPalGetTxnDetailsService" type="tns:PayPalGetTxnDetailsService" minOccurs="0" />
+            <xsd:element name="payPalTransactionSearchService" type="tns:PayPalTransactionSearchService" minOccurs="0" />
+            <xsd:element name="ccDCCUpdateService" type="tns:CCDCCUpdateService" minOccurs="0"/>
+            <xsd:element name="emvRequest" type="tns:EmvRequest" minOccurs="0" />
+            <xsd:element name="merchant" type="tns:merchant" minOccurs="0"/>
+            <xsd:element name="merchantTransactionIdentifier" type="xsd:string" minOccurs="0" />
+            <xsd:element name="hostedDataCreateService" type="tns:HostedDataCreateService" minOccurs="0"/>
+            <xsd:element name="hostedDataRetrieveService" type="tns:HostedDataRetrieveService" minOccurs="0"/>
+            <xsd:element name="merchantDomainName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="merchantCategoryCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="merchantCategoryCodeDomestic" type="xsd:string" minOccurs="0" />
+            <xsd:element name="salesSlipNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="merchandiseCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="merchandiseDescription" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paymentInitiationChannel" type="xsd:string" minOccurs="0" />
+            <xsd:element name="extendedCreditTotalCount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="authIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentNetworkToken" type="tns:PaymentNetworkToken" minOccurs="0"/>
+            <xsd:element name="recipient" type="tns:Recipient" minOccurs="0"/>
+            <xsd:element name="sender" type="tns:Sender" minOccurs="0"/>
+            <xsd:element name="autoRentalData" type="tns:AutoRentalData" minOccurs="0" />
+            <xsd:element name="paymentSolution" type="xsd:string" minOccurs="0" />
+            <xsd:element name="vc" type="tns:VC" minOccurs="0" />
+            <xsd:element name="decryptVisaCheckoutDataService" type="tns:DecryptVisaCheckoutDataService" minOccurs="0" />
+            <xsd:element name="taxManagementIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promotionGroup" type="tns:PromotionGroup" minOccurs="0" maxOccurs="100"/>
+            <xsd:element name="wallet" type="tns:Wallet" minOccurs="0" />
+            <xsd:element name="aft" type="tns:Aft" minOccurs="0" />
+            <xsd:element name="balanceInquiry" type="tns:boolean" minOccurs="0" />
+            <xsd:element name="prenoteTransaction" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="encryptPaymentDataService" type="tns:EncryptPaymentDataService" minOccurs="0"/>
+            <xsd:element name="nationalNetDomesticData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subsequentAuth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subsequentAuthOriginalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="binLookupService" type="tns:BinLookupService" minOccurs="0" />
+            <xsd:element name="verificationCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="mobileNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="issuer" type="tns:issuer" minOccurs="0" />
+            <xsd:element name="partnerSolutionID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="developerID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="getVisaCheckoutDataService" type="tns:GETVisaCheckoutDataService" minOccurs="0" />
+            <xsd:element name="customerSignatureImage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionMetadataService" type="tns:TransactionMetadataService" minOccurs="0" />
+            <xsd:element name="subsequentAuthFirst" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subsequentAuthReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subsequentAuthTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subsequentAuthStoredCredential" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="loan" type="tns:Loan" minOccurs="0" />
+            <xsd:element name="eligibilityInquiry" type="xsd:string" minOccurs="0" />
+            <xsd:element name="redemptionInquiry" type="xsd:string" minOccurs="0" />
+            <xsd:element name="feeProgramIndicator" type="xsd:string" minOccurs="0" />
+            <xsd:element name="apOrderService" type="tns:APOrderService" minOccurs="0" />
+            <xsd:element name="apCancelService" type="tns:APCancelService" minOccurs="0" />
+            <xsd:element name="apBillingAgreementService" type="tns:APBillingAgreementService" minOccurs="0" />
+            <xsd:element name="note_toPayee" type="xsd:string" minOccurs="0" />
+            <xsd:element name="note_toPayer" type="xsd:string" minOccurs="0" />
+            <xsd:element name="clientMetadataID" type="xsd:string" minOccurs="0" />
+
+            <xsd:element name="partnerSDKversion" type="xsd:string" minOccurs="0" />
+            <xsd:element name="partnerOriginalTransactionID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardTypeSelectionIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="apCreateMandateService" type="tns:APCreateMandateService" minOccurs="0" />
+            <xsd:element name="apMandateStatusService" type="tns:APMandateStatusService" minOccurs="0" />
+            <xsd:element name="apUpdateMandateService" type="tns:APUpdateMandateService" minOccurs="0" />
+            <xsd:element name="apImportMandateService" type="tns:APImportMandateService" minOccurs="0" />
+            <xsd:element name="apRevokeMandateService" type="tns:APRevokeMandateService" minOccurs="0" />
+            <xsd:element name="billPaymentType" type="xsd:string" minOccurs="0" />
+            <xsd:element name="postdatedTransaction" type="tns:PostdatedTransaction" minOccurs="0" />
+            <xsd:element name="getMasterpassDataService" type="tns:GetMasterpassDataService" minOccurs="0" />
+            <xsd:element name="ccCheckStatusService" type="tns:CCCheckStatusService"
+                         minOccurs="0" />
+            <xsd:element name="mPOS" type="tns:mPOS" minOccurs="0" />
+            <xsd:element name="abortService" type="tns:AbortService" minOccurs="0" />
+            <xsd:element name="ignoreRelaxAVS" type="tns:boolean" minOccurs="0" />
+            <xsd:element name="agencyInformation" type="tns:AgencyInformation" minOccurs="0" />
+            <xsd:element name="autoRental" type="tns:AutoRental" minOccurs="0" />
+            <xsd:element name="healthCare" type="tns:HealthCare" minOccurs="0" maxOccurs="10"/>
+            <xsd:element name="payByPoints" type="tns:payByPoints" minOccurs="0"/>
+        </xsd:sequence>
+
+    </xsd:complexType>
+
+    <!-- added for Visa Checkout -->
+    <xsd:complexType name="VC">
+        <xsd:sequence>
+            <xsd:element name="orderID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DecryptVisaCheckoutDataService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="DCC">
+        <xsd:sequence>
+            <xsd:element name="dccIndicator" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="referenceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Promotion">
+        <xsd:sequence>
+            <xsd:element name="discountedAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="code" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="receiptData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountApplied" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="description" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="PromotionGroup">
+        <xsd:sequence>
+            <xsd:element name="subtotalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="taxRate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="prohibitDiscount" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="PromotionGroupReply">
+        <xsd:sequence>
+            <xsd:element name="discountApplied" type="tns:amount" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="BalanceInfo">
+        <xsd:sequence>
+            <xsd:element name="accountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sign" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCAuthReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cvCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cvCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="personalIDCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizedDateTime" type="tns:dateTime" minOccurs="0"/>
+            <!-- dateTime -->
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bmlAccountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authFactorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fundingTotals" type="tns:FundingTotals" minOccurs="0"/>
+            <xsd:element name="fxQuoteID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fxQuoteRate" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="fxQuoteType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fxQuoteExpirationDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="authRecord" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantAdviceCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantAdviceCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavvResponseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavvResponseCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationXID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationXID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorCardType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountBalance" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="forwardCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="enhancedDataEnabled" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referralResponseNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subResponseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="approvedAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="creditLine" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="approvedTerms" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="requestCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountBalanceCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountBalanceSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="affluenceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evPhoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evStreet" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evEmailRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evPhoneNumberRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evPostalCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evNameRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evStreetRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardGroup" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="posData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardIssuerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardRegulated" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardCommercial" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardPrepaid" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardPayroll" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardHealthcare" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardSignatureDebit" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardPINlessDebit" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardLevel3Eligible" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerReasonCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerReasonDescription" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerPassThroughData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerCVNResponseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerAVSResponseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerAcquirerBankCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentCardService" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentCardServiceResult" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionQualification" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionIntegrity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="emsTransactionRiskScore" type="xsd:string" minOccurs="0" />
+            <xsd:element name="reconciliationReferenceNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardReferenceData" type="xsd:string" minOccurs="0" />
+			<xsd:element name="partialPANandIBAN" type="xsd:string" minOccurs="0" />
+			<xsd:element name="issuerPINrequest" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="OCTReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="approvalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="prepaidBalanceCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="prepaidBalanceAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponseSource" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationIdType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="VerificationReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer" />
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0" />
+            <xsd:element name="verifiedDateTime" type="xsd:string" minOccurs="0" />
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCSaleReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cvCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cvCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavvResponseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavvResponseCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardGroup" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardCategory" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountBalance" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="authorizedDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="requestAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountBalanceCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountBalanceSign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardReferenceData" type="xsd:string" minOccurs="0" />
+			<xsd:element name="partialPANandIBAN" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCSaleCreditReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizedDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCSaleReversalReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCIncrementalAuthReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0" />
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0" />
+            <xsd:element name="authorizedDateTime" type="tns:dateTime" minOccurs="0" />
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardCategory" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="CCCaptureReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fundingTotals" type="tns:FundingTotals" minOccurs="0"/>
+            <xsd:element name="fxQuoteID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fxQuoteRate" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="fxQuoteType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fxQuoteExpirationDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="purchasingLevel3Enabled" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="enhancedDataEnabled" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationReferenceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ServiceFeeCalculateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer" />
+            <xsd:element name="amount" type="tns:amount" minOccurs="0" />
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CCCreditReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchasingLevel3Enabled" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="enhancedDataEnabled" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationXID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="forwardCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationReferenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentNetworkTransactionID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PinDebitPurchaseReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="requestCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="accountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountBalance" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountBalanceCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountBalanceSign" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PinDebitCreditReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PinDebitReversalReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CCAuthReversalReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="forwardCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentCardService" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentCardServiceResult" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CCAutoAuthReversalReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="result" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ECAVSReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="validationType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="primaryStatusCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="secondaryStatusCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalStatusCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="numberOfReturns" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastReturnDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastReturnProcessorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastUpdateDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addedOrClosedDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="previousStatusCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fcraDisputeCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="scoredAccountProcessorResponse1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="scoredAccountProcessorResponse2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="scoredAccountProcessorResponse3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="scoredAccountProcessorResponse5" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerDataConditionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToFullName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToPrefix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToMiddleName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToSuffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToCompany" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToPhoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToCompanyPhoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToCompanyTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToSSN" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchBillToDateOfBirth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchPersonalIDType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchPersonalID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchPersonalIDIssuedBy" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overallMatchScore" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="calculatedResponse" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ECDebitReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="settlementMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="verificationLevel" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verificationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verificationCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correctedAccountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correctedRoutingNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ECCreditReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="settlementMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verificationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verificationCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correctedAccountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correctedRoutingNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ECAuthenticateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkpointSummary" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fraudShieldIndicators" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PayerAuthSetupReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="referenceID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceDataCollectionURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accessToken" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PayerAuthEnrollReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="acsURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accessToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationResult" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationStatusMessage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavv" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavvAlgorithm" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eci" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eciRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paReq" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="proxyPAN" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="xid" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="proofXML" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ucafAuthenticationData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ucafCollectionIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paresStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="veresEnrolled" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationPath" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="specificationVersion" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directoryServerTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="challengeRequired" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="threeDSServerTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="acsRenderingType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="acsTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationType" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="cardholderMessage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directoryServerErrorCode" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="directoryServerErrorDescription" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ivrEnabledMessage" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ivrEncryptionKey" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ivrEncryptionMandatory" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="ivrEncryptionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ivrLabel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ivrPrompt" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ivrStatusMessage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sdkTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="stepUpUrl" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="whiteListStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="whiteListStatusSource" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="effectiveAuthenticationType" type="xsd:string"  minOccurs="0"/>
+            <xsd:element name="authenticationStatusReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="networkScore" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationPayload" type="xsd:base64Binary" minOccurs="0"/>
+            <xsd:element name="challengeCancelCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="decoupledAuthenticationIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardBin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardTypeName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="resendCountRemaining" type="xsd:string" minOccurs="0"/>
+
+
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PayerAuthValidateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authenticationResult" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationStatusMessage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavv" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cavvAlgorithm" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eci" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eciRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="xid" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ucafAuthenticationData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ucafCollectionIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paresStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="specificationVersion" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directoryServerTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="threeDSServerTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="acsRenderingType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="acsTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authenticationType" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="directoryServerErrorCode" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="directoryServerErrorDescription" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="interactionCounter" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="sdkTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="whiteListStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="whiteListStatusSource" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="effectiveAuthenticationType" type="xsd:string"  minOccurs="0"/>
+            <xsd:element name="authenticationStatusReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="challengeCancelCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationPayload" type="xsd:base64Binary" minOccurs="0"/>
+            <xsd:element name="cardBin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardTypeName" type="xsd:string" minOccurs="0"/>
+
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="TaxReplyItem">
+        <xsd:sequence>
+            <xsd:element name="taxableAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="exemptAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="specialTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="cityTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countyTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="districtTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="stateTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="countryTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="totalTaxAmount" type="tns:amount"/>
+            <xsd:element name="jurisdiction" type="tns:TaxReplyItemJurisdiction" minOccurs="0" maxOccurs="1000"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="TaxReplyItemJurisdiction">
+        <xsd:sequence>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="region" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="code" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxable" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="rate" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="taxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string"/>
+            <xsd:element name="taxName" type="xsd:string"/>
+        </xsd:sequence>
+        <xsd:attribute name="jurisId" type="xsd:integer" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="TaxReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grandTotalAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="totalTaxableAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="totalExemptAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="totalSpecialTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="totalCityTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalCountyTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="county" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalDistrictTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="totalStateTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalCountryTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="totalTaxAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="commitIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="refundIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="geocode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="item" type="tns:TaxReplyItem" minOccurs="0" maxOccurs="1000"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DeviceFingerprint">
+        <xsd:sequence>
+            <xsd:element name="cookiesEnabled" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="flashEnabled" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="hash" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="imagesEnabled" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="javascriptEnabled" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="proxyIPAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="proxyIPAddressActivities" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="proxyIPAddressAttributes" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="proxyServerType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="trueIPAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="trueIPAddressActivities" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="trueIPAddressAttributes" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="trueIPAddressCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="trueIPAddressState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="trueIPAddressCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="smartID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="smartIDConfidenceLevel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="screenResolution" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="browserLanguage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="agentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="profileDuration" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="profiledURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="timeOnPage" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="deviceMatch" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstEncounter" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="flashOS" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="flashVersion" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceLatitude" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceLongitude" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="gpsAccuracy" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="jbRoot" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="jbRootReason" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="AFSReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="afsResult" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="hostSeverity" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="consumerLocalTime" type="xsd:string" minOccurs="0"/>
+            <!-- xsd:time -->
+            <xsd:element name="afsFactorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="hotlistInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="internetInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suspiciousInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceBehaviorInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="velocityInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="identityInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipRoutingMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipAnonymizerStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipCarrier" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ipOrganization" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="scoreModelUsed" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardBin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="binCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardAccountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardScheme" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardIssuer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceFingerprint" type="tns:DeviceFingerprint" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DAVReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="addressType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="apartmentInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="barCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="barCodeCheckDigit" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="careOf" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cityInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="countryInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="directionalInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lvrInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="matchScore" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="standardizedAddress1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedAddress2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedAddress3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedAddress4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedAddressNoApt" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedCounty" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedCSP" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="standardizedISOCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="stateInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="streetInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="suffixInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCodeInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="overallInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="usInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="caInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="intlInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="usErrorInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="caErrorInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="intlErrorInfo" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DeniedPartiesMatch">
+        <xsd:sequence>
+            <xsd:element name="list" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0" maxOccurs="100"/>
+            <xsd:element name="address" type="xsd:string" minOccurs="0" maxOccurs="100"/>
+            <xsd:element name="program" type="xsd:string" minOccurs="0" maxOccurs="100"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ExportReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="ipCountryConfidence" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="infoCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="FXQuote">
+        <xsd:sequence>
+            <xsd:element name="id" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="rate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="type" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expirationDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fundingCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="receivedDateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="FXRatesReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="quote" type="tns:FXQuote" minOccurs="0" maxOccurs="999"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BankTransferReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="accountHolder" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="accountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="bankName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentReference" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankSwiftCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankSpecialID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="branchCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationReferenceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BankTransferRealTimeReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="formMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="formAction" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentReference" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="reconciliationReferenceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitMandateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="mandateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateMaturationDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BankTransferRefundReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationReferenceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateAuthenticationDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mandateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationReferenceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitValidateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bankSwiftCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DirectDebitRefundReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="iban" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationReferenceNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionCreateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="subscriptionID" type="xsd:string"/>
+            <xsd:element name="instrumentIdentifierID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierNew" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierSuccessorID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionUpdateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="subscriptionID" type="xsd:string"/>
+            <xsd:element name="subscriptionIDNew" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierNew" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierSuccessorID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionEventUpdateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionRetrieveReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="approvalRequired" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="automaticRenew" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardAccountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardExpirationMonth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardExpirationYear" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardIssueNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardStartMonth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardStartYear" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkAccountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkAccountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkBankTransitNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkSecCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkAuthenticateID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="comments" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerAccountID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="email" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="endDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="frequency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantReferenceCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentsRemaining" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="recurringAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="setupAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="startDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subscriptionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subscriptionIDNew" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalPayments" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToStreet1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToStreet2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToCompany" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billPayment" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDefinedDataField1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDefinedDataField2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDefinedDataField3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDefinedDataField4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantSecureDataField1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantSecureDataField2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantSecureDataField3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantSecureDataField4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="companyTaxID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="driversLicenseNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="driversLicenseState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateOfBirth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="instrumentIdentifierSuccessorID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subsequentAuthTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="latestCardSuffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="latestCardExpirationMonth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="latestCardExpirationYear" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PaySubscriptionDeleteReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="subscriptionID" type="xsd:string"/>
+            <xsd:element name="instrumentIdentifierID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalPaymentReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="secureData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalCreditReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="VoidReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reversalSubmitted" type="tns:boolean" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PinlessDebitReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <!-- dateTime -->
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="receiptNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ownerMerchantID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PinlessDebitValidateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <!-- dateTime -->
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PinlessDebitReversalReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- payPal Upgrade Services -->
+    <xsd:complexType name="PayPalButtonCreateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="encryptedFormData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="unencryptedFormData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="buttonType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalPreapprovedPaymentReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="feeAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pendingReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mpStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="desc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mpMax" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentGrossAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="settleAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="exchangeRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentSourceID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PayPalPreapprovedUpdateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mpStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="desc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mpMax" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentSourceID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- PayPalEcSet -->
+    <xsd:complexType name="PayPalEcSetReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalEcSet -->
+    <!-- PayPalEcGetDetails -->
+    <xsd:complexType name="PayPalEcGetDetailsReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerSalutation" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerFirstname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerMiddlename" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerLastname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerSuffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToAddress1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToAddress2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToZip" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerPhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="street2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="city" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="state" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="postalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="countryCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="countryName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementAcceptedStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="item" type="tns:Item" minOccurs="0" maxOccurs="1000" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalEcGetDetails -->
+    <!-- PayPalEcDoPayment -->
+    <xsd:complexType name="PayPalEcDoPaymentReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTransactiontype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReasonCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalEcDoPayment -->
+    <!-- PayPalDoCapture -->
+    <xsd:complexType name="PayPalDoCaptureReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authorizationId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="parentTransactionId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReceiptId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTransactiontype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentGrossAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalDoCapture -->
+    <!-- PayPalAuthReversal -->
+    <xsd:complexType name="PayPalAuthReversalReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authorizationId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalAuthReversal -->
+    <!-- PayPalRefund -->
+    <xsd:complexType name="PayPalRefundReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalNetRefundAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalFeeRefundAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalGrossRefundAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalRefund -->
+    <!-- PayPalEcOrderSetup -->
+    <xsd:complexType name="PayPalEcOrderSetupReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="paypalToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTransactiontype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReasonCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalEcOrderSetup -->
+    <!-- PayPalAuthorization-->
+    <xsd:complexType name="PayPalAuthorizationReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="protectionEligibility" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="protectionEligibilityType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalAuthorization -->
+    <!-- PayPalUpdateAgreement-->
+    <xsd:complexType name="PayPalUpdateAgreementReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementDesc" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementCustom" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalBillingAgreementStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerSalutation" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerFirstname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerMiddlename" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerLastname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerSuffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalUpdateAgreement-->
+    <!-- PayPalCreateAgreement-->
+    <xsd:complexType name="PayPalCreateAgreementReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalCreateAgreement-->
+    <!-- PayPalDoRefTransaction-->
+    <xsd:complexType name="PayPalDoRefTransactionReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="paypalBillingAgreementId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTransactionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReasonCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="correlationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- end of PayPalDoRefTransaction-->
+    <xsd:complexType name="RiskUpdateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="FraudUpdateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CaseManagementActionReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="RuleResultItem">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="decision" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evaluation" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ruleID" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="RuleResultItems">
+        <xsd:sequence>
+            <xsd:element name="ruleResultItem" type="tns:RuleResultItem" minOccurs="0" maxOccurs="1000"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DecisionReply">
+        <xsd:sequence>
+            <xsd:element name="casePriority" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="activeProfileReply" type="tns:ProfileReply" minOccurs="0"/>
+            <xsd:element name="velocityInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalFields" type="tns:AdditionalFields" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="morphingElement" type="tns:MorphingElement" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="providerFields" type="tns:ProviderFields" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="travel" type="tns:Travel" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="unavailableInfoCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ProviderFields">
+        <xsd:sequence>
+            <xsd:element name="provider" type="tns:Provider" minOccurs="0" maxOccurs="30"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Provider">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="field" type="tns:ProviderField"  minOccurs="0" maxOccurs="500"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ProviderField">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- DME -->
+    <xsd:complexType name="AdditionalFields">
+        <xsd:sequence>
+            <xsd:element name="field" type="tns:Field" minOccurs="0" maxOccurs="3000"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Field">
+        <xsd:sequence>
+            <xsd:element name="provider" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="MorphingElement">
+        <xsd:sequence>
+            <xsd:element name="element" type="tns:Element" minOccurs="0" maxOccurs="1000"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Element">
+        <xsd:sequence>
+            <xsd:element name="infoCode" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="fieldName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="count" type="xsd:integer" minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Travel">
+        <xsd:sequence>
+        	<xsd:element name="actualFinalDestinationCountry" type="tns:RestrictedString" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="actualFinalDestinationCity" type="tns:RestrictedString" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="actualFinalDestinationLatitude" type="tns:RestrictedDecimal" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="actualFinalDestinationLongitude" type="tns:RestrictedDecimal" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="firstDepartureCountry" type="tns:RestrictedString" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="firstDepartureCity" type="tns:RestrictedString" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="firstDepartureLatitude" type="tns:RestrictedDecimal" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="firstDepartureLongitude" type="tns:RestrictedDecimal" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="firstDestinationCountry" type="tns:RestrictedString" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="firstDestinationCity" type="tns:RestrictedString" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="firstDestinationLatitude" type="tns:RestrictedDecimal" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="firstDestinationLongitude" type="tns:RestrictedDecimal" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="lastDestinationCountry" type="tns:RestrictedString" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="lastDestinationCity" type="tns:RestrictedString" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="lastDestinationLatitude" type="tns:RestrictedDecimal" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="lastDestinationLongitude" type="tns:RestrictedDecimal" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:simpleType name="RestrictedString">
+    	<xsd:restriction base="xsd:string">
+       		<xsd:maxLength value="90"/>
+     	</xsd:restriction>
+   	</xsd:simpleType>
+    <xsd:simpleType name="RestrictedDecimal"> 
+    	<xsd:restriction base="xsd:decimal"> 
+      		<xsd:totalDigits value="9"/> 
+      		<xsd:fractionDigits value="6"/> 
+    	</xsd:restriction> 
+  	</xsd:simpleType>
+    <xsd:complexType name="DMEReply">
+        <xsd:sequence>
+            <xsd:element name="eventType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eventInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eventDeviceBehaviorInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eventHotlistInfo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eventPolicy" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="eventVelocityInfoCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalFields" type="tns:AdditionalFields" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="morphingElement" type="tns:MorphingElement" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="cardBin" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="binCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardAccountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardScheme" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardIssuer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerFields" type="tns:ProviderFields" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ProfileReply">
+        <xsd:sequence>
+            <xsd:element name="selectedBy" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="destinationQueue" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="profileScore" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="rulesTriggered" type="tns:RuleResultItems" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CCDCCReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="dccSupported" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="validHours" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="marginRatePercentage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="paymentCurrencyOffer" type="tns:paymentCurrencyOffer" minOccurs="0" maxOccurs="150"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="paymentCurrencyOffer">
+        <xsd:sequence>
+			<xsd:element name="amount" type="tns:amount" minOccurs="0" />
+            <xsd:element name="currency" type="xsd:string" minOccurs="0" />
+            <xsd:element name="exchangeRate" type="xsd:string" minOccurs="0" />
+            <xsd:element name="marginRatePercentage" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+		<xsd:attribute name="id" type="xsd:integer" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="CCDCCUpdateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ChinaPaymentReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="formData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verifyFailure" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verifyInProcess" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="verifySuccess" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ChinaRefundReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BoletoPaymentReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="boletoNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expirationDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="url" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="barCodeNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="assignor" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="APInitiateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="merchantURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="signature" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="publicKey" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="APCheckStatusReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTradeNo" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ibanSuffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- Vme Reseller Reply-->
+
+    <xsd:complexType name="SellerProtection">
+        <xsd:sequence>
+            <xsd:element name="eligibility" type="xsd:string" minOccurs="0" />
+            <xsd:element name="type" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APReply">
+        <xsd:sequence>
+            <xsd:element name="orderID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardGroup" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardNumberSuffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardExpirationMonth" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardExpirationYear" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaseID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="productDescription" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shippingAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="handlingAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shippingHandlingAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subtotalAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalPurchaseAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="giftWrapAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardNumberPrefix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="riskIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantUUID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantSiteID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionExpirationDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="sellerProtection" type="tns:SellerProtection" minOccurs="0" />
+            <xsd:element name="processorFraudDecision" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorFraudDecisionReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="billingAgreementID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fundingSource" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- AP Auth Service -->
+    <xsd:complexType name="APAuthReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- End of AP Auth Service -->
+    <!-- AP Auth Reversal Service -->
+    <xsd:complexType name="APAuthReversalReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- End of AP Auth Reversal Service -->
+    <!-- AP Capture Service -->
+    <xsd:complexType name="APCaptureReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionFee" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- End of AP Capture Service -->
+    <!-- AP Options Service -->
+    <xsd:complexType name="APOptionsReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="offset" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="count" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalCount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="option" type="tns:APOptionsOption" minOccurs="0" maxOccurs="250"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APOptionsOption">
+        <xsd:sequence>
+            <xsd:element name="id" type="xsd:string" minOccurs="0" />
+            <xsd:element name="name" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="data" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+
+    <!-- End of Options Service -->
+    <!-- AP Refund Service -->
+    <xsd:complexType name="APRefundReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="returnRef" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- End of AP Refund Service -->
+    <!-- AP Sale Service -->
+    <xsd:complexType name="APSaleReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionFee" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="exchangeRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="foreignCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="foreignAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- End of AP Sale Service -->
+
+    <!-- AP CheckOutDetailsReply Service -->
+    <xsd:complexType name="APCheckOutDetailsReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- End of AP CheckOutDetailsReply Service -->
+    <xsd:complexType name="APTransactionDetailsReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- AP ConfirmPurchase Service -->
+    <xsd:complexType name="APConfirmPurchaseReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="providerResponse" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- End of AP ConfirmPurchase Service -->
+    <xsd:complexType name="APSessionsReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorToken" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CCCheckStatusReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ReplyMessage">
+        <xsd:sequence>
+            <xsd:element name="merchantReferenceCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestID" type="xsd:string"/>
+            <xsd:element name="decision" type="xsd:string"/>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="missingField" type="xsd:string" minOccurs="0" maxOccurs="1000"/>
+            <xsd:element name="invalidField" type="xsd:string" minOccurs="0" maxOccurs="1000"/>
+            <xsd:element name="requestToken" type="xsd:string"/>
+            <xsd:element name="purchaseTotals" type="tns:PurchaseTotals" minOccurs="0"/>
+            <xsd:element name="deniedPartiesMatch" type="tns:DeniedPartiesMatch" minOccurs="0" maxOccurs="100"/>
+            <xsd:element name="ccAuthReply" type="tns:CCAuthReply" minOccurs="0"/>
+            <xsd:element name="octReply" type="tns:OCTReply" minOccurs="0"/>
+            <xsd:element name="verificationReply" type="tns:VerificationReply" minOccurs="0"/>
+            <xsd:element name="ccSaleReply" type="tns:CCSaleReply" minOccurs="0"/>
+            <xsd:element name="ccSaleCreditReply" type="tns:CCSaleCreditReply" minOccurs="0"/>
+            <xsd:element name="ccSaleReversalReply" type="tns:CCSaleReversalReply" minOccurs="0"/>
+            <xsd:element name="ccIncrementalAuthReply" type="tns:CCIncrementalAuthReply" minOccurs="0"/>
+            <xsd:element name="serviceFeeCalculateReply" type="tns:ServiceFeeCalculateReply" minOccurs="0"/>
+            <xsd:element name="ccCaptureReply" type="tns:CCCaptureReply" minOccurs="0"/>
+            <xsd:element name="ccCreditReply" type="tns:CCCreditReply" minOccurs="0"/>
+            <xsd:element name="ccAuthReversalReply" type="tns:CCAuthReversalReply" minOccurs="0"/>
+            <xsd:element name="ccAutoAuthReversalReply" type="tns:CCAutoAuthReversalReply" minOccurs="0"/>
+            <xsd:element name="ccDCCReply" type="tns:CCDCCReply" minOccurs="0"/>
+            <xsd:element name="ccDCCUpdateReply" type="tns:CCDCCUpdateReply" minOccurs="0"/>
+            <xsd:element name="ecDebitReply" type="tns:ECDebitReply" minOccurs="0"/>
+            <xsd:element name="ecCreditReply" type="tns:ECCreditReply" minOccurs="0"/>
+            <xsd:element name="ecAuthenticateReply" type="tns:ECAuthenticateReply" minOccurs="0"/>
+            <xsd:element name="payerAuthSetupReply" type="tns:PayerAuthSetupReply" minOccurs="0"/>
+            <xsd:element name="payerAuthEnrollReply" type="tns:PayerAuthEnrollReply" minOccurs="0"/>
+            <xsd:element name="payerAuthValidateReply" type="tns:PayerAuthValidateReply" minOccurs="0"/>
+            <xsd:element name="taxReply" type="tns:TaxReply" minOccurs="0"/>
+            <xsd:element name="encryptedPayment" type="tns:EncryptedPayment" minOccurs="0" />
+            <xsd:element name="encryptPaymentDataReply" type="tns:EncryptPaymentDataReply" minOccurs="0"/>
+            <xsd:element name="dmeReply" type="tns:DMEReply" minOccurs="0"/>
+            <xsd:element name="afsReply" type="tns:AFSReply" minOccurs="0"/>
+            <xsd:element name="davReply" type="tns:DAVReply" minOccurs="0"/>
+            <xsd:element name="exportReply" type="tns:ExportReply" minOccurs="0"/>
+            <xsd:element name="fxRatesReply" type="tns:FXRatesReply" minOccurs="0"/>
+            <xsd:element name="bankTransferReply" type="tns:BankTransferReply" minOccurs="0"/>
+            <xsd:element name="bankTransferRefundReply" type="tns:BankTransferRefundReply" minOccurs="0"/>
+            <xsd:element name="bankTransferRealTimeReply" type="tns:BankTransferRealTimeReply" minOccurs="0"/>
+            <xsd:element name="directDebitMandateReply" type="tns:DirectDebitMandateReply" minOccurs="0"/>
+            <xsd:element name="directDebitReply" type="tns:DirectDebitReply" minOccurs="0"/>
+            <xsd:element name="directDebitValidateReply" type="tns:DirectDebitValidateReply" minOccurs="0"/>
+            <xsd:element name="directDebitRefundReply" type="tns:DirectDebitRefundReply" minOccurs="0"/>
+            <xsd:element name="paySubscriptionCreateReply" type="tns:PaySubscriptionCreateReply" minOccurs="0"/>
+            <xsd:element name="paySubscriptionUpdateReply" type="tns:PaySubscriptionUpdateReply" minOccurs="0"/>
+            <xsd:element name="paySubscriptionEventUpdateReply" type="tns:PaySubscriptionEventUpdateReply" minOccurs="0"/>
+            <xsd:element name="paySubscriptionRetrieveReply" type="tns:PaySubscriptionRetrieveReply" minOccurs="0"/>
+            <xsd:element name="paySubscriptionDeleteReply" type="tns:PaySubscriptionDeleteReply" minOccurs="0"/>
+            <xsd:element name="payPalPaymentReply" type="tns:PayPalPaymentReply" minOccurs="0"/>
+            <xsd:element name="payPalCreditReply" type="tns:PayPalCreditReply" minOccurs="0"/>
+            <xsd:element name="voidReply" type="tns:VoidReply" minOccurs="0"/>
+            <xsd:element name="pinlessDebitReply" type="tns:PinlessDebitReply" minOccurs="0"/>
+            <xsd:element name="pinlessDebitValidateReply" type="tns:PinlessDebitValidateReply" minOccurs="0"/>
+            <xsd:element name="pinlessDebitReversalReply" type="tns:PinlessDebitReversalReply" minOccurs="0"/>
+            <xsd:element name="payPalButtonCreateReply" type="tns:PayPalButtonCreateReply" minOccurs="0"/>
+            <xsd:element name="payPalPreapprovedPaymentReply" type="tns:PayPalPreapprovedPaymentReply" minOccurs="0"/>
+            <xsd:element name="payPalPreapprovedUpdateReply" type="tns:PayPalPreapprovedUpdateReply" minOccurs="0"/>
+            <xsd:element name="riskUpdateReply" type="tns:RiskUpdateReply" minOccurs="0"/>
+            <xsd:element name="fraudUpdateReply" type="tns:FraudUpdateReply" minOccurs="0"/>
+            <xsd:element name="caseManagementActionReply" type="tns:CaseManagementActionReply" minOccurs="0"/>
+            <xsd:element name="decisionEarlyReply" type="tns:DecisionEarlyReply" minOccurs="0"/>
+            <xsd:element name="decisionReply" type="tns:DecisionReply" minOccurs="0"/>
+            <xsd:element name="payPalRefundReply" type="tns:PayPalRefundReply" minOccurs="0"/>
+            <xsd:element name="payPalAuthReversalReply" type="tns:PayPalAuthReversalReply" minOccurs="0"/>
+            <xsd:element name="payPalDoCaptureReply" type="tns:PayPalDoCaptureReply" minOccurs="0"/>
+            <xsd:element name="payPalEcDoPaymentReply" type="tns:PayPalEcDoPaymentReply" minOccurs="0"/>
+            <xsd:element name="payPalEcGetDetailsReply" type="tns:PayPalEcGetDetailsReply" minOccurs="0"/>
+            <xsd:element name="payPalEcSetReply" type="tns:PayPalEcSetReply" minOccurs="0"/>
+            <xsd:element name="payPalAuthorizationReply" type="tns:PayPalAuthorizationReply" minOccurs="0"/>
+            <xsd:element name="payPalEcOrderSetupReply" type="tns:PayPalEcOrderSetupReply" minOccurs="0"/>
+            <xsd:element name="payPalUpdateAgreementReply" type="tns:PayPalUpdateAgreementReply" minOccurs="0"/>
+            <xsd:element name="payPalCreateAgreementReply" type="tns:PayPalCreateAgreementReply" minOccurs="0"/>
+            <xsd:element name="payPalDoRefTransactionReply" type="tns:PayPalDoRefTransactionReply" minOccurs="0"/>
+            <xsd:element name="chinaPaymentReply" type="tns:ChinaPaymentReply" minOccurs="0"/>
+            <xsd:element name="chinaRefundReply" type="tns:ChinaRefundReply" minOccurs="0"/>
+            <xsd:element name="boletoPaymentReply" type="tns:BoletoPaymentReply" minOccurs="0"/>
+            <xsd:element name="pinDebitPurchaseReply" type="tns:PinDebitPurchaseReply" minOccurs="0"/>
+            <xsd:element name="pinDebitCreditReply" type="tns:PinDebitCreditReply" minOccurs="0"/>
+            <xsd:element name="pinDebitReversalReply" type="tns:PinDebitReversalReply" minOccurs="0"/>
+            <xsd:element name="apInitiateReply" type="tns:APInitiateReply" minOccurs="0"/>
+            <xsd:element name="apCheckStatusReply" type="tns:APCheckStatusReply" minOccurs="0"/>
+            <xsd:element name="receiptNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="solutionProviderTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="apReply" type="tns:APReply" minOccurs="0"/>
+            <xsd:element name="shipTo" type="tns:ShipTo" minOccurs="0" />
+            <xsd:element name="billTo" type="tns:BillTo" minOccurs="0" />
+            <xsd:element name="apAuthReply" type="tns:APAuthReply" minOccurs="0"/>
+            <xsd:element name="apSessionsReply" type="tns:APSessionsReply" minOccurs="0" />
+            <xsd:element name="apAuthReversalReply" type="tns:APAuthReversalReply" minOccurs="0"/>
+            <xsd:element name="apCaptureReply" type="tns:APCaptureReply" minOccurs="0"/>
+            <xsd:element name="apOptionsReply" type="tns:APOptionsReply" minOccurs="0"/>
+            <xsd:element name="apRefundReply" type="tns:APRefundReply" minOccurs="0"/>
+            <xsd:element name="apSaleReply" type="tns:APSaleReply" minOccurs="0"/>
+            <xsd:element name="apCheckoutDetailsReply" type="tns:APCheckOutDetailsReply" minOccurs="0"/>
+            <xsd:element name="apTransactionDetailsReply" type="tns:APTransactionDetailsReply" minOccurs="0"/>
+            <xsd:element name="apConfirmPurchaseReply" type="tns:APConfirmPurchaseReply" minOccurs="0"/>
+            <xsd:element name="promotion" type="tns:Promotion" minOccurs="0"/>
+            <xsd:element name="promotionGroup" type="tns:PromotionGroupReply" minOccurs="0" maxOccurs="100"/>
+            <xsd:element name="payPalGetTxnDetailsReply" type="tns:PayPalGetTxnDetailsReply" minOccurs="0"/>
+            <xsd:element name="payPalTransactionSearchReply" type="tns:PayPalTransactionSearchReply" minOccurs="0"/>
+            <xsd:element name="emvReply" type="tns:EmvReply" minOccurs="0" />
+            <xsd:element name="originalTransaction" type="tns:OriginalTransaction" minOccurs="0" />
+            <xsd:element name="hostedDataCreateReply" type="tns:HostedDataCreateReply" minOccurs="0" />
+            <xsd:element name="hostedDataRetrieveReply" type="tns:HostedDataRetrieveReply" minOccurs="0" />
+            <xsd:element name="salesSlipNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="additionalProcessorResponse" type="xsd:string" minOccurs="0" />
+            <xsd:element name="jpo" type="tns:JPO" minOccurs="0" />
+            <xsd:element name="card" type="tns:Card" minOccurs="0" />
+            <xsd:element name="paymentNetworkToken" type="tns:PaymentNetworkToken" minOccurs="0"/>
+            <xsd:element name="vcReply" type="tns:VCReply" minOccurs="0" />
+            <xsd:element name="decryptVisaCheckoutDataReply" type="tns:DecryptVisaCheckoutDataReply" minOccurs="0"/>
+            <xsd:element name="getVisaCheckoutDataReply" type="tns:GetVisaCheckoutDataReply" minOccurs="0"/>
+            <xsd:element name="binLookupReply" type="tns:BinLookupReply" minOccurs="0"/>
+            <xsd:element name="issuerMessage" type="xsd:string" minOccurs="0" />
+            <xsd:element name="token" type="tns:Token" minOccurs="0" />
+            <xsd:element name="issuer" type="tns:issuer" minOccurs="0" />
+            <xsd:element name="recipient" type="tns:Recipient" minOccurs="0"/>
+            <xsd:element name="feeProgramIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="installment" type="tns:Installment" minOccurs="0" />
+            <xsd:element name="paymentAccountReference" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentSolution" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="authIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ucaf" type="tns:UCAF" minOccurs="0"/>
+            <xsd:element name="network" type="tns:Network" minOccurs="0" maxOccurs="100"/>
+            <xsd:element name="invoiceHeader" type="tns:InvoiceHeader" minOccurs="0" />
+            <xsd:element name="apOrderReply" type="tns:APOrderReply" minOccurs="0" />
+            <xsd:element name="apCancelReply" type="tns:APCancelReply" minOccurs="0" />
+            <xsd:element name="apBillingAgreementReply" type="tns:APBillingAgreementReply" minOccurs="0" />
+            <xsd:element name="customerVerificationStatus" type="xsd:string" minOccurs="0" />
+            <xsd:element name="personalID" type="tns:PersonalID" minOccurs="0" />
+            <xsd:element name="acquirerMerchantNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pos" type="tns:Pos" minOccurs="0" />
+            <xsd:element name="balanceInfo" type="tns:BalanceInfo" minOccurs="0" maxOccurs="6"/>
+            <xsd:element name="issuerMessageAction" type="xsd:string" minOccurs="0" />
+            <xsd:element name="customerID" type="xsd:string" minOccurs="0" />
+
+            <xsd:element name="routing" type="tns:Routing" minOccurs="0"/>
+            <xsd:element name="transactionLocalDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="apCreateMandateReply" type="tns:APCreateMandateReply" minOccurs="0"/>
+            <xsd:element name="apMandateStatusReply" type="tns:APMandateStatusReply" minOccurs="0"/>
+            <xsd:element name="apUpdateMandateReply" type="tns:APUpdateMandateReply" minOccurs="0"/>
+            <xsd:element name="apImportMandateReply" type="tns:APImportMandateReply" minOccurs="0"/>
+            <xsd:element name="apRevokeMandateReply" type="tns:APRevokeMandateReply" minOccurs="0"/>
+            <xsd:element name="getMasterpassDataReply" type="tns:GetMasterpassDataReply" minOccurs="0"/>
+            <xsd:element name="paymentNetworkMerchantID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="wallet" type="tns:Wallet" minOccurs="0" />
+            <xsd:element name="cashbackAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="giftCard" type="tns:GiftCard" minOccurs="0" />
+            <xsd:element name="giftCardActivationReply" type="tns:GiftCardActivationReply" minOccurs="0"/>
+            <xsd:element name="giftCardBalanceInquiryReply" type="tns:GiftCardBalanceInquiryReply" minOccurs="0"/>
+            <xsd:element name="giftCardRedemptionReply" type="tns:GiftCardRedemptionReply" minOccurs="0"/>
+            <xsd:element name="giftCardVoidReply" type="tns:GiftCardVoidReply" minOccurs="0"/>
+            <xsd:element name="giftCardReversalReply" type="tns:GiftCardReversalReply" minOccurs="0"/>
+            <xsd:element name="giftCardReloadReply" type="tns:GiftCardReloadReply" minOccurs="0"/>
+            <xsd:element name="giftCardRefundReply" type="tns:GiftCardRefundReply" minOccurs="0"/>
+            <xsd:element name="ccCheckStatusReply" type="tns:CCCheckStatusReply" minOccurs="0"/>
+            <xsd:element name="ecAVSReply" type="tns:ECAVSReply" minOccurs="0"/>
+            <xsd:element name="abortReply" type="tns:AbortReply" minOccurs="0"/>
+            <xsd:element name="payByPoints" type="tns:payByPoints" minOccurs="0"/>
+            <xsd:element name="reserved" type="tns:ReplyReserved" minOccurs="0"/>
+
+            <!--ReplyReserved should always be the last element in the xsd, new elements should be added before this-->
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="requestMessage" type="tns:RequestMessage">
+    </xsd:element>
+    <xsd:element name="replyMessage" type="tns:ReplyMessage">
+        <xsd:unique name="unique-tax-item-id">
+            <xsd:selector xpath="tns:taxReplyItem"/>
+            <xsd:field xpath="@id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="nvpRequest" type="xsd:string"/>
+    <xsd:element name="nvpReply" type="xsd:string"/>
+    <!-- used in SOAP faults -->
+    <xsd:complexType name="FaultDetails">
+        <xsd:sequence>
+            <xsd:element name="requestID" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="faultDetails" type="tns:FaultDetails"/>
+    <xsd:complexType name="AirlineData">
+        <xsd:sequence>
+            <xsd:element name="agentCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="agentName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketIssuerCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketIssuerState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketIssuerPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketIssuerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketIssuerAddress" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketIssuerCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketIssuerName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkDigit" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="restrictedTicketIndicator" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="extendedPaymentCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="carrierName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passenger" type="tns:Passenger" minOccurs="0" maxOccurs="1000"/>
+            <xsd:element name="customerCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="documentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="documentNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="documentNumberOfParts" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="chargeDetails" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bookingReference" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalFee" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="clearingSequence" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="clearingCount" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="totalClearingAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="leg" type="tns:Leg" minOccurs="0" maxOccurs="1000"/>
+            <xsd:element name="numberOfPassengers" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reservationSystem" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processIdentifier" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="iataNumericCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketIssueDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="electronicTicket" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="originalTicketNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="purchaseType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="creditReasonIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketUpdateIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="planNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="arrivalDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="ticketRestrictionText" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="exchangeTicketAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="exchangeTicketFee" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="journeyType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="boardingFee" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Leg">
+        <xsd:sequence>
+            <xsd:element name="carrierCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="flightNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="originatingAirportCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="class" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="stopoverCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="departureDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="destination" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fareBasis" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="departTax" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="conjunctionTicket" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="exchangeTicket" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="couponNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="departureTime" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="departureTimeSegment" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="arrivalTime" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="arrivalTimeSegment" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="endorsementsRestrictions" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fare" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fee" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="tax" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="AncillaryData">
+        <xsd:sequence>
+            <xsd:element name="ticketNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="passengerName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="connectedTicketNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="creditReasonIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="service" type="tns:Service" minOccurs="0" maxOccurs="1000"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Service">
+        <xsd:sequence>
+            <xsd:element name="categoryCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="subcategoryCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="LodgingData">
+        <xsd:sequence>
+            <xsd:element name="checkInDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="checkOutDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dailyRoomRate1" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dailyRoomRate2" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="dailyRoomRate3" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="roomNights1" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="roomNights2" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="roomNights3" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="guestSmokingPreference" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="numberOfRoomsBooked" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="numberOfGuests" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="roomBedType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="roomTaxElements" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="roomRateType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="guestName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerServicePhoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="corporateClientCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promotionalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalCoupon" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="roomLocation" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="specialProgramCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="tax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="prepaidCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="foodAndBeverageCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="roomTax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="adjustmentAmount" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="phoneCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="restaurantCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="roomServiceCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="miniBarCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="laundryCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="miscellaneousCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="giftShopCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="movieCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="healthClubCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="valetParkingCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="cashDisbursementCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="nonRoomCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="businessCenterCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="loungeBarCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="transportationCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="gratuityCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="conferenceRoomCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="audioVisualCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="banquetCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="internetAccessCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="earlyCheckOutCost" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="nonRoomTax" type="tns:amount" minOccurs="0"/>
+            <xsd:element name="travelAgencyCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="travelAgencyName" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Pos">
+        <xsd:sequence>
+            <xsd:element name="entryMode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardPresent" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="terminalCapability" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="trackData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="terminalID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="terminalType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="terminalLocation" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionSecurity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="catLevel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="conditionCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="environment" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceReaderData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="encryptionAlgorithm" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="encodingMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="deviceID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="serviceCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="terminalIDAlternate" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalCompliance" type="xsd:integer" minOccurs="0" />
+            <xsd:element name="terminalCardCaptureCapability" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalOutputCapability" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalPINcapability" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalCVMcapabilities_0" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalCVMcapabilities_1" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalCVMcapabilities_2" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalInputCapabilities_0" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalInputCapabilities_1" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalInputCapabilities_2" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalInputCapabilities_3" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalInputCapabilities_4" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalInputCapabilities_5" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalInputCapabilities_6" type="xsd:string" minOccurs="0" />
+            <xsd:element name="terminalSerialNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="storeAndForwardIndicator" type="xsd:string" minOccurs="0" />
+            <xsd:element name="panEntryMode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="endlessAisleTransactionIndicator" type="tns:boolean" minOccurs="0" />
+            <xsd:element name="terminalModel" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Pin">
+        <xsd:sequence>
+            <xsd:element name="entryCapability" type="xsd:string" minOccurs="0"/>
+
+
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="EncryptedPayment">
+        <xsd:sequence>
+            <xsd:element name="descriptor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="data" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="encoding" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="wrappedKey" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="referenceID" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="keySerialNumber" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Installment">
+        <xsd:sequence>
+            <xsd:element name="sequence" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalCount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="totalAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="frequency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="planType" type="xsd:string" minOccurs="0"/>
+
+            <xsd:element name="firstInstallmentDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amountFunded" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amountRequestedPercentage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expenses" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expensesPercentage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fees" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="feesPercentage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxes" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="taxesPercentage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="insurance" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="insurancePercentage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalCosts" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalCostsPercentage" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="monthlyInterestRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="annualInterestRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="annualFinancingCost" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="downPayment" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="firstInstallmentAmount" type="xsd:string" minOccurs="0"/>
+		  	<xsd:element name="minimumTotalCount" type="xsd:string" minOccurs="0"/>
+		  	<xsd:element name="maximumTotalCount" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="gracePeriodDuration" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="gracePeriodDurationType" type="xsd:string" minOccurs="0"/>		 
+            <xsd:element name="planID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="interestAmount" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="MDDField">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="id" type="xsd:integer" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="MerchantDefinedData">
+        <xsd:sequence>
+            <xsd:element name="field1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field4" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field5" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field6" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field7" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field8" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field9" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field10" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field11" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field12" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field13" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field14" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field15" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field16" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field17" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field18" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field19" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field20" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="mddField" type="tns:MDDField" minOccurs="0" maxOccurs="100"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="AuxiliaryField">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="id" type="xsd:integer" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="AuxiliaryData">
+        <xsd:sequence>
+            <xsd:element name="field" type="tns:AuxiliaryField" minOccurs="0" maxOccurs="900"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="MerchantSecureData">
+        <xsd:sequence>
+            <xsd:element name="field1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field3" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="field4" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ReplyReserved">
+        <xsd:sequence>
+            <xsd:any processContents="skip" minOccurs="0" maxOccurs="999"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="RequestReserved">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string"/>
+            <xsd:element name="value" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- PayPalGetTxnDetails -->
+    <xsd:complexType name="PayPalGetTxnDetailsReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="payer" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerBusiness" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerSalutation" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerFirstname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerMiddlename" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerLastname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerSuffix" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="addressStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToAddress1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToAddress2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="shipToZip" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="payerPhone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="parentTransactionId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReceiptId" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTransactiontype" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalOrderTime" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentGrossAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalSettleAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalTaxAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalExchangeRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPendingReason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalReasonCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="protectionEligibility" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="protectionEligibilityType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalNote" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="invoiceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="item" type="tns:Item" minOccurs="0" maxOccurs="1000" />
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- end of PayPalGetTxnDetails -->
+
+    <!-- PayPalTransactionSearchReply -->
+    <xsd:complexType name="PayPalTransactionSearchReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="transaction" type="tns:PaypalTransaction" minOccurs="0" maxOccurs="999" />
+            <xsd:element name="errorCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="PaypalTransaction">
+        <xsd:sequence>
+            <xsd:element name="transactionTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="transactionTimeZone" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPayerOrPayeeEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="customerDisplayName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalPaymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="grandTotalAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalFeeAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paypalNetAmount" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+    <!-- end of PayPalTransactionSearchReply -->
+
+    <xsd:complexType name="CCDCCUpdateService">
+        <xsd:sequence>
+            <xsd:element name="reason" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="action" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dccRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="captureRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="creditRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <!-- Merchant Descriptor fields for Service Fee. goes into RequestMessage-->
+    <xsd:complexType name="ServiceFee">
+        <xsd:sequence>
+            <xsd:element name="merchantDescriptor" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorContact" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="merchantDescriptorState" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- EMV transaction data request/reply start -->
+    <xsd:complexType name="EmvRequest">
+        <xsd:sequence>
+            <xsd:element name="combinedTags" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="repeat" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardSequenceNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="aidAndDFname" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fallback" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="fallbackCondition" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="EmvReply">
+        <xsd:sequence>
+            <xsd:element name="combinedTags" type="xsd:string" minOccurs="0"/>
+			<xsd:element name="decryptedRequestTags" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="chipValidationResults" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="chipValidationType" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- EMV transaction data request/reply end -->
+    <!-- Auth Reversal time out merchant intitated -->
+    <xsd:complexType name="OriginalTransaction">
+        <xsd:sequence>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0" />
+            <xsd:element name="reasonCode" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="HostedDataCreateService">
+        <xsd:sequence>
+            <xsd:element name="profileID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="paymentMethod" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="HostedDataRetrieveService">
+        <xsd:sequence>
+            <xsd:element name="profileID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="tokenValue" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="HostedDataCreateReply">
+        <xsd:sequence>
+            <xsd:element name="responseMessage" type="xsd:string" minOccurs="0" />
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="cardAccountNumberToken" type="xsd:string" minOccurs="0" />
+            <xsd:element name="customerID" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="HostedDataRetrieveReply">
+        <xsd:sequence>
+            <xsd:element name="responseMessage" type="xsd:string" minOccurs="0" />
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="aggregatorMerchantIdentifier" type="xsd:string" minOccurs="0" />
+            <xsd:element name="customerFirstName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="customerLastName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="customerID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paymentMethod" type="xsd:string" minOccurs="0" />
+            <xsd:element name="billToStreet1" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToStreet2" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToEmail" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToState" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToFirstName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToLastName" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToCity" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToCountry" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="billToPostalCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardAccountNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardType" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardExpirationMonth" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardExpirationYear" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardIssueNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardStartMonth" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardStartYear" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="AutoRentalData">
+        <xsd:sequence>
+            <xsd:element name="adjustmentCost" type="tns:amount" minOccurs="0" />
+            <xsd:element name="adjustmentCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="agreementNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="classCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="customerServicePhoneNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="dailyRate" type="tns:amount" minOccurs="0" />
+            <xsd:element name="mileageCost" type="tns:amount" minOccurs="0" />
+            <xsd:element name="gasCost" type="tns:amount" minOccurs="0" />
+            <xsd:element name="insuranceCost" type="tns:amount" minOccurs="0" />
+            <xsd:element name="lateReturnCost" type="tns:amount" minOccurs="0" />
+            <xsd:element name="maximumFreeMiles" type="xsd:integer" minOccurs="0" />
+            <xsd:element name="milesTraveled" type="xsd:integer" minOccurs="0" />
+            <xsd:element name="oneWayCost" type="tns:amount" minOccurs="0" />
+            <xsd:element name="parkingViolationCost" type="tns:amount" minOccurs="0" />
+            <xsd:element name="pickUpCity" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pickUpCountry" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pickUpDate" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pickUpState" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pickUpTime" type="xsd:integer" minOccurs="0" />
+            <xsd:element name="ratePerMile" type="tns:amount" minOccurs="0" />
+            <xsd:element name="renterName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="returnCity" type="xsd:string" minOccurs="0" />
+            <xsd:element name="returnCountry" type="xsd:string" minOccurs="0" />
+            <xsd:element name="returnDate" type="xsd:string" minOccurs="0" />
+            <xsd:element name="returnLocationID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="returnState" type="xsd:string" minOccurs="0" />
+            <xsd:element name="returnTime" type="xsd:integer" minOccurs="0" />
+            <xsd:element name="specialProgramCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="noShowIndicator" type="tns:boolean" minOccurs="0" />
+            <xsd:element name="timePeriod" type="xsd:string" minOccurs="0" />
+            <xsd:element name="weeklyRentalRate" type="tns:amount" minOccurs="0" />
+            <xsd:element name="distanceUnit" type="xsd:string" minOccurs="0" />
+            <xsd:element name="rentalLocationID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="vehicleInsuranceIndicator" type="tns:boolean" minOccurs="0" />
+            <xsd:element name="programCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="otherCharges" type="tns:amount" minOccurs="0" />
+            <xsd:element name="taxRate" type="tns:amount" minOccurs="0" />
+            <xsd:element name="taxIndicator" type="tns:boolean" minOccurs="0" />
+            <xsd:element name="taxStatusIndicator" type="xsd:string" minOccurs="0" />
+            <xsd:element name="taxAmount" type="tns:amount" minOccurs="0" />
+            <xsd:element name="taxType" type="xsd:string" minOccurs="0" />
+            <xsd:element name="taxSummary" type="xsd:string" minOccurs="0" />
+            <xsd:element name="returnLocation" type="xsd:string" minOccurs="0" />
+            <xsd:element name="odometerReading" type="xsd:integer" minOccurs="0" />
+            <xsd:element name="vehicleIdentificationNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="commodityCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="companyId" type="xsd:string" minOccurs="0" />
+            <xsd:element name="regularMileageCost" type="tns:amount" minOccurs="0" />
+            <xsd:element name="towingCharge" type="tns:amount" minOccurs="0" />
+            <xsd:element name="extraCharge" type="tns:amount" minOccurs="0" />
+            <xsd:element name="additionalDrivers" type="xsd:integer" minOccurs="0" />
+            <xsd:element name="rentalAddress" type="xsd:string" minOccurs="0" />
+            <xsd:element name="driverAge" type="xsd:integer" minOccurs="0" />
+            <xsd:element name="vehicleMake" type="xsd:string" minOccurs="0" />
+            <xsd:element name="vehicleModel" type="xsd:string" minOccurs="0" />
+            <xsd:element name="corporateClientCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="phoneCharge" type="tns:amount" minOccurs="0" />
+            <xsd:element name="gpsCharge" type="tns:amount" minOccurs="0" />
+            <xsd:element name="pickupLocation" type="xsd:string" minOccurs="0" />
+            <xsd:element name="taxAmountSign" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="AutoRental">
+        <xsd:sequence>
+            <xsd:element name="promotion" type="tns:Promotion" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="AgencyInformation">
+        <xsd:sequence>
+            <xsd:element name="code" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="HealthCare">
+        <xsd:sequence>
+            <xsd:element name="amountType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="tns:amount" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="VCReply">
+        <xsd:sequence>
+            <xsd:element name="creationTimeStamp" type="xsd:string" minOccurs="0" />
+            <xsd:element name="alternateShippingAddressCountryCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="alternateShippingAddressPostalCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="vcAccountLoginName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="vcAccountFirstName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="vcAccountLastName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="vcAccountEncryptedID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="vcAccountEmail" type="xsd:string" minOccurs="0" />
+            <xsd:element name="vcAccountMobilePhoneNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="merchantReferenceID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="subtotalAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="shippingHandlingAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="taxAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="discountAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="giftWrapAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="uncategorizedAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="totalPurchaseAmount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="walletReferenceID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="promotionCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paymentInstrumentID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardVerificationStatus" type="xsd:string" minOccurs="0" />
+            <xsd:element name="issuerID" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paymentInstrumentNickName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="nameOnCard" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardType" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardGroup" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardArt" type="tns:VCCardArt" minOccurs="0" />
+            <xsd:element name="riskAdvice" type="xsd:string" minOccurs="0" />
+            <xsd:element name="riskScore" type="xsd:string" minOccurs="0" />
+            <xsd:element name="riskAdditionalData" type="xsd:string" minOccurs="0" />
+            <xsd:element name="avsCodeRaw" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cvnCodeRaw" type="xsd:string" minOccurs="0" />
+            <xsd:element name="eciRaw" type="xsd:string" minOccurs="0" />
+            <xsd:element name="eci" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cavv" type="xsd:string" minOccurs="0" />
+            <xsd:element name="veresEnrolled" type="xsd:string" minOccurs="0" />
+            <xsd:element name="veresTimeStamp" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paresStatus" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paresTimeStamp" type="xsd:string" minOccurs="0" />
+            <xsd:element name="xid" type="xsd:string" minOccurs="0" />
+            <xsd:element name="customData" type="tns:VCCustomData" minOccurs="0" />
+            <xsd:element name="vcAccountFullName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="paymentDescription" type="xsd:string" minOccurs="0" />
+            <xsd:element name="billingAddressStreetName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="billingAddressAdditionalLocation" type="xsd:string" minOccurs="0" />
+            <xsd:element name="billingAddressStreetNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="expiredCard" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardFirstName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="cardLastName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="shippingAddressStreetName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="shippingAddressAdditionalLocation" type="xsd:string" minOccurs="0" />
+            <xsd:element name="shippingAddressStreetNumber" type="xsd:string" minOccurs="0" />
+            <xsd:element name="ageOfAccount" type="xsd:string" minOccurs="0" />
+            <xsd:element name="newUser" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="VCCardArt">
+        <xsd:sequence>
+            <xsd:element name="fileName" type="xsd:string" minOccurs="0" />
+            <xsd:element name="height" type="xsd:string" minOccurs="0" />
+            <xsd:element name="width" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="VCCustomData">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" minOccurs="0" />
+            <xsd:element name="value" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="optional"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="DecryptVisaCheckoutDataReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="GetVisaCheckoutDataReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="EncryptPaymentDataReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="BinLookupService">
+        <xsd:sequence>
+            <xsd:element name="mode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="networkOrder" type="xsd:string" minOccurs="0" />
+            <xsd:element name="retrievalReferenceNumber" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="BinLookupReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="cardCategory" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="issuer">
+        <xsd:sequence>
+            <xsd:element name="additionalData" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="country" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="countryNumericCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="phoneNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0" />
+            <xsd:element name="riskAnalysisExemptionResult" type="xsd:string" minOccurs="0" />
+            <xsd:element name="trustedMerchantExemptionResult" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="GETVisaCheckoutDataService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="TransactionMetadataService">
+        <xsd:sequence>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="Loan">
+        <xsd:sequence>
+            <xsd:element name="assetType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="type" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APOrderService">
+        <xsd:sequence>
+            <xsd:element name="sessionsRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="APOrderReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APCancelService">
+        <xsd:sequence>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="saleRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="APCancelReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="paymentStatus" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APBillingAgreementService">
+        <xsd:sequence>
+            <xsd:element name="sessionsRequestID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="APBillingAgreementReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="amount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="status" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Passenger">
+        <xsd:sequence>
+            <xsd:element name="firstName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="lastName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:integer" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="PostdatedTransaction">
+        <xsd:sequence>
+            <xsd:element name="guaranteeIndicator" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="guaranteeAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="settlementDate" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APCreateMandateService">
+        <xsd:sequence>
+            <xsd:element name="saleRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cancelURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="successURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="failureURL" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="APCreateMandateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="mandateID" type="xsd:string"/>
+            <xsd:element name="status" type="xsd:string"/>
+            <xsd:element name="merchantURL" type="xsd:string"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="riskScore" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="encodedHTML" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="encodedPopupHTML" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateSigned" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateCreated" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APMandateStatusService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="APMandateStatusReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="mandateID" type="xsd:string"/>
+            <xsd:element name="status" type="xsd:string"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateCreated" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateSigned" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateRevoked" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="APUpdateMandateService">
+        <xsd:sequence>
+            <xsd:element name="esign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cancelURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="successURL" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="failureURL" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="GetMasterpassDataService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="GetMasterpassDataReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APUpdateMandateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="mandateID" type="xsd:string"/>
+            <xsd:element name="status" type="xsd:string"/>
+            <xsd:element name="merchantURL" type="xsd:string"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="riskScore" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="encodedHTML" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="encodedPopupHTML" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateSigned" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateCreated" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APImportMandateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="mandateID" type="xsd:string"/>
+            <xsd:element name="status" type="xsd:string"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateSigned" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateCreated" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="APRevokeMandateService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="APRevokeMandateReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="mandateID" type="xsd:string"/>
+            <xsd:element name="status" type="xsd:string"/>
+            <xsd:element name="responseCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorTransactionID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="dateSigned" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateCreated" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateRevoked" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="dateTime" type="tns:dateTime" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="Category">
+        <xsd:sequence>
+            <xsd:element name="affiliate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="campaign" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="group" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="ECAVSService">
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+
+    <xsd:complexType name="GiftCardActivationService">
+        <xsd:sequence>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardBalanceInquiryService">
+        <xsd:sequence>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardVoidService">
+
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardReversalService">
+
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardRedemptionService">
+        <xsd:sequence>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardReloadService">
+        <xsd:sequence>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardRefundService">
+        <xsd:sequence>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCard">
+        <xsd:sequence>
+            <xsd:element name="originalRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="redemptionType" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="count" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="escheatable" type="tns:boolean" minOccurs="0"/>
+            <xsd:element name="groupID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="transactionPostingDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="balanceCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="previousBalance" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="currentBalance" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="baseCurrencyPreviousBalance" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="baseCurrencyCurrentBalance" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="baseCurrencyCashbackAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="baseCurrency" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="expirationDate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="exchangeRate" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="bonusAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="discountAmount" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="extendedAccountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="additionalAccountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="physicalCard" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="returnExtendedAccountNumber" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="promoCode" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardActivationReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardBalanceInquiryReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardRedemptionReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardReversalReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardVoidReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDeTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardReloadReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="GiftCardRefundReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="authorizationCode" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="processorResponse" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reconciliationID" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+
+    <xsd:complexType name="mPOS">
+		<xsd:sequence>
+			<xsd:element name="deviceType" type="xsd:string" minOccurs="0" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+    <xsd:complexType name="AbortService">
+        <xsd:sequence>
+            <xsd:element name="authRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="creditRequestID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="cardholderVerificationMethod" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="commerceIndicator" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="run" type="tns:boolean" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="AbortReply">
+        <xsd:sequence>
+            <xsd:element name="reasonCode" type="xsd:integer"/>
+            <xsd:element name="requestDateTime" type="tns:dateTime" minOccurs="0"/>
+            <xsd:element name="reason" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="merchant">
+        <xsd:sequence>
+            <xsd:element name="acquirerBIN" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="cardAcceptorID" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="visaMerchantID" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="DecisionEarlyReply">
+        <xsd:sequence>
+            <xsd:element name="casePriority" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="decision" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="action" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="applicableOrderModifications" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="appliedOrderModifications" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="activeProfileReply" type="tns:ProfileReplyEarly" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="ProfileReplyEarly">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="selectedBy" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="pauseRulesTriggered" type="tns:PauseRuleResultItems" minOccurs="0"/>
+            <xsd:element name="rulesTriggered" type="tns:RuleResultItems" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PauseRuleResultItems">
+        <xsd:sequence>
+            <xsd:element name="ruleResultItem" type="tns:PauseRuleResultItem" minOccurs="0" maxOccurs="1000"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="PauseRuleResultItem">
+        <xsd:sequence>
+            <xsd:element name="ruleID" type="xsd:integer" minOccurs="0"/>
+            <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="action" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="evaluation" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="orderModification" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="payByPoints">
+        <xsd:sequence>
+            <xsd:element name="indicator" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pointsBeforeRedemption" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pointsValueBeforeRedemption" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pointsRedeemed" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pointsValueRedeemed" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pointsAfterRedemption" type="xsd:string" minOccurs="0" />
+            <xsd:element name="pointsValueAfterRedemption" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
This PR adds the following five fields to the CyberSource gateway adapter:

- billTo.merchantTaxID
- salesSlipNumber
- installment.planType
- installment.firstInstallmentDate
- airlineData.agentCode

This PR also includes a new XML Schema Definition (XSD) for the CyberSource Gateway. This serves as a reference for the expected format/nesting of the new fields.

CE-1541

Remote:
98 tests, 502 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.8776% passed
**The following remote tests are currently failing on master as well as this branch:**
test_successful_validate_pinless_debit_card
test_successful_pinless_debit_card_purchase
test_successful_tax_calculation
test_successful_authorization_and_failed_capture
test_successful_3ds_validate_authorize_request
test_successful_3ds_validate_purchase_request

Local:
4725 tests, 73476 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
699 files inspected, no offenses detected