### PR TITLE
Support braintree 3.0.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Braintree: Bump required braintree gem version to 3.0.1
 * Stripe PI: ensure `setup_future_sage` and `off_session` work when using SetupIntents.
 * Orbital: Update commit to accept retry_logic in params [jessiagee] #3890
 * Orbital: Update remote 3DS tests [jessiagee] #3892

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rubocop', '~> 0.62.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.98.0', '< 3.0'
+  gem 'braintree', '>= 3.0.0', '<= 3.0.1'
   gem 'jwe'
   gem 'mechanize'
 end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -7,7 +7,7 @@ rescue LoadError
   raise 'Could not load the braintree gem.  Use `gem install braintree` to install it.'
 end
 
-raise "Need braintree gem >= 2.78.0. Run `gem install braintree --version '~>2.78'` to get the correct version." unless Braintree::Version::Major == 2 && Braintree::Version::Minor >= 78
+raise "Need braintree gem >= 3.0.0. Run `gem install braintree --version '~>3.0.0'` to get the correct version." unless Braintree::Version::Major == 3 && Braintree::Version::Minor == 0
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -801,7 +801,7 @@ module ActiveMerchant #:nodoc:
                 eci_indicator: credit_card_or_vault_id.eci
               }
             elsif credit_card_or_vault_id.source == :android_pay || credit_card_or_vault_id.source == :google_pay
-              parameters[:android_pay_card] = {
+              parameters[:google_pay_card] = {
                 number: credit_card_or_vault_id.number,
                 cryptogram: credit_card_or_vault_id.payment_cryptogram,
                 expiration_month: credit_card_or_vault_id.month.to_s.rjust(2, '0'),

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -953,7 +953,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
                    first_name: 'Longbob', last_name: 'Longsen' },
         options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
         custom_fields: nil,
-        android_pay_card: {
+        google_pay_card: {
           number: '4111111111111111',
           expiration_month: '09',
           expiration_year: (Time.now.year + 1).to_s,
@@ -986,7 +986,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
                    first_name: 'Longbob', last_name: 'Longsen' },
         options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
         custom_fields: nil,
-        android_pay_card: {
+        google_pay_card: {
           number: '4111111111111111',
           expiration_month: '09',
           expiration_year: (Time.now.year + 1).to_s,


### PR DESCRIPTION
We want to be able to support Braintree's 3.0.1 gem with active merchant, as this give us access to some new parameters we need. 

This required two changes:

1. Update lib/active_merchant/billing/gateways/braintree_blue.rb to support braintree versions of 3.0.x
2. `android_pay_card` has been renamed to `google_pay_card`, so `ActiveMerchant::Billing::BraintreeBlueGateway#add_payment_method` has been modified to be aware of that.

I have ran the Braintree remote test suite, and nothing is breaking with this change. This shouldn't introduce any breaking changes.

```
4731 tests, 73512 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```