### PR TITLE
PayTrace: Adjust capture method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * BluePay: Add support for Stored Credentials [dsmcclain] #4009
 * Orbital: Add support for SCARecurringPayment [jessiagee] #4010
 * Braintree: Support recurring_first and moto reasons [curiousepic] #4013
+* PayTrace: Adjust capture method [meagabeth] #4015
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/pay_trace.rb
+++ b/lib/active_merchant/billing/gateways/pay_trace.rb
@@ -44,7 +44,7 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment_or_customer_id, options = {})
         post = {}
-        add_invoice(post, money, options)
+        add_amount(post, money, options)
         if customer_id?(payment_or_customer_id)
           post[:customer_id] = payment_or_customer_id
           endpoint = ENDPOINTS[:customer_id_sale]
@@ -64,7 +64,7 @@ module ActiveMerchant #:nodoc:
 
       def authorize(money, payment_or_customer_id, options = {})
         post = {}
-        add_invoice(post, money, options)
+        add_amount(post, money, options)
         if customer_id?(payment_or_customer_id)
           post[:customer_id] = payment_or_customer_id
           endpoint = ENDPOINTS[:customer_id_auth]
@@ -78,10 +78,10 @@ module ActiveMerchant #:nodoc:
         check_token_response(response, endpoint, post, options)
       end
 
-      def capture(authorization, options = {})
+      def capture(money, authorization, options = {})
         post = {}
-        post[:amount] = amount(options[:amount]) if options[:amount]
         post[:transaction_id] = authorization
+        add_amount(post, money, options) if options[:include_capture_amount] == true
         response = commit(ENDPOINTS[:capture], post)
         check_token_response(response, ENDPOINTS[:capture], post, options)
 
@@ -204,7 +204,7 @@ module ActiveMerchant #:nodoc:
         post[:billing_address][:zip] = address[:zip]
       end
 
-      def add_invoice(post, money, options)
+      def add_amount(post, money, options)
         post[:amount] = amount(money)
       end
 

--- a/test/remote/gateways/remote_pay_trace_test.rb
+++ b/test/remote/gateways/remote_pay_trace_test.rb
@@ -169,7 +169,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
     auth = @gateway.authorize(300, @credit_card, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(auth.authorization, @options.merge(amount: 300))
+    assert capture = @gateway.capture(@amount, auth.authorization, @options)
     assert_success capture
     assert_equal 'Your transaction was successfully captured.', capture.message
   end
@@ -208,7 +208,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
     auth = @gateway.authorize(100, @mastercard, options)
     assert_success auth
 
-    assert capture = @gateway.capture(auth.authorization, options)
+    assert capture = @gateway.capture(@amount, auth.authorization, options)
     assert_success capture
 
     transaction_id = auth.authorization
@@ -225,12 +225,12 @@ class RemotePayTraceTest < Test::Unit::TestCase
     auth = @gateway.authorize(500, @amex, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(auth.authorization, @options.merge(amount: 300))
+    assert capture = @gateway.capture(200, auth.authorization, @options.merge(include_capture_amount: true))
     assert_success capture
   end
 
   def test_failed_capture
-    response = @gateway.capture('')
+    response = @gateway.capture(@amount, '')
     assert_failure response
     assert_equal 'One or more errors has occurred.', response.message
   end

--- a/test/unit/gateways/pay_trace_test.rb
+++ b/test/unit/gateways/pay_trace_test.rb
@@ -104,7 +104,16 @@ class PayTraceTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_capture_response)
     transaction_id = 10598543
 
-    response = @gateway.capture(transaction_id, @options)
+    response = @gateway.capture(@amount, transaction_id, @options)
+    assert_success response
+    assert_equal 'Your transaction was successfully captured.', response.message
+  end
+
+  def test_successful_partial_capture
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+    transaction_id = 11223344
+
+    response = @gateway.capture(@amount, transaction_id, @options.merge(include_capture_amount: true))
     assert_success response
     assert_equal 'Your transaction was successfully captured.', response.message
   end
@@ -118,7 +127,7 @@ class PayTraceTest < Test::Unit::TestCase
       }
     }
     stub_comms(@gateway) do
-      @gateway.capture(authorization, options)
+      @gateway.capture(@amount, authorization, options)
     end.check_request do |endpoint, data, _headers|
       next unless endpoint == 'https://api.paytrace.com/v1/level_three/visa'
 
@@ -129,7 +138,7 @@ class PayTraceTest < Test::Unit::TestCase
   def test_failed_capture
     @gateway.expects(:ssl_post).returns(failed_capture_response)
 
-    response = @gateway.capture('', @options)
+    response = @gateway.capture(@amount, '', @options)
     assert_failure response
     assert_equal 'One or more errors has occurred.', response.message
   end


### PR DESCRIPTION
Add option to pass `include_capture_amount` field to trigger the sending of specified amount. Without this option set to true, the capture method will act on whatever dollar amount the original authorization included.

Local:
4784 tests, 73748 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
19 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
25 tests, 64 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed