### PR TITLE
Ce 1646 barclays e pdq extra plus add gsf

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Orbital: Add support for SCARecurringPayment [jessiagee] #4010
 * Braintree: Support recurring_first and moto reasons [curiousepic] #4013
 * PayTrace: Adjust capture method [meagabeth] #4015
+* BarclaysEpdqExtraPlus: updated custom_eci test + remote tests [yyapuncich] #4022
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
+++ b/test/remote/gateways/remote_barclays_epdq_extra_plus_test.rb
@@ -75,6 +75,15 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
   end
 
+  def test_successful_purchase_with_custom_eci
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(eci: 1))
+    assert_success response
+    assert_equal BarclaysEpdqExtraPlusGateway::SUCCESS_MESSAGE, response.message
+    assert_equal '1', response.params['ECI']
+    assert_equal @options[:currency], response.params['currency']
+    assert_equal @options[:order_id], response.order_id
+  end
+
   def test_successful_with_non_numeric_order_id
     @options[:order_id] = "##{@options[:order_id][0...26]}.12"
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -92,7 +101,7 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'No brand', response.message
+    assert_equal 'No brand or invalid card number', response.message
   end
 
   def test_successful_authorize_with_mastercard
@@ -113,7 +122,7 @@ class RemoteBarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   def test_unsuccessful_capture
     assert response = @gateway.capture(@amount, '')
     assert_failure response
-    assert_equal 'No card no, no exp date, no brand', response.message
+    assert_equal 'No card no, no exp date, no brand or invalid card number', response.message
   end
 
   def test_successful_void


### PR DESCRIPTION
`add_eci` is already a method used in this gateway. 
- wrote a test for checking a custom eci option works
- there are remote tests failing, but they are failing on master as well:
  -  `test_unsuccessful_refund`
  - `test_successful_refund`
  - `test_invalid_login`