### PR TITLE
Checkout: add support for `metadata` fields

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -37,12 +37,15 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, amount, options)
         add_customer_data(post, options)
+        add_metadata(post, options)
 
         commit(:capture, post, authorization)
       end
 
       def void(authorization, _options = {})
         post = {}
+        add_metadata(post, options)
+
         commit(:void, post, authorization)
       end
 
@@ -50,6 +53,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, amount, options)
         add_customer_data(post, options)
+        add_metadata(post, options)
 
         commit(:refund, post, authorization)
       end
@@ -82,8 +86,9 @@ module ActiveMerchant #:nodoc:
         add_stored_credential_options(post, options)
         add_transaction_data(post, options)
         add_3ds(post, options)
+        add_metadata(post, options)
       end
-
+  
       def add_invoice(post, money, options)
         post[:amount] = localized_amount(money, options[:currency])
         post[:reference] = options[:order_id]
@@ -95,6 +100,14 @@ module ActiveMerchant #:nodoc:
         end
         post[:metadata] = {}
         post[:metadata][:udf5] = application_id || 'ActiveMerchant'
+      end
+
+      def add_metadata(post, options)
+        puts options[:metadata]
+        post[:metadata] = {} unless post[:metadata]
+        post[:metadata].merge(options[:metadata]) if options[:metadata]
+        # puts post[:metadata]
+        # puts options[:metadata]
       end
 
       def add_payment_method(post, payment_method, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -155,6 +155,18 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_metadata
+    options = @options.merge(
+      metadata: {
+        "coupon_code": "NY2018",
+        "partner_id": 123989
+      }
+    )
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_minimal_options
     response = @gateway.purchase(@amount, @credit_card, billing_address: address)
     assert_success response
@@ -223,6 +235,22 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorize_and_capture_with_metadata
+    options = @options.merge(
+      metadata: {
+        "coupon_code": "NY2018",
+        "partner_id": 123989
+      }
+    )
+
+    auth = @gateway.authorize(@amount, @credit_card, options)
+    assert_success auth
+
+    assert capture = @gateway.capture(nil, auth.authorization)
+    assert_success capture
+  end
+
+
   def test_direct_3ds_authorize
     auth = @gateway.authorize(@amount, @threeds_card, @options.merge(execute_threed: true))
 
@@ -260,6 +288,24 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_success refund
   end
 
+  def test_successful_refund_with_metadata
+    options = @options.merge(
+      metadata: {
+        "coupon_code": "NY2018",
+        "partner_id": 123989
+      }
+    )
+
+    purchase = @gateway.purchase(@amount, @credit_card, options)
+    assert_success purchase
+
+    sleep 1
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+  end
+
+
   def test_partial_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
@@ -277,6 +323,21 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
 
   def test_successful_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+  end
+
+  def test_successful_void_with_metadata
+    options = @options.merge(
+      metadata: {
+        "coupon_code": "NY2018",
+        "partner_id": 123989
+      }
+    )
+
+    auth = @gateway.authorize(@amount, @credit_card, options)
     assert_success auth
 
     assert void = @gateway.void(auth.authorization)

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -164,14 +164,38 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_purchase_with_metadata
+    response = stub_comms do
+      options = {
+        metadata: {
+          coupon_code: "NY2018",
+          partner_id: "123989"
+        }
+      }
+      # puts options
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r{metadata:{"coupon_code":"NY2018"}}, data)
+      assert_match(%r{metadata:{"partner_id":"123989"}}, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+  end 
+
   def test_moto_transaction_is_properly_set
     response = stub_comms do
       options = {
-        metadata: { manual_entry: true }
+        metadata: { 
+          manual_entry: true,
+          # coupon_code: "NY2018",
+          # partner_id: "123989"
+        }
       }
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"payment_type":"MOTO"}, data)
+      # assert_match(%r{metadata:{"coupon_code":"NY2018"}}, data)
+      # assert_match(%r{metadata:{"partner_id":"123989"}}, data)
     end.respond_with(successful_authorize_response)
 
     assert_success response


### PR DESCRIPTION
Draft - `metatdata` fields not merging correctly.

Metadata information, found in [Checkout's documentation](https://api-reference.checkout.com/#operation/requestAPaymentOrPayout)

More detailed notes in CE-1043