### PR TITLE
Braintree 4 Upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rubocop', '~> 0.62.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 3.0.0', '<= 3.0.1'
+  gem 'braintree', '>= 3.0.0'
   gem 'jwe'
   gem 'mechanize'
 end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -7,7 +7,7 @@ rescue LoadError
   raise 'Could not load the braintree gem.  Use `gem install braintree` to install it.'
 end
 
-raise 'Need braintree gem >= 2.0.0.' unless Braintree::Version::Major >= 2 && Braintree::Version::Minor >= 0
+raise "Need braintree gem >= 3.0.0. Run `gem install braintree --version '>=3.0'` to get the correct version." unless Braintree::Version::Major >= 3
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -801,8 +801,7 @@ module ActiveMerchant #:nodoc:
                 eci_indicator: credit_card_or_vault_id.eci
               }
             elsif credit_card_or_vault_id.source == :android_pay || credit_card_or_vault_id.source == :google_pay
-              Braintree::Version::Major < 3 ? pay_card = :android_pay_card : pay_card = :google_pay_card
-              parameters[pay_card] = {
+              parameters[:google_pay_card] = {
                 number: credit_card_or_vault_id.number,
                 cryptogram: credit_card_or_vault_id.payment_cryptogram,
                 expiration_month: credit_card_or_vault_id.month.to_s.rjust(2, '0'),


### PR DESCRIPTION
Testing the the Braintree 4.1 gem

CE-1579

Unit: 83 tests, 190 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: