### PR TITLE
Merchant Warrior: handle unexpected XML response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * BlueSnap: Handle 429 errors [britth] #4044
 * Orbital: Update unit test files [meagabeth] #4046
 * Orbital: Strip null characters from responses [britth] #4041
+* Merchant Warrior: Handle invalid XML responses [arbianchi] #4047
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -187,6 +187,8 @@ module ActiveMerchant #:nodoc:
       def parse(body)
         xml = REXML::Document.new(body)
 
+        return { response_message: 'Invalid gateway response' } unless xml.root.present?
+
         response = {}
         xml.root.elements.to_a.each do |node|
           parse_element(response, node)

--- a/test/remote/gateways/remote_merchant_warrior_test.rb
+++ b/test/remote/gateways/remote_merchant_warrior_test.rb
@@ -76,7 +76,7 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
 
   def test_failed_refund
     assert refund = @gateway.refund(@success_amount, 'invalid-transaction-id')
-    assert_match %r{'transactionID' not found}, refund.message
+    assert_match %r{MW - 011:Invalid transactionID}, refund.message
     assert_failure refund
   end
 
@@ -91,7 +91,7 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
 
   def test_failed_void
     assert void = @gateway.void('invalid-transaction-id', amount: @success_amount)
-    assert_match %r{'transactionID' not found}, void.message
+    assert_match %r{MW - 011:Invalid transactionID}, void.message
     assert_failure void
   end
 

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -31,6 +31,15 @@ class MerchantWarriorTest < Test::Unit::TestCase
     assert_equal '1336-20be3569-b600-11e6-b9c3-005056b209e0', response.authorization
   end
 
+  def test_failed_authorize
+    @gateway.expects(:ssl_post).returns(nil)
+
+    assert response = @gateway.authorize(@success_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Invalid gateway response', response.message
+    assert response.test?
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 


### PR DESCRIPTION
Handle the case when Merchant Warrior response contains invalid XML.

ECS-1373

Test Summary
Local: 4834 tests, 73895 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
Unit: 26 tests, 138 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
Remote: