### PR TITLE
PayTrace: Support level_3_data fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * SafeCharge: Add challenge_preference for 3DS [klaiv] #3999
 * Adyen: Pass networkTxReference in all transactions [naashton] #4006
 * Adyen: Ensure correct transaction reference is selected [dsmcclain] #4007
+* PayTrace: Support level_3_data fields [meagabeth] #4008
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/test/unit/gateways/pay_trace_test.rb
+++ b/test/unit/gateways/pay_trace_test.rb
@@ -11,6 +11,8 @@ module ActiveMerchant #:nodoc:
 end
 
 class PayTraceTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = PayTraceGateway.new(username: 'username', password: 'password', integrator_id: 'uniqueintegrator')
     @credit_card = credit_card
@@ -27,6 +29,51 @@ class PayTraceTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 392483066, response.authorization
+  end
+
+  def test_successful_purchase_with_level_3_data
+    @gateway.expects(:ssl_post).times(2).returns(successful_purchase_response).then.returns(successful_level_3_response)
+
+    options = {
+      visa_or_mastercard: 'visa',
+      invoice_id: 'inv12345',
+      customer_reference_id: '123abcd',
+      tax_amount: 499,
+      national_tax_amount: 172,
+      merchant_tax_id: '3456defg',
+      customer_tax_id: '3456test',
+      commodity_code: '4321',
+      discount_amount: 99,
+      freight_amount: 75,
+      duty_amount: 32,
+      source_address: {
+        zip: '94947'
+      },
+      shipping_address: {
+        zip: '94948',
+        country: 'US'
+      },
+      additional_tax_amount: 4,
+      additional_tax_rate: 1,
+      line_items: [
+        {
+          additional_tax_amount: 0,
+            additional_tax_rate: 8,
+            amount: 1999,
+            commodity_code: '123commodity',
+            description: 'plumbing',
+            discount_amount: 327,
+            product_id: 'skucode123',
+            quantity: 4,
+            unit_of_measure: 'EACH',
+            unit_cost: 424
+        }
+      ]
+    }
+
+    response = @gateway.purchase(100, @credit_card, options)
+    assert_success response
+    assert_equal 170, response.params['response_code']
   end
 
   def test_failed_purchase
@@ -60,6 +107,23 @@ class PayTraceTest < Test::Unit::TestCase
     response = @gateway.capture(transaction_id, @options)
     assert_success response
     assert_equal 'Your transaction was successfully captured.', response.message
+  end
+
+  def test_successful_level_3_data_field_mapping
+    authorization = 123456789
+    options = {
+      visa_or_mastercard: 'visa',
+      address: {
+        zip: '99201'
+      }
+    }
+    stub_comms(@gateway) do
+      @gateway.capture(authorization, options)
+    end.check_request do |endpoint, data, _headers|
+      next unless endpoint == 'https://api.paytrace.com/v1/level_three/visa'
+
+      assert_match(/"source_address":{"zip":"99201"}/, data)
+    end.respond_with(successful_level_3_visa)
   end
 
   def test_failed_capture
@@ -246,6 +310,14 @@ class PayTraceTest < Test::Unit::TestCase
 
   def successful_purchase_response
     '{"success":true,"response_code":101,"status_message":"Your transaction was successfully approved.","transaction_id":392483066,"approval_code":"TAS610","approval_message":"  NO  MATCH - Approved and completed","avs_response":"No Match","csc_response":"","external_transaction_id":"","masked_card_number":"xxxxxxxxxxxx5439"}'
+  end
+
+  def successful_level_3_response
+    '{"success":true,"response_code":170,"status_message":"Visa/MasterCard enhanced data was successfully added to Transaction ID 392483066. 1 line item records were created."}'
+  end
+
+  def successful_level_3_visa
+    '{"success":true,"response_code":170,"status_message":"Visa/MasterCard enhanced data was successfully added to Transaction ID 123456789. 2 line item records were created."}'
   end
 
   def failed_purchase_response


### PR DESCRIPTION
PayTrace supports the addition of level_3_data to any approved and unsettled sale transaction. In order to add level_3_data to an approved transaction, the transaction will have to have been completed and returned a transaction_id. Due to this workflow, the method to add level_3_data has been built into the end of the purchase method. As of now, only Visa and MasterCard are supported for level_3_data so an additional test has been included in the remote file to make sure that if a card other than visa or MasterCard is processed, the purchase will go through and the attempt to add level_3_data will be ignored.

CE-1737

Local:
4774 tests, 73670 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
17 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
24 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed