### PR TITLE
Kushki: Add support for fullResponse field

### DIFF
--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -37,6 +37,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:ticketNumber] = authorization
         add_invoice(action, post, amount, options)
+        add_full_response(post, options)
 
         commit(action, post)
       end
@@ -46,6 +47,7 @@ module ActiveMerchant #:nodoc:
 
         post = {}
         post[:ticketNumber] = authorization
+        add_full_response(post, options)
 
         commit(action, post)
       end
@@ -55,6 +57,7 @@ module ActiveMerchant #:nodoc:
 
         post = {}
         post[:ticketNumber] = authorization
+        add_full_response(post, options)
 
         commit(action, post)
       end
@@ -78,6 +81,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_invoice(action, post, amount, options)
         add_payment_method(post, payment_method, options)
+        add_full_response(post, options)
 
         commit(action, post)
       end
@@ -89,6 +93,7 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization, options)
         add_invoice(action, post, amount, options)
         add_contact_details(post, options[:contact_details]) if options[:contact_details]
+        add_full_response(post, options)
 
         commit(action, post)
       end
@@ -99,6 +104,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_reference(post, authorization, options)
         add_invoice(action, post, amount, options)
+        add_full_response(post, options)
 
         commit(action, post)
       end
@@ -165,6 +171,10 @@ module ActiveMerchant #:nodoc:
         contact_details[:secondLastName] = contact_details_options[:second_last_name] if contact_details_options[:second_last_name]
         contact_details[:phoneNumber] = contact_details_options[:phone_number] if contact_details_options[:phone_number]
         post[:contactDetails] = contact_details
+      end
+
+      def add_full_response(post, options)
+        post[:fullResponse] = options[:full_response] if options[:full_response]
       end
 
       ENDPOINT = {

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -68,6 +68,17 @@ class RemoteKushkiTest < Test::Unit::TestCase
     assert_match %r(^\d+$), response.authorization
   end
 
+  def test_approval_code_comes_back_when_passing_full_response
+    options = {
+      full_response: true
+    }
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+
+    assert_not_empty response.params.dig('details', 'approvalCode')
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_failed_authorize
     options = {
       amount: {

--- a/test/unit/gateways/kushki_test.rb
+++ b/test/unit/gateways/kushki_test.rb
@@ -279,6 +279,23 @@ class KushkiTest < Test::Unit::TestCase
     assert_equal '205', response.error_code
   end
 
+  def test_successful_purchase_with_full_response_flag
+    options = {
+      full_response: 'true'
+    }
+
+    @gateway.expects(:ssl_post).returns(successful_charge_response)
+    @gateway.expects(:ssl_post).returns(successful_token_response)
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_includes data, 'fullResponse'
+    end.respond_with(successful_token_response, successful_charge_response)
+
+    assert_success response
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
CE-1800

Local: 4828 tests, 73843 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit Test: 16 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Test: 14 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed