### PR TITLE
PaymentezGateway: Add more_info field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Elavon: Support recurring transactions with stored credentials [cdmackeyfree] #4086
 * Orbital: Truncate three_d_secure[:version] [carrigan] #4087
 * Credorax: Determine ISK decimal by datetime [curiousepic] #4088
+* Paymentez: Add more_info field [reblevins] #4091
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -82,6 +82,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options = {})
         post = { transaction: { id: authorization } }
         post[:order] = { amount: amount(money).to_f } if money
+        add_more_info(post, options)
 
         commit_transaction('refund', post)
       end
@@ -196,6 +197,10 @@ module ActiveMerchant #:nodoc:
         return if auth_data.empty?
 
         extra_params[:auth_data] = auth_data
+      end
+
+      def add_more_info(post, options)
+        post[:more_info] = options[:more_info] if options[:more_info]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -142,6 +142,17 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_equal 'Completed', refund.message
   end
 
+  def test_successful_refund_with_more_info
+    auth = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert refund = @gateway.refund(@amount, auth.authorization, @options.merge(more_info: true))
+    assert_success refund
+    assert_equal 'Completed', refund.message
+    assert_equal '00', refund.params['transaction']['carrier_code']
+    assert_equal 'Reverse by mock', refund.params['transaction']['message']
+  end
+
   def test_successful_refund_with_elo
     auth = @gateway.purchase(@amount, @elo_credit_card, @options)
     assert_success auth

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -279,6 +279,17 @@ class PaymentezTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_void_with_more_info
+    @gateway.expects(:ssl_post).returns(successful_void_response_with_more_info)
+
+    response = @gateway.void('1234', @options.merge(more_info: true))
+    assert_success response
+    assert_equal 'Completed', response.message
+    assert_equal '00', response.params['transaction']['carrier_code']
+    assert_equal 'Reverse by mock', response.params['transaction']['message']
+    assert response.test?
+  end
+
   def test_simple_store
     @gateway.expects(:ssl_post).returns(successful_store_response)
 
@@ -607,8 +618,13 @@ Conn close
     '{"status": "failure", "detail": "Invalid Status"}'
   end
 
+  def successful_void_response_with_more_info
+    '{"status": "success", "detail": "Completed", "transaction": {"carrier_code": "00", "message": "Reverse by mock"}}'
+  end
+
   alias successful_refund_response successful_void_response
   alias failed_refund_response failed_void_response
+  alias successful_refund_response_with_more_info successful_void_response_with_more_info
 
   def already_stored_response
     '{"error": {"type": "Card already added: 14436664108567261211", "help": "If you want to update the card, first delete it", "description": "{}"}}'


### PR DESCRIPTION
Add the optional `more_info` field to the PaymentezGateway request. When present and true, the following fields will be returned in the response:
`transaction.carrier_code`
`transaction.message`

CE-1896

Unit:
28 tests, 114 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
31 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed