### PR TITLE
Orbital: Truncate three_d_secure[:version]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 == HEAD
 * Paysafe: Add gateway integration [meagabeth] #4085
 * Elavon: Support recurring transactions with stored credentials [cdmackeyfree] #4086
+* Orbital: Truncate three_d_secure[:version] [carrigan] #4087
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -605,8 +605,10 @@ module ActiveMerchant #:nodoc:
 
       def add_mc_program_protocol(xml, creditcard, three_d_secure)
         return unless three_d_secure && creditcard.brand == 'master'
+        return unless three_d_secure[:version]
 
-        xml.tag!(:MCProgramProtocol, three_d_secure[:version]) if three_d_secure[:version]
+        truncated_version = three_d_secure[:version].to_s[0]
+        xml.tag!(:MCProgramProtocol, truncated_version)
       end
 
       def add_mc_directory_trans_id(xml, creditcard, three_d_secure)

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -206,7 +206,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
         xid: 'TESTXID',
         cavv: 'AAAEEEDDDSSSAAA2243234',
         ds_transaction_id: '97267598FAE648F28083C23433990FBC',
-        version: 2
+        version: '2.2.0'
       },
       sca_recurring: 'Y'
     }
@@ -350,7 +350,7 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
         eci: '5',
         cavv: 'AAAEEEDDDSSSAAA2243234',
         xid: 'Asju1ljfl86bAAAAAACm9zU6aqY=',
-        version: '2',
+        version: '2.2.0',
         ds_transaction_id: '8dh4htokdf84jrnxyemfiosheuyfjt82jiek'
       },
       address: {

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -98,7 +98,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
         eci: '5',
         xid: 'TESTXID',
         cavv: 'TESTCAVV',
-        version: '2',
+        version: '2.2.0',
         ds_transaction_id: '97267598FAE648F28083C23433990FBC'
       }
     }
@@ -295,7 +295,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
         xid: 'TESTXID',
         cavv: 'AAAEEEDDDSSSAAA2243234',
         ds_transaction_id: '97267598FAE648F28083C23433990FBC',
-        version: 2
+        version: '2.2.0'
       },
       sca_recurring: 'Y'
     }
@@ -314,13 +314,12 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_three_d_secure_data_on_master_sca_recurring_with_invalid_eci
     options_local = {
-      three_d_version: '2',
       three_d_secure: {
         eci: '5',
         xid: 'TESTXID',
         cavv: 'AAAEEEDDDSSSAAA2243234',
         ds_transaction_id: '97267598FAE648F28083C23433990FBC',
-        version: 2
+        version: '2.2.0'
       },
       sca_recurring: 'Y'
     }


### PR DESCRIPTION
## Why?

ECS-2012

When a 3DS version is given to Orbital with the minor version numbers (i.e. "2.2.0"), Orbital returns an error:

> Error. The Orbital Gateway has received a badly formatted message. Field [MasterCard Program Protocol] exceeded max length of [1]

## What Changed?

This commit converts the version number to a string and truncates it to only include the major version number (i.e. "2").

## Initial Test Suite

After changing just the tests, the remote tests were able to recreate the error. There were four failures:

```
Failure: test_successful_master_authorization_with_3ds(RemoteOrbitalGatewayTest)
Failure: test_successful_master_purchase_with_3ds(RemoteOrbitalGatewayTest)
Failure: test_successful_purchase_with_sca_recurring_master_card(RemoteOrbitalGatewayTest)
Failure: test_transcript_scrubbing(RemoteOrbitalGatewayTest)
```

The unit test changes also caused 4 failures:

```
129 tests, 741 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.8992% passed
```

## Final Test Suite

After applying the patch, all tests are at parity with master.

### Remote tests (same as master):

71 tests, 324 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.5915% passed

### Unit tests:

4864 tests, 74030 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Linting:

710 files inspected, no offenses detected