### PR TITLE
Updates fields for Payeezy gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,8 @@
 * Maestro: support BINs [therufs] #4098
 * Redsys: Route MIT Exemptions to webservice endpoint [curiousepic] #4081
 * Adyen: Update Classic Integration API to v64 and Recurring API to v49 [almalee24] #4090
+* Payeezy: support soft_descriptor and merchant_ref [cdmackeyfree] #4099
+
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -75,6 +75,8 @@ module ActiveMerchant
 
         add_authorization_info(params, authorization)
         add_amount(params, (amount || amount_from_authorization(authorization)), options)
+        add_soft_descriptors(params, options)
+        add_invoice(params, options)
 
         commit(params, options)
       end
@@ -85,6 +87,7 @@ module ActiveMerchant
         add_amount(params, amount, options)
         add_payment_method(params, payment_method, options)
         add_soft_descriptors(params, options)
+        add_invoice(params, options)
         commit(params, options)
       end
 

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -168,6 +168,28 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_refund_with_soft_descriptors
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_match(/Transaction Normal/, purchase.message)
+    assert_success purchase
+
+    assert response = @gateway.refund(50, purchase.authorization, @options.merge(@options_mdd))
+    assert_success response
+    assert_match(/Transaction Normal/, response.message)
+    assert response.authorization
+  end
+
+  def test_successful_refund_with_order_id
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_match(/Transaction Normal/, purchase.message)
+    assert_success purchase
+
+    assert response = @gateway.refund(50, purchase.authorization, @options.merge(order_id: '1234'))
+    assert_success response
+    assert_match(/Transaction Normal/, response.message)
+    assert response.authorization
+  end
+
   def test_successful_refund_with_echeck
     assert purchase = @gateway.purchase(@amount, @check, @options)
     assert_match(/Transaction Normal/, purchase.message)
@@ -214,6 +236,14 @@ class RemotePayeezyTest < Test::Unit::TestCase
 
   def test_successful_general_credit
     assert response = @gateway.credit(@amount, @credit_card, @options.merge(@options_mdd))
+    assert_match(/Transaction Normal/, response.message)
+    assert_equal '100', response.params['bank_resp_code']
+    assert_equal nil, response.error_code
+    assert_success response
+  end
+
+  def test_successful_general_credit_with_order_id
+    assert response = @gateway.credit(@amount, @credit_card, @options.merge(order_id: '1234'))
     assert_match(/Transaction Normal/, response.message)
     assert_equal '100', response.params['bank_resp_code']
     assert_equal nil, response.error_code


### PR DESCRIPTION
Adds the merchant_ref field to general credit transactions and the soft_descriptor hash to refunds.

Unit
40 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
41 tests, 170 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed