### PR TITLE
BlueSnap: Handle 429 errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@
 * CyberSource: Allow string content for Ignore AVS/CVV flags [curiousepic] #4043
 * Decidir: Update validation error message handling [arbianchi] #4042
 * Authorize.net: Remove cardholderAuthentication for non-3DS transactions [BritneyS] #4045
+* BlueSnap: Handle 429 errors [britth] #4044
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -386,7 +386,7 @@ module ActiveMerchant
 
       def parse(response)
         return bad_authentication_response if response.code.to_i == 401
-        return forbidden_response(response.body) if response.code.to_i == 403
+        return generic_error_response(response.body) if [403, 429].include?(response.code.to_i)
 
         parsed = {}
         doc = Nokogiri::XML(response.body)
@@ -564,7 +564,7 @@ module ActiveMerchant
         { 'description' => 'Unable to authenticate.  Please check your credentials.' }
       end
 
-      def forbidden_response(body)
+      def generic_error_response(body)
         { 'description' => body }
       end
     end

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -481,6 +481,14 @@ class BlueSnapTest < Test::Unit::TestCase
     assert_equal '<xml>You are not authorized to perform this request due to inappropriate role permissions.</xml>', response.message
   end
 
+  def test_failed_rate_limit_response
+    @gateway.expects(:raw_ssl_request).returns(rate_limit_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal '<xml>Client request rate is too high</xml>', response.message
+  end
+
   def test_does_not_send_level_3_when_empty
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
@@ -1229,6 +1237,10 @@ class BlueSnapTest < Test::Unit::TestCase
 
   def forbidden_response
     MockResponse.new(403, '<xml>You are not authorized to perform this request due to inappropriate role permissions.</xml>')
+  end
+
+  def rate_limit_response
+    MockResponse.new(429, '<xml>Client request rate is too high</xml>')
   end
 
   def fraudulent_purchase_response


### PR DESCRIPTION
BlueSnap can throw 429 errors (rate limiting) at times, which are not
currently handled by the AM adapter. We do however, handle 401s and
403s. This PR adds 429s to the types of errors specifically handled.
When they occur, we will send back the response body without trying to
parse any xml.

Info on 429 error from bluesnap docs: https://developers.bluesnap.com/v8976-JSON/docs/error-handling-overview#section-http-503-and-429-errors

Unit:
40 tests, 233 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: PENDING