### PR TITLE
PayTrace: new gateway build

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Checkout v2: Support metadata field [saschakala] #3992
 * Adyen: Support networkTxReference field [naashton] #3997
 * Paypal Express: Enable PayPal express reference transaction request to send merchant session id [janees-e] #3994
+* PayTrace: Support gateway [meagabeth] #3985
 
 == Version 1.120.0 (May 28th, 2021)
 * Braintree: Bump required braintree gem version to 3.0.1

--- a/lib/active_merchant/billing/gateways/pay_trace.rb
+++ b/lib/active_merchant/billing/gateways/pay_trace.rb
@@ -1,0 +1,265 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PayTraceGateway < Gateway
+      self.test_url = 'https://api.paytrace.com'
+      self.live_url = 'https://api.paytrace.com'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = %i[visa master american_express discover]
+
+      self.homepage_url = 'https://paytrace.com/'
+      self.display_name = 'PayTrace'
+
+      # Response codes based on API Response Codes found here: https://developers.paytrace.com/support/home#14000041297
+      STANDARD_ERROR_CODE_MAPPING = {
+        '1'   => STANDARD_ERROR_CODE[:error_occurred],
+        '102' => STANDARD_ERROR_CODE[:declined],
+        '103' => STANDARD_ERROR_CODE[:auto_voided],
+        '107' => STANDARD_ERROR_CODE[:unsuccessful_refund],
+        '108' => STANDARD_ERROR_CODE[:test_refund],
+        '110' => STANDARD_ERROR_CODE[:unsuccessful_void],
+        '113' => STANDARD_ERROR_CODE[:unsuccessful_capture]
+      }
+
+      ENDPOINTS = {
+        customer_id_sale: 'transactions/sale/by_customer',
+        keyed_sale: 'transactions/sale/keyed',
+        customer_id_auth: 'transactions/authorization/by_customer',
+        keyed_auth: 'transactions/authorization/keyed',
+        capture: 'transactions/authorization/capture',
+        transaction_refund: 'transactions/refund/for_transaction',
+        transaction_void: 'transactions/void',
+        store: 'customer/create',
+        redact: 'customer/delete'
+      }
+
+      def initialize(options = {})
+        requires!(options, :username, :password, :integrator_id)
+        super
+        acquire_access_token
+      end
+
+      def purchase(money, payment_or_customerid, options = {})
+        post = {}
+        add_invoice(post, money, options)
+        if payment_or_customerid.class == String
+          post[:customer_id] = payment_or_customerid
+
+          response = commit(ENDPOINTS[:customer_id_sale], post)
+          check_token_response(response, ENDPOINTS[:customer_id_sale], post, options)
+        else
+          add_payment(post, payment_or_customerid)
+          add_address(post, payment_or_customerid, options)
+          add_customer_data(post, options)
+
+          response = commit(ENDPOINTS[:keyed_sale], post)
+          check_token_response(response, ENDPOINTS[:keyed_sale], post, options)
+        end
+      end
+
+      def authorize(money, payment_or_customerid, options = {})
+        post = {}
+        add_invoice(post, money, options)
+        if payment_or_customerid.class == String
+          post[:customer_id] = payment_or_customerid
+
+          response = commit(ENDPOINTS[:customer_id_auth], post)
+          check_token_response(response, ENDPOINTS[:customer_id_auth], post, options)
+        else
+          add_payment(post, payment_or_customerid)
+          add_address(post, payment_or_customerid, options)
+          add_customer_data(post, options)
+
+          response = commit(ENDPOINTS[:keyed_auth], post)
+          check_token_response(response, ENDPOINTS[:keyed_auth], post, options)
+        end
+      end
+
+      def capture(authorization, options = {})
+        post = {}
+        post[:amount] = amount(options[:amount]) if options[:amount]
+        post[:transaction_id] = authorization
+        response = commit(ENDPOINTS[:capture], post)
+        check_token_response(response, ENDPOINTS[:capture], post, options)
+      end
+
+      def refund(authorization, options = {})
+        # currently only support full and partial refunds of settled transactions via a transaction ID
+        post = {}
+        post[:amount] = amount(options[:amount]) if options[:amount]
+        post[:transaction_id] = authorization
+        response = commit(ENDPOINTS[:transaction_refund], post)
+        check_token_response(response, ENDPOINTS[:transaction_refund], post, options)
+      end
+
+      def void(authorization, options = {})
+        post = {}
+        post[:transaction_id] = authorization
+
+        response = commit(ENDPOINTS[:transaction_void], post)
+        check_token_response(response, ENDPOINTS[:transaction_void], post, options)
+      end
+
+      def verify(credit_card, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      # The customer_IDs that come from storing cards can be used for auth and purchase transaction types
+      def store(credit_card, options = {})
+        post = {}
+        post[:customer_id] = options[:customer_id] || SecureRandom.hex(12)
+        add_payment(post, credit_card)
+        add_address(post, credit_card, options)
+        response = commit(ENDPOINTS[:store], post)
+        check_token_response(response, ENDPOINTS[:store], post, options)
+      end
+
+      def redact(customer_id)
+        post = {}
+        post[:customer_id] = customer_id
+        response = commit(ENDPOINTS[:redact], post)
+        check_token_response(response, ENDPOINTS[:redact], post, options)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: Bearer )[a-zA-Z0-9:_]+), '\1[FILTERED]').
+          gsub(%r(("credit_card\\?":{\\?"number\\?":\\?")\d+), '\1[FILTERED]').
+          gsub(%r(("cvv\\?":\\?")\d+), '\1[FILTERED]').
+          gsub(%r(("username\\?":\\?")\w+@+\w+.+\w+), '\1[FILTERED]').
+          gsub(%r(("password\\?":\\?")\w+), '\1[FILTERED]').
+          gsub(%r(("integrator_id\\?":\\?")\w+), '\1[FILTERED]')
+      end
+
+      def acquire_access_token
+        post = {}
+        post[:grant_type] = 'password'
+        post[:username] = @options[:username]
+        post[:password] = @options[:password]
+        data = post.collect { |key, value| "#{key}=#{CGI.escape(value.to_s)}" }.join('&')
+        url = live_url + '/oauth/token'
+        oauth_headers = {
+          'Accept'            => '*/*',
+          'Content-Type'      => 'application/x-www-form-urlencoded'
+        }
+        response = ssl_post(url, data, oauth_headers)
+        json_response = JSON.parse(response)
+
+        @options[:access_token] = json_response['access_token'] if json_response['access_token']
+        response
+      end
+
+      private
+
+      def add_customer_data(post, options)
+        return unless options[:email]
+
+        post[:email] = options[:email]
+      end
+
+      def add_address(post, creditcard, options)
+        return unless options[:billing_address] || options[:address]
+
+        address = options[:billing_address] || options[:address]
+        post[:billing_address] = {}
+        post[:billing_address][:name] = creditcard.name
+        post[:billing_address][:street_address] = address[:address1]
+        post[:billing_address][:city] = address[:city]
+        post[:billing_address][:state] = address[:state]
+        post[:billing_address][:zip] = address[:zip]
+      end
+
+      def add_invoice(post, money, options)
+        post[:amount] = amount(money)
+      end
+
+      def add_payment(post, payment)
+        post[:credit_card] = {}
+        post[:credit_card][:number] = payment.number
+        post[:credit_card][:expiration_month] = payment.month
+        post[:credit_card][:expiration_year] = payment.year
+      end
+
+      def check_token_response(response, endpoint, body = {}, options = {})
+        return response unless response.params['error'] == 'invalid_token'
+
+        acquire_access_token
+        commit(endpoint, body)
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def commit(action, parameters)
+        base_url = (test? ? test_url : live_url)
+        url = base_url + '/v1/' + action
+        raw_response = ssl_post(url, post_data(parameters), headers)
+        response = parse(raw_response)
+        success = success_from(response)
+
+        Response.new(
+          success,
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          avs_result: AVSResult.new(code: response['avs_response']),
+          cvv_result: response['csc_response'],
+          test: test?,
+          error_code: success ? nil : error_code_from(response)
+        )
+      rescue JSON::ParserError
+        unparsable_response(raw_response)
+      end
+
+      def unparsable_response(raw_response)
+        message = 'Unparsable response received from PayTrace. Please contact PayTrace if you continue to receive this message.'
+        message += " (The raw response returned by the API was #{raw_response.inspect})"
+        return Response.new(false, message)
+      end
+
+      def headers
+        {
+          'Content-type' => 'application/json',
+          'Authorization' => 'Bearer ' + @options[:access_token]
+        }
+      end
+
+      def success_from(response)
+        response['success']
+      end
+
+      def message_from(response)
+        response['status_message']
+      end
+
+      def authorization_from(response)
+        response['transaction_id']
+      end
+
+      def post_data(parameters = {})
+        parameters[:password] = @options[:password]
+        parameters[:username] = @options[:username]
+        parameters[:integrator_id] = @options[:integrator_id]
+
+        parameters.to_json
+      end
+
+      def error_code_from(response)
+        STANDARD_ERROR_CODE_MAPPING[response['response_code']]
+      end
+
+      def handle_response(response)
+        response.body
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -688,6 +688,11 @@ pay_secure:
   login: LOGIN
   password: PASSWORD
 
+pay_trace:
+  username: USERNAME
+  password: PASSWORD
+  integrator_id: INTEGRATOR_ID
+
 paybox_direct:
   login: 1999888
   password: 1999888I

--- a/test/remote/gateways/remote_pay_trace_test.rb
+++ b/test/remote/gateways/remote_pay_trace_test.rb
@@ -1,0 +1,214 @@
+require 'test_helper'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PayTraceGateway < Gateway
+      def settle
+        post = {}
+        response = commit('transactions/settle', post)
+        check_token_response(response, 'transactions/settle', post, options)
+      end
+    end
+  end
+end
+
+class RemotePayTraceTest < Test::Unit::TestCase
+  def setup
+    @gateway = PayTraceGateway.new(fixtures(:pay_trace))
+
+    @amount = 100
+    @credit_card = credit_card('4012000098765439')
+    @mastercard = credit_card('5499740000000057')
+    @discover = credit_card('6011000993026909')
+    @amex = credit_card('371449635392376')
+    @options = {
+      billing_address: {
+        address1: '8320 This Way Lane',
+        city: 'Placeville',
+        state: 'CA',
+        zip: '85284'
+      },
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_acquire_token
+    response = @gateway.acquire_access_token
+    assert_not_nil response['access_token']
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Your transaction was successfully approved.', response.message
+  end
+
+  def test_successful_purchase_with_customer_id
+    create = @gateway.store(@mastercard, @options)
+    customer_id = create.params['customer_id']
+    response = @gateway.purchase(500, customer_id, @options)
+    assert_success response
+    assert_equal 'Your transaction was successfully approved.', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      email: 'joe@example.com'
+    }
+
+    response = @gateway.purchase(200, @discover, options)
+    assert_success response
+    assert_equal 'Your transaction was successfully approved.', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(29, @amex, @options)
+    assert_failure response
+    assert_equal false, response.success?
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(300, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(auth.authorization, @options.merge(amount: 300))
+    assert_success capture
+    assert_equal 'Your transaction was successfully captured.', capture.message
+  end
+
+  def test_successful_authorize_with_customer_id
+    store = @gateway.store(@mastercard, @options)
+    assert_success store
+    customer_id = store.params['customer_id']
+
+    response = @gateway.authorize(200, customer_id, @options)
+    assert_success response
+    assert_equal 'Your transaction was successfully approved.', response.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(29, @mastercard, @options)
+    assert_failure response
+    assert_equal 'Your transaction was not approved.', response.message
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(500, @amex, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(auth.authorization, @options.merge(amount: 300))
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture('')
+    assert_failure response
+    assert_equal 'One or more errors has occurred.', response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(200, @credit_card, @options)
+    assert_success purchase
+    authorization = purchase.authorization
+
+    settle = @gateway.settle()
+    assert_success settle
+
+    refund = @gateway.refund(authorization, @options.merge(amount: 200))
+    assert_success refund
+    assert_equal 'Your transaction was successfully refunded.', refund.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(400, @mastercard, @options)
+    assert_success purchase
+    authorization = purchase.authorization
+
+    settle = @gateway.settle()
+    assert_success settle
+
+    refund = @gateway.refund(authorization, @options.merge(amount: 300))
+    assert_success refund
+    assert_equal 'Your transaction was successfully refunded.', refund.message
+  end
+
+  def test_refund_without_amount
+    purchase = @gateway.purchase(@amount, @discover, @options)
+    assert_success purchase
+    authorization = purchase.authorization
+
+    settle = @gateway.settle()
+    assert_success settle
+
+    refund = @gateway.refund(authorization)
+    assert_success refund
+    assert_equal 'Your transaction was successfully refunded.', refund.message
+  end
+
+  def test_failed_refund
+    response = @gateway.refund('', @options)
+    assert_failure response
+    assert_equal 'One or more errors has occurred.', response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @amex, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'Your transaction was successfully voided.', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'One or more errors has occurred.', response.message
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@mastercard, @options)
+    assert_success response
+    assert_equal 'Your transaction was successfully approved.', response.message
+  end
+
+  def test_successful_store_and_redact_customer_profile
+    response = @gateway.store(@mastercard, @options)
+    assert_success response
+    customer_id = response.params['customer_id']
+    redact = @gateway.redact(customer_id)
+    assert_success redact
+    assert_equal true, redact.success?
+  end
+
+  def test_duplicate_customer_creation
+    create = @gateway.store(@discover, @options)
+    customer_id = create.params['customer_id']
+    response = @gateway.store(@discover, @options.merge(customer_id: customer_id))
+    assert_failure response
+  end
+
+  # Not including a test_failed_verify since the only way to force a failure on this
+  # gateway is with a specific dollar amount. Since verify is auth and void combined,
+  # having separate tests for auth and void should suffice.
+
+  def test_invalid_login
+    gateway = PayTraceGateway.new(username: 'username', password: 'password', integrator_id: 'integrator_id')
+
+    response = gateway.acquire_access_token
+    assert_match 'invalid_grant', response
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @amex, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@amex.number, transcript)
+    assert_scrubbed(@amex.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+    assert_scrubbed(@gateway.options[:username], transcript)
+    assert_scrubbed(@gateway.options[:integrator_id], transcript)
+  end
+end

--- a/test/unit/gateways/pay_trace_test.rb
+++ b/test/unit/gateways/pay_trace_test.rb
@@ -1,0 +1,294 @@
+require 'test_helper'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PayTraceGateway < Gateway
+      def acquire_access_token
+        @options[:access_token] = SecureRandom.hex(16)
+      end
+    end
+  end
+end
+
+class PayTraceTest < Test::Unit::TestCase
+  def setup
+    @gateway = PayTraceGateway.new(username: 'username', password: 'password', integrator_id: 'uniqueintegrator')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      billing_address: address
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 392483066, response.authorization
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal PayTraceGateway::STANDARD_ERROR_CODE[:declined], response.error_code
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal true, response.success?
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Your transaction was not approved.', response.message
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+    transaction_id = 10598543
+
+    response = @gateway.capture(transaction_id, @options)
+    assert_success response
+    assert_equal 'Your transaction was successfully captured.', response.message
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_post).returns(failed_capture_response)
+
+    response = @gateway.capture('', @options)
+    assert_failure response
+    assert_equal 'One or more errors has occurred.', response.message
+  end
+
+  def test_successful_refund
+    transaction_id = 105968532
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+
+    response = @gateway.refund(transaction_id)
+    assert_success response
+    assert_equal 'Your transaction successfully refunded.', response.message
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+
+    response = @gateway.refund('', @options.merge(amount: @amount))
+    assert_failure response
+    assert_equal 'One or more errors has occurred.', response.message
+  end
+
+  def test_successful_void
+    transaction_id = 105968551
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+
+    assert void = @gateway.void(transaction_id, @options)
+    assert_success void
+    assert_equal 'Your transaction was successfully voided.', void.message
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_post).returns(failed_void_response)
+
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'One or more errors has occurred.', response.message
+  end
+
+  def test_successful_verify
+    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response).then.returns(successful_void_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_verify_with_failed_void
+    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response).then.returns(failed_void_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+  end
+
+  def test_failed_verify
+    @gateway.expects(:ssl_post).times(1).returns(failed_authorize_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_failure response
+    assert_equal 'Your transaction was not approved.', response.message
+  end
+
+  def test_successful_customer_creation
+    @gateway.expects(:ssl_post).returns(successful_create_customer_response)
+
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal true, response.success?
+  end
+
+  def test_duplicate_customer_creation
+    options = {
+      customer_id: '7cad678781bf0456d50e1478',
+      billing_address: {
+        address1: '8320 This Way Lane',
+        city: 'Placeville',
+        state: 'CA',
+        zip: '85284'
+      }
+    }
+    @gateway.expects(:ssl_post).returns(failed_customer_creation_response)
+    response = @gateway.store(@credit_card, options)
+    assert_failure response
+    assert_equal false, response.success?
+    assert_match 'Please provide a unique customer ID.', response.params['errors'].to_s
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      opening connection to api.paytrace.com:443...
+      opened
+      starting SSL for api.paytrace.com:443...
+      SSL established
+      <- "POST /v1/transactions/sale/keyed HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Bearer 96e647567627164796f6e63704370727565646c697e236f6d6:5427e43707866415555426a68723848763574533d476a466:QryC8bI6hfidGVcFcwnago3t77BSzW8ItUl9GWhsx9Y\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: api.paytrace.com\r\nContent-Length: 335\r\n\r\n"
+      <- "{\"amount\":\"1.00\",\"credit_card\":{\"number\":\"4012000098765439\",\"expiration_month\":9,\"expiration_year\":2022},\"billing_address\":{\"name\":\"Longbob Longsen\",\"street_address\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zip\":\"K1C2N6\"},\"password\":\"ErNsphFQUEbjx2Hx6uT3MgJf\",\"username\":\"integrations@spreedly.com\",\"integrator_id\":\"9575315uXt4u\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Thu, 03 Jun 2021 22:03:24 GMT\r\n"
+      -> "Content-Type: application/json; charset=utf-8\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "Status: 200 OK\r\n"
+      -> "Cache-Control: max-age=0, private, must-revalidate\r\n"
+      -> "Referrer-Policy: strict-origin-when-cross-origin\r\n"
+      -> "X-Permitted-Cross-Domain-Policies: none\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "X-Request-Id: f008583e-3755-4eca-b8a0-83d8d82cefca\r\n"
+      -> "X-Download-Options: noopen\r\n"
+      -> "ETag: W/\"4edcbabd892d2f033a4cbc7932f26fae\"\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-Runtime: 1.984489\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "Content-Security-Policy: frame-ancestors 'self';\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains\r\n"
+      -> "\r\n"
+      -> "142\r\n"
+      reading 322 bytes...
+      -> "{\"success\":true,\"response_code\":101,\"status_message\":\"Your transaction was successfully approved.\",\"transaction_id\":395970044,\"approval_code\":\"TAS679\",\"approval_message\":\"  NO  MATCH - Approved and completed\",\"avs_response\":\"No Match\",\"csc_response\":\"\",\"external_transaction_id\":\"\",\"masked_card_number\":\"xxxxxxxxxxxx5439\"}"
+      read 322 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      opening connection to api.paytrace.com:443...
+      opened
+      starting SSL for api.paytrace.com:443...
+      SSL established
+      <- "POST /v1/transactions/sale/keyed HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Bearer [FILTERED]\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: api.paytrace.com\r\nContent-Length: 335\r\n\r\n"
+      <- "{\"amount\":\"1.00\",\"credit_card\":{\"number\":\"[FILTERED]\",\"expiration_month\":9,\"expiration_year\":2022},\"billing_address\":{\"name\":\"Longbob Longsen\",\"street_address\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zip\":\"K1C2N6\"},\"password\":\"[FILTERED]\",\"username\":\"[FILTERED]\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Thu, 03 Jun 2021 22:03:24 GMT\r\n"
+      -> "Content-Type: application/json; charset=utf-8\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "Status: 200 OK\r\n"
+      -> "Cache-Control: max-age=0, private, must-revalidate\r\n"
+      -> "Referrer-Policy: strict-origin-when-cross-origin\r\n"
+      -> "X-Permitted-Cross-Domain-Policies: none\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "X-Request-Id: f008583e-3755-4eca-b8a0-83d8d82cefca\r\n"
+      -> "X-Download-Options: noopen\r\n"
+      -> "ETag: W/\"4edcbabd892d2f033a4cbc7932f26fae\"\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-Runtime: 1.984489\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "X-Frame-Options: SAMEORIGIN\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "Content-Security-Policy: frame-ancestors 'self';\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains\r\n"
+      -> "\r\n"
+      -> "142\r\n"
+      reading 322 bytes...
+      -> "{\"success\":true,\"response_code\":101,\"status_message\":\"Your transaction was successfully approved.\",\"transaction_id\":395970044,\"approval_code\":\"TAS679\",\"approval_message\":\"  NO  MATCH - Approved and completed\",\"avs_response\":\"No Match\",\"csc_response\":\"\",\"external_transaction_id\":\"\",\"masked_card_number\":\"xxxxxxxxxxxx5439\"}"
+      read 322 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    POST_SCRUBBED
+  end
+
+  def successful_purchase_response
+    '{"success":true,"response_code":101,"status_message":"Your transaction was successfully approved.","transaction_id":392483066,"approval_code":"TAS610","approval_message":"  NO  MATCH - Approved and completed","avs_response":"No Match","csc_response":"","external_transaction_id":"","masked_card_number":"xxxxxxxxxxxx5439"}'
+  end
+
+  def failed_purchase_response
+    '{"success":false,"response_code":102,"status_message":"Your transaction was not approved.","transaction_id":392501201,"approval_code":"","approval_message":"    DECLINE - Do not honor","avs_response":"No Match","csc_response":"","external_transaction_id":"","masked_card_number":"xxxxxxxxxxxx5439"}'
+  end
+
+  def successful_authorize_response
+    '{"success":true,"response_code":101,"status_message":"Your transaction was successfully approved.","transaction_id":392224547,"approval_code":"TAS161","approval_message":"  NO  MATCH - Approved and completed","avs_response":"No Match","csc_response":"","external_transaction_id":"","masked_card_number":"xxxxxxxxxxxx2224"}'
+  end
+
+  def failed_authorize_response
+    '{"success":false,"response_code":102,"status_message":"Your transaction was not approved.","transaction_id":395971008,"approval_code":"","approval_message":"  EXPIRED CARD - Expired card","avs_response":"No Match","csc_response":"","external_transaction_id":"","masked_card_number":"xxxxxxxxxxxx5439"}'
+  end
+
+  def successful_capture_response
+    '{"success":true,"response_code":112,"status_message":"Your transaction was successfully captured.","transaction_id":392442990,"external_transaction_id":""}'
+  end
+
+  def failed_capture_response
+    '{"success":false,"response_code":1,"status_message":"One or more errors has occurred.","errors":{"58":["Please provide a valid Transaction ID."]},"external_transaction_id":""}'
+  end
+
+  def successful_refund_response
+    '{"success":true,"response_code":106,"status_message":"Your transaction successfully refunded.","transaction_id":105968559,"external_transaction_id":""}'
+  end
+
+  def failed_refund_response
+    '{"success":false,"response_code":1,"status_message":"One or more errors has occurred.","errors":{"981":["Log in failed for insufficient permissions."]},"external_transaction_id":""}'
+  end
+
+  def successful_void_response
+    '{"success":true,"response_code":109,"status_message":"Your transaction was successfully voided.","transaction_id":395971574}'
+  end
+
+  def failed_void_response
+    '{"success":false,"response_code":1,"status_message":"One or more errors has occurred.","errors":{"58":["Please provide a valid Transaction ID."]}}'
+  end
+
+  def successful_create_customer_response
+    '{"success":true,"response_code":160,"status_message":"The customer profile for customerTest150/Steve Smith was successfully created","customer_id":"customerTest150","masked_card_number":"xxxxxxxxxxxx1111"}'
+  end
+
+  def failed_customer_creation_response
+    '{"success":false,"response_code":1,"status_message":"One or more errors has occurred.","errors":{"171":["Please provide a unique customer ID."]},"masked_card_number":"xxxxxxxxxxxx5439"}'
+  end
+end


### PR DESCRIPTION
- Support the following standard AM methods: authorize, capture, purchase, void, refund, store and verify
- Authorize and purchase methods support receiving PAN or vaulted customer ID
- Support additional general methods: redact, settle
- [PayTrace API documentation](https://developers.paytrace.com/support/home)

CE-1601

Local:
4748 tests, 73563 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
16 tests, 49 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
21 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed