### PR TITLE
Nuvei(formerly SafeCharge): Add support for `product_id`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Paymentez: Add more_info field [reblevins] #4091
 * Worldpay: Support $0 auth [therufs] #4092
 * Elavon: Support recurring transactions with token, revert stored credentials recurring [cdmackeyfree] #4089
+* SafeCharge(Nuvei): Add support for product_id [rachelkirk] #4095
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -143,6 +143,7 @@ module ActiveMerchant #:nodoc:
         post[:sg_Descriptor] = options[:merchant_descriptor] if options[:merchant_descriptor]
         post[:sg_MerchantPhoneNumber] = options[:merchant_phone_number] if options[:merchant_phone_number]
         post[:sg_MerchantName] = options[:merchant_name] if options[:merchant_name]
+        post[:sg_ProductID] = options[:product_id] if options[:product_id]
       end
 
       def add_payment(post, payment, options = {})

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -150,7 +150,8 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
       merchant_descriptor: 'Test Descriptor',
       merchant_phone_number: '(555)555-5555',
       merchant_name: 'Test Merchant',
-      stored_credential_mode: true
+      stored_credential_mode: true,
+      product_id: 'Test Product'
     }
 
     response = @gateway.purchase(@amount, @credit_card, options)
@@ -184,7 +185,8 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
       merchant_descriptor: 'Test Descriptor',
       merchant_phone_number: '(555)555-5555',
       merchant_name: 'Test Merchant',
-      stored_credential_mode: true
+      stored_credential_mode: true,
+      product_id: 'Test Product'
     }
     auth = @gateway.authorize(@amount, @credit_card, extra)
     assert_success auth
@@ -254,7 +256,8 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
       merchant_descriptor: 'Test Descriptor',
       merchant_phone_number: '(555)555-5555',
       merchant_name: 'Test Merchant',
-      stored_credential_mode: true
+      stored_credential_mode: true,
+      product_id: 'Test Product'
     }
 
     response = @gateway.credit(@amount, credit_card('4444436501403986'), extra)

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -26,7 +26,8 @@ class SafeChargeTest < Test::Unit::TestCase
     @merchant_options = @options.merge(
       merchant_descriptor: 'Test Descriptor',
       merchant_phone_number: '(555)555-5555',
-      merchant_name: 'Test Merchant'
+      merchant_name: 'Test Merchant',
+      product_id: 'Test Product'
     )
 
     @three_ds_options = @options.merge(three_d_secure: true)


### PR DESCRIPTION
[CE-1877](https://spreedly.atlassian.net/browse/CE-1877)

Local Tests:
4888 tests, 74134 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit Tests:
24 tests, 132 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
28 tests, 74 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.4286% passed
Failure: test_successful_regular_purchase_through_3ds_flow_with_invalid_pa_res(RemoteSafeChargeTest). This test was already failing before these changes.