### PR TITLE
PayArc currency and parameters updates

### DIFF
--- a/lib/active_merchant/billing/gateways/pay_arc.rb
+++ b/lib/active_merchant/billing/gateways/pay_arc.rb
@@ -296,7 +296,7 @@ module ActiveMerchant #:nodoc:
 
       def add_money(post, money, options)
         post['amount'] = money
-        post['currency'] = (options[:currency] || currency(money))
+        post['currency'] = currency(money) unless options[:currency]
         post['statement_description'] = options[:statement_description]
       end
 
@@ -315,7 +315,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def filter_gateway_fields(post, options, gateway_fields)
-        filtered_options = options.slice(*gateway_fields)
+        filtered_options = options.slice(*gateway_fields).compact
         post.update(filtered_options)
         post
       end


### PR DESCRIPTION
* Ensure that currency field isn't added twice if currency is already
passed in options param
* Call .compact on filtered_options to remove all nil values and ensure
duplicates are not sent erroneously

Loaded suite test/unit/gateways/pay_arc_test

14 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_pay_arc_test

Failure: test_successful_credit(RemotePayArcTest) due to MID set up on PayArc's side

19 tests, 48 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.7368% passed

bundle exec rake test:local

4835 tests, 73897 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...
Inspecting 707 files

707 files inspected, no offenses detected