### PR TITLE
StripePaymentIntentsGateway: Add GSF `claim_without_transaction_id`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Adyen: Add ACH Support [almalee24] #4105
 * Moka: Support 3DS endpoint and update test url [dsmcclain] #4110
 * Paysafe: Adjust profile data [meagabeth] #4112
+* Stripe Payment Intents: Add support for claim_without_transaction_id field [BritneyS] #4111
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -32,6 +32,7 @@ module ActiveMerchant #:nodoc:
         add_exemption(post, options)
         add_stored_credentials(post, options)
         add_ntid(post, options)
+        add_claim_without_transaction_id(post, options)
         add_error_on_requires_action(post, options)
         request_three_d_secure(post, options)
 
@@ -324,6 +325,19 @@ module ActiveMerchant #:nodoc:
         post[:payment_method_options][:card][:mit_exemption] = {}
 
         post[:payment_method_options][:card][:mit_exemption][:network_transaction_id] = options[:network_transaction_id] if options[:network_transaction_id]
+      end
+
+      def add_claim_without_transaction_id(post, options = {})
+        return if options[:stored_credential] || options[:network_transaction_id] || options[:ds_transaction_id]
+        return unless options[:claim_without_transaction_id]
+
+        post[:payment_method_options] ||= {}
+        post[:payment_method_options][:card] ||= {}
+        post[:payment_method_options][:card][:mit_exemption] = {}
+
+        # Stripe PI accepts claim_without_transaction_id for transactions without transaction ids.
+        # Gateway validation for this field occurs through a different service, before the transaction request is sent to the gateway.
+        post[:payment_method_options][:card][:mit_exemption][:claim_without_transaction_id] = options[:claim_without_transaction_id]
       end
 
       def add_error_on_requires_action(post, options = {})


### PR DESCRIPTION
This work adds support for the GSF `claim_without_transaction_id`. Gateway validation for this field occurs through a different service, before the transaction request is sent to the gateway.

Test Summary
Local: 4897 tests, 74189 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
       100% passed
Unit: 26 tests, 152 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote: 58 tests, 285 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed