### PR TITLE
Moka: New Gateway Adapter

### DIFF
--- a/lib/active_merchant/billing/gateways/moka.rb
+++ b/lib/active_merchant/billing/gateways/moka.rb
@@ -1,0 +1,226 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class MokaGateway < Gateway
+      self.test_url = 'https://service.testmoka.com'
+      self.live_url = 'https://service.moka.com'
+
+      self.supported_countries = %w[GB TR US]
+      self.default_currency = 'TRY'
+      self.money_format = :dollars
+      self.supported_cardtypes = %i[visa master american_express discover]
+
+      self.homepage_url = 'http://developer.moka.com/'
+      self.display_name = 'Moka'
+
+      ERROR_CODE_MAPPING = {
+        '000' =>	'General error',
+        '001' =>	'3D Not authenticated',
+        '002' =>	'Limit is insufficient',
+        '003' =>	'Credit card number format is wrong',
+        '004' =>	'General decline',
+        '005' =>	'This process is invalid for the card owner',
+        '006' =>	'Expiration date is wrong',
+        '007' =>	'Invalid transaction',
+        '008' =>	'Connection with the bank not established',
+        '009' =>	'Undefined error code',
+        '010' =>	'Bank SSL error',
+        '011' =>	'Call the bank for the manual authentication',
+        '012' =>	'Card info is wrong - Kart Number or CVV2',
+        '013' =>	'3D secure is not supported other than Visa MC cards',
+        '014' =>	'Invalid account number',
+        '015' =>	'CVV is wrong',
+        '016' =>	'Authentication process is not present',
+        '017' =>	'System error',
+        '018' =>	'Stolen card',
+        '019' =>	'Lost card',
+        '020' =>	'Card with limited properties',
+        '021' =>	'Timeout',
+        '022' =>	'Invalid merchant',
+        '023' =>	'False authentication',
+        '024' =>	'3D authorization is successful but the procedd cannot be completed',
+        '025' =>	'3D authorization failure',
+        '026' =>	'Either the issuer bank or the card is not enrolled to the 3D process',
+        '027' =>	'The bank did not allow the process',
+        '028' =>	'Fraud suspect',
+        '029' =>	'The card is closed to the e-commerce operations'
+      }
+
+      def initialize(options = {})
+        requires!(options, :dealer_code, :username, :password)
+        super
+      end
+
+      def purchase(money, payment, options = {})
+        post = {}
+        post[:PaymentDealerRequest] = {}
+        options[:pre_auth] = 0
+        add_auth_purchase(post, money, payment, options)
+
+        commit('purchase', post)
+      end
+
+      def authorize(money, payment, options = {})
+        post = {}
+        post[:PaymentDealerRequest] = {}
+        options[:pre_auth] = 1
+        add_auth_purchase(post, money, payment, options)
+
+        commit('authorize', post)
+      end
+
+      def capture(money, authorization, options = {})
+        post = {}
+        post[:PaymentDealerRequest] = {}
+        add_payment_dealer_authentication(post)
+        add_transaction_reference(post, authorization)
+        add_additional_transaction_data(post, options)
+
+        commit('capture', post)
+      end
+
+      def refund(money, authorization, options = {})
+        post = {}
+        post[:PaymentDealerRequest] = {}
+        add_payment_dealer_authentication(post)
+        add_transaction_reference(post, authorization)
+        add_additional_transaction_data(post, options)
+        add_void_refund_reason(post)
+        add_amount(post, money)
+
+        commit('refund', post)
+      end
+
+      def void(authorization, options = {})
+        post = {}
+        post[:PaymentDealerRequest] = {}
+        add_payment_dealer_authentication(post)
+        add_transaction_reference(post, authorization)
+        add_additional_transaction_data(post, options)
+        add_void_refund_reason(post)
+
+        commit('void', post)
+      end
+
+      private
+
+      def add_auth_purchase(post, money, payment, options)
+        add_payment_dealer_authentication(post)
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_additional_auth_purchase_data(post, options)
+        add_additional_transaction_data(post, options)
+      end
+
+      def add_payment_dealer_authentication(post)
+        post[:PaymentDealerAuthentication] = {
+          DealerCode: @options[:dealer_code],
+          Username: @options[:username],
+          Password: @options[:password],
+          CheckKey: check_key
+        }
+      end
+
+      def check_key
+        str = "#{@options[:dealer_code]}MK#{@options[:username]}PD#{@options[:password]}"
+        Digest::SHA256.hexdigest(str)
+      end
+
+      def add_invoice(post, money, options)
+        post[:PaymentDealerRequest][:Amount] = amount(money) || 0
+        post[:PaymentDealerRequest][:Currency] = options[:currency] || 'TL'
+      end
+
+      def add_payment(post, card)
+        post[:PaymentDealerRequest][:CardHolderFullName] = card.name
+        post[:PaymentDealerRequest][:CardNumber] = card.number
+        post[:PaymentDealerRequest][:ExpMonth] = card.month
+        post[:PaymentDealerRequest][:ExpYear] = card.year
+        post[:PaymentDealerRequest][:CvcNumber] = card.verification_value
+      end
+
+      def add_amount(post, money)
+        post[:PaymentDealerRequest][:Amount] = money || 0
+      end
+
+      def add_additional_auth_purchase_data(post, options)
+        post[:PaymentDealerRequest][:IsPreAuth] = options[:pre_auth]
+        post[:PaymentDealerRequest][:Description] = options[:order_id] if options[:order_id]
+      end
+
+      def add_additional_transaction_data(post, options)
+        post[:PaymentDealerRequest][:ClientIP] = options[:ip] if options[:ip]
+        post[:PaymentDealerRequest][:OtherTrxCode] = options[:order_id] if options[:order_id]
+      end
+
+      def add_transaction_reference(post, authorization)
+        post[:PaymentDealerRequest][:VirtualPosOrderId] = authorization
+      end
+
+      def add_void_refund_reason(post)
+        post[:PaymentDealerRequest][:VoidRefundReason] = 2
+      end
+
+      def commit(action, parameters)
+        response = parse(ssl_post(url(action), post_data(parameters), request_headers))
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def url(action)
+        host = (test? ? test_url : live_url)
+        endpoint = endpoint(action)
+
+        "#{host}/PaymentDealer/#{endpoint}"
+      end
+
+      def endpoint(action)
+        case action
+        when 'purchase', 'authorize'
+          'DoDirectPayment'
+        when 'capture'
+          'DoCapture'
+        when 'void'
+          'DoVoid'
+        when 'refund'
+          'DoCreateRefundRequest'
+        end
+      end
+
+      def request_headers
+        { 'Content-Type' => 'application/json' }
+      end
+
+      def post_data(parameters = {})
+        JSON.generate(parameters)
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def success_from(response)
+        response.dig('Data', 'IsSuccessful')
+      end
+
+      def message_from(response)
+        response.dig('Data', 'ResultMessage').presence || response['ResultCode']
+      end
+
+      def authorization_from(response)
+        response.dig('Data', 'VirtualPosOrderId')
+      end
+
+      def error_code_from(response)
+        codes = [response['ResultCode'], response.dig('Data', 'ResultCode')].flatten
+        codes.reject! { |code| code.blank? || code.casecmp('success').zero? }
+        codes.map { |code| ERROR_CODE_MAPPING[code] || code }.join(', ')
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/moka.rb
+++ b/lib/active_merchant/billing/gateways/moka.rb
@@ -101,6 +101,27 @@ module ActiveMerchant #:nodoc:
         commit('void', post)
       end
 
