### PR TITLE
Adyen: Upgrade API Version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Maestro: support BINs without Luhn check [therufs] #4097
 * Maestro: support BINs [therufs] #4098
 * Redsys: Route MIT Exemptions to webservice endpoint [curiousepic] #4081
+* Adyen: Update Classic Integration API to v64 and Recurring API to v49 [almalee24] #4090
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -16,8 +16,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://www.adyen.com/'
       self.display_name = 'Adyen'
 
-      PAYMENT_API_VERSION = 'v40'
-      RECURRING_API_VERSION = 'v30'
+      PAYMENT_API_VERSION = 'v64'
+      RECURRING_API_VERSION = 'v49'
 
       STANDARD_ERROR_CODE_MAPPING = {
         '101' => STANDARD_ERROR_CODE[:incorrect_number],


### PR DESCRIPTION
Upgrade the Payment API Version to v64 and the Recurring
API Version to v49.

103 tests, 399 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

77 tests, 402 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed