### PR TITLE
Orbital: Adding MC SCARecurringPayment field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Adyen: Ensure correct transaction reference is selected [dsmcclain] #4007
 * PayTrace: Support level_3_data fields [meagabeth] #4008
 * BluePay: Add support for Stored Credentials [dsmcclain] #4009
+* Orbital: Add support for SCARecurringPayment [jessiagee] #4010
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -612,10 +612,18 @@ module ActiveMerchant #:nodoc:
         xml.tag!(:MCDirectoryTransID, three_d_secure[:ds_transaction_id]) if three_d_secure[:ds_transaction_id]
       end
 
-      def add_ucafind(xml, creditcard, three_d_secure)
+      def add_mc_ucafind(xml, creditcard, three_d_secure)
         return unless three_d_secure && creditcard.brand == 'master'
 
         xml.tag! :UCAFInd, '4'
+      end
+
+      def add_mc_scarecurring(xml, creditcard, parameters, three_d_secure)
+        return unless parameters && parameters[:sca_recurring] && creditcard.brand == 'master'
+
+        valid_eci = three_d_secure && three_d_secure[:eci] && three_d_secure[:eci] == '7'
+
+        xml.tag!(:SCARecurringPayment, parameters[:sca_recurring]) if valid_eci
       end
 
       def add_dpanind(xml, creditcard)
@@ -884,9 +892,10 @@ module ActiveMerchant #:nodoc:
             add_card_indicators(xml, parameters)
             add_stored_credentials(xml, parameters)
             add_pymt_brand_program_code(xml, payment_source, three_d_secure)
+            add_mc_scarecurring(xml, payment_source, parameters, three_d_secure)
             add_mc_program_protocol(xml, payment_source, three_d_secure)
             add_mc_directory_trans_id(xml, payment_source, three_d_secure)
-            add_ucafind(xml, payment_source, three_d_secure)
+            add_mc_ucafind(xml, payment_source, three_d_secure)
           end
         end
         xml.target!

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -197,6 +197,27 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_false response.authorization.blank?
   end
 
+  def test_successful_purchase_with_sca_recurring_master_card
+    cc = credit_card('5555555555554444', first_name: 'Joe', last_name: 'Smith',
+                     month: '12', year: '2022', brand: 'master', verification_value: '999')
+    options_local = {
+      three_d_secure: {
+        eci: '7',
+        xid: 'TESTXID',
+        cavv: 'AAAEEEDDDSSSAAA2243234',
+        ds_transaction_id: '97267598FAE648F28083C23433990FBC',
+        version: 2
+      },
+      sca_recurring: 'Y'
+    }
+
+    assert response = @three_ds_gateway.purchase(100, cc, @options.merge(options_local))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
   def test_successful_purchase_with_american_express_network_tokenization_credit_card
     network_card = network_tokenization_credit_card('4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
@@ -693,7 +714,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
     assert_match(/<AVSname>Jim Smith/, transcript)
     assert_match(/<RespCode>00/, transcript)
-    assert_match(/<StatusMsg>Approved/, transcript)
+    assert_match(/atusMsg>Approved</, transcript)
   end
 
   def test_echeck_purchase_with_no_address_responds_with_name
@@ -705,7 +726,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
 
     assert_match(/<AVSname>Test McTest/, transcript)
     assert_match(/<RespCode>00/, transcript)
-    assert_match(/<StatusMsg>Approved/, transcript)
+    assert_match(/atusMsg>Approved</, transcript)
   end
 
   def test_credit_purchase_with_address_responds_with_name


### PR DESCRIPTION
Loaded suite test/unit/gateways/orbital_test

122 tests, 716 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_orbital_test

69 tests, 320 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

bundle exec rake test:local

4778 tests, 73709 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

705 files inspected, no offenses detected