### PR TITLE
Payeezy: Add support for `add_soft_descriptors`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@
 * Maestro: Update BINs [therufs] #4067
 * Monei: Change domain to monei.com [jimmyn] #4068
 * Spreedly: Support gateway_specific_response_fields in response params [abarrak] #4064
+* Payeezy: Add support for `add_soft_descriptors` [rachelkirk] #4069
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -84,6 +84,7 @@ module ActiveMerchant
 
         add_amount(params, amount, options)
         add_payment_method(params, payment_method, options)
+        add_soft_descriptors(params, options)
         commit(params, options)
       end
 

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -213,7 +213,7 @@ class RemotePayeezyTest < Test::Unit::TestCase
   end
 
   def test_successful_general_credit
-    assert response = @gateway.credit(@amount, @credit_card, @options)
+    assert response = @gateway.credit(@amount, @credit_card, @options.merge(@options_mdd))
     assert_match(/Transaction Normal/, response.message)
     assert_equal '100', response.params['bank_resp_code']
     assert_equal nil, response.error_code


### PR DESCRIPTION
Implement `add_soft_descriptors` option in the `credit` method.

Remote: 38 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit: 38 tests, 180 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Local: 4844 tests, 73935 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed