### PR TITLE
PayTrace: Support $0 authorize in verify method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * Valid Canadian Institution Numbers [naashton] #4024
 * PayTrace: Adjust purchase and capture methods to handle MultiResponse scenarios [meagabeth] #4027
 * Payflow: Add support for MERCHDESCR field [rachelkirk] #4028
+* PayTrace: Support $0 authorize in verify method [meagabeth] #4030
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/pay_trace.rb
+++ b/lib/active_merchant/billing/gateways/pay_trace.rb
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options = {})
         # currently only support full and partial refunds of settled transactions via a transaction ID
         post = {}
-        add_amount(post, money, options) if money.class == Integer
+        add_amount(post, money, options)
         post[:transaction_id] = authorization
         response = commit(ENDPOINTS[:transaction_refund], post)
         check_token_response(response, ENDPOINTS[:transaction_refund], post, options)
@@ -105,10 +105,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options = {})
-        MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
-        end
+        authorize(0, credit_card, options)
       end
 
       # The customer_IDs that come from storing cards can be used for auth and purchase transaction types
@@ -179,7 +176,7 @@ module ActiveMerchant #:nodoc:
       def build_capture_request(money, authorization, options)
         post = {}
         post[:transaction_id] = authorization
-        add_amount(post, money, options) if options[:include_capture_amount] == true
+        add_amount(post, money, options)
 
         post
       end

--- a/test/remote/gateways/remote_pay_trace_test.rb
+++ b/test/remote/gateways/remote_pay_trace_test.rb
@@ -16,7 +16,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
   def setup
     @gateway = PayTraceGateway.new(fixtures(:pay_trace))
 
-    @amount = 1000
+    @amount = 100
     @credit_card = credit_card('4012000098765439')
     @mastercard = credit_card('5499740000000057')
     @invalid_card = credit_card('54545454545454', month: '14', year: '1999')
@@ -39,7 +39,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    response = @gateway.purchase(@amount, @credit_card, @options)
+    response = @gateway.purchase(1000, @credit_card, @options)
     assert_success response
     assert_equal 'Your transaction was successfully approved.', response.message
   end
@@ -173,11 +173,11 @@ class RemotePayTraceTest < Test::Unit::TestCase
     assert_equal 'Errors- code:35, message:["Please provide a valid Credit Card Number."] code:43, message:["Please provide a valid Expiration Month."]', response.message
   end
 
-  def test_successful_authorize_and_capture
-    auth = @gateway.authorize(300, @credit_card, @options)
+  def test_successful_authorize_and_full_capture
+    auth = @gateway.authorize(4000, @credit_card, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(@amount, auth.authorization, @options)
+    assert capture = @gateway.capture(4000, auth.authorization, @options)
     assert_success capture
     assert_equal 'Your transaction was successfully captured.', capture.message
   end
@@ -213,7 +213,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
         }
       ]
     }
-    auth = @gateway.authorize(100, @mastercard, options)
+    auth = @gateway.authorize(@amount, @mastercard, options)
     assert_success auth
 
     assert capture = @gateway.capture(@amount, auth.authorization, options)
@@ -233,7 +233,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
     auth = @gateway.authorize(500, @amex, @options)
     assert_success auth
 
-    assert capture = @gateway.capture(200, auth.authorization, @options.merge(include_capture_amount: true))
+    assert capture = @gateway.capture(200, auth.authorization, @options)
     assert_success capture
   end
 
@@ -277,7 +277,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
     settle = @gateway.settle()
     assert_success settle
 
-    refund = @gateway.refund('', authorization)
+    refund = @gateway.refund(@amount, authorization)
     assert_success refund
     assert_equal 'Your transaction was successfully refunded.', refund.message
   end

--- a/test/unit/gateways/pay_trace_test.rb
+++ b/test/unit/gateways/pay_trace_test.rb
@@ -109,15 +109,6 @@ class PayTraceTest < Test::Unit::TestCase
     assert_equal 'Your transaction was successfully captured.', response.message
   end
 
-  def test_successful_partial_capture
-    @gateway.expects(:ssl_post).returns(successful_capture_response)
-    transaction_id = 11223344
-
-    response = @gateway.capture(@amount, transaction_id, @options.merge(include_capture_amount: true))
-    assert_success response
-    assert_equal 'Your transaction was successfully captured.', response.message
-  end
-
   def test_successful_level_3_data_field_mapping
     authorization = 123456789
     options = {
@@ -178,21 +169,14 @@ class PayTraceTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response).then.returns(successful_void_response)
-
-    response = @gateway.verify(@credit_card, @options)
-    assert_success response
-  end
-
-  def test_successful_verify_with_failed_void
-    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response).then.returns(failed_void_response)
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
     response = @gateway.verify(@credit_card, @options)
     assert_success response
   end
 
   def test_failed_verify
-    @gateway.expects(:ssl_post).times(1).returns(failed_authorize_response)
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
 
     response = @gateway.verify(@credit_card, @options)
     assert_failure response


### PR DESCRIPTION
Remove support for `include_capture_amount` field, it is not needed for partial captures to succeed

CE-1777

Local:
4795 tests, 73802 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
17 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
27 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed