### PR TITLE
PayArc: handle requests when billing_address is not present

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * Orbital: Scrub Payment Cryptogram [naashton] #4121
 * Paysafe: Add support for airline fields [meagabeth] #4120
 * Stripe and Stripe PI: Add Radar Session Option [tatsianaclifton] #4119
+* PayArc: Fix billing address nil and phone_number issues [dsmcclain] #4114
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/pay_arc.rb
+++ b/lib/active_merchant/billing/gateways/pay_arc.rb
@@ -286,16 +286,18 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        post['address_line1'] = options[:billing_address][:address1]
-        post['address_line2'] = options[:billing_address][:address2]
-        post['city'] = options[:billing_address][:city]
-        post['state'] = options[:billing_address][:state]
-        post['zip'] = options[:billing_address][:zip]
-        post['country'] = options[:billing_address][:country]
+        return unless billing_address = options[:billing_address]
+
+        post['address_line1'] = billing_address[:address1]
+        post['address_line2'] = billing_address[:address2]
+        post['city'] = billing_address[:city]
+        post['state'] = billing_address[:state]
+        post['zip'] = billing_address[:zip]
+        post['country'] = billing_address[:country]
       end
 
       def add_phone(post, options)
-        post['receipt_phone'] = options[:billing_address][:phone] if options[:billing_address][:phone]
+        post['phone_number'] = options[:billing_address][:phone] if options.dig(:billing_address, :phone)
       end
 
       def add_money(post, money, options)

--- a/test/remote/gateways/remote_pay_arc_test.rb
+++ b/test/remote/gateways/remote_pay_arc_test.rb
@@ -106,7 +106,15 @@ class RemotePayArcTest < Test::Unit::TestCase
       PayArcGateway::SUCCESS_STATUS.include? response.message
     end
 
-    assert_equal '8772036624', response.params['receipt_phone']
+    assert_equal '8772036624', response.params['data']['phone_number']
+  end
+
+  def test_successful_purchase_without_billing_address
+    @options.delete(:billing_address)
+    response = @gateway.purchase(250, @credit_card, @options)
+
+    assert_nil response.params['data']['card']['data']['address1']
+    assert_success response
   end
 
   def test_failed_purchase


### PR DESCRIPTION
CE-1912

Remote:
Loaded suite test/remote/gateways/remote_pay_arc_test
24 tests, 59 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.6667% passed

Local:
4918 tests, 74276 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

Rubocop:
716 files inspected, no offenses detected

Currently failing remote tests:
`test_successful_credit`
`test_successful_adds_phone_number_for_purchase`

@jessiagee Here is the bug fix for PayArc. We are waiting to hear back from the gateway about a fix on their end so that `receiver_phone` shows up in the gateway response.