### PR TITLE
Kushki: Add 'contactDetails' fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@
 * PayTrace: Support $0 authorize in verify method [meagabeth] #4030
 * PayArc: Add error_code in response [cdm-83] #4021
 * Update bank routing account validation check [jessiagee] #4029
+* Kushki: Add 'contactDetails' fields [mbreenlyles] #4033
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -88,6 +88,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_reference(post, authorization, options)
         add_invoice(action, post, amount, options)
+        add_contact_details(post, options[:contact_details]) if options[:contact_details]
 
         commit(action, post)
       end
@@ -152,6 +153,18 @@ module ActiveMerchant #:nodoc:
 
       def add_reference(post, authorization, options)
         post[:token] = authorization
+      end
+
+      def add_contact_details(post, contact_details_options)
+        contact_details = {}
+        contact_details[:documentType] = contact_details_options[:document_type] if contact_details_options[:document_type]
+        contact_details[:documentNumber] = contact_details_options[:document_number] if contact_details_options[:document_number]
+        contact_details[:email] = contact_details_options[:email] if contact_details_options[:email]
+        contact_details[:firstName] = contact_details_options[:first_name] if contact_details_options[:first_name]
+        contact_details[:lastName] = contact_details_options[:last_name] if contact_details_options[:last_name]
+        contact_details[:secondLastName] = contact_details_options[:second_last_name] if contact_details_options[:second_last_name]
+        contact_details[:phoneNumber] = contact_details_options[:phone_number] if contact_details_options[:phone_number]
+        post[:contactDetails] = contact_details
       end
 
       ENDPOINT = {

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -23,6 +23,15 @@ class RemoteKushkiTest < Test::Unit::TestCase
         subtotal_iva: '10',
         iva: '1.54',
         ice: '3.50'
+      },
+      contact_details: {
+        document_type: 'CC',
+        document_number: '123456',
+        email: 'who_dis@monkeys.tv',
+        first_name: 'Who',
+        last_name: 'Dis',
+        second_last_name: 'Buscemi',
+        phone_number: '+13125556789'
       }
     }
 

--- a/test/unit/gateways/kushki_test.rb
+++ b/test/unit/gateways/kushki_test.rb
@@ -28,6 +28,15 @@ class KushkiTest < Test::Unit::TestCase
         subtotal_iva: '10',
         iva: '1.54',
         ice: '3.50'
+      },
+      contact_details: {
+        document_type: 'CC',
+        document_number: '123456',
+        email: 'who_dis@monkeys.tv',
+        first_name: 'Who',
+        last_name: 'Dis',
+        second_last_name: 'Buscemi',
+        phone_number: '+13125556789'
       }
     }
 


### PR DESCRIPTION
Added 'contactDetails' object to the charge request when options under 'contact_details' are present.

CE-647

Unit:
15 tests, 98 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 
13 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed