### PR TITLE
Kushki: Add support for fullResponse, fix boolean bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,7 +31,6 @@
 * Update bank routing account validation check [jessiagee] #4029
 * Kushki: Add 'contactDetails' fields [mbreenlyles] #4033
 * Adyen: Truncating order_id and remote test [yyapuncich] #4036
-* Kushki: Add support for fullResponse field [rachelkirk] #4040
 * CyberSource: Allow string content for Ignore AVS/CVV flags [curiousepic] #4043
 * Decidir: Update validation error message handling [arbianchi] #4042
 * Authorize.net: Remove cardholderAuthentication for non-3DS transactions [BritneyS] #4045
@@ -44,6 +43,7 @@
 * PayArc: Currency and parameters updates [jessiagee] #4051
 * Elavon: Add support for special characters [mbreenlyles] #4049
 * PayArc: Formatting CC month, adding tax_rate, removing default void reason [jessiagee] #4053
+* Kushki: Add support for fullResponse field [rachelkirk] #4057
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -174,7 +174,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_full_response(post, options)
-        post[:fullResponse] = options[:full_response] if options[:full_response]
+        post[:fullResponse] = options[:full_response].to_s.casecmp('true').zero? if options[:full_response]
       end
 
       ENDPOINT = {

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -74,7 +74,6 @@ class RemoteKushkiTest < Test::Unit::TestCase
     }
     response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
-
     assert_not_empty response.params.dig('details', 'approvalCode')
     assert_equal 'Succeeded', response.message
   end


### PR DESCRIPTION
CE-1800

Unit: 16 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 14 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Local: 4829 tests, 73857 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed