### PR TITLE
Paysafe: Add support for 3DS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * UnionPay: Pull UnionPay's 62* BIN ranges out of Discover's #4103
 * Monei: Update Creation of Billing Details [tatsianaclifton] #4107
 * Monei: Typo Correction on Billing Details [tatsianaclifton] #4108
+* Paysafe: Add support for 3DS [meagabeth] #4109
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014


### PR DESCRIPTION
- Include remote tests for visa and MasterCard each for 3DS1 and 3DS2. Mastercard requires a specific field be sent, which is why it has its own test separate from the visa test.

CE-1572

Local:
4891 tests, 74161 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Rubocop:
713 files inspected, no offenses detected
Unit:
12 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
26 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed