### PR TITLE
dlocal: Add device_id and ip to payer object and add additional_data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* dlocal: Add device_id and ip to payer object and add additional_data [aenand] #4116
 * Adyen: Add network tokenization support to Adyen gateway [mymir] #4101
 * Adyen: Add ACH Support [almalee24] #4105
 * Moka: Support 3DS endpoint and update test url [dsmcclain] #4110

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -78,6 +78,7 @@ module ActiveMerchant #:nodoc:
         add_country(post, card, options)
         add_payer(post, card, options)
         add_card(post, card, action, options)
+        add_additional_data(post, options)
         post[:order_id] = options[:order_id] || generate_unique_id
         post[:description] = options[:description] if options[:description]
       end
@@ -85,6 +86,10 @@ module ActiveMerchant #:nodoc:
       def add_invoice(post, money, options)
         post[:amount] = amount(money)
         post[:currency] = (options[:currency] || currency(money))
+      end
+
+      def add_additional_data(post, options)
+        post[:additional_risk_data] = options[:additional_data]
       end
 
       def add_country(post, card, options)
@@ -109,6 +114,8 @@ module ActiveMerchant #:nodoc:
         post[:payer][:document] = options[:document] if options[:document]
         post[:payer][:document2] = options[:document2] if options[:document2]
         post[:payer][:user_reference] = options[:user_reference] if options[:user_reference]
+        post[:payer][:event_uuid] = options[:device_id] if options[:device_id]
+        post[:payer][:onboarding_ip_address] = options[:ip] if options[:ip]
         post[:payer][:address] = add_address(post, card, options)
       end
 

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -72,6 +72,7 @@ class RemoteDLocalTest < Test::Unit::TestCase
     options = @options.merge(
       order_id: '1',
       ip: '127.0.0.1',
+      device_id: '123',
       email: 'joe@example.com',
       birth_date: '03-01-1970',
       document2: '87648987569',
@@ -79,6 +80,15 @@ class RemoteDLocalTest < Test::Unit::TestCase
       user_reference: generate_unique_id
     )
 
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_match 'The payment was paid', response.message
+  end
+
+  def test_successful_purchase_with_additional_data
+    options = @options.merge(
+      additional_data: { submerchant: { name: 'socks' } }
+    )
     response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
     assert_match 'The payment was paid', response.message

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -44,6 +44,16 @@ class DLocalTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_additional_data
+    additional_data = { 'submerchant' => { 'name' => 'socks' } }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(additional_data: additional_data))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal additional_data, JSON.parse(data)['additional_risk_data']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 


### PR DESCRIPTION
Added the fields device_id and ip to the payer object. dlocal's device_id is event_uuid and dlocal's ip is onboarding_ip_address. The additional_data field is a blob, anything can be sent in under that.

unit: 23 tests, 93 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

remote: 28 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed