### PR TITLE
Worldpay: Synchronous Response with purchase transaction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Update bank routing account validation check [jessiagee] #4029
 * Kushki: Add 'contactDetails' fields [mbreenlyles] #4033
 * Adyen: Truncating order_id and remote test [yyapuncich] #4036
+* Worldpay: Synchronous Response with purchase transaction [naashton] #4037
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -144,7 +144,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def authorize_request(money, payment_method, options)
-        commit('authorize', build_authorization_request(money, payment_method, options), 'AUTHORISED', options)
+        commit('authorize', build_authorization_request(money, payment_method, options), 'AUTHORISED', 'CAPTURED', options)
       end
 
       def capture_request(money, authorization, options)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -188,7 +188,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
+    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -283,7 +283,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
+    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -306,7 +306,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
+    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -771,6 +771,20 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     refund = @cftgateway.refund(@amount * 2, auth.authorization, authorization_validated: true)
     assert_failure refund
     assert_equal 'Refund amount too high', refund.message
+  end
+
+  def test_successful_purchase_with_options_synchronous_response
+    options = @options
+    stored_credential_params = {
+      initial_transaction: true,
+      reason_type: 'unscheduled',
+      initiator: 'merchant',
+      network_transaction_id: nil
+    }
+    options.merge(stored_credential: stored_credential_params)
+
+    assert purchase = @cftgateway.purchase(@amount, @credit_card, options.merge(instalments: 3, skip_capture: true, authorization_validated: true))
+    assert_success purchase
   end
 
   private

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1067,6 +1067,15 @@ class WorldpayTest < Test::Unit::TestCase
     assert_match "Unparsable response received from Worldpay. Please contact Worldpay if you continue to receive this message. \(The raw response returned by the API was: \"Temporary Failure, please Retry\"\)", response.message
   end
 
+  def test_successful_purchase_synchronous_response
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(skip_capture: true))
+    end.check_request do |_endpoint, data, _headers|
+    end.respond_with(successful_purchase_synchronous_response)
+    assert_success response
+    assert_equal 'CAPTURED', response.params.dig('last_event')
+  end
+
   def test_successful_authorize_synchronous_response
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
@@ -1635,6 +1644,34 @@ class WorldpayTest < Test::Unit::TestCase
         <reply>
           <orderStatus orderCode="49a9d4e8a52bccbd3a3a6ac228ae0998">
             <error code="5"><![CDATA[Refund amount too high]]></error>
+          </orderStatus>
+        </reply>
+      </paymentService>
+    RESPONSE
+  end
+
+  def successful_purchase_synchronous_response
+    <<~RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                      "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="RAPPICLP">
+        <reply>
+          <orderStatus orderCode="60117615_20210707170459921">
+            <payment>
+              <paymentMethod>VISA-SSL</paymentMethod>
+              <amount value="7277500" currencyCode="CLP" exponent="2" debitCreditIndicator="credit"/>
+              <lastEvent>CAPTURED</lastEvent>
+              <AuthorisationId id="443754"/>
+              <CVCResultCode description="NOT SUPPLIED BY SHOPPER"/>
+              <cardHolderName>
+                <![CDATA[JAVIER PEREZ CERDA]]>
+              </cardHolderName>
+              <issuerCountryCode>CL</issuerCountryCode>
+              <balance accountType="IN_PROCESS_CAPTURED">
+                <amount value="7277500" currencyCode="CLP" exponent="2" debitCreditIndicator="credit"/>
+              </balance>
+            </payment>
           </orderStatus>
         </reply>
       </paymentService>


### PR DESCRIPTION
Worldpay is moving to a new synchronous response workflow and in some
scenarios will lead to different success cases, particularly for the
`purchase` transaction, where a `MultiResponse`, asynchronous
transaction workflow is invoked.

For some MID configurations, a transaction can be executed with a
`skip_capture` option, which allows for the `authorize` to be
executed and subsequently will be implicitly captured, rendering a
`CAPTURED` value for the `lastEvent` tag.

This change is for broadening the scope of our success criteria within
the context of an `authorize` transaction to allow for `AUTHORISED` or
`CAPTURED`.

CE-1786

Unit: 89 tests, 542 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 71 tests, 304 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.1831% passed