### PR TITLE
Monei: Update Creation of Billing Details

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * Elavon: add ssl_token field [cdmackeyfree] #4100
 * Credorax: Remove special logic for ISK [curiousepic] #4102
 * UnionPay: Pull UnionPay's 62* BIN ranges out of Discover's #4103
+* Monei: Update Creation of Billing Details [tatsianaclifton] #4107
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/gateways/monei.rb
+++ b/lib/active_merchant/billing/gateways/monei.rb
@@ -206,19 +206,27 @@ module ActiveMerchant #:nodoc:
 
       # Private: Add customer part to request
       def add_customer(request, payment_method, options)
-        address = options[:billing_address] || options[:address] || {}
+        address = options[:billing_address] || options[:address]
 
         request[:customer] = {}
         request[:customer][:email] = options[:email] || 'support@monei.net'
-        request[:customer][:name] = address[:name].to_s
 
-        request[:billingDetails] = {}
-        request[:billingDetails][:address] = {}
-        request[:billingDetails][:address][:line1] = address[:address1].to_s
-        request[:billingDetails][:address][:city] = address[:city].to_s
-        request[:billingDetails][:address][:state] = address[:state].to_s if address.has_key? :state
-        request[:billingDetails][:address][:zip] = address[:zip].to_s
-        request[:billingDetails][:address][:country] = address[:country].to_s
+        if address
+          request[:customer][:name] = address[:name].to_s if address[:name]
+
+          request[:billingDetails] = {}
+          request[:billingDetails][:email] = options[:email] if options[:email]
+          request[:billingDetails][:name] = address[:name] if address[:name]
+          request[:billingDetails][:company] = address[:company] if address[:company]
+          request[:billingDetails][:phone] = address[:phone] if address[:phone]
+          request[:billingDetails][:address] = {}
+          request[:billingDetails][:address][:line1] = address[:address1] if address[:address1]
+          request[:billingDetails][:address][:line2] = address[:address2] if address[:address2]
+          request[:billingDetails][:address][:city] = address[:city] if address[:city]
+          request[:billingDetails][:address][:state] = address[:state] if address[:state].present?
+          request[:billingDetails][:address][:zip] = address[:zip].to_s if address[:zip]
+          request[:billingDetails][:address][:country] = address[:country] if address[:coutry]
+        end
 
         request[:sessionDetails] = {}
         request[:sessionDetails][:ip] = options[:ip] if options[:ip]

--- a/test/remote/gateways/remote_monei_test.rb
+++ b/test/remote/gateways/remote_monei_test.rb
@@ -31,6 +31,35 @@ class RemoteMoneiTest < Test::Unit::TestCase
     assert_equal 'Transaction approved', response.message
   end
 
+  def test_successful_purchase_with_no_billing_address
+    options = {
+      order_id: random_order_id,
+      description: 'Store Purchase'
+    }
+    response = @gateway.purchase(@amount, @credit_card, options)
+
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+  end
+
+  def test_successful_purchase_with_partial_billing_address
+    partial_address = {
+      name:     'Jim Smith',
+      address1: '456 My Street',
+      city:     'MIlan',
+      zip:      'K1C2N6'
+    }
+    options = {
+      billing_address: partial_address,
+      order_id: random_order_id,
+      description: 'Store Purchase'
+    }
+    response = @gateway.purchase(@amount, @credit_card, options)
+
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+  end
+
   def test_successful_purchase_with_3ds
     options = @options.merge!({
       order_id: random_order_id,


### PR DESCRIPTION
Billing detils fields are not required as per Gateway documentation https://docs.monei.com/api/#operation/payments_create, but empty fields cause validation errors. This commit forces to fill billing details fields only if they are provided. Additionaly, some fields were added to billing details as per documentation.
ECS-1694

Unit:
17 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
25 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed