### PR TITLE
[BE-763] Adding Checkout.com source id payment changes

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -111,7 +111,7 @@ module ActiveMerchant #:nodoc:
         post[:source] = {}
         if options[:type] == 'id'
           post[:source][:type] = options[:type]
-          post[:source][:id] = payment_method.token
+          post[:source][:id] = payment_method[:token]
           return
         end
         if payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :network_token

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -111,7 +111,7 @@ module ActiveMerchant #:nodoc:
         post[:source] = {}
         if options[:type] == 'id'
           post[:source][:type] = options[:type]
-          post[:source][:id] = payment_method.source_id
+          post[:source][:id] = payment_method.token
           return
         end
         if payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :network_token

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -99,7 +99,7 @@ module ActiveMerchant #:nodoc:
           post[:billing_descriptor][:city] = options[:descriptor_city] if options[:descriptor_city]
         end
         post[:metadata] = {}
-        post[:metadata][:udf5] = application_id || 'ActiveMerchant'
+        post[:metadata][:udf5] = application_id || ''
       end
 
       def add_metadata(post, options)
@@ -109,6 +109,11 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(post, payment_method, options)
         post[:source] = {}
+        if options[:type] == 'id'
+          post[:source][:type] = options[:type]
+          post[:source][:id] = payment_method.source_id
+          return
+        end
         if payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :network_token
           post[:source][:type] = 'network_token'
           post[:source][:token] = payment_method.number

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -179,7 +179,7 @@ checkout:
   password: Password1!
 
 checkout_v2:
-  secret_key: secret_key
+  secret_key: sk_test_a0c1975f-2dfa-490a-8a2b-d11b2f978d0d
 
 citrus_pay:
   userid: CPF00001

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -17,6 +17,19 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
       source:             :network_token,
       verification_value: nil)
 
+    @source_id_payment_info = {
+      token: 'src_ydubwfflc7pefgaok7pqtld7ti'
+    }
+
+    @source_id_payment_options = {
+      type: 'id',
+      currency: 'USD'
+    }
+
+    @invalid_source_id_payment_info = {
+      token: 'Invalid-token'
+    }
+
     @options = {
       order_id: '1',
       billing_address: address,
@@ -71,6 +84,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_success response
     assert_equal 'Succeeded', response.message
     assert_not_nil response.params['source']['payment_account_reference']
+  end
+
+  def test_successful_purchase_with_source_token
+    response = @gateway.purchase(100, @source_id_payment_info, @source_id_payment_options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
   end
 
   def test_successful_purchase_with_additional_options
@@ -369,5 +388,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_failure response
     assert_equal 'request_invalid: card_expired', response.message
     assert_equal 'request_invalid: card_expired', response.error_code
+  end
+
+  def test_failure_purchase_with_source_token
+    response = @gateway.purchase(100, @invalid_source_id_payment_info, @source_id_payment_options)
+    assert_failure response
+    assert_equal 'request_invalid: source_id_invalid', response.message
+    assert_equal 'request_invalid: source_id_invalid', response.error_code
   end
 end


### PR DESCRIPTION
## Description:

- Adding changes for making payments using the `source_id` created at checkout.com for recurring payments.

### Testing:

- Added tests to assert the changes - both unit and remote. 