### PR TITLE
Braintree Gem Upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ gem 'rubocop', '~> 0.62.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.98.0', '< 3.0'
+  # gem 'braintree', '>= 2.98.0', '< 3.0'
+  gem 'braintree', '~> 3.4.0'
   gem 'jwe'
   gem 'mechanize'
 end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -7,7 +7,7 @@ rescue LoadError
   raise 'Could not load the braintree gem.  Use `gem install braintree` to install it.'
 end
 
-raise "Need braintree gem >= 2.78.0. Run `gem install braintree --version '~>2.78'` to get the correct version." unless Braintree::Version::Major == 2 && Braintree::Version::Minor >= 78
+raise "Need braintree gem >= 3.4.0. Run `gem install braintree --version '~>3.4'` to get the correct version." unless Braintree::Version::Major == 3 && Braintree::Version::Minor >= 4
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -801,7 +801,7 @@ module ActiveMerchant #:nodoc:
                 eci_indicator: credit_card_or_vault_id.eci
               }
             elsif credit_card_or_vault_id.source == :android_pay || credit_card_or_vault_id.source == :google_pay
-              parameters[:android_pay_card] = {
+              parameters[:google_pay_card] = {
                 number: credit_card_or_vault_id.number,
                 cryptogram: credit_card_or_vault_id.payment_cryptogram,
                 expiration_month: credit_card_or_vault_id.month.to_s.rjust(2, '0'),

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -953,7 +953,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
                    first_name: 'Longbob', last_name: 'Longsen' },
         options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
         custom_fields: nil,
-        android_pay_card: {
+        google_pay_card: {
           number: '4111111111111111',
           expiration_month: '09',
           expiration_year: (Time.now.year + 1).to_s,
@@ -986,7 +986,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
                    first_name: 'Longbob', last_name: 'Longsen' },
         options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
         custom_fields: nil,
-        android_pay_card: {
+        google_pay_card: {
           number: '4111111111111111',
           expiration_month: '09',
           expiration_year: (Time.now.year + 1).to_s,


### PR DESCRIPTION
Upgrade Braintree gem to 3.4

CE-1579

Unit: 83 tests, 190 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 84 tests, 444 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.619% passed