### PR TITLE
Remove cardholderAuthentication for non-3DS transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,6 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-* Decidir: Update validation error message handling. #4042
-* Kushki: Add support for fullResponse field [rachelkirk] #4040
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014
 * usaepay: Added pin gateway setting [DustinHaefele] #4026
 * MercadoPago: Added external_reference, more payer object options, and metadata field [DustinHaefele] #4020
@@ -33,7 +31,10 @@
 * Update bank routing account validation check [jessiagee] #4029
 * Kushki: Add 'contactDetails' fields [mbreenlyles] #4033
 * Adyen: Truncating order_id and remote test [yyapuncich] #4036
+* Kushki: Add support for fullResponse field [rachelkirk] #4040
 * CyberSource: Allow string content for Ignore AVS/CVV flags [curiousepic] #4043
+* Decidir: Update validation error message handling [arbianchi] #4042
+* Authorize.net: Remove cardholderAuthentication for non-3DS transactions [BritneyS] #4045
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -567,14 +567,16 @@ module ActiveMerchant
 
         xml.customerIP(options[:ip]) unless empty?(options[:ip])
 
-        xml.cardholderAuthentication do
-          three_d_secure = options.fetch(:three_d_secure, {})
-          xml.authenticationIndicator(
-            options[:authentication_indicator] || three_d_secure[:eci]
-          )
-          xml.cardholderAuthenticationValue(
-            options[:cardholder_authentication_value] || three_d_secure[:cavv]
-          )
+        if !empty?(options.fetch(:three_d_secure, {})) || options[:authentication_indicator] || options[:cardholder_authentication_value]
+          xml.cardholderAuthentication do
+            three_d_secure = options.fetch(:three_d_secure, {})
+            xml.authenticationIndicator(
+              options[:authentication_indicator] || three_d_secure[:eci]
+            )
+            xml.cardholderAuthenticationValue(
+              options[:cardholder_authentication_value] || three_d_secure[:cavv]
+            )
+          end
         end
       end
 

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -1050,6 +1050,16 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_does_not_add_cardholder_authentication_element_without_relevant_values
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      parse(data) do |doc|
+        assert !doc.at_xpath('//cardholderAuthentication'), data
+      end
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_capture_passing_extra_info
     response = stub_comms do
       @gateway.capture(50, '123456789', description: 'Yo', order_id: 'Sweetness')


### PR DESCRIPTION
The element `cardholderAuthentication` was removed from the request for the `authorize_net` gateway for non-3DS transactions.

ECS-1456

Test Summary

Unit:
Loaded suite test/unit/gateways/authorize_net_test
108 tests, 640 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_authorize_net_test
73 tests, 269 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed