### PR TITLE
SecurePayAU: Allow custom request_timeout

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -23,9 +23,6 @@ module ActiveMerchant #:nodoc:
       # The name of the gateway
       self.display_name = 'SecurePay'
 
-      class_attribute :request_timeout
-      self.request_timeout = 60
-
       self.money_format = :cents
       self.default_currency = 'AUD'
 
@@ -59,6 +56,10 @@ module ActiveMerchant #:nodoc:
       def initialize(options = {})
         requires!(options, :login, :password)
         super
+      end
+
+      def request_timeout
+        @options[:request_timeout] || 60
       end
 
       def purchase(money, credit_card_or_stored_id, options = {})

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -5,6 +5,10 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
     include ActiveMerchant::Billing::CreditCardMethods
     attr_accessor :number, :month, :year, :first_name, :last_name, :verification_value, :brand
 
+    def initialize(params)
+      params.each { |k,v| instance_variable_set("@#{k.to_s}".to_sym,v) }
+    end
+
     def verification_value?
       !@verification_value.blank?
     end
@@ -94,10 +98,11 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
 
     assert response = @gateway.refund(@amount + 1, authorization)
     assert_failure response
-    assert_equal 'Only $1.0 available for refund', response.message
+    assert_equal 'Only 1.00 AUD available for refund', response.message
   end
 
   def test_successful_void
+    omit("It appears that SecurePayAU no longer supports void")
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
 
@@ -110,6 +115,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
   end
 
   def test_failed_void
+    omit("It appears that SecurePayAU no longer supports void")
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     authorization = response.authorization

--- a/test/remote/gateways/remote_secure_pay_au_test.rb
+++ b/test/remote/gateways/remote_secure_pay_au_test.rb
@@ -122,7 +122,7 @@ class RemoteSecurePayAuTest < Test::Unit::TestCase
 
     assert response = @gateway.void(authorization + '1')
     assert_failure response
-    assert_equal 'Unable to retrieve original FDR txn', response.message
+    assert_equal 'Transaction type not available', response.message
   end
 
   def test_successful_unstore

--- a/test/unit/gateways/secure_pay_au_test.rb
+++ b/test/unit/gateways/secure_pay_au_test.rb
@@ -190,6 +190,23 @@ class SecurePayAuTest < Test::Unit::TestCase
     assert_equal 'test3', response.params['client_id']
   end
 
+  def test_request_timeout_default
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/<timeoutValue>60/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_override_request_timeout
+    gateway = SecurePayAuGateway.new(login: 'login', password: 'password', request_timeout: 44)
+    stub_comms(gateway, :ssl_request) do
+      gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert_match(/<timeoutValue>44/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_scrub
     assert_equal @gateway.scrub(pre_scrub), post_scrub
   end


### PR DESCRIPTION
This method was copied from similar NabTransactGateway, but placed at the
top because it contains a default value.

Note that the remote tests fix from https://github.com/activemerchant/active_merchant/pull/3979 (awaiting merge) is also included in order for tests to pass.

rake test TEST=test/unit/gateways/secure_pay_au_test.rb
25 tests, 109 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

rake test TEST=test/remote/gateways/remote_secure_pay_au_test.rb
18 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed