### PR TITLE
Add specific amount for verify

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -86,8 +86,8 @@ module ActiveMerchant #:nodoc:
         refund(money, identification, options)
       end
 
-      def verify(money, payment_source, options = {})
-        request = build_purchase_or_authorization_request(money, payment_source, options)
+      def verify(payment_source, options = {})
+        request = build_purchase_or_authorization_request(100, payment_source, options)
         commit(:validate, request)
       end
 

--- a/test/remote/gateways/remote_payment_express_test.rb
+++ b/test/remote/gateways/remote_payment_express_test.rb
@@ -98,7 +98,7 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
   end
 
   def test_verify
-    assert response = @gateway.verify(@amount, @credit_card, @options)
+    assert response = @gateway.verify(@credit_card, @options)
     assert_success response
     assert_equal 'The Transaction was approved', response.message
     assert_not_nil token = response.authorization


### PR DESCRIPTION
Hardcoded amount of $1 for verify calls per convention.

Local
4757 tests, 73618 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit
37 tests, 263 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
17 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed