### PR TITLE
Worldpay: Support 'CAPTURED' response for `authorize` transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@
 * Spreedly: Support gateway_specific_response_fields in response params [abarrak] #4064
 * Payeezy: Add support for `add_soft_descriptors` [rachelkirk] #4069
 * Stripe Payment Intents: Add support for network_transaction_id field [cdmackeyfree] #4060
+* Worldpay: Support 'CAPTURED' response for authorize transactions [naashton] #4070
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -144,7 +144,7 @@ module ActiveMerchant #:nodoc:
       private
 
       def authorize_request(money, payment_method, options)
-        commit('authorize', build_authorization_request(money, payment_method, options), 'AUTHORISED', options)
+        commit('authorize', build_authorization_request(money, payment_method, options), 'AUTHORISED', 'CAPTURED', options)
       end
 
       def capture_request(money, authorization, options)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -188,7 +188,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
+    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -283,7 +283,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
+    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -306,7 +306,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' is required.", first_message.message
+    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -771,6 +771,20 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     refund = @cftgateway.refund(@amount * 2, auth.authorization, authorization_validated: true)
     assert_failure refund
     assert_equal 'Refund amount too high', refund.message
+  end
+
+  def test_successful_purchase_with_options_synchronous_response
+    options = @options
+    stored_credential_params = {
+      initial_transaction: true,
+      reason_type: 'unscheduled',
+      initiator: 'merchant',
+      network_transaction_id: nil
+    }
+    options.merge(stored_credential: stored_credential_params)
+
+    assert purchase = @cftgateway.purchase(@amount, @credit_card, options.merge(instalments: 3, skip_capture: true, authorization_validated: true))
+    assert_success purchase
   end
 
   private


### PR DESCRIPTION
Some merchants that execute `authorize` transactions with Worldpay are configured to
automatically capture those transactions via the payment processor
(dependent on region) and therefore can expect to receive 'CAPTURED' in
the list of success criteria when checking the `last_event` value.

Expanding the `authorize_request` to expect `AUTHORISED` or `CAPTURED`
handles this case for those merchants

CE-1786

Unit: 88 tests, 538 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 71 tests, 304 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.1831% passed