### PR TITLE
Stripe and Stripe PI: Add Radar Session Option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Routex: add card type [rachelkirk] #4115
 * Orbital: Scrub Payment Cryptogram [naashton] #4121
 * Paysafe: Add support for airline fields [meagabeth] #4120
+* Stripe and Stripe PI: Add Radar Session Option [tatsianaclifton] #4119
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -379,6 +379,7 @@ module ActiveMerchant #:nodoc:
         add_destination(post, options)
         add_level_three(post, options)
         add_connected_account(post, options)
+        add_radar_data(post, options)
         post
       end
 
@@ -568,6 +569,14 @@ module ActiveMerchant #:nodoc:
         post[:transfer_data][:amount] = options[:transfer_amount] if options[:transfer_amount]
         post[:transfer_group] = options[:transfer_group] if options[:transfer_group]
         post[:application_fee_amount] = options[:application_fee_amount] if options[:application_fee_amount]
+      end
+
+      def add_radar_data(post, options = {})
+        return unless options[:radar_session_id]
+
+        post[:radar_options] = {
+          session: options[:radar_session_id]
+        }
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -27,6 +27,7 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_return_url(post, options)
         add_connected_account(post, options)
+        add_radar_data(post, options)
         add_shipping_address(post, options)
         setup_future_usage(post, options)
         add_exemption(post, options)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -189,6 +189,16 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert purchase.params.dig('charges', 'data')[0]['captured']
   end
 
+  def test_successful_purchase_with_radar_session
+    options = {
+      radar_session_id: 'rse_1JXSfZAWOtgoysogUpPJa4sm'
+    }
+    assert purchase = @gateway.purchase(@amount, @visa_card, options)
+
+    assert_equal 'succeeded', purchase.params['status']
+    assert purchase.params.dig('charges', 'data')[0]['captured']
+  end
+
   def test_successful_authorization_with_external_auth_data_3ds_2
     options = {
       currency: 'GBP',
@@ -201,6 +211,16 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     }
 
     assert authorization = @gateway.authorize(@amount, @three_ds_external_data_card, options)
+
+    assert_equal 'requires_capture', authorization.params['status']
+    refute authorization.params.dig('charges', 'data')[0]['captured']
+  end
+
+  def test_successful_authorization_with_radar_session
+    options = {
+      radar_session_id: 'rse_1JXSfZAWOtgoysogUpPJa4sm'
+    }
+    assert authorization = @gateway.authorize(@amount, @visa_card, options)
 
     assert_equal 'requires_capture', authorization.params['status']
     refute authorization.params.dig('charges', 'data')[0]['captured']

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -430,6 +430,26 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_payment_method_response, successful_create_customer_response, successful_payment_method_attach_response)
   end
 
+  def test_succesful_purchase_with_radar_session
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, {
+        radar_session_id: 'test_radar_session_id'
+      })
+    end.check_request do |_method, endpoint, data, _headers|
+      assert_match(/radar_options\[session\]=test_radar_session_id/, data) if /payment_intents/.match?(endpoint)
+    end.respond_with(successful_create_intent_response)
+  end
+
+  def test_succesful_authorize_with_radar_session
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@amount, @credit_card, {
+        radar_session_id: 'test_radar_session_id'
+      })
+    end.check_request do |_method, endpoint, data, _headers|
+      assert_match(/radar_options\[session\]=test_radar_session_id/, data) if /payment_intents/.match?(endpoint)
+    end.respond_with(successful_create_intent_response)
+  end
+
   private
 
   def successful_create_intent_response

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -1007,6 +1007,26 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_radar_session_is_submitted_for_purchase
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, {
+        radar_session_id: 'test_radar_session_id'
+      })
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/radar_options\[session\]=test_radar_session_id/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_radar_session_is_submitted_for_authorize
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@amount, @credit_card, {
+        radar_session_id: 'test_radar_session_id'
+      })
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/radar_options\[session\]=test_radar_session_id/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
   def test_client_data_submitted_with_purchase
     stub_comms(@gateway, :ssl_request) do
       updated_options = @options.merge({ description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', order_id: '42', email: 'foo@wonderfullyfakedomain.com', receipt_email: 'receipt-receiver@wonderfullyfakedomain.com', referrer: 'http://www.shopify.com' })


### PR DESCRIPTION
Add option to pass `"radar_options[session]"="{{RADAR_SESSION_ID}}"` when creating a charge and when creating a Payment Intent

ECS-2059

Stripe
Unit
140 tests, 745 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote
73 tests, 337 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.6301% passed
Note: failed test fails on master also

Stripe Payment Intents
Unit
30 tests, 168 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote
62 tests, 299 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

bundle exec rake test:local
4922 tests, 74288 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
716 files inspected, no offenses detected