### PR TITLE
Payflow: add THREEDSVERSION and DSTRANSACTIONID when present

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,6 +59,7 @@
 * PayTrace: Adjust handling of line_items subfields [meagabeth] #4074
 * Worldpay: Correct Expiration Year Format [tatsianaclifton] #4076
 * Monei: Improve Scrub Regex [tatsianaclifton] #4072
+* Payflow: add THREEDSVERSION and DSTRANSACTIONID when present [bbraschi] #4075
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -289,6 +289,8 @@ module ActiveMerchant #:nodoc:
             xml.tag! 'ECI', three_d_secure[:eci] unless three_d_secure[:eci].blank?
             xml.tag! 'CAVV', three_d_secure[:cavv] unless three_d_secure[:cavv].blank?
             xml.tag! 'XID', three_d_secure[:xid] unless three_d_secure[:xid].blank?
+            xml.tag! 'THREEDSVERSION', three_d_secure[:version] unless three_d_secure[:version].blank?
+            xml.tag! 'DSTRANSACTIONID', three_d_secure[:ds_transaction_id] unless three_d_secure[:ds_transaction_id].blank?
           end
         end
       end


### PR DESCRIPTION
See https://developer.paypal.com/docs/payflow/3d-secure-mpi/

- Rubocop:
  ```
  707 files inspected, no offenses detected
  ```    

- Local tests:
    ```
    4848 tests, 73971 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed
    ```
    
- Remote tests:

   ```
   bundle exec rake test:remote TEST=test/remote/gateways/remote_payflow_test.rb
   ```
   | branch |  results |
   | -- | -- |
   | payflow_3ds2_update |  `38 tests, 163 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 73.6842% passed` |
   | master | `38 tests, 163 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 73.6842% passed` <br> the same |
   
   
   In the most recent Payflow PR, [here](https://github.com/activemerchant/active_merchant/pull/4066#issue-698834138), only 8 tests failed.