### PR TITLE
Enables Recurring Transactions on Elavon

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Paysafe: Add gateway integration [meagabeth] #4085
+* Elavon: Support recurring transactions with stored credentials [cdmackeyfree] #4086
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -301,6 +301,7 @@ module ActiveMerchant #:nodoc:
         xml.ssl_entry_mode                      entry_mode(options) if entry_mode(options)
         add_custom_fields(xml, options) if options[:custom_fields]
         add_stored_credential(xml, options) if options[:stored_credential]
+        recurring_transaction(xml, options) if options[:stored_credential] && options.dig(:stored_credential, :reason_type) == 'recurring'
       end
 
       def add_custom_fields(xml, options)
@@ -367,7 +368,16 @@ module ActiveMerchant #:nodoc:
 
       def merchant_initiated_unscheduled(options)
         return options[:merchant_initiated_unscheduled] if options[:merchant_initiated_unscheduled]
-        return 'Y' if options.dig(:stored_credential, :initiator) == 'merchant' && options.dig(:stored_credential, :reason_type) == 'unscheduled'
+        return 'Y' if options.dig(:stored_credential, :initiator) == 'merchant' && options.dig(:stored_credential, :reason_type) == 'unscheduled' || options.dig(:stored_credential, :reason_type) == 'recurring'
+      end
+
+      def recurring_transaction(xml, options)
+        init_txn = options.dig(:stored_credential, :initial_transaction)
+        if init_txn == true
+          xml.ssl_add_token     'Y'
+        else
+          xml.ssl_add_token     'N'
+        end
       end
 
       def entry_mode(options)


### PR DESCRIPTION
For recurring transactions, an initial call must be made to the gateway using merchant_initiated_unscheduled, as well as ssl_get_token (to request the token) and ssl_add_token (to store that token with the payment method). Once stored the ssl_token will be sent with subsequent purchases that are marked as "recurring".

Local:
4853 tests, 73995 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
46 tests, 243 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
38 tests, 171 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
89.4737% passed

The four failing remote tests are also failing on the master branch and I am working with Elavon to get them resolved.