### PR TITLE
Update NMI 3DS2 field for eci

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * PayTrace: Support gateway [meagabeth] #3985
 * vPOS: Support credit + refund [therufs] #3998
 * PayArc: Support gateway [senthil-code] #3974
+* NMI: Support cardholder_auth field for 3DS2 [cdmackeyfree] #4002
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -254,7 +254,7 @@ module ActiveMerchant #:nodoc:
         return unless options[:three_d_secure]
 
         if (three_d_secure = options[:three_d_secure])
-          post[:eci] = three_d_secure[:eci]
+          post[:cardholder_auth] = three_d_secure[:cardholder_auth]
           post[:cavv] = three_d_secure[:cavv]
           post[:xid] = three_d_secure[:xid]
           post[:three_ds_version] = three_d_secure[:version]

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -107,7 +107,7 @@ class RemoteNmiTest < Test::Unit::TestCase
     three_d_secure_options = @options.merge({
       three_d_secure: {
         version: '2.1.0',
-        eci: '02',
+        cardholder_auth: 'verified',
         cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA',
         ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC'
       }

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -98,14 +98,14 @@ class NmiTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_3ds
     version = '2.1.0'
-    eci = '02'
+    cardholder_auth = 'verified'
     cavv = 'jJ81HADVRtXfCBATEp01CJUAAAA'
     ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'
     xid = '00000000000000000501'
     options_with_3ds = @transaction_options.merge(
       three_d_secure: {
         version: version,
-        eci: eci,
+        cardholder_auth: cardholder_auth,
         cavv: cavv,
         ds_transaction_id: ds_transaction_id,
         xid: xid
@@ -116,7 +116,7 @@ class NmiTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, options_with_3ds)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/three_ds_version=2.1.0/, data)
-      assert_match(/eci=02/, data)
+      assert_match(/cardholder_auth=verified/, data)
       assert_match(/cavv=jJ81HADVRtXfCBATEp01CJUAAAA/, data)
       assert_match(/directory_server_id=97267598-FAE6-48F2-8083-C23433990FBC/, data)
       assert_match(/xid=00000000000000000501/, data)


### PR DESCRIPTION
NMI is now using `cardholder_auth` to determine the `eci` value at the gateway level.

Local:
4757 tests, 73618 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
46 tests, 352 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
42 tests, 156 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed