### PR TITLE
Decidir: generalize handling of unique error messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Decidir: Update validation error message handling. #4042
 * Kushki: Add support for fullResponse field [rachelkirk] #4040
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014
 * usaepay: Added pin gateway setting [DustinHaefele] #4026

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -282,7 +282,13 @@ module ActiveMerchant #:nodoc:
         if error = response.dig('status_details', 'error')
           message = "#{error.dig('reason', 'description')} | #{error['type']}"
         elsif response['error_type']
-          message = response['validation_errors'].map { |errors| "#{errors['code']}: #{errors['param']}" }.join(', ') if response['validation_errors']
+          if response['validation_errors'].is_a?(Array)
+            message = response['validation_errors'].map { |errors| "#{errors['code']}: #{errors['param']}" }.join(', ')
+          elsif response['validation_errors'].is_a?(Hash)
+            errors = response['validation_errors'].map { |k, v| "#{k}: #{v}" }.join(', ')
+            message = "#{response['error_type']} - #{errors}"
+          end
+
           message ||= response['error_type']
         end
 

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -176,8 +176,8 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway_for_auth.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'PEDIR AUTORIZACION | request_authorization_card', response.message
-    assert_match 'call_issuer', response.error_code
+    assert_equal 'COMERCIO INVALIDO | invalid_card', response.message
+    assert_match '3, config_error', response.error_code
   end
 
   def test_failed_partial_capture
@@ -251,7 +251,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway_for_auth.verify(@declined_card, @options)
     assert_failure response
-    assert_match %r{PEDIR AUTORIZACION | request_authorization_card}, response.message
+    assert_match %r{COMERCIO INVALIDO | invalid_card}, response.message
   end
 
   def test_invalid_login_without_api_key


### PR DESCRIPTION
ECS-1582

Ensures error message parsing and string building is handled correctly
regardless of type. Also updates remote Decidir tests with correct
error message.

Test Summary

Local: 4830 tests, 73862 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

Unit: 36 tests, 175 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

Remote: 23 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications