### PR TITLE
Worldpay: Correct Expiration Year Format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,7 @@
 * Worldpay: Support 'CAPTURED' response for authorize transactions [naashton] #4070
 * Ingenico (Global Collect): New idempotence key header [BritneyS] #4073
 * PayTrace: Adjust handling of line_items subfields [meagabeth] #4074
+* Worldpay: Correct Expiration Year Format [tatsianaclifton] #4076
 
 == Version 1.121 (June 8th, 2021)
 * Braintree: Lift restriction on gem version to allow for backwards compatibility [naashton] #3993

--- a/lib/active_merchant/billing/credit_card_formatting.rb
+++ b/lib/active_merchant/billing/credit_card_formatting.rb
@@ -15,6 +15,7 @@ module ActiveMerchant #:nodoc:
         case option
         when :two_digits  then sprintf('%.2i', number.to_i)[-2..-1]
         when :four_digits then sprintf('%.4i', number.to_i)[-4..-1]
+        when :four_digits_year then number.to_s.length == 2 ? '20' + number.to_s : format(number, :four_digits)
         else number
         end
       end

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -431,7 +431,7 @@ module ActiveMerchant #:nodoc:
             xml.expiryDate do
               xml.date(
                 'month' => format(payment_method.month, :two_digits),
-                'year' => format(payment_method.year, :four_digits)
+                'year' => format(payment_method.year, :four_digits_year)
               )
             end
             xml.cryptogram payment_method.payment_cryptogram
@@ -458,7 +458,7 @@ module ActiveMerchant #:nodoc:
         xml.expiryDate do
           xml.date(
             'month' => format(payment_method.month, :two_digits),
-            'year' => format(payment_method.year, :four_digits)
+            'year' => format(payment_method.year, :four_digits_year)
           )
         end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -14,6 +14,9 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       last_name: 'Smith',
       verification_value: '737',
       brand: 'elo')
+    @credit_card_with_two_digits_year = credit_card('4111111111111111',
+      month: 10,
+      year: 22)
     @cabal_card = credit_card('6035220000000006')
     @naranja_card = credit_card('5895620000000002')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
@@ -51,6 +54,12 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_elo
     assert response = @gateway.purchase(@amount, @elo_credit_card, @options.merge(currency: 'BRL'))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_purchase_with_two_digits_expiration_year
+    assert response = @gateway.purchase(@amount, @credit_card_with_two_digits_year, @options)
     assert_success response
     assert_equal 'SUCCESS', response.message
   end

--- a/test/unit/credit_card_formatting_test.rb
+++ b/test/unit/credit_card_formatting_test.rb
@@ -6,6 +6,11 @@ class CreditCardFormattingTest < Test::Unit::TestCase
   def test_should_format_number_by_rule
     assert_equal 2005, format(2005, :steven_colbert)
 
+    assert_equal '2022', format(22, :four_digits_year)
+    assert_equal '2022', format(2022, :four_digits_year)
+    assert_equal '2022', format('22', :four_digits_year)
+    assert_equal '2022', format('2022', :four_digits_year)
+
     assert_equal '0005', format(05, :four_digits)
     assert_equal '2005', format(2005, :four_digits)
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -24,6 +24,12 @@ class WorldpayTest < Test::Unit::TestCase
       eci: '07',
       source: :network_token,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+    @credit_card_with_two_digits_year = credit_card('4514 1600 0000 0008',
+      month: 10,
+      year: 22,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
     @options = { order_id: 1 }
     @store_options = {
@@ -196,6 +202,13 @@ class WorldpayTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'CAD'))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/CAD/, data)
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_two_digits_year
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card_with_two_digits_year, @options)
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
   end


### PR DESCRIPTION
This pull request fixes the issue when expiration 2 digits year is converted to 4 digits by adding 00to the beginning. For example, '22' becomes '0022'. Now if year is 2 digits '20' is added to the beginning. For example, '22' becomes '2022'.

ECS-1973
bundle exec rake test:local
4847 tests, 73948 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
534.01 tests/s, 8147.08 assertions/s
Running RuboCop...
Inspecting 707 files
707 files inspected, no offenses detected

Unit:
89 tests, 541 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote (2 failed same as on master):
72 tests, 307 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.2222% passed