### PR TITLE
Add amount to verify calls for Payment Express/Windcave

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993
+* Payment Express/Windcave: Send amount on verify calls [cdmackeyfree] #3995
 
 == Version 1.120.0 (May 28th, 2021)
 * Braintree: Bump required braintree gem version to 3.0.1

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -86,8 +86,8 @@ module ActiveMerchant #:nodoc:
         refund(money, identification, options)
       end
 
-      def verify(payment_source, options = {})
-        request = build_purchase_or_authorization_request(nil, payment_source, options)
+      def verify(money, payment_source, options = {})
+        request = build_purchase_or_authorization_request(money, payment_source, options)
         commit(:validate, request)
       end
 

--- a/test/remote/gateways/remote_payment_express_test.rb
+++ b/test/remote/gateways/remote_payment_express_test.rb
@@ -98,7 +98,7 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_verify
-    assert response = @gateway.verify(@credit_card, @options)
+    assert response = @gateway.verify(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'The Transaction was approved', response.message
     assert_not_nil token = response.authorization

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -45,10 +45,18 @@ class PaymentExpressTest < Test::Unit::TestCase
     assert_equal '00000004011a2478', response.authorization
   end
 
+  def test_pass_currency_code_on_validation
+    stub_comms do
+      @gateway.verify(@amount, @visa, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<InputCurrency>NZD<\/InputCurrency>/, data)
+    end.respond_with(successful_validation_response)
+  end
+
   def test_successful_validation
     @gateway.expects(:ssl_post).returns(successful_validation_response)
 
-    assert response = @gateway.verify(@visa, @options)
+    assert response = @gateway.verify(@amount, @visa, @options)
     assert_success response
     assert response.test?
     assert_equal 'The Transaction was approved', response.message


### PR DESCRIPTION
Verify call was not passing the currency code to the Payment Express aka Windcave gateway. It appears it was not passing an amount originally, which is needed in order to verify with a currency code.

Local:
4733 tests, 73517 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
37 tests, 263 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
17 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed