### PR TITLE
Payflow: Add support for MERCHDESCR field.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * CyberSource: Adjust Auth [naashton] #3956
 * Valid Canadian Institution Numbers [naashton] #4024
 * PayTrace: Adjust purchase and capture methods to handle MultiResponse scenarios [meagabeth] #4027
+* Payflow: Add support for MERCHDESCR field [rachelkirk] #4028
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -141,6 +141,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'FreightAmt', options[:freightamt] unless options[:freightamt].blank?
               xml.tag! 'DutyAmt', options[:dutyamt] unless options[:dutyamt].blank?
               xml.tag! 'DiscountAmt', options[:discountamt] unless options[:discountamt].blank?
+              xml.tag! 'MerchDescr', options[:merch_descr] unless options[:merch_descr].blank?
 
               billing_address = options[:billing_address] || options[:address]
               add_address(xml, 'BillTo', billing_address, options) if billing_address
@@ -176,6 +177,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'DutyAmt', options[:dutyamt] unless options[:dutyamt].blank?
               xml.tag! 'DiscountAmt', options[:discountamt] unless options[:discountamt].blank?
               xml.tag! 'EMail', options[:email] unless options[:email].nil?
+              xml.tag! 'MerchDescr', options[:merch_descr] unless options[:merch_descr].blank?
 
               billing_address = options[:billing_address] || options[:address]
               add_address(xml, 'BillTo', billing_address, options) if billing_address
@@ -239,6 +241,7 @@ module ActiveMerchant #:nodoc:
               xml.tag! 'InvNum', options[:order_id].to_s.gsub(/[^\w.]/, '') unless options[:order_id].blank?
               xml.tag! 'Description', options[:description] unless options[:description].blank?
               xml.tag! 'OrderDesc', options[:order_desc] unless options[:order_desc].blank?
+              xml.tag! 'MerchDescr', options[:merch_descr] unless options[:merch_descr].blank?
               xml.tag! 'BillTo' do
                 xml.tag! 'Name', check.name
               end

--- a/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
+++ b/lib/active_merchant/billing/gateways/payflow/payflow_common_api.rb
@@ -118,6 +118,7 @@ module ActiveMerchant #:nodoc:
               xml.tag!('Description', options[:description]) unless options[:description].blank?
               xml.tag!('Comment', options[:comment]) unless options[:comment].blank?
               xml.tag!('ExtData', 'Name' => 'COMMENT2', 'Value' => options[:comment2]) unless options[:comment2].blank?
+              xml.tag!('MerchDescr', options[:merch_descr]) unless options[:merch_descr].blank?
               xml.tag!(
                 'ExtData',
                 'Name' => 'CAPTURECOMPLETE',

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -22,7 +22,8 @@ class RemotePayflowTest < Test::Unit::TestCase
       description: 'Description string',
       order_desc: 'OrderDesc string',
       comment: 'Comment string',
-      comment2: 'Comment2 string'
+      comment2: 'Comment2 string',
+      merch_descr: 'MerchDescr string'
     }
 
     @check = check(

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -78,7 +78,8 @@ class PayflowTest < Test::Unit::TestCase
         description: 'Description string',
         order_desc: 'OrderDesc string',
         comment: 'Comment string',
-        comment2: 'Comment2 string'
+        comment2: 'Comment2 string',
+        merch_descr: 'MerchDescr string'
       }
     )
 
@@ -91,6 +92,7 @@ class PayflowTest < Test::Unit::TestCase
       assert_match %r(<Comment>Comment string</Comment>), data
       assert_match %r(<ExtData Name=\"COMMENT2\" Value=\"Comment2 string\"/>), data
       assert_match %r(</PayData><ExtData Name=\"BUTTONSOURCE\" Value=\"partner_id\"/></Authorization>), data
+      assert_match %r(<MerchDescr>MerchDescr string</MerchDescr>), data
     end.respond_with(successful_authorization_response)
     assert_equal 'Approved', response.message
     assert_success response


### PR DESCRIPTION
CE-1704

Local: 4792 tests, 73784 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit: 49 tests, 244 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote: 38 tests, 169 assertions, 8 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
78.9474% passed