### PR TITLE
Mercado Pago: Added more fields purchase requests.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* MercadoPago: Added external_reference, more payer object options, and metadata field [DustinHaefele] #4020
 * Element: Add duplicate_override_flag [almalee24] #4012
 * PayTrace: Support gateway [meagabeth] #3985
 * vPOS: Support credit + refund [therufs] #3998

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -129,6 +129,7 @@ module ActiveMerchant #:nodoc:
 
       def add_additional_data(post, options)
         post[:sponsor_id] = options[:sponsor_id]
+        post[:metadata] = options[:metadata] if options[:metadata]
         post[:device_id] = options[:device_id] if options[:device_id]
         post[:additional_info] = {
           ip_address: options[:ip_address]
@@ -143,7 +144,7 @@ module ActiveMerchant #:nodoc:
           email: options[:email],
           first_name: payment.first_name,
           last_name: payment.last_name
-        }
+        }.merge(options[:payer] || {})
       end
 
       def add_address(post, options)
@@ -191,7 +192,7 @@ module ActiveMerchant #:nodoc:
         post[:description] = options[:description]
         post[:installments] = options[:installments] ? options[:installments].to_i : 1
         post[:statement_descriptor] = options[:statement_descriptor] if options[:statement_descriptor]
-        post[:external_reference] = options[:order_id] || SecureRandom.hex(16)
+        post[:external_reference] = options[:order_id] || options[:external_reference] || SecureRandom.hex(16)
       end
 
       def add_payment(post, options)

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -44,6 +44,13 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
       fraud_manual_review: true,
       payment_method_option_id: '123abc'
     }
+    @payer = {
+      entity_type: 'individual',
+      type: 'customer',
+      identification: {},
+      first_name: 'Longbob',
+      last_name: 'Longsen'
+    }
   end
 
   def test_successful_purchase
@@ -111,6 +118,21 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options.merge(notification_url: 'https://www.spreedly.com/'))
     assert_success response
     assert_equal 'https://www.spreedly.com/', response.params['notification_url']
+  end
+
+  def test_successful_purchase_with_payer
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ payer: @payer }))
+    assert_success response
+    assert_equal 'accredited', response.message
+  end
+
+  def test_successful_purchase_with_metadata_passthrough
+    metadata = { 'key_1' => 'value_1',
+      'key_2' => 'value_2',
+      'key_3' => { 'nested_key_1' => 'value_3' } }
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ metadata: metadata }))
+    assert_success response
+    assert_equal metadata, response.params['metadata']
   end
 
   def test_failed_purchase

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -385,6 +385,18 @@ class MercadoPagoTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_purchase_includes_metadata
+    key1 = 'value_1'
+    key2 = 'value_2'
+    metadata_object = { key_1: key1, key_2: key2 }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(metadata: metadata_object))
+    end.check_request do |endpoint, data, _headers|
+      assert_match("\"metadata\":{\"key_1\":\"#{key1}\",\"key_2\":\"#{key2}\"}", data) if endpoint =~ /payments/
+    end.respond_with(successful_purchase_with_metadata_response)
+  end
+
   def test_authorize_includes_taxes_array
     taxes_type = 'IVA'
     taxes_value = 500.0
@@ -676,6 +688,12 @@ class MercadoPagoTest < Test::Unit::TestCase
   def failed_void_response
     %(
       {"message":"Method not allowed","error":"method_not_allowed","status":405,"cause":[{"code":"Method not allowed","description":"Method not allowed","data":null}]}
+    )
+  end
+
+  def successful_purchase_with_metadata_response
+    %(
+      {"id":4141491,"date_created":"2017-07-06T09:49:35.000-04:00","date_approved":"2017-07-06T09:49:35.000-04:00","date_last_updated":"2017-07-06T09:49:35.000-04:00","date_of_expiration":null,"money_release_date":"2017-07-18T09:49:35.000-04:00","operation_type":"regular_payment","issuer_id":"166","payment_method_id":"visa","payment_type_id":"credit_card","status":"approved","status_detail":"accredited","currency_id":"MXN","description":"Store Purchase","live_mode":false,"sponsor_id":null,"authorization_code":null,"related_exchange_rate":null,"collector_id":261735089,"payer":{"type":"guest","id":null,"email":"user@example.com","identification":{"type":null,"number":null},"phone":{"area_code":null,"number":null,"extension":""},"first_name":"First User","last_name":"User","entity_type":null},"metadata":{"key_1":"value_1","key_2":"value_2","key_3":{"nested_key_1":"value_3"}},"additional_info":{"payer":{"address":{"zip_code":"K1C2N6","street_name":"My Street","street_number":"456"}}},"order":{"type":"mercadopago","id":"2326513804447055222"},"external_reference":null,"transaction_amount":5,"transaction_amount_refunded":0,"coupon_amount":0,"differential_pricing_id":null,"deduction_schema":null,"transaction_details":{"net_received_amount":0.14,"total_paid_amount":5,"overpaid_amount":0,"external_resource_url":null,"installment_amount":5,"financial_institution":null,"payment_method_reference_id":null,"payable_deferral_period":null,"acquirer_reference":null},"fee_details":[{"type":"mercadopago_fee","amount":4.86,"fee_payer":"collector"}],"captured":true,"binary_mode":false,"call_for_authorize_id":null,"statement_descriptor":"WWW.MERCADOPAGO.COM","installments":1,"card":{"id":null,"first_six_digits":"450995","last_four_digits":"3704","expiration_month":9,"expiration_year":2018,"date_created":"2017-07-06T09:49:35.000-04:00","date_last_updated":"2017-07-06T09:49:35.000-04:00","cardholder":{"name":"Longbob Longsen","identification":{"number":null,"type":null}}},"notification_url":null,"refunds":[],"processing_mode":null,"merchant_account_id":null,"acquirer":null,"merchant_number":null}
     )
   end
 end


### PR DESCRIPTION
Added more options to the payer object if they are present, added
Metadata object if present. Checking for exact external_reference field
as a second option when setting

CE-843

Unit:
39 tests, 181 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: The failed tests here are also failing for me on the master branch.
35 tests, 100 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.4286% passed