### PR TITLE
CASHNet: Update Gateway Adapter

### DIFF
--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = ['US']
       self.supported_cardtypes = %i[visa master american_express discover diners_club jcb]
-      self.homepage_url        = 'http://www.higherone.com/'
+      self.homepage_url        = 'https://transactcampus.com'
       self.display_name        = 'Cashnet'
       self.money_format        = :dollars
       self.max_retries         = 0
@@ -76,7 +76,7 @@ module ActiveMerchant #:nodoc:
 
         return unparsable_response(raw_response) unless parsed_response
 
-        success = (parsed_response[:result] == '0')
+        success = success?(parsed_response)
         Response.new(
           success,
           CASHNET_CODES[parsed_response[:result]],
@@ -84,6 +84,10 @@ module ActiveMerchant #:nodoc:
           test:          test?,
           authorization: (success ? parsed_response[:tx] : '')
         )
+      end
+
+      def success?(response)
+        response[:result] == '0'
       end
 
       def post_data(action, parameters = {})
@@ -191,6 +195,7 @@ module ActiveMerchant #:nodoc:
         '215' => 'Old PIN does not validate ',
         '221' => 'Invalid credit card processor type specified in location or payment code',
         '222' => 'Credit card processor error',
+        '230' => 'Host Error (USE VOID OR REVERSAL TO REFUND UNSETTLED TRANSACTIONS)',
         '280' => 'SmartPay transaction not posted',
         '301' => 'Original transaction not found for this customer',
         '302' => 'Amount to refund exceeds original payment amount or is missing',

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -86,7 +86,7 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert response = @gateway.get_customer_profile(
       customer_profile_id: @customer_profile_id,
       unmask_expiration_date: true,
-      include_issuer_info: true,
+      include_issuer_info: true
     )
     assert response.test?
     assert_success response

--- a/test/remote/gateways/remote_cashnet_test.rb
+++ b/test/remote/gateways/remote_cashnet_test.rb
@@ -7,12 +7,19 @@ class CashnetTest < Test::Unit::TestCase
     @credit_card = credit_card(
       '5454545454545454',
       month: 12,
-      year: 2015
+      year: Time.new.year + 1
     )
     @options = {
       order_id: generate_unique_id,
       billing_address: address
     }
+  end
+
+  def test_successful_purchase
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    assert purchase.test?
+    assert_equal 'Success', purchase.message
   end
 
   def test_successful_purchase_and_refund


### PR DESCRIPTION
**Note for running CASHNet remote tests:**

If you run the remote tests as is, you will see a failure on `test_successful_purchase_and_refund` and `test_successful_refund_with_options`. This is because CASHNet's test api requires one business day to pass between the purchase transactions and the attempted refund. One way around this is to send a test purchase transaction, copy the transaction number in the `tx` field of the response, _wait one day_, and then replace the `purchase.authorization` variable with your saved transaction number in the test's refund call.

I have saved up a few of these transactions numbers so you can message me whenever you intend to run the remote tests.

CE-798

Local:
4719 tests, 73458 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
6 tests, 28 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
699 files inspected, no offenses detected