### PR TITLE
Adyen: Pass networkTxReference in additionalData hash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Maestro: Add BIN [therufs] #4003
 * PayULatam: Ensure phone number is pulled from shipping_address correctly [dsmcclain] #4005
 * SafeCharge: Add challenge_preference for 3DS [klaiv] #3999
+* Adyen: Pass networkTxReference in all transactions [naashton] #4006
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -59,6 +59,7 @@ module ActiveMerchant #:nodoc:
         add_3ds_authenticated_data(post, options)
         add_splits(post, options)
         add_recurring_contract(post, options)
+        add_network_transaction_reference(post, options)
         commit('authorise', post, options)
       end
 
@@ -67,6 +68,7 @@ module ActiveMerchant #:nodoc:
         add_invoice_for_modification(post, money, options)
         add_reference(post, authorization, options)
         add_splits(post, options)
+        add_network_transaction_reference(post, options)
         commit('capture', post, options)
       end
 
@@ -75,6 +77,7 @@ module ActiveMerchant #:nodoc:
         add_invoice_for_modification(post, money, options)
         add_original_reference(post, authorization, options)
         add_splits(post, options)
+        add_network_transaction_reference(post, options)
         commit('refund', post, options)
       end
 
@@ -83,6 +86,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_payment(post, payment, options)
         add_shopper_reference(post, options)
+        add_network_transaction_reference(post, options)
         commit('refundWithData', post, options)
       end
 
@@ -90,6 +94,7 @@ module ActiveMerchant #:nodoc:
         post = init_post(options)
         endpoint = options[:cancel_or_refund] ? 'cancelOrRefund' : 'cancel'
         add_reference(post, authorization, options)
+        add_network_transaction_reference(post, options)
         commit(endpoint, post, options)
       end
 
@@ -397,7 +402,6 @@ module ActiveMerchant #:nodoc:
       def add_reference(post, authorization, options = {})
         _, psp_reference, = authorization.split('#')
         post[:originalReference] = single_reference(authorization) || psp_reference
-        post[:networkTxReference] = options[:network_transaction_id] if options[:network_transaction_id]
       end
 
       def add_original_reference(post, authorization, options = {})
@@ -407,6 +411,11 @@ module ActiveMerchant #:nodoc:
           original_psp_reference, = authorization.split('#')
         end
         post[:originalReference] = single_reference(authorization) || original_psp_reference
+      end
+
+      def add_network_transaction_reference(post, options)
+        post[:additionalData] = {} unless post[:additionalData]
+        post[:additionalData][:networkTxReference] = options[:network_transaction_id] if options[:network_transaction_id]
       end
 
       def add_mpi_data_for_network_tokenization_card(post, payment)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1117,10 +1117,22 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_auth_and_capture_with_network_txn_id
     initial_options = stored_credential_options(:merchant, :recurring, :initial)
     assert auth = @gateway.authorize(@amount, @credit_card, initial_options)
-    assert_success auth
+    assert auth.network_transaction_id
 
-    capture = @gateway.capture(@amount, auth.authorization, { network_transaction_id: auth.network_transaction_id })
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge(network_transaction_id: auth.network_transaction_id))
     assert_success capture
+  end
+
+  def test_auth_capture_refund_with_network_txn_id
+    initial_options = stored_credential_options(:merchant, :recurring, :initial)
+    assert auth = @gateway.authorize(@amount, @credit_card, initial_options)
+    assert auth.network_transaction_id
+
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge(network_transaction_id: auth.network_transaction_id))
+    assert_success capture
+
+    assert refund = @gateway.refund(@amount, auth.authorization, @options.merge(network_transaction_id: auth.network_transaction_id))
+    assert_success refund
   end
 
   def test_successful_authorize_with_sub_merchant_data


### PR DESCRIPTION
Pass networkTxReference in additionalData hash for all relevant
transactions. This value should be passed with stored credential fields
used in MIT.

CE-1603

Unit: 76 tests, 397 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 100 tests, 385 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed