### PR TITLE
RouteX: Support cardtype

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Monei: Update Creation of Billing Details [tatsianaclifton] #4107
 * Monei: Typo Correction on Billing Details [tatsianaclifton] #4108
 * Paysafe: Add support for 3DS [meagabeth] #4109
+* RouteX: add card type [rachelkirk] #4115
 
 == Version 1.122.0 (August 3rd, 2021)
 * Orbital: Correct success logic for refund [tatsianaclifton] #4014

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -35,7 +35,8 @@ module ActiveMerchant #:nodoc:
         'olimpica' => ->(num) { num =~ /^636853\d{10}$/ },
         'creditel' => ->(num) { num =~ /^601933\d{10}$/ },
         'confiable' => ->(num) { num =~ /^560718\d{10}$/ },
-        'synchrony' => ->(num) { num =~ /^700600\d{10}$/ }
+        'synchrony' => ->(num) { num =~ /^700600\d{10}$/ },
+        'routex' => ->(num) { num =~ /^700676\d{13}$/ }
       }
 
       # http://www.barclaycard.co.uk/business/files/bin_rules.pdf

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -286,6 +286,12 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'synchrony', CreditCard.brand?('7006000000000000')
   end
 
+  def test_should_detect_routex_card
+    number = '7006760000000000000'
+    assert_equal 'routex', CreditCard.brand?(number)
+    assert CreditCard.valid_number?(number)
+  end
+
   def test_should_detect_when_an_argument_brand_does_not_match_calculated_brand
     assert CreditCard.matching_brand?('4175001000000000', 'visa')
     assert_false CreditCard.matching_brand?('4175001000000000', 'master')


### PR DESCRIPTION
[CE-1885](https://spreedly.atlassian.net/browse/CE-1885)

Unit Tests:
4919 tests, 74278 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed