### PR TITLE
Adyen: Support networkTxReference field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Orbital: Use billing_address name as fallback [curiousepic] #3966
 * vPOS: handle shop_process_id correctly [therufs] #3996
 * Checkout v2: Support metadata field [saschakala] #3992
+* Adyen: Support networkTxReference field [naashton] #3997
 
 == Version 1.120.0 (May 28th, 2021)
 * Braintree: Bump required braintree gem version to 3.0.1

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -397,6 +397,7 @@ module ActiveMerchant #:nodoc:
       def add_reference(post, authorization, options = {})
         _, psp_reference, = authorization.split('#')
         post[:originalReference] = single_reference(authorization) || psp_reference
+        post[:networkTxReference] = options[:network_transaction_id] if options[:network_transaction_id]
       end
 
       def add_original_reference(post, authorization, options = {})
@@ -511,6 +512,7 @@ module ActiveMerchant #:nodoc:
           raw_response = e.response.body
           response = parse(raw_response)
         end
+
         success = success_from(action, response, options)
         Response.new(
           success,
@@ -519,6 +521,7 @@ module ActiveMerchant #:nodoc:
           authorization: authorization_from(action, parameters, response),
           test: test?,
           error_code: success ? nil : error_code_from(response),
+          network_transaction_id: network_transaction_id_from(response),
           avs_result: AVSResult.new(code: avs_code_from(response)),
           cvv_result: CVVResult.new(cvv_result_from(response))
         )
@@ -619,6 +622,10 @@ module ActiveMerchant #:nodoc:
 
       def error_code_from(response)
         STANDARD_ERROR_CODE_MAPPING[response['errorCode']]
+      end
+
+      def network_transaction_id_from(response)
+        response.dig('additionalData', 'networkTxReference')
       end
 
       def add_browser_info(browser_info, post)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1114,6 +1114,15 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success purchase
   end
 
+  def test_auth_and_capture_with_network_txn_id
+    initial_options = stored_credential_options(:merchant, :recurring, :initial)
+    assert auth = @gateway.authorize(@amount, @credit_card, initial_options)
+    assert_success auth
+
+    capture = @gateway.capture(@amount, auth.authorization, { network_transaction_id: auth.network_transaction_id })
+    assert_success capture
+  end
+
   def test_successful_authorize_with_sub_merchant_data
     sub_merchant_data = {
       sub_merchant_id: '123451234512345',


### PR DESCRIPTION
Add support to pass `networkTxReference`, from initial auth
transactions, to subsequent MIT requests. We also extract the
`networkTxReference` from the gateway response and add it to the
`network_transaction_id` field in the Response object.

CE-1603

Unit: 76 tests, 397 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 99 tests, 378 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed