### PR TITLE
PayULatam: adjust phone number mapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * NMI: Support cardholder_auth field for 3DS2 [cdmackeyfree] #4002
 * Confiable: Support cardtype [therufs] #4004
 * Maestro: Add BIN [therufs] #4003
+* PayULatam: Ensure phone number is pulled from shipping_address correctly [dsmcclain] #4005
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -208,7 +208,7 @@ module ActiveMerchant #:nodoc:
           buyer[:merchantBuyerId] = buyer_hash[:merchant_buyer_id]
           buyer[:cnpj] = buyer_hash[:cnpj] if @options[:payment_country] == 'BR'
           buyer[:emailAddress] = buyer_hash[:email]
-          buyer[:contactPhone] = (options[:billing_address][:phone] if options[:billing_address]) || (options[:shipping_address][:phone] if options[:shipping_address]) || ''
+          buyer[:contactPhone] = (options[:billing_address][:phone] if options[:billing_address]) || (options[:shipping_address][:phone_number] if options[:shipping_address]) || ''
           buyer[:shippingAddress] = shipping_address_fields(options) if options[:shipping_address]
         else
           buyer[:fullName] = payment_method.name.strip
@@ -217,7 +217,7 @@ module ActiveMerchant #:nodoc:
           buyer[:merchantBuyerId] = options[:merchant_buyer_id]
           buyer[:cnpj] = options[:cnpj] if @options[:payment_country] == 'BR'
           buyer[:emailAddress] = options[:email]
-          buyer[:contactPhone] = (options[:billing_address][:phone] if options[:billing_address]) || (options[:shipping_address][:phone] if options[:shipping_address]) || ''
+          buyer[:contactPhone] = (options[:billing_address][:phone] if options[:billing_address]) || (options[:shipping_address][:phone_number] if options[:shipping_address]) || ''
           buyer[:shippingAddress] = shipping_address_fields(options) if options[:shipping_address]
         end
         post[:transaction][:order][:buyer] = buyer
@@ -233,7 +233,7 @@ module ActiveMerchant #:nodoc:
         shipping_address[:state] = address[:state]
         shipping_address[:country] = address[:country]
         shipping_address[:postalCode] = address[:zip]
-        shipping_address[:phone] = address[:phone]
+        shipping_address[:phone] = address[:phone_number]
         shipping_address
       end
 

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -5,9 +5,9 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     @gateway = PayuLatamGateway.new(fixtures(:payu_latam).update(payment_country: 'AR'))
 
     @amount = 4000
-    @credit_card = credit_card('4097440000000004', verification_value: '444', first_name: 'APPROVED', last_name: '')
-    @declined_card = credit_card('4097440000000004', verification_value: '444', first_name: 'REJECTED', last_name: '')
-    @pending_card = credit_card('4097440000000004', verification_value: '444', first_name: 'PENDING', last_name: '')
+    @credit_card = credit_card('4097440000000004', verification_value: '777', first_name: 'APPROVED', last_name: '')
+    @declined_card = credit_card('4097440000000004', verification_value: '777', first_name: 'REJECTED', last_name: '')
+    @pending_card = credit_card('4097440000000004', verification_value: '777', first_name: 'PENDING', last_name: '')
     @naranja_credit_card = credit_card('5895620000000002', verification_value: '123', first_name: 'APPROVED', last_name: '', brand: 'naranja')
     @cabal_credit_card = credit_card('5896570000000004', verification_value: '123', first_name: 'APPROVED', last_name: '', brand: 'cabal')
     @invalid_cabal_card = credit_card('6271700000000000', verification_value: '123', first_name: 'APPROVED', last_name: '', brand: 'cabal')

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -202,6 +202,15 @@ class PayuLatamTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_phone_number
+    options = @options.merge(billing_address: {}, shipping_address: { phone_number: 5555555555 })
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 5555555555, JSON.parse(data)['transaction']['order']['buyer']['contactPhone']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_verify_good_credentials
     @gateway.expects(:ssl_post).returns(credentials_are_legit_response)
     assert @gateway.verify_credentials
@@ -287,7 +296,7 @@ class PayuLatamTest < Test::Unit::TestCase
         state: 'SP',
         country: 'BR',
         zip: '01019-030',
-        phone: '(11)756312345'
+        phone_number: '(11)756312345'
       ),
       buyer: {
         name: 'Jorge Borges',
@@ -361,7 +370,7 @@ class PayuLatamTest < Test::Unit::TestCase
         state: 'SP',
         country: 'BR',
         zip: '01019-030',
-        phone: '(11)756312633'
+        phone_number: '(11)756312633'
       ),
       buyer: {
         cnpj: '32593371000110'
@@ -396,7 +405,7 @@ class PayuLatamTest < Test::Unit::TestCase
         state: 'Bogota DC',
         country: 'CO',
         zip: '01019-030',
-        phone: '(11)756312633'
+        phone_number: '(11)756312633'
       ),
       tx_tax: '3193',
       tx_tax_return_base: '16806'
@@ -430,7 +439,7 @@ class PayuLatamTest < Test::Unit::TestCase
         state: 'Jalisco',
         country: 'MX',
         zip: '01019-030',
-        phone: '(11)756312633'
+        phone_number: '(11)756312633'
       ),
       birth_date: '1985-05-25'
     }


### PR DESCRIPTION
Corrects the mapping of phone numbers from `shipping_address` object, so that if a payment method has a phone number saved to it that will be mapped first (`billing_address[:phone]`), otherwise if the transaction contains `shipping_address[:phone_number]` that will be mapped, otherwise we will map an empty string.

CE-1665

2 unrelated failing tests (also failing on master):
`test_successful_purchase_colombia` (timeout response from colombia sandbox)
`test_well_formed_refund_fails_as_expected` (failing for at least a while, e.g.: https://github.com/activemerchant/active_merchant/pull/3657)

Rubocop:
702 files inspected, no offenses detected

Unit:
4760 tests, 73628 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
35 tests, 83 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.2857% passed