### PR TITLE
CE-1043 checkout metadata

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Payment Express/Windcave: Send amount on verify calls [cdmackeyfree] #3995
 * Orbital: Use billing_address name as fallback [curiousepic] #3966
 * vPOS: handle shop_process_id correctly [therufs] #3996
+* Checkout v2: Support metadata field [saschakala] #3992
 
 == Version 1.120.0 (May 28th, 2021)
 * Braintree: Bump required braintree gem version to 3.0.1

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -37,12 +37,15 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, amount, options)
         add_customer_data(post, options)
+        add_metadata(post, options)
 
         commit(:capture, post, authorization)
       end
 
       def void(authorization, _options = {})
         post = {}
+        add_metadata(post, options)
+
         commit(:void, post, authorization)
       end
 
@@ -50,6 +53,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(post, amount, options)
         add_customer_data(post, options)
+        add_metadata(post, options)
 
         commit(:refund, post, authorization)
       end
@@ -82,6 +86,7 @@ module ActiveMerchant #:nodoc:
         add_stored_credential_options(post, options)
         add_transaction_data(post, options)
         add_3ds(post, options)
+        add_metadata(post, options)
       end
 
       def add_invoice(post, money, options)
@@ -95,6 +100,11 @@ module ActiveMerchant #:nodoc:
         end
         post[:metadata] = {}
         post[:metadata][:udf5] = application_id || 'ActiveMerchant'
+      end
+
+      def add_metadata(post, options)
+        post[:metadata] = {} unless post[:metadata]
+        post[:metadata].merge!(options[:metadata]) if options[:metadata]
       end
 
       def add_payment_method(post, payment_method, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -155,6 +155,18 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_metadata
+    options = @options.merge(
+      metadata: {
+        coupon_code: 'NY2018',
+        partner_id: '123989'
+      }
+    )
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_minimal_options
     response = @gateway.purchase(@amount, @credit_card, billing_address: address)
     assert_success response
@@ -223,6 +235,21 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorize_and_capture_with_metadata
+    options = @options.merge(
+      metadata: {
+        coupon_code: 'NY2018',
+        partner_id: '123989'
+      }
+    )
+
+    auth = @gateway.authorize(@amount, @credit_card, options)
+    assert_success auth
+
+    assert capture = @gateway.capture(nil, auth.authorization)
+    assert_success capture
+  end
+
   def test_direct_3ds_authorize
     auth = @gateway.authorize(@amount, @threeds_card, @options.merge(execute_threed: true))
 
@@ -260,6 +287,23 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_success refund
   end
 
+  def test_successful_refund_with_metadata
+    options = @options.merge(
+      metadata: {
+        coupon_code: 'NY2018',
+        partner_id: '123989'
+      }
+    )
+
+    purchase = @gateway.purchase(@amount, @credit_card, options)
+    assert_success purchase
+
+    sleep 1
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+  end
+
   def test_partial_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
@@ -277,6 +321,21 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
 
   def test_successful_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+  end
+
+  def test_successful_void_with_metadata
+    options = @options.merge(
+      metadata: {
+        coupon_code: 'NY2018',
+        partner_id: '123989'
+      }
+    )
+
+    auth = @gateway.authorize(@amount, @credit_card, options)
     assert_success auth
 
     assert void = @gateway.void(auth.authorization)


### PR DESCRIPTION
Added `metadata` fields to request payment, capture, void, and refund per [Checkout's documentation](https://api-reference.checkout.com/#operation/requestAPaymentOrPayout)

Local
4735 tests, 73541 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit
34 tests, 169 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote
38 tests, 99 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed