### PR TITLE
Elavon: pass ssl_vendor_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,8 @@
 * Qvalent: remove `pem_password` from required credentials [dsmcclain] #3982
 * Authorize.net: Fix stored credentials [tatsianaclifton] #3971
 * CyberSource: Add support for multiple new fields [dsmcclain] #3984
+* CASHNet: Update gateway adapter [dsmcclain] #3986
+* Elavon: Send `ssl_vendor_id` field via options on gateway initialization [dsmcclain] #3989
 
 == Version 1.119.0 (February 9th, 2021)
 * Payment Express: support verify/validate [therufs] #3874

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment_method, options = {})
         request = build_xml_request do |xml|
-          xml.ssl_vendor_id         options[:ssl_vendor_id]
+          xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:purchase]
           xml.ssl_amount            amount(money)
 
@@ -64,7 +64,7 @@ module ActiveMerchant #:nodoc:
 
       def authorize(money, creditcard, options = {})
         request = build_xml_request do |xml|
-          xml.ssl_vendor_id         options[:ssl_vendor_id]
+          xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:authorize]
           xml.ssl_amount            amount(money)
 
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options = {})
         request = build_xml_request do |xml|
-          xml.ssl_vendor_id         options[:ssl_vendor_id]
+          xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
 
           if options[:credit_card]
             xml.ssl_transaction_type self.actions[:capture]
@@ -111,7 +111,7 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, identification, options = {})
         request = build_xml_request do |xml|
-          xml.ssl_vendor_id         options[:ssl_vendor_id]
+          xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:refund]
           xml.ssl_amount            amount(money)
           add_txn_id(xml, identification)
@@ -122,7 +122,7 @@ module ActiveMerchant #:nodoc:
 
       def void(identification, options = {})
         request = build_xml_request do |xml|
-          xml.ssl_vendor_id         options[:ssl_vendor_id]
+          xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:void]
 
           add_txn_id(xml, identification)
@@ -135,7 +135,7 @@ module ActiveMerchant #:nodoc:
         raise ArgumentError, 'Reference credits are not supported. Please supply the original credit card or use the #refund method.' if creditcard.is_a?(String)
 
         request = build_xml_request do |xml|
-          xml.ssl_vendor_id         options[:ssl_vendor_id]
+          xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:credit]
           xml.ssl_amount            amount(money)
           add_invoice(xml, options)
@@ -150,7 +150,7 @@ module ActiveMerchant #:nodoc:
 
       def verify(credit_card, options = {})
         request = build_xml_request do |xml|
-          xml.ssl_vendor_id         options[:ssl_vendor_id]
+          xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:verify]
           add_creditcard(xml, credit_card)
           add_address(xml, options)
@@ -162,7 +162,7 @@ module ActiveMerchant #:nodoc:
 
       def store(creditcard, options = {})
         request = build_xml_request do |xml|
-          xml.ssl_vendor_id         options[:ssl_vendor_id]
+          xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:store]
           xml.ssl_add_token 'Y'
           add_creditcard(xml, creditcard)
@@ -176,7 +176,7 @@ module ActiveMerchant #:nodoc:
 
       def update(token, creditcard, options = {})
         request = build_xml_request do |xml|
-          xml.ssl_vendor_id         options[:ssl_vendor_id]
+          xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:update]
           add_token(xml, token)
           add_creditcard(xml, creditcard)

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -17,6 +17,13 @@ class ElavonTest < Test::Unit::TestCase
       multi_currency: true
     )
 
+    @gateway_with_ssl_vendor_id = ElavonGateway.new(
+      login: 'login',
+      user: 'user',
+      password: 'password',
+      ssl_vendor_id: 'ABC123'
+    )
+
     @credit_card = credit_card
     @amount = 100
 
@@ -385,11 +392,19 @@ class ElavonTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_ssl_vendor_id_in_request
+  def test_ssl_vendor_id_from_gateway_credentials
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(ssl_vendor_id: 'ABC123'))
+      @gateway_with_ssl_vendor_id.purchase(@amount, @credit_card, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<ssl_vendor_id>ABC123<\/ssl_vendor_id/, data)
+      assert_match(/<ssl_vendor_id>ABC123<\/ssl_vendor_id>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_ssl_vendor_id_from_options
+    stub_comms do
+      @gateway_with_ssl_vendor_id.purchase(@amount, @credit_card, @options.merge(ssl_vendor_id: 'My special ID'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_vendor_id>My special ID<\/ssl_vendor_id>/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
This PR makes it so that ssl_vendor_id can be passed via the options provided to the gateway on initialization (`@options`) as opposed to just on a per-transaction basis (`options`).

CE-1660

Remote:
35 tests, 165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Local:
4732 tests, 73513 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
699 files inspected, no offenses detected