### PR TITLE
Adyen: Truncating order_id and remote test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@
 * PayArc: Add error_code in response [cdm-83] #4021
 * Update bank routing account validation check [jessiagee] #4029
 * Kushki: Add 'contactDetails' fields [mbreenlyles] #4033
+* Adyen: Truncating order_id and remote test [yyapuncich] #4036
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -608,7 +608,7 @@ module ActiveMerchant #:nodoc:
       def init_post(options = {})
         post = {}
         add_merchant_account(post, options)
-        post[:reference] = options[:order_id] if options[:order_id]
+        post[:reference] = options[:order_id][0..79] if options[:order_id]
         post
       end
 

--- a/lib/active_merchant/billing/three_d_secure_eci_mapper.rb
+++ b/lib/active_merchant/billing/three_d_secure_eci_mapper.rb
@@ -1,7 +1,6 @@
 module ActiveMerchant
   module Billing
     module ThreeDSecureEciMapper
-
       NON_THREE_D_SECURE_TRANSACTION = :non_three_d_secure_transaction
       ATTEMPTED_AUTHENTICATION_TRANSACTION = :attempted_authentication_transaction
       FULLY_AUTHENTICATED_TRANSACTION = :fully_authenticated_transaction
@@ -17,7 +16,7 @@ module ActiveMerchant
         jcb: ECI_05_06_07_MAP,
         maestro: ECI_00_01_02_MAP,
         master: ECI_00_01_02_MAP,
-        visa: ECI_05_06_07_MAP,
+        visa: ECI_05_06_07_MAP
       }.freeze
 
       def self.map(brand, eci)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -132,6 +132,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
       }
     }
 
+    @long_order_id = 'asdfjkl;asdfjkl;asdfj;aiwyutinvpoaieryutnmv;203987528752098375j3q-p489756ijmfpvbijpq348nmdf;vbjp3845'
+
     @sub_seller_options = {
       "subMerchant.numberOfSubSellers": '2',
       "subMerchant.subSeller1.id": '111111111',
@@ -503,6 +505,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_google_pay
     response = @gateway.purchase(@amount, @google_pay_card, @options)
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
+  def test_successful_purchase_with_google_pay_and_truncate_order_id
+    response = @gateway.purchase(@amount, @google_pay_card, @options.merge(order_id: @long_order_id))
     assert_success response
     assert_equal '[capture-received]', response.message
   end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -93,6 +93,8 @@ class AdyenTest < Test::Unit::TestCase
         }
       }
     }
+
+    @long_order_id = 'asdfjkl;asdfjkl;asdfj;aiwyutinvpoaieryutnmv;203987528752098375j3q-p489756ijmfpvbijpq348nmdf;vbjp3845'
   end
 
   # Subdomains are only valid for production gateways, so the test_url check must be manually bypassed for this test to pass.
@@ -813,6 +815,16 @@ class AdyenTest < Test::Unit::TestCase
     assert_equal @options[:shipping_address][:zip], post[:deliveryAddress][:postalCode]
     assert_equal @options[:shipping_address][:city], post[:deliveryAddress][:city]
     assert_equal @options[:shipping_address][:country], post[:deliveryAddress][:country]
+  end
+
+  def test_purchase_with_long_order_id
+    options = @options.merge({ order_id: @long_order_id })
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal @long_order_id[0..79], JSON.parse(data)['reference']
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
   end
 
   def test_authorize_with_credit_card_no_name


### PR DESCRIPTION
EVS-830
Needs to be less than 80 characters for Google Pay transactions

Unit:
Finished in 9.874792 seconds.
----------------------------------------------------------------------------------------------------------------------------------------
4798 tests, 73809 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------
485.88 tests/s, 7474.49 assertions/s
Running RuboCop...
Inspecting 705 files

705 files inspected, no offenses detected

Remote:
Finished in 115.285449 seconds.
----------------------------------------------------------------------------------------------------------------------------------------
103 tests, 399 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------
0.89 tests/s, 3.46 assertions/s

Adyen: replaced truncate method with slice

truncate method is rails method and slice is Ruby

rm puts