### PR TITLE
NMI: Change cardholder_auth 3DS field population

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Worldpay: Support $0 auth [therufs] #4092
 * Elavon: Support recurring transactions with token, revert stored credentials recurring [cdmackeyfree] #4089
 * SafeCharge(Nuvei): Add support for product_id [rachelkirk] #4095
+* NMI: Change cardholder_auth 3DS field population [carrigan] #4094
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -251,15 +251,20 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_three_d_secure(post, options)
-        return unless options[:three_d_secure]
+        three_d_secure = options[:three_d_secure]
+        return unless three_d_secure
 
-        if (three_d_secure = options[:three_d_secure])
-          post[:cardholder_auth] = three_d_secure[:cardholder_auth]
-          post[:cavv] = three_d_secure[:cavv]
-          post[:xid] = three_d_secure[:xid]
-          post[:three_ds_version] = three_d_secure[:version]
-          post[:directory_server_id] = three_d_secure[:ds_transaction_id]
-        end
+        post[:cardholder_auth] = cardholder_auth(three_d_secure[:authentication_response_status])
+        post[:cavv] = three_d_secure[:cavv]
+        post[:xid] = three_d_secure[:xid]
+        post[:three_ds_version] = three_d_secure[:version]
+        post[:directory_server_id] = three_d_secure[:ds_transaction_id]
+      end
+
+      def cardholder_auth(trans_status)
+        return nil if trans_status.nil?
+
+        trans_status == 'Y' ? 'verified' : 'attempted'
       end
 
       def add_reference(post, authorization)

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -107,7 +107,7 @@ class RemoteNmiTest < Test::Unit::TestCase
     three_d_secure_options = @options.merge({
       three_d_secure: {
         version: '2.1.0',
-        cardholder_auth: 'verified',
+        authentication_response_status: 'Y',
         cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA',
         ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC'
       }

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -96,16 +96,16 @@ class NmiTest < Test::Unit::TestCase
     assert_equal 'FAILED', response.message
   end
 
-  def test_successful_purchase_with_3ds
+  def test_successful_purchase_with_3ds_verified
     version = '2.1.0'
-    cardholder_auth = 'verified'
+    authentication_response_status = 'Y'
     cavv = 'jJ81HADVRtXfCBATEp01CJUAAAA'
     ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'
     xid = '00000000000000000501'
     options_with_3ds = @transaction_options.merge(
       three_d_secure: {
         version: version,
-        cardholder_auth: cardholder_auth,
+        authentication_response_status: authentication_response_status,
         cavv: cavv,
         ds_transaction_id: ds_transaction_id,
         xid: xid
@@ -117,6 +117,37 @@ class NmiTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       assert_match(/three_ds_version=2.1.0/, data)
       assert_match(/cardholder_auth=verified/, data)
+      assert_match(/cavv=jJ81HADVRtXfCBATEp01CJUAAAA/, data)
+      assert_match(/directory_server_id=97267598-FAE6-48F2-8083-C23433990FBC/, data)
+      assert_match(/xid=00000000000000000501/, data)
+    end.respond_with(successful_3ds_purchase_response)
+
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_3ds_attempted
+    version = '2.1.0'
+    authentication_response_status = 'A'
+    cavv = 'jJ81HADVRtXfCBATEp01CJUAAAA'
+    ds_transaction_id = '97267598-FAE6-48F2-8083-C23433990FBC'
+    xid = '00000000000000000501'
+    options_with_3ds = @transaction_options.merge(
+      three_d_secure: {
+        version: version,
+        authentication_response_status: authentication_response_status,
+        cavv: cavv,
+        ds_transaction_id: ds_transaction_id,
+        xid: xid
+      }
+    )
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_3ds)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/three_ds_version=2.1.0/, data)
+      assert_match(/cardholder_auth=attempted/, data)
       assert_match(/cavv=jJ81HADVRtXfCBATEp01CJUAAAA/, data)
       assert_match(/directory_server_id=97267598-FAE6-48F2-8083-C23433990FBC/, data)
       assert_match(/xid=00000000000000000501/, data)


### PR DESCRIPTION
## Why

The `cardholder_auth` field of the NMI integration is a non-standard 3DS field. It was originally implemented in ActiveMerchant by adding a new field to the `three_d_secure` hash, but it turns out that it can be derived via the `authentication_response_status` standard field in there already.

## What Changed

This commit changes the NMI gateway to use the populate the `cardholder_auth` field using the 3DS standard field `authentication_response_status`.

## Test Suite

test/remote/gateways/remote_nmi_test:

42 tests, 156 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

rake test:local:

4867 tests, 74048 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

710 files inspected, no offenses detected