+      def verify(credit_card, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r(("CardNumber\\?":\\?")[^"]*)i, '\1[FILTERED]').
+          gsub(%r(("CvcNumber\\?":\\?")[^"]*)i, '\1[FILTERED]').
+          gsub(%r(("DealerCode\\?":\\?")[^"]*)i, '\1[FILTERED]').
+          gsub(%r(("Username\\?":\\?")[^"]*)i, '\1[FILTERED]').
+          gsub(%r(("Password\\?":\\?")[^"]*)i, '\1[FILTERED]').
+          gsub(%r(("CheckKey\\?":\\?")[^"]*)i, '\1[FILTERED]')
+      end
+
       private
 
       def add_auth_purchase(post, money, payment, options)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -552,6 +552,11 @@ modern_payments:
   login: login
   password: password
 
+moka:
+  dealer_code: DEALER_CODE
+  username: USERNAME
+  password: PASSWORD
+
 # Working credentials, no need to replace
 monei:
   api_key: pk_test_3cb2d54b7ee145fa92d683c01816ad15

--- a/test/remote/gateways/remote_moka_test.rb
+++ b/test/remote/gateways/remote_moka_test.rb
@@ -26,6 +26,55 @@ class RemoteMokaTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: '127.0.0.1',
+      sub_merchant_name: 'Example Co.',
+      is_pool_payment: 1
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
+  def test_successful_purchase_with_buyer_information
+    options = {
+      billing_address: address,
+      email: 'safiye.ali@example.com'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
+  def test_successful_purchase_with_basket_products
+    # Basket Products must be on the list of Merchant Products for your Moka account.
+    # To see this list or add products to it, log in to your Moka Dashboard
+    options = {
+      basket_product: [
+        {
+          product_id: 333,
+          product_code: '0173',
+          unit_price: 19900,
+          quantity: 1
+        },
+        {
+          product_id: 281,
+          product_code: '38',
+          unit_price: 5000,
+          quantity: 1
+        }
+      ]
+    }
+
+    response = @gateway.purchase(24900, @credit_card, options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_moka_test.rb
+++ b/test/remote/gateways/remote_moka_test.rb
@@ -1,0 +1,106 @@
+require 'test_helper'
+
+class RemoteMokaTest < Test::Unit::TestCase
+  def setup
+    @gateway = MokaGateway.new(fixtures(:moka))
+
+    @amount = 100
+    @credit_card = credit_card('5269111122223332', month: '10', year: '2024')
+    @declined_card = credit_card('4000300011112220')
+    @options = {
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_invalid_login
+    gateway = MokaGateway.new(dealer_code: '', username: '', password: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match 'PaymentDealer.CheckPaymentDealerAuthentication.InvalidAccount', response.message
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+
+    assert_equal 'PaymentDealer.DoDirectPayment.VirtualPosNotAvailable', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'Success', capture.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'PaymentDealer.DoDirectPayment.VirtualPosNotAvailable', response.error_code
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount - 0.1, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'PaymentDealer.DoCapture.OtherTrxCodeOrVirtualPosOrderIdMustGiven', response.message
+  end
+
+  # # Moka does not allow a same-day refund on a purchase/capture. In order to test refund,
+  # # you must pass a reference that has 'matured' at least one day.
+  # def test_successful_refund
+  #   my_matured_reference = 'REPLACE ME'
+  #   assert refund = @gateway.refund(0, my_matured_reference)
+  #   assert_success refund
+  #   assert_equal 'Success', refund.message
+  # end
+
+  # # Moka does not allow a same-day refund on a purchase/capture. In order to test refund,
+  # # you must pass a reference that has 'matured' at least one day. For the purposes of testing
+  # # a partial refund, make sure the original transaction being referenced was for an amount
+  # # greater than the 'partial_amount' supplied in the test.
+  # def test_partial_refund
+  #   my_matured_reference = 'REPLACE ME'
+  #   partial_amount = 50
+  #   assert refund = @gateway.refund(partial_amount, my_matured_reference)
+  #   assert_success refund
+  #   assert_equal 'Success', refund.message
+  # end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_equal 'PaymentDealer.DoCreateRefundRequest.OtherTrxCodeOrVirtualPosOrderIdMustGiven', response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'Success', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'PaymentDealer.DoVoid.InvalidRequest', response.message
+  end
+end

--- a/test/unit/gateways/moka_test.rb
+++ b/test/unit/gateways/moka_test.rb
@@ -106,6 +106,28 @@ class MokaTest < Test::Unit::TestCase
     assert_equal 'PaymentDealer.DoVoid.InvalidRequest', response.error_code
   end
 
+  def test_successful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card)
+    end.respond_with(successful_response)
+    assert_success response
+    assert_equal 'Test-9732c2ce-08d9-4ff6-a89f-bd3fa345811c', response.authorization
+    assert_equal 'Success', response.message
+  end
+
+  def test_failed_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card)
+    end.respond_with(failed_response_with_top_level_error)
+    assert_failure response
+    assert_equal 'PaymentDealer.DoDirectPayment.InvalidRequest', response.message
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
   def test_buyer_information_is_passed
     options = @options.merge({
       billing_address: address,
@@ -155,6 +177,64 @@ class MokaTest < Test::Unit::TestCase
   end
 
   private
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      opening connection to service.testmoka.com:443...
+      opened
+      starting SSL for service.testmoka.com:443...
+      SSL established
+      <- "POST /PaymentDealer/DoDirectPayment HTTP/1.1\r\nContent-Type: application/json\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: service.testmoka.com\r\nContent-Length: 443\r\n\r\n"
+      <- "{\"PaymentDealerRequest\":{\"Amount\":\"1.00\",\"Currency\":\"TL\",\"CardHolderFullName\":\"Longbob Longsen\",\"CardNumber\":\"5269111122223332\",\"ExpMonth\":10,\"ExpYear\":2024,\"CvcNumber\":\"123\",\"IsPreAuth\":0,\"BuyerInformation\":{\"BuyerFullName\":\"Longbob Longsen\"}},\"PaymentDealerAuthentication\":{\"DealerCode\":\"1731\",\"Username\":\"TestMoka2\",\"Password\":\"HYSYHDS8DU8HU\",\"CheckKey\":\"1c1cccfe19b782415c207f1d66f97889cf11ed6d1e1ad6f585e5fe70b6f5da90\"},\"IsPoolPayment\":0}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Cache-Control: no-cache\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "Content-Type: application/json; charset=utf-8\r\n"
+      -> "Expires: -1\r\n"
+      -> "Server: Microsoft-IIS/10.0\r\n"
+      -> "X-AspNet-Version: 4.0.30319\r\n"
+      -> "X-Powered-By: ASP.NET\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Allow-Headers: *\r\n"
+      -> "Date: Mon, 16 Aug 2021 20:33:17 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Content-Length: 188\r\n"
+      -> "\r\n"
+      reading 188 bytes...
+      -> "{\"Data\":{\"IsSuccessful\":true,\"ResultCode\":\"\",\"ResultMessage\":\"\",\"VirtualPosOrderId\":\"Test-e8345c66-b614-4490-83ce-7be510f22312\"},\"ResultCode\":\"Success\",\"ResultMessage\":\"\",\"Exception\":null}"
+      read 188 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      opening connection to service.testmoka.com:443...
+      opened
+      starting SSL for service.testmoka.com:443...
+      SSL established
+      <- "POST /PaymentDealer/DoDirectPayment HTTP/1.1\r\nContent-Type: application/json\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: service.testmoka.com\r\nContent-Length: 443\r\n\r\n"
+      <- "{\"PaymentDealerRequest\":{\"Amount\":\"1.00\",\"Currency\":\"TL\",\"CardHolderFullName\":\"Longbob Longsen\",\"CardNumber\":\"[FILTERED]\",\"ExpMonth\":10,\"ExpYear\":2024,\"CvcNumber\":\"[FILTERED]\",\"IsPreAuth\":0,\"BuyerInformation\":{\"BuyerFullName\":\"Longbob Longsen\"}},\"PaymentDealerAuthentication\":{\"DealerCode\":\"[FILTERED]\",\"Username\":\"[FILTERED]\",\"Password\":\"[FILTERED]\",\"CheckKey\":\"[FILTERED]\"},\"IsPoolPayment\":0}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Cache-Control: no-cache\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "Content-Type: application/json; charset=utf-8\r\n"
+      -> "Expires: -1\r\n"
+      -> "Server: Microsoft-IIS/10.0\r\n"
+      -> "X-AspNet-Version: 4.0.30319\r\n"
+      -> "X-Powered-By: ASP.NET\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Allow-Headers: *\r\n"
+      -> "Date: Mon, 16 Aug 2021 20:33:17 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Content-Length: 188\r\n"
+      -> "\r\n"
+      reading 188 bytes...
+      -> "{\"Data\":{\"IsSuccessful\":true,\"ResultCode\":\"\",\"ResultMessage\":\"\",\"VirtualPosOrderId\":\"Test-e8345c66-b614-4490-83ce-7be510f22312\"},\"ResultCode\":\"Success\",\"ResultMessage\":\"\",\"Exception\":null}"
+      read 188 bytes
+      Conn close
+    POST_SCRUBBED
+  end
 
   def successful_response
     <<-RESPONSE

--- a/test/unit/gateways/moka_test.rb
+++ b/test/unit/gateways/moka_test.rb
@@ -1,0 +1,202 @@
+require 'test_helper'
+
+class MokaTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = MokaGateway.new(dealer_code: '123', username: 'username', password: 'password')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal 'Test-9732c2ce-08d9-4ff6-a89f-bd3fa345811c', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase_with_top_level_error
+    @gateway.expects(:ssl_post).returns(failed_response_with_top_level_error)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'PaymentDealer.DoDirectPayment.InvalidRequest', response.error_code
+    assert_equal 'PaymentDealer.DoDirectPayment.InvalidRequest', response.message
+  end
+
+  def test_failed_purchase_with_nested_error
+    @gateway.expects(:ssl_post).returns(failed_response_with_nested_error)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+
+    assert_equal 'General error', response.error_code
+    assert_equal 'Genel Hata(Geçersiz kart numarası)', response.message
+  end
+
+  def test_successful_authorize
+    response = stub_comms do
+      @gateway.authorize(@amount, credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 1, JSON.parse(data)['PaymentDealerRequest']['IsPreAuth']
+    end.respond_with(successful_response)
+    assert_success response
+
+    assert_equal 'Test-9732c2ce-08d9-4ff6-a89f-bd3fa345811c', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_post).returns(failed_response_with_top_level_error)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_post).returns(successful_response)
+
+    response = @gateway.capture(@amount, 'Test-9732c2ce-08d9-4ff6-a89f-bd3fa345811c', @options)
+    assert_success response
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_post).returns(failed_capture_response)
+
+    response = @gateway.capture(@amount, 'wrong-authorization', @options)
+    assert_failure response
+    assert_equal 'PaymentDealer.DoCapture.PaymentNotFound', response.error_code
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+
+    response = @gateway.refund(0, 'Test-9732c2ce-08d9-4ff6-a89f-bd3fa345811c')
+    assert_success response
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+
+    response = @gateway.refund(0, '')
+    assert_failure response
+    assert_equal 'PaymentDealer.DoCreateRefundRequest.OtherTrxCodeOrVirtualPosOrderIdMustGiven', response.error_code
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_response)
+
+    response = @gateway.void('Test-9732c2ce-08d9-4ff6-a89f-bd3fa345811c')
+    assert_success response
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_post).returns(failed_void_response)
+
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal 'PaymentDealer.DoVoid.InvalidRequest', response.error_code
+  end
+
+  private
+
+  def successful_response
+    <<-RESPONSE
+      {
+        "Data": {
+          "IsSuccessful": true,
+          "ResultCode": "",
+          "ResultMessage": "",
+          "VirtualPosOrderId": "Test-9732c2ce-08d9-4ff6-a89f-bd3fa345811c"
+        },
+        "ResultCode": "Success",
+        "ResultMessage": "",
+        "Exception": null
+      }
+    RESPONSE
+  end
+
+  def successful_refund_response
+    <<-RESPONSE
+      {
+        "Data": {
+          "IsSuccessful": true,
+          "ResultCode": "",
+          "ResultMessage": "",
+          "RefundRequestId": 2320
+        },
+        "ResultCode": "Success",
+        "ResultMessage": "",
+        "Exception": null
+      }
+    RESPONSE
+  end
+
+  def failed_response_with_top_level_error
+    <<-RESPONSE
+      {
+        "Data": null,
+        "ResultCode": "PaymentDealer.DoDirectPayment.InvalidRequest",
+        "ResultMessage": "",
+        "Exception": null
+      }
+    RESPONSE
+  end
+
+  def failed_response_with_nested_error
+    <<-RESPONSE
+    {
+      "Data": {
+        "IsSuccessful": false,
+        "ResultCode": "000",
+        "ResultMessage": "Genel Hata(Geçersiz kart numarası)",
+        "VirtualPosOrderId": ""
+      },
+      "ResultCode": "Success",
+      "ResultMessage": "",
+      "Exception": null
+    }
+    RESPONSE
+  end
+
+  def failed_capture_response
+    <<-RESPONSE
+      {
+        "Data": null,
+        "ResultCode": "PaymentDealer.DoCapture.PaymentNotFound",
+        "ResultMessage": "",
+        "Exception": null
+      }
+    RESPONSE
+  end
+
+  def failed_refund_response
+    <<-RESPONSE
+      {
+        "Data": null,
+        "ResultCode": "PaymentDealer.DoCreateRefundRequest.OtherTrxCodeOrVirtualPosOrderIdMustGiven",
+        "ResultMessage": "",
+        "Exception": null
+      }
+    RESPONSE
+  end
+
+  def failed_void_response
+    <<-RESPONSE
+      {
+        "Data": null,
+        "ResultCode": "PaymentDealer.DoVoid.InvalidRequest",
+        "ResultMessage": "",
+        "Exception": null
+      }
+    RESPONSE
+  end
+end


### PR DESCRIPTION
CE-1808

Adds support for the Moka Gateway. 

A few notes about the remote tests:
* Occasionally, when you run the entire remote test file, one or more tests will fail with the message `PaymentDealer.Fraud.SuspiciousPaymentTrial`. This is a result of too many transactions in too short of a time. If you rerun any of these failing tests individually, waiting 20 or 30 seconds between tests, they should all pass.
* You will notice the refund tests are commented-out, with an explanation for why. You can retrieve transaction references from 1+ day in the past for use in these tests by logging in to the Moka account dashboard and clicking the `Payments` tab.  From there you can select the `VirtualPosOrderId` of a transaction and paste it into the refund test in order to get the test to pass.

Rubocop:
710 files inspected, no offenses detected

Unit:
4868 tests, 74062 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_moka_test
16 tests, 33 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed