### PR TITLE
Paysafe: Add gateway integration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Paysafe: Add gateway integration [meagabeth] #4085
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -1,0 +1,278 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PaysafeGateway < Gateway
+      self.test_url = 'https://api.test.paysafe.com'
+      self.live_url = 'https://api.paysafe.com'
+
+      self.supported_countries = %w(FR)
+      self.default_currency = 'EUR'
+      self.supported_cardtypes = %i[visa master american_express discover]
+
+      self.homepage_url = 'https://www.paysafe.com/'
+      self.display_name = 'Paysafe'
+
+      def initialize(options = {})
+        requires!(options, :username, :password, :account_id)
+        super
+      end
+
+      def purchase(money, payment, options = {})
+        post = {}
+        post[:settleWithAuth] = true
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_billing_address(post, options)
+        add_merchant_details(post, options)
+        add_customer_data(post, payment, options) unless payment.is_a?(String)
+
+        commit(:post, 'auths', post, options)
+      end
+
+      def authorize(money, payment, options = {})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+        add_billing_address(post, options)
+        add_merchant_details(post, options)
+        add_customer_data(post, payment, options) unless payment.is_a?(String)
+
+        commit(:post, 'auths', post, options)
+      end
+
+      def capture(money, authorization, options = {})
+        post = {}
+        add_invoice(post, money, options)
+
+        commit(:post, "auths/#{authorization}/settlements", post, options)
+      end
+
+      def refund(money, authorization, options = {})
+        post = {}
+        add_invoice(post, money, options)
+
+        commit(:post, "settlements/#{authorization}/refunds", post, options)
+      end
+
+      def void(authorization, options = {})
+        post = {}
+        money = options[:amount]
+        add_invoice(post, money, options)
+
+        commit(:post, "auths/#{authorization}/voidauths", post, options)
+      end
+
+      def credit(money, payment, options = {})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment)
+
+        commit(:post, 'standalonecredits', post, options)
+      end
+
+      # This is a '$0 auth' done at a specific verification endpoint at the gateway
+      def verify(payment, options = {})
+        post = {}
+        add_payment(post, payment)
+        add_billing_address(post, options)
+        add_customer_data(post, payment, options) unless payment.is_a?(String)
+
+        commit(:post, 'verifications', post, options)
+      end
+
+      def store(payment, options = {})
+        post = {}
+        add_payment(post, payment)
+        add_address_for_vaulting(post, options)
+        add_profile_data(post, payment, options)
+        add_store_data(post, payment, options)
+
+        commit(:post, 'profiles', post, options)
+      end
+
+      def redact(pm_profile_id)
+        commit_for_redact(:delete, "profiles/#{pm_profile_id}", nil, nil)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: Basic )[a-zA-Z0-9:_]+), '\1[FILTERED]').
+          gsub(%r(("cardNum\\?":\\?")\d+), '\1[FILTERED]').
+          gsub(%r(("cvv\\?":\\?")\d+), '\1[FILTERED]')
+      end
+
+      private
+
+      # Customer data can be included in transactions where the payment method is a credit card
+      # but should not be sent when the payment method is a token
+      def add_customer_data(post, creditcard, options)
+        post[:profile] = {}
+        post[:profile][:firstName] = creditcard.first_name
+        post[:profile][:lastName] = creditcard.last_name
+        post[:profile][:email] = options[:email] if options[:email]
+        post[:customerIp] = options[:ip] if options[:ip]
+      end
+
+      def add_billing_address(post, options)
+        return unless options[:billing_address] || options[:address]
+
+        address = options[:billing_address] || options[:address]
+        post[:billingDetails] = {}
+        post[:billingDetails][:street] = address[:address1]
+        post[:billingDetails][:city] = address[:city]
+        post[:billingDetails][:state] = address[:state]
+        post[:billingDetails][:country] = address[:country]
+        post[:billingDetails][:zip] = address[:zip]
+        post[:billingDetails][:phone] = address[:phone]
+      end
+
+      # The add_address_for_vaulting method is applicable to the store method, as the APIs address
+      # object is formatted differently from the standard transaction billing address
+      def add_address_for_vaulting(post, options)
+        return unless options[:billing_address || options[:address]]
+
+        address = options[:billing_address] || options[:address]
+        post[:billingAddress] = {}
+        post[:billingAddress][:street] = address[:address1]
+        post[:billingAddress][:city] = address[:city]
+        post[:billingAddress][:zip] = address[:zip]
+        post[:billingAddress][:country] = address[:country]
+        post[:billingAddress][:state] = address[:state] if address[:state]
+      end
+
+      # This data is specific to creating a profile at the gateway's vault level
+      def add_profile_data(post, payment, options)
+        address = options[:billing_address] || options[:address]
+
+        post[:firstName] = payment.first_name
+        post[:lastName] = payment.last_name
+        post[:dateOfBirth] = {}
+        post[:dateOfBirth][:year] = options[:date_of_birth][:year]
+        post[:dateOfBirth][:month] = options[:date_of_birth][:month]
+        post[:dateOfBirth][:day] = options[:date_of_birth][:day]
+        post[:email] = options[:email] if options[:email]
+        post[:phone] = (address[:phone] || options[:phone]) if address[:phone] || options[:phone]
+        post[:ip] = options[:ip] if options[:ip]
+      end
+
+      def add_store_data(post, payment, options)
+        post[:merchantCustomerId] = options[:customer_id] || SecureRandom.hex(12)
+        post[:locale] = options[:locale] || 'en_US'
+        post[:card][:holderName] = payment.name
+      end
+
+      # Paysafe expects minor units so we are not calling amount method on money parameter
+      def add_invoice(post, money, options)
+        post[:amount] = money
+      end
+
+      def add_payment(post, payment)
+        if payment.is_a?(String)
+          post[:card] = {}
+          post[:card][:paymentToken] = payment
+        else
+          post[:card] = { cardExpiry: {} }
+          post[:card][:cardNum] = payment.number
+          post[:card][:cardExpiry][:month] = payment.month
+          post[:card][:cardExpiry][:year] = payment.year
+          post[:card][:cvv] = payment.verification_value
+        end
+      end
+
+      def add_merchant_details(post, options)
+        return unless options[:merchant_descriptor]
+
+        post[:merchantDescriptor] = {}
+        post[:merchantDescriptor][:dynamicDescriptor] = options[:merchant_descriptor][:dynamic_descriptor] if options[:merchant_descriptor][:dynamic_descriptor]
+        post[:merchantDescriptor][:phone] = options[:merchant_descriptor][:phone] if options[:merchant_descriptor][:phone]
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def commit(method, action, parameters, options)
+        url = url(action)
+        raw_response = ssl_request(method, url, post_data(parameters, options), headers)
+        response = parse(raw_response)
+        success = success_from(response)
+
+        Response.new(
+          success,
+          message_from(success, response),
+          response,
+          authorization: authorization_from(response),
+          avs_result: AVSResult.new(code: response['avsResponse']),
+          cvv_result: CVVResult.new(response['cvvVerification']),
+          test: test?,
+          error_code: success ? nil : error_code_from(response)
+        )
+      end
+
+      def commit_for_redact(method, action, parameters, options)
+        url = url(action)
+        response = raw_ssl_request(method, url, post_data(parameters, options), headers)
+        success = true if response.code == '200'
+
+        Response.new(
+          success,
+          message: response.message
+        )
+      end
+
+      def headers
+        {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Basic #{Base64.strict_encode64(@options[:api_key].to_s)}"
+        }
+      end
+
+      def url(action, options = {})
+        base_url = (test? ? test_url : live_url)
+
+        if action.include? 'profiles'
+          "#{base_url}/customervault/v1/#{action}"
+        else
+          "#{base_url}/cardpayments/v1/accounts/#{@options[:account_id]}/#{action}"
+        end
+      end
+
+      def success_from(response)
+        return false if response['status'] == 'FAILED' || response['error']
+
+        true
+      end
+
+      def message_from(success, response)
+        return response['status'] unless response['error']
+
+        "Error(s)- code:#{response['error']['code']}, message:#{response['error']['message']}"
+      end
+
+      def authorization_from(response)
+        response['id']
+      end
+
+      def post_data(parameters = {}, options = {})
+        return unless parameters.present?
+
+        parameters[:merchantRefNum] = options[:merchant_ref_num] || SecureRandom.hex(16).to_s
+
+        parameters.to_json
+      end
+
+      def error_code_from(response)
+        return unless response['error']
+
+        response['error']['code']
+      end
+
+      def handle_response(response)
+        response.body
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -785,6 +785,11 @@ paypal_signature:
   password: HBC6A84QLRWC923A
   signature: AFcWxV21C7fd0v3bYYYRCpSSRl31AC-11AKBL8FFO9tjImL311y8a0hx
 
+paysafe:
+  login: SOMECREDENTIAL
+  secret_key: ANOTHERCREDENTIAL
+  account_id: CREDENTIAL
+
 payscout:
   username: demo
   password: password

--- a/test/remote/gateways/remote_paysafe_test.rb
+++ b/test/remote/gateways/remote_paysafe_test.rb
@@ -1,0 +1,189 @@
+require 'test_helper'
+
+class RemotePaysafeTest < Test::Unit::TestCase
+  def setup
+    @gateway = PaysafeGateway.new(fixtures(:paysafe))
+
+    @amount = 100
+    @credit_card = credit_card('4107857757053670')
+    @pm_token = 'Ci3S9DWyOP9CiJ5'
+    @options = {
+      billing_address: address,
+      merchant_descriptor: {
+        dynamic_descriptor: 'Store Purchase',
+        phone: '999-8887777'
+      }
+    }
+    @profile_options = {
+      date_of_birth: {
+        year: 1979,
+        month: 1,
+        day: 1
+      },
+      email: 'profile@memail.com',
+      phone: '111-222-3456',
+      address: address
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'COMPLETED', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      ip: '127.0.0.1',
+      email: 'joe@example.com'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(options))
+    assert_success response
+    assert_equal 'COMPLETED', response.message
+  end
+
+  def test_successful_purchase_with_token
+    purchase = @gateway.purchase(200, @pm_token, @options)
+    assert_success purchase
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(11, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Error(s)- code:3022, message:The card has been declined due to insufficient funds.', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'PENDING', capture.message
+  end
+
+  def test_successful_authorize_and_capture_with_token
+    auth = @gateway.authorize(@amount, @pm_token, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'PENDING', capture.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(5, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Error(s)- code:3009, message:Your request has been declined by the issuing bank.', response.message
+  end
+
+  def test_partial_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount - 1, auth.authorization)
+    assert_success capture
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, 'invalidtransactionid')
+    assert_failure response
+    assert_equal 'Error(s)- code:3201, message:The authorization ID included in this settlement request could not be found.', response.message
+  end
+
+  # Can test refunds by logging into our portal and grabbing transaction IDs from settled transactions
+  # Refunds will return 'PENDING' status until they are batch processed at EOD
+  # def test_successful_refund
+  #   auth = ''
+
+  #   assert refund = @gateway.refund(@amount, auth)
+  #   assert_failure refund
+  #   assert_equal 'PENDING', refund.message
+  # end
+
+  # def test_partial_refund
+  #   auth = ''
+
+  #   assert refund = @gateway.refund(@amount - 1, auth)
+  #   assert_success refund
+  #   assert_equal 'PENDING', refund.message
+  # end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, 'thisisnotavalidtrasactionid')
+    assert_failure response
+    assert_equal 'Error(s)- code:3407, message:The settlement referred to by the transaction response ID you provided cannot be found.', response.message
+  end
+
+  def test_successful_void
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'COMPLETED', void.message
+  end
+
+  def test_successful_void_with_token_purchase
+    auth = @gateway.authorize(@amount, @pm_token, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'COMPLETED', void.message
+  end
+
+  def test_failed_void
+    response = @gateway.void('')
+    assert_failure response
+    assert_equal "Error(s)- code:5023, message:Request method 'POST' not supported", response.message
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match 'COMPLETED', response.message
+  end
+
+  def test_successful_verify_with_token
+    response = @gateway.verify(@pm_token, @options)
+    assert_success response
+    assert_match 'COMPLETED', response.message
+  end
+
+  # Not including a test_failed_verify since the only way to force a failure on this
+  # gateway is with a specific dollar amount
+
+  def test_successful_store
+    response = @gateway.store(credit_card('4111111111111111'), @profile_options)
+    assert_success response
+  end
+
+  def test_successful_store_and_redact
+    response = @gateway.store(credit_card('4111111111111111'), @profile_options)
+    assert_success response
+    id = response.authorization
+    redact = @gateway.redact(id)
+    assert_success redact
+  end
+
+  def test_invalid_login
+    gateway = PaysafeGateway.new(username: '', password: '', account_id: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal '5279', response.error_code
+    assert_match 'invalid', response.params['error']['message'].downcase
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value, clean_transcript)
+  end
+end

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -1,0 +1,218 @@
+require 'test_helper'
+
+class PaysafeTest < Test::Unit::TestCase
+  def setup
+    @gateway = PaysafeGateway.new(username: 'username', password: 'password', account_id: 'account_id')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      billing_address: address,
+      merchant_descriptor: {
+        dynamic_descriptor: 'Store Purchase'
+      }
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal 'cddbd29d-4983-4719-983a-c6a862895781', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_request).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal '3022', response.error_code
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_request).returns(successful_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '3155d89c-dfff-49a2-9352-b531e69102f7', response.authorization
+    assert_equal 'COMPLETED', response.message
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_request).returns(failed_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal '3009', response.error_code
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_request).returns(successful_capture_response)
+    auth = '3155d89c-dfff-49a2-9352-b531e69102f7'
+
+    response = @gateway.capture(@amount, auth)
+    assert_success response
+
+    assert_equal '6ee71dc2-00c0-4891-b226-ab741e63f43a', response.authorization
+    assert_equal 'PENDING', response.message
+  end
+
+  def test_failed_capture
+    @gateway.expects(:ssl_request).returns(failed_capture_response)
+
+    response = @gateway.capture(@amount, '')
+    assert_failure response
+
+    assert_equal '5023', response.error_code
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_request).returns(successful_refund_response)
+    auth = 'originaltransactionsauthorization'
+
+    response = @gateway.refund(@amount, auth)
+    assert_success response
+
+    assert_equal 'e86fe7c3-9d92-4149-89a9-fd2b3da95b05', response.authorization
+    assert_equal 'PENDING', response.message
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_request).returns(failed_refund_response)
+    auth = 'invalidauthorizationid'
+
+    response = @gateway.refund(@amount, auth)
+    assert_failure response
+
+    assert_equal '3407', response.error_code
+    assert_equal 'Error(s)- code:3407, message:The settlement referred to by the transaction response ID you provided cannot be found.', response.message
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_request).returns(successful_void_response)
+    auth = '3155d89c-dfff-49a2-9352-b531e69102f7'
+
+    response = @gateway.void(auth)
+    assert_success response
+
+    assert_equal 'eb4d45ac-35ef-49e8-93d0-58b20a4c470e', response.authorization
+    assert_equal 'COMPLETED', response.message
+  end
+
+  def test_failed_void
+    @gateway.expects(:ssl_request).returns(failed_void_response)
+
+    response = @gateway.void('')
+    assert_failure response
+
+    assert_equal '5023', response.error_code
+  end
+
+  def test_successful_verify
+    @gateway.expects(:ssl_request).returns(successful_verify_response)
+
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+
+    assert_equal '493936', response.params['authCode']
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    '
+      <- "POST /cardpayments/v1/accounts/1002158490/auths HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic cG1sZS03MTA1MjA6Qi1xYTItMC02MGY1YTg5MS0wLTMwMmMwMjE0NDkwZTdlYjliM2IxOWRlOTRlM2FkNjVhOTcxMGM4MTFmYjc4NzhiZTAyMTQxNzQwM2FiYjgyNmQ1NDg2MDdhZGQ3NTNjNmZhMjE0YjYxYmU5YTdj\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: api.test.paysafe.com\r\nContent-Length: 443\r\n\r\n"
+      <- "{\"amount\":100,\"card\":{\"cardExpiry\":{\"month\":9,\"year\":2022},\"cardNum\":\"4107857757053670\",\"cvv\":\"123\"},\"billingDetails\":{\"street\":\"999 This Way Lane\",\"city\":\"Hereville\",\"state\":\"NC\",\"country\":\"FR\",\"zip\":\"98989\",\"phone\":\"999-9999999\"},\"profile\":{\"firstName\":\"Longbob\",\"lastName\":\"Longsen\"},\"merchantDescriptor\":{\"dynamicDescriptor\":\"Store Purchase\",\"phone\":\"999-8887777\"},\"settleWithAuth\":true,\"merchantRefNum\":\"08498355c7f86bf096dc5f3fe77bd1da\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: envoy\r\n"
+      -> "Content-Length: 1324\r\n"
+      -> "X-Applicationuid: GUID=f26c8e32-e8a4-435d-a288-703750d8a941\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "X-Envoy-Upstream-Service-Time: 144\r\n"
+      -> "Expires: Tue, 10 Aug 2021 16:56:06 GMT\r\n"
+      -> "Cache-Control: max-age=0, no-cache, no-store\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "Date: Tue, 10 Aug 2021 16:56:06 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Set-Cookie: WLSESSIONID=g3Ew_iMEkM_6zDo4AisqhBlyuLi5UbyaVrkLVx3hmj-gOgZeKDl9!-2065395402!6582410; path=/; secure; HttpOnly\r\n"
+      -> "\r\n"
+      reading 1324 bytes...
+      -> "{\"id\":\"f26c8e32-e8a4-435d-a288-703750d8a941\",\"merchantRefNum\":\"08498355c7f86bf096dc5f3fe77bd1da\",\"txnTime\":\"2021-08-10T16:56:06Z\",\"status\":\"COMPLETED\",\"amount\":100,\"settleWithAuth\":true,\"preAuth\":false,\"availableToSettle\":0,\"card\":{\"type\":\"VI\",\"lastDigits\":\"3670\",\"cardExpiry\":{\"month\":9,\"year\":2022}},\"authCode\":\"976920\",\"profile\":{\"firstName\":\"Longbob\",\"lastName\":\"Longsen\"},\"billingDetails\":{\"street\":\"999 This Way Lane\",\"city\":\"Hereville\",\"state\":\"NC\",\"country\":\"FR\",\"zip\":\"98989\",\"phone\":\"999-9999999\"},\"merchantDescriptor\":{\"dynamicDescriptor\":\"Store Purchase\",\"phone\":\"999-8887777\"},\"visaAdditionalAuthData\":{},\"currencyCode\":\"EUR\",\"avsResponse\":\"MATCH\",\"cvvVerification\":\"MATCH\",\"settlements\":[{\"id\":\"f26c8e32-e8a4-435d-a288-703750d8a941\",\"merchantRefNum\":\"08498355c7f86bf096dc5f3fe77bd1da\",\"txnTime\":\"2021-08-10T16:56:06Z\",\"status\":\"PENDING\",\"amount\":100,\"availableToRefund\":100,\"links\":[{\"rel\":\"self\",\"href\":\"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/settlements/f26c8e32-e8a4-435d-a288-703750d8a941\"}]}],\"links\":[{\"rel\":\"settlement\",\"href\":\"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/settlements/f26c8e32-e8a4-435d-a288-703750d8a941\"},{\"rel\":\"self\",\"href\":\"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/auths/f26c8e32-e8a4-435d-a288-703750d8a941\"}]}"
+    '
+  end
+
+  def post_scrubbed
+    '
+      <- "POST /cardpayments/v1/accounts/1002158490/auths HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic [FILTERED]\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: api.test.paysafe.com\r\nContent-Length: 443\r\n\r\n"
+      <- "{\"amount\":100,\"card\":{\"cardExpiry\":{\"month\":9,\"year\":2022},\"cardNum\":\"[FILTERED]\",\"cvv\":\"[FILTERED]\"},\"billingDetails\":{\"street\":\"999 This Way Lane\",\"city\":\"Hereville\",\"state\":\"NC\",\"country\":\"FR\",\"zip\":\"98989\",\"phone\":\"999-9999999\"},\"profile\":{\"firstName\":\"Longbob\",\"lastName\":\"Longsen\"},\"merchantDescriptor\":{\"dynamicDescriptor\":\"Store Purchase\",\"phone\":\"999-8887777\"},\"settleWithAuth\":true,\"merchantRefNum\":\"08498355c7f86bf096dc5f3fe77bd1da\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: envoy\r\n"
+      -> "Content-Length: 1324\r\n"
+      -> "X-Applicationuid: GUID=f26c8e32-e8a4-435d-a288-703750d8a941\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "X-Envoy-Upstream-Service-Time: 144\r\n"
+      -> "Expires: Tue, 10 Aug 2021 16:56:06 GMT\r\n"
+      -> "Cache-Control: max-age=0, no-cache, no-store\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "Date: Tue, 10 Aug 2021 16:56:06 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Set-Cookie: WLSESSIONID=g3Ew_iMEkM_6zDo4AisqhBlyuLi5UbyaVrkLVx3hmj-gOgZeKDl9!-2065395402!6582410; path=/; secure; HttpOnly\r\n"
+      -> "\r\n"
+      reading 1324 bytes...
+      -> "{\"id\":\"f26c8e32-e8a4-435d-a288-703750d8a941\",\"merchantRefNum\":\"08498355c7f86bf096dc5f3fe77bd1da\",\"txnTime\":\"2021-08-10T16:56:06Z\",\"status\":\"COMPLETED\",\"amount\":100,\"settleWithAuth\":true,\"preAuth\":false,\"availableToSettle\":0,\"card\":{\"type\":\"VI\",\"lastDigits\":\"3670\",\"cardExpiry\":{\"month\":9,\"year\":2022}},\"authCode\":\"976920\",\"profile\":{\"firstName\":\"Longbob\",\"lastName\":\"Longsen\"},\"billingDetails\":{\"street\":\"999 This Way Lane\",\"city\":\"Hereville\",\"state\":\"NC\",\"country\":\"FR\",\"zip\":\"98989\",\"phone\":\"999-9999999\"},\"merchantDescriptor\":{\"dynamicDescriptor\":\"Store Purchase\",\"phone\":\"999-8887777\"},\"visaAdditionalAuthData\":{},\"currencyCode\":\"EUR\",\"avsResponse\":\"MATCH\",\"cvvVerification\":\"MATCH\",\"settlements\":[{\"id\":\"f26c8e32-e8a4-435d-a288-703750d8a941\",\"merchantRefNum\":\"08498355c7f86bf096dc5f3fe77bd1da\",\"txnTime\":\"2021-08-10T16:56:06Z\",\"status\":\"PENDING\",\"amount\":100,\"availableToRefund\":100,\"links\":[{\"rel\":\"self\",\"href\":\"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/settlements/f26c8e32-e8a4-435d-a288-703750d8a941\"}]}],\"links\":[{\"rel\":\"settlement\",\"href\":\"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/settlements/f26c8e32-e8a4-435d-a288-703750d8a941\"},{\"rel\":\"self\",\"href\":\"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/auths/f26c8e32-e8a4-435d-a288-703750d8a941\"}]}"
+    '
+  end
+
+  def successful_purchase_response
+    '{"id":"cddbd29d-4983-4719-983a-c6a862895781","merchantRefNum":"c9b2ad852a1a37c1cc5c39b741be7484","txnTime":"2021-08-10T18:25:40Z","status":"COMPLETED","amount":100,"settleWithAuth":true,"preAuth":false,"availableToSettle":0,"card":{"type":"VI","lastDigits":"3670","cardExpiry":{"month":9,"year":2022}},"authCode":"544454","profile":{"firstName":"Longbob","lastName":"Longsen"},"billingDetails":{"street":"999 This Way Lane","city":"Hereville","state":"NC","country":"FR","zip":"98989","phone":"999-9999999"},"merchantDescriptor":{"dynamicDescriptor":"Store Purchase","phone":"999-8887777"},"visaAdditionalAuthData":{},"currencyCode":"EUR","avsResponse":"MATCH","cvvVerification":"MATCH","settlements":[{"id":"cddbd29d-4983-4719-983a-c6a862895781","merchantRefNum":"c9b2ad852a1a37c1cc5c39b741be7484","txnTime":"2021-08-10T18:25:40Z","status":"PENDING","amount":100,"availableToRefund":100,"links":[{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/settlements/cddbd29d-4983-4719-983a-c6a862895781"}]}],"links":[{"rel":"settlement","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/settlements/cddbd29d-4983-4719-983a-c6a862895781"},{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/auths/cddbd29d-4983-4719-983a-c6a862895781"}]}'
+  end
+
+  def failed_purchase_response
+    '{"id":"c671d488-3f27-46f1-b0a7-2123e4e68f35","merchantRefNum":"12b616e548d7b866c6a61e6d585a762b","error":{"code":"3022","message":"The card has been declined due to insufficient funds.","links":[{"rel":"errorinfo","href":"https://developer.paysafe.com/en/rest-api/cards/test-and-go-live/card-errors/#ErrorCode3022"}]},"riskReasonCode":[1059],"settleWithAuth":true,"cvvVerification":"MATCH","links":[{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/auths/c671d488-3f27-46f1-b0a7-2123e4e68f35"}]}'
+  end
+
+  def successful_authorize_response
+    '{"id":"3155d89c-dfff-49a2-9352-b531e69102f7","merchantRefNum":"8b3c5142fdce91299e76a39d89e32bc1","txnTime":"2021-08-10T18:31:26Z","status":"COMPLETED","amount":100,"settleWithAuth":false,"preAuth":false,"availableToSettle":100,"card":{"type":"VI","lastDigits":"3670","cardExpiry":{"month":9,"year":2022}},"authCode":"659078","profile":{"firstName":"Longbob","lastName":"Longsen"},"billingDetails":{"street":"999 This Way Lane","city":"Hereville","state":"NC","country":"FR","zip":"98989","phone":"999-9999999"},"merchantDescriptor":{"dynamicDescriptor":"Store Purchase","phone":"999-8887777"},"visaAdditionalAuthData":{},"currencyCode":"EUR","avsResponse":"MATCH","cvvVerification":"MATCH","links":[{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/auths/3155d89c-dfff-49a2-9352-b531e69102f7"}]}'
+  end
+
+  def failed_authorize_response
+    '{"id":"bde4a254-7df9-462e-8de1-bfaa205d299a","merchantRefNum":"939b24ab14825b7d365842957dbda683","error":{"code":"3009","message":"Your request has been declined by the issuing bank.","links":[{"rel":"errorinfo","href":"https://developer.paysafe.com/en/rest-api/cards/test-and-go-live/card-errors/#ErrorCode3009"}]},"riskReasonCode":[1100],"settleWithAuth":false,"links":[{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/auths/bde4a254-7df9-462e-8de1-bfaa205d299a"}]}'
+  end
+
+  def successful_capture_response
+    '{"id":"6ee71dc2-00c0-4891-b226-ab741e63f43a","merchantRefNum":"09bf1e741aa1485ceae9b779e550f929","txnTime":"2021-08-10T18:31:26Z","status":"PENDING","amount":100,"availableToRefund":100,"links":[{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/settlements/6ee71dc2-00c0-4891-b226-ab741e63f43a"}]}'
+  end
+
+  def failed_capture_response
+    '{"error":{"code":"5023","message":"Request method POST not supported","links":[{"rel":"errorinfo","href":"https://developer.paysafe.com/en/rest-api/cards/test-and-go-live/card-errors/#ErrorCode5023"}]}}'
+  end
+
+  def successful_verify_response
+    '{"id":"2b48475a-e3e7-47b0-8d84-66a331db9945","merchantRefNum":"fe95dee377466d9a54550c228227c5be","txnTime":"2021-08-18T20:06:55Z","status":"COMPLETED","card":{"type":"VI","lastDigits":"3670","cardExpiry":{"month":9,"year":2022}},"authCode":"493936","profile":{"firstName":"Longbob","lastName":"Longsen"},"billingDetails":{"street":"999 This Way Lane","city":"Hereville","state":"NC","country":"FR","zip":"98989","phone":"999-9999999"},"merchantDescriptor":{"dynamicDescriptor":"Test","phone":"123-1234123"},"visaAdditionalAuthData":{},"currencyCode":"EUR","avsResponse":"NOT_PROCESSED","cvvVerification":"MATCH","links":[{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/verifications/2b48475a-e3e7-47b0-8d84-66a331db9945"}]}'
+  end
+
+  def successful_refund_response
+    '{"id":"e86fe7c3-9d92-4149-89a9-fd2b3da95b05","merchantRefNum":"b8e04a4ff196b20f8aea42558aec8cbd","txnTime":"2021-08-11T13:40:59Z","status":"PENDING","amount":100,"links":[{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/refunds/e86fe7c3-9d92-4149-89a9-fd2b3da95b05"}]}'
+  end
+
+  def failed_refund_response
+    '{"id":"0c498606-3690-4b24-a083-0f8a75b8e043","merchantRefNum":"2becb71485cb38c862d2589decce99df","error":{"code":"3407","message":"The settlement referred to by the transaction response ID you provided cannot be found.","links":[{"rel":"errorinfo","href":"https://developer.paysafe.com/en/rest-api/cards/test-and-go-live/card-errors/#ErrorCode3407"}]},"links":[{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/refunds/0c498606-3690-4b24-a083-0f8a75b8e043"}]}'
+  end
+
+  def successful_void_response
+    '{"id":"eb4d45ac-35ef-49e8-93d0-58b20a4c470e","merchantRefNum":"dbeb1095b191c16715052d4bcc98b42d","txnTime":"2021-08-10T18:35:05Z","status":"COMPLETED","amount":100,"links":[{"rel":"self","href":"https://api.test.paysafe.com/cardpayments/v1/accounts/1002158490/voidauths/eb4d45ac-35ef-49e8-93d0-58b20a4c470e"}]}'
+  end
+
+  def failed_void_response
+    '{"error":{"code":"5023","message":"Request method POST not supported","links":[{"rel":"errorinfo","href":"https://developer.paysafe.com/en/rest-api/cards/test-and-go-live/card-errors/#ErrorCode5023"}]}}'
+  end
+end


### PR DESCRIPTION
- Support the following AM methods: authorize, capture, purchase, verify, void, refund, store
- Add support for payment tokens in all transaction types
- Support additional methods: credit and redact
- [Paysafe card API documentation](https://developer.paysafe.com/en/cards/api/)
- [Paysafe vault API documentation](https://developer.paysafe.com/en/vault/api/)

CE-1555

Rubocop:
710 files inspected, no offenses detected
Local:
4864 tests, 74030 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
13 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
21 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed