### PR TITLE
Updated BIN ranges on JCB card types

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
         'american_express'   => ->(num) { num =~ /^3[47]\d{13}$/ },
         'naranja'            => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), NARANJA_RANGES) },
         'diners_club'        => ->(num) { num =~ /^3(0[0-5]|[68]\d)\d{11,16}$/ },
-        'jcb'                => ->(num) { num =~ /^(35(28|29|[3-8]\d)\d{12}|308800\d{10})$/ },
+        'jcb'                => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 4), JCB_RANGES) },
         'dankort'            => ->(num) { num =~ /^5019\d{12}$/ },
         'maestro'            => lambda { |num|
           (12..19).cover?(num&.size) && (
@@ -196,6 +196,10 @@ module ActiveMerchant #:nodoc:
       # Because UnionPay cards are able to run on Discover rails, this was kept the same.
       UNIONPAY_RANGES = [
         81000000..81099999, 81100000..81319999, 81320000..81519999, 81520000..81639999, 81640000..81719999
+      ]
+
+      JCB_RANGES = [
+        3528..3589, 3088..3094, 3096..3102, 3112..3120, 3158..3159, 3337..3349
       ]
 
       def self.included(base)

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -131,6 +131,15 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'jcb', CreditCard.brand?('3528000000000000')
     assert_equal 'jcb', CreditCard.brand?('3580000000000000')
     assert_equal 'jcb', CreditCard.brand?('3088000000000017')
+    assert_equal 'jcb', CreditCard.brand?('3094000000000017')
+    assert_equal 'jcb', CreditCard.brand?('3096000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3102000000000017')
+    assert_equal 'jcb', CreditCard.brand?('3112000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3120000000000017')
+    assert_equal 'jcb', CreditCard.brand?('3158000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3159000000000017')
+    assert_equal 'jcb', CreditCard.brand?('3337000000000000')
+    assert_equal 'jcb', CreditCard.brand?('3349000000000017')
   end
 
   def test_should_detect_maestro_dk_as_maestro


### PR DESCRIPTION
Added new JCB BIN ranges to card detector.

Test Summary

Local: 4828 tests, 73852 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit: 46 tests, 534 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: None