### PR TITLE
usaEPay gateway: Added pin as a gateway setting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* usaepay: Added pin gateway setting [DustinHaefele] #4026
 * MercadoPago: Added external_reference, more payer object options, and metadata field [DustinHaefele] #4020
 * Element: Add duplicate_override_flag [almalee24] #4012
 * PayTrace: Support gateway [meagabeth] #3985

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -343,7 +343,7 @@ module ActiveMerchant #:nodoc:
         parameters[:software] = 'Active Merchant'
         parameters[:testmode] = (@options[:test] ? 1 : 0) unless parameters.has_key?(:testmode)
         seed = SecureRandom.hex(32).upcase
-        hash = Digest::SHA1.hexdigest("#{parameters[:command]}:#{@options[:password]}:#{parameters[:amount]}:#{parameters[:invoice]}:#{seed}")
+        hash = Digest::SHA1.hexdigest("#{parameters[:command]}:#{@options[:pin] || @options[:password]}:#{parameters[:amount]}:#{parameters[:invoice]}:#{seed}")
         parameters[:hash] = "s/#{seed}/#{hash}/n"
 
         parameters.collect { |key, value| "UM#{key}=#{CGI.escape(value.to_s)}" }.join('&')

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
   def setup
     @gateway = UsaEpayTransactionGateway.new(fixtures(:usa_epay))
+    @gateway_with_pin = UsaEpayTransactionGateway.new(fixtures(:usa_epay_with_pin))
     @credit_card = credit_card('4000100011112224')
     @declined_card = credit_card('4000300011112220')
     @credit_card_with_track_data = credit_card_with_track_data('4000100011112224')
@@ -107,6 +108,20 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(line_items: line_items))
     assert_equal 'Success', response.message
     assert_success response
+  end
+
+  def test_successful_purchase_with_pin
+    assert response = @gateway_with_pin.purchase(@amount, @credit_card, @options)
+    assert_equal 'Success', response.message
+    assert_success response
+  end
+
+  def test_unsuccessful_purchase_with_bad_pin
+    gateway = UsaEpayTransactionGateway.new(fixtures(:usa_epay_with_pin).merge({ pin: 'bad_pin' }))
+
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_equal 'Transaction authentication failed', response.message
+    assert_failure response
   end
 
   def test_unsuccessful_purchase


### PR DESCRIPTION
The gateway uses the pin and other data to create a  SHA hash to
authenticate transactions for accounts where pin is enabled. So now if
pin is set when creating the gatway it will pass it into the hash if
not it will be ignored like it has been.

CE-1743

unit: 50 tests, 303 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications 100% passed

remote: 32 tests, 114 assertions, 1 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications 96.875% passed <= the failed test is
the scrubbed test, and it foils because the response from the gateway
includes UMrefNum field which happens to have in the log number the
same 3 digit verification_value as the test card.