### PR TITLE
Remove Braintree Version Restriction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-
+* Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993
 
 == Version 1.120.0 (May 28th, 2021)
 * Braintree: Bump required braintree gem version to 3.0.1

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -7,7 +7,7 @@ rescue LoadError
   raise 'Could not load the braintree gem.  Use `gem install braintree` to install it.'
 end
 
-raise "Need braintree gem >= 3.0.0. Run `gem install braintree --version '~>3.0.0'` to get the correct version." unless Braintree::Version::Major == 3 && Braintree::Version::Minor == 0
+raise 'Need braintree gem >= 2.0.0.' unless Braintree::Version::Major >= 2 && Braintree::Version::Minor >= 0
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -801,7 +801,8 @@ module ActiveMerchant #:nodoc:
                 eci_indicator: credit_card_or_vault_id.eci
               }
             elsif credit_card_or_vault_id.source == :android_pay || credit_card_or_vault_id.source == :google_pay
-              parameters[:google_pay_card] = {
+              Braintree::Version::Major < 3 ? pay_card = :android_pay_card : pay_card = :google_pay_card
+              parameters[pay_card] = {
                 number: credit_card_or_vault_id.number,
                 cryptogram: credit_card_or_vault_id.payment_cryptogram,
                 expiration_month: credit_card_or_vault_id.month.to_s.rjust(2, '0'),


### PR DESCRIPTION
Lift restriction on the Braintree gem version to allow for versions
older than 3.* to work with AM. A part of this is to dynamically
determine the key name for pay card (`google_pay_card` for versions > 3
and `android_pay_card` for older versions).

CE-1579

Unit: 83 tests, 190 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 84 tests, 444 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.619% passed