### PR TITLE
PayArc: Formatting CC month, adding tax_rate, removing default void reason

### DIFF
--- a/lib/active_merchant/billing/gateways/pay_arc.rb
+++ b/lib/active_merchant/billing/gateways/pay_arc.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
                                card_level sales_tax purchase_order supplier_reference_number customer_ref_id ship_to_zip
                                amex_descriptor customer_vat_number summary_commodity_code shipping_charges duty_charges
                                ship_from_zip destination_country_code vat_invoice order_date tax_category tax_type
-                               tax_amount address_line1 zip terminal_id surcharge description email receipt_phone
+                               tax_amount tax_rate address_line1 zip terminal_id surcharge description email receipt_phone
                                statement_descriptor ] },
         void:
           { end_point: 'charges/{{chargeID}}/void',
@@ -190,7 +190,7 @@ module ActiveMerchant #:nodoc:
 
       def void(tx_reference, options = {})
         post = {}
-        post['reason'] = options[:reason] || 'duplicate'
+        post['reason'] = options[:reason]
         action = STANDARD_ACTIONS[:void][:end_point].gsub(/{{chargeID}}/, tx_reference)
         post = filter_gateway_fields(post, options, STANDARD_ACTIONS[:void][:allowed_fields])
         commit(action, post)
@@ -279,7 +279,7 @@ module ActiveMerchant #:nodoc:
 
       def add_creditcard(post, creditcard, options)
         post['card_number'] = creditcard.number
-        post['exp_month'] = creditcard.month
+        post['exp_month'] = format(creditcard.month, :two_digits)
         post['exp_year'] = creditcard.year
         post['cvv'] = creditcard.verification_value unless creditcard.verification_value.nil?
         post['card_holder_name'] = options[:card_holder_name] || "#{creditcard.first_name} #{creditcard.last_name}"

--- a/test/remote/gateways/remote_pay_arc_test.rb
+++ b/test/remote/gateways/remote_pay_arc_test.rb
@@ -51,6 +51,57 @@ class RemotePayArcTest < Test::Unit::TestCase
     end
   end
 
+  def test_successful_two_digit_card_exp_month
+    credit_card_options = {
+      month: '02',
+      year: '2022',
+      first_name: 'Rex Joseph',
+      last_name: '',
+      verification_value: '999'
+    }
+    credit_card = credit_card('4111111111111111', credit_card_options)
+
+    response = @gateway.purchase(1022, credit_card, @options)
+    assert_success response
+
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+  end
+
+  def test_successful_one_digit_card_exp_month
+    credit_card_options = {
+      month: '2',
+      year: '2022',
+      first_name: 'Rex Joseph',
+      last_name: '',
+      verification_value: '999'
+    }
+    credit_card = credit_card('4111111111111111', credit_card_options)
+
+    response = @gateway.purchase(1022, credit_card, @options)
+    assert_success response
+
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+  end
+
+  def test_failed_three_digit_card_exp_month
+    credit_card_options = {
+      month: '200',
+      year: '2022',
+      first_name: 'Rex Joseph',
+      last_name: '',
+      verification_value: '999'
+    }
+    credit_card = credit_card('4111111111111111', credit_card_options)
+
+    response = @gateway.purchase(1022, credit_card, @options)
+    assert_failure response
+    assert_equal 'error', response.params['status']
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(1300, @invalid_credit_card, @options)
     assert_failure response
@@ -87,6 +138,7 @@ class RemotePayArcTest < Test::Unit::TestCase
   end
 
   def test_successful_void
+    @options.update(reason: 'duplicate')
     charge_response = @gateway.purchase(1200, @credit_card, @options)
     assert_success charge_response
 


### PR DESCRIPTION
* Fixed an issue with CC months not working for '01', '02', etc.
* Added `tax_rate` to the charges allowed list
* Removed the `duplicate` default void reason

Loaded suite test/remote/gateways/remote_pay_arc_test

`test_successful_credit` fails due to MID configuration on PayArc's side

22 tests, 54 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.4545% passed

Loaded suite test/unit/gateways/pay_arc_test

14 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

bundle exec rake test:local

4835 tests, 73897 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...
Inspecting 707 files

707 files inspected, no offenses detected