### PR TITLE
Mundipagg: Added support to overwrite api_key

### DIFF
--- a/test/remote/gateways/remote_mundipagg_test.rb
+++ b/test/remote/gateways/remote_mundipagg_test.rb
@@ -22,6 +22,8 @@ class RemoteMundipaggTest < Test::Unit::TestCase
       description: 'Store Purchase'
     }
 
+    @authorization_secret_options = { authorization_secret_key: fixtures(:mundipagg)[:api_key] }
+
     @submerchant_options = {
       submerchant: {
         "merchant_category_code": '44444',
@@ -249,6 +251,18 @@ class RemoteMundipaggTest < Test::Unit::TestCase
 
   def test_successful_store_and_purchase_with_alelo_card
     test_successful_store_and_purchase_with(@alelo_voucher)
+  end
+
+  def test_invalid_login_with_bad_api_key_overwrite
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ authorization_secret_key: 'bad_key' }))
+    assert_failure response
+    assert_match %r{Invalid API key; Authorization has been denied for this request.}, response.message
+  end
+
+  def test_successful_purchase_with_api_key_overwrite
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(@authorization_secret_options))
+    assert_success response
+    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
   end
 
   def test_failed_store_with_top_level_errors


### PR DESCRIPTION
This allows a user to pass in authorization_secret_key for a transaction
and use that for Basic Auth instead of the api_key that is passed in
when the gateway is instantiated

CE-1829

remote tests:Finished in 24.491592 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
39 tests, 97 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1.59 tests/s, 3.96 assertions/s

unit tests: Finished in 0.227902 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
31 tests, 158 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
136.02 tests/s, 693.28 assertions/s

Running RuboCop...
Inspecting 707 files

707 files inspected, no offenses detected