### PR TITLE
Ingenico (Global Collect): New idempotence key header

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,6 +55,7 @@
 * Payeezy: Add support for `add_soft_descriptors` [rachelkirk] #4069
 * Stripe Payment Intents: Add support for network_transaction_id field [cdmackeyfree] #4060
 * Worldpay: Support 'CAPTURED' response for authorize transactions [naashton] #4070
+* Ingenico (Global Collect): New idempotence key header [BritneyS] #4073
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -195,6 +195,12 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_equal 'Succeeded', capture.message
   end
 
+  def test_authorize_with_optional_idempotency_key_header
+    response = @gateway.authorize(@accepted_amount, @credit_card, @options.merge(idempotency_key: 'test123'))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -368,6 +368,16 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(response), scrubbed_invalid_json_plus
   end
 
+  def test_authorize_with_optional_idempotency_key_header
+    response = stub_comms do
+      @gateway.authorize(@accepted_amount, @credit_card, @options.merge(idempotency_key: 'test123'))
+    end.check_request do |_endpoint, _data, headers|
+      assert_equal headers['X-GCS-Idempotence-Key'], 'test123'
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
This change adds a new header capable of passing an idempotence key to the `global_collect` gateway. Note that the only non-passing remote test fails with a `502` bad gateway error response, but this is noted as being an intermittent response from the gateway's side.

Test Summary
Local: 4844 tests, 73931 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Unit: 28 tests, 136 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Remote: 25 tests, 86 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96% passed