### PR TITLE
PayArc: Updating `add_address`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@
 * PayArc: Formatting CC month, adding tax_rate, removing default void reason [jessiagee] #4053
 * Kushki: Add support for fullResponse field [rachelkirk] #4057
 * Element: Add support for `MerchantDescriptor` field [BritneyS] #4058
+* PayArc: Added email and phone to credit and charge [jessiagee] #4056
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/test/remote/gateways/remote_pay_arc_test.rb
+++ b/test/remote/gateways/remote_pay_arc_test.rb
@@ -17,15 +17,11 @@ class RemotePayArcTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      billing_address: address,
       description: 'Store Purchase',
       card_source: 'INTERNET',
-      address_line1: '920 Sunnyslope Ave',
-      address_line2: 'Bronx',
-      city: 'New York',
-      state: 'New York',
-      zip: '10469',
-      country: 'USA'
+      billing_address: address.update(phone: '8772036624'),
+      email: 'testy@test.com',
+      phone: '8772036624'
     }
   end
 
@@ -100,6 +96,17 @@ class RemotePayArcTest < Test::Unit::TestCase
     response = @gateway.purchase(1022, credit_card, @options)
     assert_failure response
     assert_equal 'error', response.params['status']
+  end
+
+  def test_successful_adds_phone_number_for_purchase
+    response = @gateway.purchase(250, @credit_card, @options)
+    assert_success response
+
+    assert_block do
+      PayArcGateway::SUCCESS_STATUS.include? response.message
+    end
+
+    assert_equal '8772036624', response.params['receipt_phone']
   end
 
   def test_failed_purchase


### PR DESCRIPTION
* Use `options[:billing_address]` to look at the payment method
data
* Added email and phone_number to `credit` and `token`

bundle exec rake test:local

4836 tests, 73901 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

707 files inspected, no offenses detected

Loaded suite test/remote/gateways/remote_pay_arc_test

`test_successful_credit` fails due to MID configuration on PayArc's side
`test_successful_adds_phone_number_for_purchase` fails due to an issue with the PayArc API, I've reached out to PayArc and waiting on a response

23 tests, 57 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.3043% passed

Loaded suite test/unit/gateways/pay_arc_test

14 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
