### PR TITLE
BluePay: Add Stored Credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * Adyen: Pass networkTxReference in all transactions [naashton] #4006
 * Adyen: Ensure correct transaction reference is selected [dsmcclain] #4007
 * PayTrace: Support level_3_data fields [meagabeth] #4008
+* BluePay: Add support for Stored Credentials [dsmcclain] #4009
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -84,6 +84,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_rebill(post, options) if options[:rebill]
         add_duplicate_override(post, options)
+        add_stored_credential(post, options)
         post[:TRANS_TYPE] = 'AUTH'
         commit('AUTH_ONLY', money, post, options)
       end
@@ -107,6 +108,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_rebill(post, options) if options[:rebill]
         add_duplicate_override(post, options)
+        add_stored_credential(post, options)
         post[:TRANS_TYPE] = 'SALE'
         commit('AUTH_CAPTURE', money, post, options)
       end
@@ -459,6 +461,33 @@ module ActiveMerchant #:nodoc:
         post[:REB_FIRST_DATE]  = options[:rebill_start_date]
         post[:REB_EXPR]        = options[:rebill_expression]
         post[:REB_CYCLES]      = options[:rebill_cycles]
+      end
+
+      def add_stored_credential(post, options)
+        post[:cof] = initiator(options)
+        post[:cofscheduled] = scheduled(options)
+      end
+
+      def initiator(options)
+        return unless initiator = options.dig(:stored_credential, :initiator)
+
+        case initiator
+        when 'merchant'
+          'M'
+        when 'cardholder'
+          'C'
+        end
+      end
+
+      def scheduled(options)
+        return unless reason_type = options.dig(:stored_credential, :reason_type)
+
+        case reason_type
+        when 'recurring' || 'installment'
+          'Y'
+        when 'unscheduled'
+          'N'
+        end
       end
 
       def post_data(action, parameters = {})

--- a/test/remote/gateways/remote_blue_pay_test.rb
+++ b/test/remote/gateways/remote_blue_pay_test.rb
@@ -41,6 +41,15 @@ class BluePayTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_stored_credential
+    options = @options.merge(stored_credential: { initiator: 'cardholder', reason_type: 'recurring' })
+    assert response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert response.test?
+    assert_equal 'This transaction has been approved', response.message
+    assert response.authorization
+  end
+
   def test_expired_credit_card
     @credit_card.year = 2004
     assert response = @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -224,6 +224,36 @@ class BluePayTest < Test::Unit::TestCase
       @gateway.send(:parse, 'STATUS=2&CVV2=M&AVS=A&MESSAGE=FAILURE').message
   end
 
+  def test_passing_stored_credentials_data_for_mit_transaction
+    options = @options.merge({ stored_credential: { initiator: 'merchant', reason_type: 'recurring' } })
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/cof=M/, data)
+      assert_match(/cofscheduled=Y/, data)
+    end.respond_with(RSP[:approved_auth])
+  end
+
+  def test_passing_stored_credentials_for_cit_transaction
+    options = @options.merge({ stored_credential: { initiator: 'cardholder', reason_type: 'unscheduled' } })
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/cof=C/, data)
+      assert_match(/cofscheduled=N/, data)
+    end.respond_with(RSP[:approved_auth])
+  end
+
+  def test_passes_nothing_for_unrecognized_stored_credentials_values
+    options = @options.merge({ stored_credential: { initiator: 'unknown', reason_type: 'something weird' } })
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/cof=&/, data)
+      assert_match(/cofscheduled=&/, data)
+    end.respond_with(RSP[:approved_auth])
+  end
+
   # Recurring Billing Unit Tests
   def test_successful_recurring
     @gateway.expects(:ssl_post).returns(successful_recurring_response)


### PR DESCRIPTION
This PR adds support for Stored Credentials to the BluePay Gateway Adapter.

According to their [docs](https://support.cardpointe.com/compliance/visa-stored-credential-transaction-framework-mandate#new-authorization-request-parameters), BluePay expects two fields, `cof` and `cofscheduled`, on all authorization requests using Stored Credentials. This PR maps incoming `stored_credential` parameters to these fields.

CE-1669

Rubocop:
705 files inspected, no offenses detected

Unit:
4779 tests, 73706 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_blue_pay_test
18 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed