### PR TITLE
Moka: make sure month is always two digits

### DIFF
--- a/lib/active_merchant/billing/gateways/moka.rb
+++ b/lib/active_merchant/billing/gateways/moka.rb
@@ -166,7 +166,7 @@ module ActiveMerchant #:nodoc:
       def add_payment(post, card)
         post[:PaymentDealerRequest][:CardHolderFullName] = card.name
         post[:PaymentDealerRequest][:CardNumber] = card.number
-        post[:PaymentDealerRequest][:ExpMonth] = card.month
+        post[:PaymentDealerRequest][:ExpMonth] = card.month.to_s.rjust(2, '0')
         post[:PaymentDealerRequest][:ExpYear] = card.year
         post[:PaymentDealerRequest][:CvcNumber] = card.verification_value
       end

--- a/test/remote/gateways/remote_moka_test.rb
+++ b/test/remote/gateways/remote_moka_test.rb
@@ -5,7 +5,7 @@ class RemoteMokaTest < Test::Unit::TestCase
     @gateway = MokaGateway.new(fixtures(:moka))
 
     @amount = 100
-    @credit_card = credit_card('5269111122223332', month: '10')
+    @credit_card = credit_card('5269111122223332')
     @declined_card = credit_card('4000300011112220')
     @options = {
       description: 'Store Purchase'
@@ -26,6 +26,13 @@ class RemoteMokaTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
+  def test_successful_purchase_with_single_digit_exp_month
+    @credit_card.month = 1
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message


### PR DESCRIPTION
Moka's API only accepts two-digit strings in the ExpMonth field.

Loaded suite test/remote/gateways/remote_moka_test
22 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

Unit tests:
4918 tests, 74276 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

Rubocop:
716 files inspected, no offenses detected