### PR TITLE
Adds ssl_token field for Elavon gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Redsys: Route MIT Exemptions to webservice endpoint [curiousepic] #4081
 * Adyen: Update Classic Integration API to v64 and Recurring API to v49 [almalee24] #4090
 * Payeezy: support soft_descriptor and merchant_ref [cdmackeyfree] #4099
+* Elavon: add ssl_token field [cdmackeyfree] #4100
 
 
 == Version 1.122.0 (August 3rd, 2021)

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -298,6 +298,7 @@ module ActiveMerchant #:nodoc:
         xml.ssl_dynamic_dba                     options[:dba] if options.has_key?(:dba)
         xml.ssl_merchant_initiated_unscheduled  merchant_initiated_unscheduled(options) if merchant_initiated_unscheduled(options)
         xml.ssl_add_token                       options[:add_recurring_token] if options.has_key?(:add_recurring_token)
+        xml.ssl_token                           options[:ssl_token] if options.has_key?(:ssl_token)
         xml.ssl_customer_code                   options[:customer] if options.has_key?(:customer)
         xml.ssl_customer_number                 options[:customer_number] if options.has_key?(:customer_number)
         xml.ssl_entry_mode                      entry_mode(options) if entry_mode(options)

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -251,6 +251,22 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert_equal 'APPROVAL', purchase.message
   end
 
+  def test_successful_purchase_with_ssl_token
+    options = {
+      email: 'paul@domain.com',
+      description: 'Test Transaction',
+      billing_address: address,
+      ip: '203.0.113.0',
+      merchant_initiated_unscheduled: 'Y',
+      ssl_token: '4000000000000002'
+    }
+
+    purchase = @gateway.purchase(@amount, @credit_card, options)
+
+    assert_success purchase
+    assert_equal 'APPROVAL', purchase.message
+  end
+
   def test_successful_auth_and_capture_with_unscheduled_stored_credential
     stored_credential_params = {
       initial_transaction: true,

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -155,6 +155,16 @@ class ElavonTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_sends_ssl_token_field
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(ssl_token: '8675309'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_token>8675309<\/ssl_token>/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_authorization_with_dynamic_dba
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(dba: 'MANYMAG*BAKERS MONTHLY'))


### PR DESCRIPTION
To give the user full control of when the token is added.

Unit:
47 tests, 243 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
38 tests, 172 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.3684% passed