### PR TITLE
Braintree: Fix NoMethodError for failed card verification

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@
 * Orbital: Update unit test files [meagabeth] #4046
 * Orbital: Strip null characters from responses [britth] #4041
 * Merchant Warrior: Handle invalid XML responses [arbianchi] #4047
+* Braintree: Fix NoMethodError for failed card verification [molbrown] #4048
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -135,8 +135,8 @@ module ActiveMerchant #:nodoc:
             result = @braintree_gateway.verification.create(payload)
             response = Response.new(result.success?, message_from_transaction_result(result), response_options(result))
             response.cvv_result['message'] = ''
-            response.cvv_result['code'] = response.params['cvv_result']
-            response.avs_result['code'] = response.params['avs_result'][:code]
+            response.cvv_result['code'] = response.params['cvv_result'] if response.params['cvv_result']
+            response.avs_result['code'] = response.params['avs_result'][:code] if response.params.dig('avs_result', :code)
             response
           end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -199,6 +199,14 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'P', response.avs_result['code']
   end
 
+  def test_failed_credit_card_verification
+    credit_card = credit_card('378282246310005', verification_value: '544')
+
+    assert response = @gateway.verify(credit_card, @options.merge({ allow_card_verification: true }))
+    assert_failure response
+    assert_match 'CVV must be 4 digits for American Express and 3 digits for other card types. (81707)', response.message
+  end
+
   def test_successful_verify_with_device_data
     # Requires Advanced Fraud Tools to be enabled
     assert response = @gateway.verify(@credit_card, @options.merge({ device_data: 'device data for verify' }))

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -145,6 +145,21 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'P', response.avs_result['code']
   end
 
+  def test_failed_verification_transaction
+    Braintree::CreditCardVerificationGateway.any_instance.expects(:create).
+      returns(braintree_error_result(message: 'CVV must be 4 digits for American Express and 3 digits for other card types. (81707)'))
+
+    card = credit_card('4111111111111111')
+    options = {
+      allow_card_verification: true,
+      billing_address: {
+        zip: '10000'
+      }
+    }
+    response = @gateway.verify(card, options)
+    assert_failure response
+  end
+
   def test_user_agent_includes_activemerchant_version
     assert @internal_gateway.config.user_agent.include?("(ActiveMerchant #{ActiveMerchant::VERSION})")
   end


### PR DESCRIPTION
Responses from failed verify transactions using the verification endpoint
instead of the MultiResponse authorize + void have a different response
structure than successes and other transaction responses. Adds guards to
fix NoMethodError when contents are not present.

Remote:
87 tests, 458 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
85 tests, 192 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ECS-1933