### PR TITLE
Resolve safe_load warnings

### DIFF
--- a/generators/gateway/gateway_generator.rb
+++ b/generators/gateway/gateway_generator.rb
@@ -38,7 +38,7 @@ EOYAML
   end
 
   def next_identifier
-    fixtures = (YAML.safe_load(File.read(fixtures_file), [], [], true).keys + [identifier]).uniq.sort
+    fixtures = (YAML.safe_load(File.read(fixtures_file), aliases: true).keys + [identifier]).uniq.sort
     fixtures[fixtures.sort.index(identifier)+1]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -281,7 +281,7 @@ module ActiveMerchant
     def load_fixtures
       [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
         if File.exist?(file_name)
-          yaml_data = YAML.safe_load(File.read(file_name), [], [], true)
+          yaml_data = YAML.safe_load(File.read(file_name), aliases: true)
           credentials.merge!(symbolize_keys(yaml_data))
         end
         credentials

--- a/test/unit/fixtures_test.rb
+++ b/test/unit/fixtures_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class FixturesTest < Test::Unit::TestCase
   def test_sort
-    keys = YAML.safe_load(File.read(ActiveMerchant::Fixtures::DEFAULT_CREDENTIALS), [], [], true).keys
+    keys = YAML.safe_load(File.read(ActiveMerchant::Fixtures::DEFAULT_CREDENTIALS), aliases: true).keys
     assert_equal(
       keys,
       keys.sort

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -1049,7 +1049,7 @@ class FirstdataE4Test < Test::Unit::TestCase
         read: true
         socket:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def bad_credentials_response
@@ -1086,7 +1086,7 @@ class FirstdataE4Test < Test::Unit::TestCase
         http_version: '1.1'
         socket:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def successful_void_response

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -1001,7 +1001,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
         read: true
         socket:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def bad_credentials_response
@@ -1038,7 +1038,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
         http_version: '1.1'
         socket:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def successful_void_response

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -597,7 +597,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def failed_purchase_response_for_insufficient_funds
@@ -676,7 +676,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def successful_void_response
@@ -721,7 +721,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def failed_capture_response
@@ -761,7 +761,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def invalid_token_response
@@ -800,7 +800,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def invalid_token_response_integration
@@ -825,7 +825,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def bad_credentials_response
@@ -850,6 +850,6 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPForbidden', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPForbidden', 'ActiveMerchant::ResponseError'])
   end
 end


### PR DESCRIPTION
Psych `safe_load` takes arguments as keys instead of being indexed in
the method call.

4787 tests, 73769 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

first_data_e4 unit test: 33 tests, 160 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

first_data_e4_v27 unit test: 33 tests, 154 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

payeezy unit test: 38 tests, 180 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed