### PR TITLE
Updating bank routing number validation check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@
 * Payflow: Add support for MERCHDESCR field [rachelkirk] #4028
 * PayTrace: Support $0 authorize in verify method [meagabeth] #4030
 * PayArc: Add error_code in response [cdm-83] #4021
+* Update bank routing account validation check [jessiagee] #4029
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -15,7 +15,7 @@ module ActiveMerchant #:nodoc:
 
       # Canadian Institution Numbers
       # Found here: https://en.wikipedia.org/wiki/Routing_number_(Canada)
-      INSTITUTION_NUMBERS = %w(
+      CAN_INSTITUTION_NUMBERS = %w(
         001 002 003 004	006 010 016 030 039 117 127 177 219 245 260 269 270 308
         309 310 315 320	338 340 509 540 608 614 623 809 815 819 828 829 837 839
         865 879 889 899 241 242 248 250 265 275 277 290 294 301 303 307 311 314
@@ -66,22 +66,17 @@ module ActiveMerchant #:nodoc:
       # See http://en.wikipedia.org/wiki/Routing_transit_number#Internal_checksums
       def valid_routing_number?
         digits = routing_number.to_s.split('').map(&:to_i).select { |d| (0..9).cover?(d) }
-        case digits.size
-        when 9
+        if digits.size == 9
           checksum = ((3 * (digits[0] + digits[3] + digits[6])) +
-                      (7 * (digits[1] + digits[4] + digits[7])) +
-                           (digits[2] + digits[5] + digits[8])) % 10
-          case checksum
-          when 0
-            true
-          else
-            false
-          end
-        when 8
-          true if INSTITUTION_NUMBERS.include?(routing_number[0..2].to_s)
-        else
-          false
+            (7 * (digits[1] + digits[4] + digits[7])) +
+            (digits[2] + digits[5] + digits[8])) % 10
+
+          return checksum == 0
         end
+
+        return CAN_INSTITUTION_NUMBERS.include?(routing_number[0..2]) if digits.size == 8
+
+        false
       end
     end
   end

--- a/test/unit/check_test.rb
+++ b/test/unit/check_test.rb
@@ -5,6 +5,8 @@ class CheckTest < Test::Unit::TestCase
   INVALID_ABA   = '999999999'
   MALFORMED_ABA = 'I like fish'
   VALID_CBA = '00194611'
+  INVALID_NINE_DIGIT_CBA = '012345678'
+  INVALID_SEVEN_DIGIT_ROUTING_NUMBER = '0123456'
 
   ACCOUNT_NUMBER = '123456789012'
 
@@ -88,5 +90,29 @@ class CheckTest < Test::Unit::TestCase
       account_holder_type: 'personal',
       account_type: 'checking'
     )
+  end
+
+  def test_invalid_nine_digit_canada_routing_number
+    errors = assert_not_valid Check.new(
+      name: 'Tim Horton',
+      routing_number: INVALID_NINE_DIGIT_CBA,
+      account_number: ACCOUNT_NUMBER,
+      account_holder_type: 'personal',
+      account_type: 'checking'
+    )
+
+    assert_equal ['is invalid'], errors[:routing_number]
+  end
+
+  def test_invalid_routing_number_length
+    errors = assert_not_valid Check.new(
+      name: 'Routing Shortlength',
+      routing_number: INVALID_SEVEN_DIGIT_ROUTING_NUMBER,
+      account_number: ACCOUNT_NUMBER,
+      account_holder_type: 'personal',
+      account_type: 'checking'
+    )
+
+    assert_equal ['is invalid'], errors[:routing_number]
   end
 end


### PR DESCRIPTION
* American routing numbers are always 9 digits and
must pass the Luhn test
* Canadian routing numbers are 8 digits and must exist
in a pre-approved list

Loaded suite test/unit/check_test

12 tests, 26 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

bundle exec rake test:local

4799 tests, 73813 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

705 files inspected, no offenses detected

Running RuboCop...

705 files inspected, no offenses detected