### PR TITLE
PayTrace: Adjust purchase and capture methods to handle MultiResponse…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * CyberSource: Add customerID field [deemeyers] #4025
 * CyberSource: Adjust Auth [naashton] #3956
 * Valid Canadian Institution Numbers [naashton] #4024
+* PayTrace: Adjust purchase and capture methods to handle MultiResponse scenarios [meagabeth] #4027
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/pay_trace.rb
+++ b/lib/active_merchant/billing/gateways/pay_trace.rb
@@ -43,23 +43,19 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(money, payment_or_customer_id, options = {})
-        post = {}
-        add_amount(post, money, options)
-        if customer_id?(payment_or_customer_id)
-          post[:customer_id] = payment_or_customer_id
-          endpoint = ENDPOINTS[:customer_id_sale]
+        if visa_or_mastercard?(options)
+          MultiResponse.run(:use_first_response) do |r|
+            endpoint = customer_id?(payment_or_customer_id) ? ENDPOINTS[:customer_id_sale] : ENDPOINTS[:keyed_sale]
+
+            r.process { commit(endpoint, build_purchase_request(money, payment_or_customer_id, options)) }
+            r.process { commit(ENDPOINTS[:"level_3_#{options[:visa_or_mastercard]}"], send_level_3_data(r, options)) }
+          end
         else
-          add_payment(post, payment_or_customer_id)
-          add_address(post, payment_or_customer_id, options)
-          add_customer_data(post, options)
-          endpoint = ENDPOINTS[:keyed_sale]
+          post = build_purchase_request(money, payment_or_customer_id, options)
+          post[:customer_id] ? endpoint = ENDPOINTS[:customer_id_sale] : endpoint = ENDPOINTS[:keyed_sale]
+          response = commit(endpoint, post)
+          check_token_response(response, endpoint, post, options)
         end
-        response = commit(endpoint, post)
-        check_token_response(response, endpoint, post, options)
-
-        return response unless visa_or_mastercard?(options)
-
-        send_level_3_data(response, options)
       end
 
       def authorize(money, payment_or_customer_id, options = {})
@@ -79,21 +75,22 @@ module ActiveMerchant #:nodoc:
       end
 
       def capture(money, authorization, options = {})
-        post = {}
-        post[:transaction_id] = authorization
-        add_amount(post, money, options) if options[:include_capture_amount] == true
-        response = commit(ENDPOINTS[:capture], post)
-        check_token_response(response, ENDPOINTS[:capture], post, options)
-
-        return response unless visa_or_mastercard?(options)
-
-        send_level_3_data(response, options)
+        if visa_or_mastercard?(options)
+          MultiResponse.run do |r|
+            r.process { commit(ENDPOINTS[:capture], build_capture_request(money, authorization, options)) }
+            r.process { commit(ENDPOINTS[:"level_3_#{options[:visa_or_mastercard]}"], send_level_3_data(r, options)) }
+          end
+        else
+          post = build_capture_request(money, authorization, options)
+          response = commit(ENDPOINTS[:capture], post)
+          check_token_response(response, ENDPOINTS[:capture], post, options)
+        end
       end
 
-      def refund(authorization, options = {})
+      def refund(money, authorization, options = {})
         # currently only support full and partial refunds of settled transactions via a transaction ID
         post = {}
-        post[:amount] = amount(options[:amount]) if options[:amount]
+        add_amount(post, money, options) if money.class == Integer
         post[:transaction_id] = authorization
         response = commit(ENDPOINTS[:transaction_refund], post)
         check_token_response(response, ENDPOINTS[:transaction_refund], post, options)
@@ -165,15 +162,35 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def build_purchase_request(money, payment_or_customer_id, options)
+        post = {}
+        add_amount(post, money, options)
+        if customer_id?(payment_or_customer_id)
+          post[:customer_id] = payment_or_customer_id
+        else
+          add_payment(post, payment_or_customer_id)
+          add_address(post, payment_or_customer_id, options)
+          add_customer_data(post, options)
+        end
+
+        post
+      end
+
+      def build_capture_request(money, authorization, options)
+        post = {}
+        post[:transaction_id] = authorization
+        add_amount(post, money, options) if options[:include_capture_amount] == true
+
+        post
+      end
+
       # method can only be used to add level 3 data to any approved and unsettled sale transaction so it is built into the standard purchase workflow above
       def send_level_3_data(response, options)
         post = {}
         post[:transaction_id] = response.authorization
-        endpoint = ENDPOINTS[:"level_3_#{options[:visa_or_mastercard]}"]
-
         add_level_3_data(post, options)
-        adjust = commit(endpoint, post)
-        check_token_response(adjust, endpoint, post, options)
+
+        post
       end
 
       def visa_or_mastercard?(options)
@@ -306,9 +323,9 @@ module ActiveMerchant #:nodoc:
 
         Response.new(
           success,
-          message_from(response),
+          message_from(success, response),
           response,
-          authorization: authorization_from(response),
+          authorization: authorization_from(action, response),
           avs_result: AVSResult.new(code: response['avs_response']),
           cvv_result: response['csc_response'],
           test: test?,
@@ -335,12 +352,28 @@ module ActiveMerchant #:nodoc:
         response['success']
       end
 
-      def message_from(response)
-        response['status_message']
+      def message_from(success, response)
+        return response['status_message'] if success
+
+        if error = response['errors']
+          message = 'Errors-'
+          error.each do |k, v|
+            message.concat(" code:#{k}, message:#{v}")
+          end
+        else
+          message = response['status_message'].to_s + " #{response['approval_message']}"
+        end
+
+        message
       end
 
-      def authorization_from(response)
-        response['transaction_id']
+      # store transactions do not return a transaction_id, but they return a customer_id that will then be used as the third_party_token for the stored payment method
+      def authorization_from(action, response)
+        if action == ENDPOINTS[:store]
+          response['customer_id']
+        else
+          response['transaction_id']
+        end
       end
 
       def post_data(parameters = {})

--- a/test/remote/gateways/remote_pay_trace_test.rb
+++ b/test/remote/gateways/remote_pay_trace_test.rb
@@ -16,9 +16,10 @@ class RemotePayTraceTest < Test::Unit::TestCase
   def setup
     @gateway = PayTraceGateway.new(fixtures(:pay_trace))
 
-    @amount = 100
+    @amount = 1000
     @credit_card = credit_card('4012000098765439')
     @mastercard = credit_card('5499740000000057')
+    @invalid_card = credit_card('54545454545454', month: '14', year: '1999')
     @discover = credit_card('6011000993026909')
     @amex = credit_card('371449635392376')
     @options = {
@@ -99,9 +100,10 @@ class RemotePayTraceTest < Test::Unit::TestCase
       ]
     }
 
-    response = @gateway.purchase(250, @credit_card, options)
+    response = @gateway.purchase(3000, @credit_card, options)
     assert_success response
-    assert_equal 170, response.params['response_code']
+    assert_equal 101, response.params['response_code']
+    assert_not_nil response.authorization
   end
 
   def test_successful_purchase_with_level_3_data_mastercard
@@ -142,7 +144,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
 
     response = @gateway.purchase(250, @mastercard, options)
     assert_success response
-    assert_equal 170, response.params['response_code']
+    assert_equal 101, response.params['response_code']
   end
 
   # Level three data can only be added to approved sale transactions done with visa or mastercard.
@@ -163,6 +165,12 @@ class RemotePayTraceTest < Test::Unit::TestCase
     response = @gateway.purchase(29, @amex, @options)
     assert_failure response
     assert_equal false, response.success?
+  end
+
+  def test_failed_purchase_with_multiple_errors
+    response = @gateway.purchase(25000, @invalid_card, @options)
+    assert_failure response
+    assert_equal 'Errors- code:35, message:["Please provide a valid Credit Card Number."] code:43, message:["Please provide a valid Expiration Month."]', response.message
   end
 
   def test_successful_authorize_and_capture
@@ -218,7 +226,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway.authorize(29, @mastercard, @options)
     assert_failure response
-    assert_equal 'Your transaction was not approved.', response.message
+    assert_equal 'Your transaction was not approved.   EXPIRED CARD - Expired card', response.message
   end
 
   def test_partial_capture
@@ -232,7 +240,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
   def test_failed_capture
     response = @gateway.capture(@amount, '')
     assert_failure response
-    assert_equal 'One or more errors has occurred.', response.message
+    assert_equal 'Errors- code:58, message:["Please provide a valid Transaction ID."]', response.message
   end
 
   def test_successful_refund
@@ -243,7 +251,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
     settle = @gateway.settle()
     assert_success settle
 
-    refund = @gateway.refund(authorization, @options.merge(amount: 200))
+    refund = @gateway.refund(200, authorization, @options)
     assert_success refund
     assert_equal 'Your transaction was successfully refunded.', refund.message
   end
@@ -256,7 +264,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
     settle = @gateway.settle()
     assert_success settle
 
-    refund = @gateway.refund(authorization, @options.merge(amount: 300))
+    refund = @gateway.refund(300, authorization, @options)
     assert_success refund
     assert_equal 'Your transaction was successfully refunded.', refund.message
   end
@@ -269,15 +277,19 @@ class RemotePayTraceTest < Test::Unit::TestCase
     settle = @gateway.settle()
     assert_success settle
 
-    refund = @gateway.refund(authorization)
+    refund = @gateway.refund('', authorization)
     assert_success refund
     assert_equal 'Your transaction was successfully refunded.', refund.message
   end
 
   def test_failed_refund
-    response = @gateway.refund('', @options)
+    purchase = @gateway.purchase(2000, @credit_card, @options)
+    assert_success purchase
+    authorization = purchase.authorization
+
+    response = @gateway.refund(2000, authorization, @options)
     assert_failure response
-    assert_equal 'One or more errors has occurred.', response.message
+    assert_equal 'Errors- code:817, message:["The Transaction ID that you provided could not be refunded. Only settled transactions can be refunded.  Please try to void the transaction instead."]', response.message
   end
 
   def test_successful_void
@@ -292,13 +304,18 @@ class RemotePayTraceTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void('')
     assert_failure response
-    assert_equal 'One or more errors has occurred.', response.message
+    assert_equal 'Errors- code:58, message:["Please provide a valid Transaction ID."]', response.message
   end
 
   def test_successful_verify
     response = @gateway.verify(@mastercard, @options)
     assert_success response
     assert_equal 'Your transaction was successfully approved.', response.message
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
   end
 
   def test_successful_store_and_redact_customer_profile

--- a/test/unit/gateways/pay_trace_test.rb
+++ b/test/unit/gateways/pay_trace_test.rb
@@ -73,7 +73,7 @@ class PayTraceTest < Test::Unit::TestCase
 
     response = @gateway.purchase(100, @credit_card, options)
     assert_success response
-    assert_equal 170, response.params['response_code']
+    assert_equal 101, response.params['response_code']
   end
 
   def test_failed_purchase
@@ -97,7 +97,7 @@ class PayTraceTest < Test::Unit::TestCase
 
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal 'Your transaction was not approved.', response.message
+    assert_equal 'Your transaction was not approved.   EXPIRED CARD - Expired card', response.message
   end
 
   def test_successful_capture
@@ -140,14 +140,14 @@ class PayTraceTest < Test::Unit::TestCase
 
     response = @gateway.capture(@amount, '', @options)
     assert_failure response
-    assert_equal 'One or more errors has occurred.', response.message
+    assert_equal 'Errors- code:58, message:["Please provide a valid Transaction ID."]', response.message
   end
 
   def test_successful_refund
     transaction_id = 105968532
     @gateway.expects(:ssl_post).returns(successful_refund_response)
 
-    response = @gateway.refund(transaction_id)
+    response = @gateway.refund(100, transaction_id)
     assert_success response
     assert_equal 'Your transaction successfully refunded.', response.message
   end
@@ -155,9 +155,9 @@ class PayTraceTest < Test::Unit::TestCase
   def test_failed_refund
     @gateway.expects(:ssl_post).returns(failed_refund_response)
 
-    response = @gateway.refund('', @options.merge(amount: @amount))
+    response = @gateway.refund(200, '', @options)
     assert_failure response
-    assert_equal 'One or more errors has occurred.', response.message
+    assert_equal 'Errors- code:981, message:["Log in failed for insufficient permissions."]', response.message
   end
 
   def test_successful_void
@@ -174,7 +174,7 @@ class PayTraceTest < Test::Unit::TestCase
 
     response = @gateway.void('')
     assert_failure response
-    assert_equal 'One or more errors has occurred.', response.message
+    assert_equal 'Errors- code:58, message:["Please provide a valid Transaction ID."]', response.message
   end
 
   def test_successful_verify
@@ -196,7 +196,7 @@ class PayTraceTest < Test::Unit::TestCase
 
     response = @gateway.verify(@credit_card, @options)
     assert_failure response
-    assert_equal 'Your transaction was not approved.', response.message
+    assert_equal 'Your transaction was not approved.   EXPIRED CARD - Expired card', response.message
   end
 
   def test_successful_customer_creation


### PR DESCRIPTION
… scenarios

- Adjust refund method to include money argument
- Revise message_from method to include error message details and handle multiple errors
- Revise authorization_from to support returning a third_party_token for store
- Revise necessary tests

Local:
4787 tests, 73769 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
19 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
27 tests, 68 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed