### PR TITLE
Worldpay: support $0 auth

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,8 +5,10 @@
 * Elavon: Support recurring transactions with stored credentials [cdmackeyfree] #4086
 * Orbital: Truncate three_d_secure[:version] [carrigan] #4087
 * Credorax: Determine ISK decimal by datetime [curiousepic] #4088
+* Moka: support new gateway type [dsmcclain] #4089
 * Paymentez: Add more_info field [reblevins] #4091
 * Visanet Peru: use timestamp instead of random for purchaseNumber [therufs] #4093
+* Worldpay: Support $0 auth [therufs] #4092
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -115,8 +115,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(payment_method, options = {})
+        amount = (eligible_for_0_auth?(payment_method, options) ? 0 : 100)
         MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, payment_method, options) }
+          r.process { authorize(amount, payment_method, options) }
           r.process(:ignore_result) { void(r.authorization, options.merge(authorization_validated: true)) }
         end
       end
@@ -792,6 +793,10 @@ module ActiveMerchant #:nodoc:
 
       def card_code_for(payment_method)
         CARD_CODES[card_brand(payment_method)] || CARD_CODES['unknown']
+      end
+
+      def eligible_for_0_auth?(payment_method, options = {})
+        payment_method.is_a?(CreditCard) && %w(visa master).include?(payment_method.brand) && options[:zero_dollar_auth]
       end
     end
   end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -7,6 +7,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4111111111111111')
+    @amex_card = credit_card('3714 496353 98431')
     @elo_credit_card = credit_card('4514 1600 0000 0008',
       month: 10,
       year: 2020,
@@ -495,6 +496,20 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{SUCCESS}, response.message
+  end
+
+  def test_successful_verify_with_0_auth
+    options = @options.merge(zero_dollar_auth: true)
+    response = @gateway.verify(@credit_card, options)
+    assert_success response
+    assert_match %r{SUCCESS}, response.message
+  end
+
+  def test_successful_verify_with_0_auth_and_ineligible_card
+    options = @options.merge(zero_dollar_auth: true)
+    response = @gateway.verify(@amex_card, options)
     assert_success response
     assert_match %r{SUCCESS}, response.message
   end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -742,6 +742,22 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_verify_with_0_auth
+    stub_comms do
+      @gateway.verify(@credit_card, @options.merge(zero_dollar_auth: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/amount value="0"/, data) if /<submit>/.match?(data)
+    end.respond_with(successful_authorize_response, successful_void_response)
+  end
+
+  def test_successful_verify_with_0_auth_and_ineligible_card
+    stub_comms do
+      @gateway.verify(@elo_credit_card, @options.merge(zero_dollar_auth: true))
+    end.check_request do |_endpoint, data, _headers|
+      refute_match(/amount value="0"/, data)
+    end.respond_with(successful_authorize_response, successful_void_response)
+  end
+
   def test_successful_verify_with_elo
     @gateway.expects(:ssl_post).times(2).returns(successful_authorize_with_elo_response, successful_void_with_elo_response)
 


### PR DESCRIPTION
Unit:
90 tests, 544 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
74 tests, 311 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.2973% passed

Failing remote tests:
- test_3ds_version_1_parameters_pass_thru
- test_3ds_version_2_parameters_pass_thru

CE-1792