### PR TITLE
Spreedly: Support gateway_specific_response_fields within the reponse parameters

### DIFF
--- a/lib/active_merchant/billing/gateways/spreedly_core.rb
+++ b/lib/active_merchant/billing/gateways/spreedly_core.rb
@@ -254,11 +254,20 @@ module ActiveMerchant #:nodoc:
       end
 
       def childnode_to_response(response, node, childnode)
-        name = "#{node.name.downcase}_#{childnode.name.downcase}"
-        if name == 'payment_method_data' && !childnode.elements.empty?
-          response[name.to_sym] = Hash.from_xml(childnode.to_s).values.first
+        node_name = node.name.downcase
+        childnode_name = childnode.name.downcase
+        composed_name = "#{node_name}_#{childnode_name}"
+
+        childnodes_present = !childnode.elements.empty?
+
+        if childnodes_present && composed_name == 'payment_method_data'
+          response[composed_name.to_sym] = Hash.from_xml(childnode.to_s).values.first
+        elsif childnodes_present && node_name == 'gateway_specific_response_fields'
+          response[node_name.to_sym] = {
+            childnode_name => Hash.from_xml(childnode.to_s).values.first
+          }
         else
-          response[name.to_sym] = childnode.text
+          response[composed_name.to_sym] = childnode.text
         end
       end
 

--- a/test/unit/gateways/spreedly_core_test.rb
+++ b/test/unit/gateways/spreedly_core_test.rb
@@ -294,6 +294,21 @@ class SpreedlyCoreTest < Test::Unit::TestCase
     assert_match %r(#{@not_found_transaction}), response.message
   end
 
+  def test_gateway_specific_response_fileds_returned_correctly
+    @gateway.expects(:raw_ssl_request).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @payment_method_token)
+    assert_success response
+
+    assert_not_empty response.params['gateway_specific_response_fields']
+    assert_includes response.params['gateway_specific_response_fields'].keys, 'migs'
+
+    migs_response_fields = response.params.dig('gateway_specific_response_fields', 'migs')
+    assert_equal migs_response_fields['batch_no'], '20122018'
+    assert_equal migs_response_fields['receipt_no'], 'rxI320t'
+    assert_equal migs_response_fields['authorize_id'], '800385'
+  end
+
   def test_scrubbing
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
@@ -332,6 +347,13 @@ class SpreedlyCoreTest < Test::Unit::TestCase
           <created_at type="datetime">2012-12-06T20:28:14Z</created_at>
           <updated_at type="datetime">2012-12-06T20:28:14Z</updated_at>
         </response>
+        <gateway_specific_response_fields>
+          <migs>
+           <batch_no>20122018</batch_no>
+           <authorize_id>800385</authorize_id>
+           <receipt_no>rxI320t</receipt_no>
+          </migs>
+        </gateway_specific_response_fields>
         <payment_method>
           <token>5WxC03VQ0LmmkYvIHl7XsPKIpUb</token>
           <created_at type="datetime">2012-12-06T20:20:29Z</created_at>


### PR DESCRIPTION
Previously, gateway_specific_response_fields gets rendered as single text, which doesn't represent the different keys in the response and their values correctly.

Unit Tests:
27 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
34 tests, 160 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed