### PR TITLE
Adyen: Truncating order_id and remote test

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -608,7 +608,7 @@ module ActiveMerchant #:nodoc:
       def init_post(options = {})
         post = {}
         add_merchant_account(post, options)
-        post[:reference] = options[:order_id] if options[:order_id]
+        post[:reference] = options[:order_id].truncate(80) if options[:order_id]
         post
       end
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -132,6 +132,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
       }
     }
 
+    @long_order_id = 'asdfjkl;asdfjkl;asdfj;aiwyutinvpoaieryutnmv;203987528752098375j3q-p489756ijmfpvbijpq348nmdf;vbjp3845'
+
     @sub_seller_options = {
       "subMerchant.numberOfSubSellers": '2',
       "subMerchant.subSeller1.id": '111111111',
@@ -503,6 +505,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_google_pay
     response = @gateway.purchase(@amount, @google_pay_card, @options)
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
+  def test_successful_purchase_with_google_pay_and_truncate_order_id
+    response = @gateway.purchase(@amount, @google_pay_card, @options.merge(order_id: @long_order_id))
     assert_success response
     assert_equal '[capture-received]', response.message
   end


### PR DESCRIPTION
EVS-830
Needs to be less than 80 characters for Google Pay transactions

Unit:
Finished in 9.835254 seconds.
----------------------------------------------------------------------------------------------------------------------------------------
4798 tests, 73809 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------
487.84 tests/s, 7504.53 assertions/s
Running RuboCop...
Inspecting 705 files

705 files inspected, no offenses detected

Remote:
Finished in 114.748358 seconds.
----------------------------------------------------------------------------------------------------------------------------------------
103 tests, 399 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------
0.90 tests/s, 3.48 assertions/s