### PR TITLE
Pull UnionPay's 62* BIN ranges out of Discover's

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Payeezy: support soft_descriptor and merchant_ref [cdmackeyfree] #4099
 * Elavon: add ssl_token field [cdmackeyfree] #4100
 * Credorax: Remove special logic for ISK [curiousepic] #4102
+* UnionPay: Pull UnionPay's 62* BIN ranges out of Discover's #4103
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
         'master'             => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), MASTERCARD_RANGES) },
         'elo'                => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), ELO_RANGES) },
         'alelo'              => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), ALELO_RANGES) },
-        'discover'           => ->(num) { num =~ /^(6011|65\d{2}|64[4-9]\d)\d{12,15}|(62\d{14,17})$/ },
+        'discover'           => ->(num) { num =~ /^(6011|65\d{2}|64[4-9]\d)\d{12,15}$/ },
         'american_express'   => ->(num) { num =~ /^3[47]\d{13}$/ },
         'naranja'            => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), NARANJA_RANGES) },
         'diners_club'        => ->(num) { num =~ /^3(0[0-5]|[68]\d)\d{11,16}$/ },
@@ -196,11 +196,9 @@ module ActiveMerchant #:nodoc:
         589562..589562
       ]
 
-      # In addition to the BIN ranges listed here that all begin with 81, UnionPay cards
-      # include many ranges that start with 62.
-      # Prior to adding UnionPay, cards that start with 62 were all classified as Discover.
-      # Because UnionPay cards are able to run on Discover rails, this was kept the same.
+      # https://www.discoverglobalnetwork.com/content/dam/discover/en_us/dgn/pdfs/IPP-VAR-Enabler-Compliance.pdf
       UNIONPAY_RANGES = [
+        62212600..62379699, 62400000..62699999, 62820000..62889999,
         81000000..81099999, 81100000..81319999, 81320000..81519999, 81520000..81639999, 81640000..81719999
       ]
 

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -272,17 +272,10 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'cabal', CreditCard.brand?('6035224400000000')
   end
 
-  # UnionPay BINs beginning with 62 overlap with Discover's range of valid card numbers.
-  # We intentionally misidentify these cards as Discover, which works because transactions with
-  # UnionPay cards will run on Discover rails.
-  def test_should_detect_unionpay_cards_beginning_with_62_as_discover
-    assert_equal 'discover', CreditCard.brand?('6212345678901265')
-    assert_equal 'discover', CreditCard.brand?('6221260000000000')
-    assert_equal 'discover', CreditCard.brand?('6250941006528599')
-    assert_equal 'discover', CreditCard.brand?('6212345678900000003')
-  end
-
   def test_should_detect_unionpay_card
+    assert_equal 'unionpay', CreditCard.brand?('6221260000000000')
+    assert_equal 'unionpay', CreditCard.brand?('6250941006528599')
+    assert_equal 'unionpay', CreditCard.brand?('6282000000000000')
     assert_equal 'unionpay', CreditCard.brand?('8100000000000000')
     assert_equal 'unionpay', CreditCard.brand?('814400000000000000')
     assert_equal 'unionpay', CreditCard.brand?('8171999927660000')


### PR DESCRIPTION
China UnionPay cards beginning with 62 are able to run on Discover rails in the US and Canada. Because of this, these cards were previously lumped together with Discover. There is no change to how these transactions will be processed, but we would like to break them out in order to identify UnionPay cards correctly. 

Discover's [BIN list](https://www.discoverglobalnetwork.com/content/dam/discover/en_us/dgn/pdfs/IPP-VAR-Enabler-Compliance.pdf) was used in order to understand specific BIN ranges belonging to UnionPay.

____

**Unit tests:**
4897 tests, 74184 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

