### PR TITLE
Paysafe: Add support for airline fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Mit: Add New Gateway [EsporaInfra] #3820
 * Routex: add card type [rachelkirk] #4115
 * Orbital: Scrub Payment Cryptogram [naashton] #4121
+* Paysafe: Add support for airline fields [meagabeth] #4120
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -22,8 +22,10 @@ module ActiveMerchant #:nodoc:
         add_payment(post, payment)
         add_billing_address(post, options)
         add_merchant_details(post, options)
+        add_airline_travel_details(post, options)
         add_customer_data(post, payment, options) unless payment.is_a?(String)
         add_three_d_secure(post, payment, options) if options[:three_d_secure]
+        add_split_pay_details(post, options)
         post[:settleWithAuth] = true
 
         commit(:post, 'auths', post, options)
@@ -135,12 +137,13 @@ module ActiveMerchant #:nodoc:
       def add_address_for_vaulting(post, options)
         return unless address = options[:billing_address] || options[:address]
 
-        post[:billingAddress] = {}
-        post[:billingAddress][:street] = address[:address1]
-        post[:billingAddress][:city] = address[:city]
-        post[:billingAddress][:zip] = address[:zip]
-        post[:billingAddress][:country] = address[:country]
-        post[:billingAddress][:state] = address[:state] if address[:state]
+        post[:card][:billingAddress] = {}
+        post[:card][:billingAddress][:street] = address[:address1]
+        post[:card][:billingAddress][:street2] = address[:address2]
+        post[:card][:billingAddress][:city] = address[:city]
+        post[:card][:billingAddress][:zip] = address[:zip]
+        post[:card][:billingAddress][:country] = address[:country]
+        post[:card][:billingAddress][:state] = address[:state] if address[:state]
       end
 
       # This data is specific to creating a profile at the gateway's vault level
@@ -204,6 +207,84 @@ module ActiveMerchant #:nodoc:
         post[:authentication][:directoryServerTransactionId] = three_d_secure[:ds_transaction_id] unless payment.is_a?(String) || payment.brand != 'mastercard'
       end
 
+      def add_airline_travel_details(post, options)
+        return unless options[:airline_travel_details]
+
+        post[:airlineTravelDetails] = {}
+        post[:airlineTravelDetails][:passengerName] = options[:airline_travel_details][:passenger_name] if options[:airline_travel_details][:passenger_name]
+        post[:airlineTravelDetails][:departureDate] = options[:airline_travel_details][:departure_date] if options[:airline_travel_details][:departure_date]
+        post[:airlineTravelDetails][:origin] = options[:airline_travel_details][:origin] if options[:airline_travel_details][:origin]
+        post[:airlineTravelDetails][:computerizedReservationSystem] = options[:airline_travel_details][:computerized_reservation_system] if options[:airline_travel_details][:computerized_reservation_system]
+        post[:airlineTravelDetails][:customerReferenceNumber] = options[:airline_travel_details][:customer_reference_number] if options[:airline_travel_details][:customer_reference_number]
+
+        add_ticket_details(post, options)
+        add_travel_agency_details(post, options)
+        add_trip_legs(post, options)
+      end
+
+      def add_ticket_details(post, options)
+        return unless ticket = options[:airline_travel_details][:ticket]
+
+        post[:airlineTravelDetails][:ticket] = {}
+        post[:airlineTravelDetails][:ticket][:ticketNumber] = ticket[:ticket_number] if ticket[:ticket_number]
+        post[:airlineTravelDetails][:ticket][:isRestrictedTicket] = ticket[:is_restricted_ticket] if ticket[:is_restricted_ticket]
+      end
+
+      def add_travel_agency_details(post, options)
+        return unless agency = options[:airline_travel_details][:travel_agency]
+
+        post[:airlineTravelDetails][:travelAgency] = {}
+        post[:airlineTravelDetails][:travelAgency][:name] = agency[:name] if agency[:name]
+        post[:airlineTravelDetails][:travelAgency][:code] = agency[:code] if agency[:code]
+      end
+
+      def add_trip_legs(post, options)
+        return unless trip_legs = options[:airline_travel_details][:trip_legs]
+
+        trip_legs_hash = {}
+        trip_legs.each.with_index(1) do |leg, i|
+          my_leg = "leg#{i}".to_sym
+          details = add_leg_details(my_leg, leg[1])
+
+          trip_legs_hash[my_leg] = details
+        end
+        post[:airlineTravelDetails][:tripLegs] = trip_legs_hash
+      end
+
+      def add_leg_details(obj, leg)
+        details = {}
+        add_flight_details(details, obj, leg)
+        details[:serviceClass] = leg[:service_class] if leg[:service_class]
+        details[:isStopOverAllowed] = leg[:is_stop_over_allowed] if leg[:is_stop_over_allowed]
+        details[:destination] = leg[:destination] if leg[:destination]
+        details[:fareBasis] = leg[:fare_basis] if leg[:fare_basis]
+        details[:departureDate] = leg[:departure_date] if leg[:departure_date]
+
+        details
+      end
+
+      def add_flight_details(details, obj, leg)
+        details[:flight] = {}
+        details[:flight][:carrierCode] = leg[:flight][:carrier_code] if leg[:flight][:carrier_code]
+        details[:flight][:flightNumber] = leg[:flight][:flight_number] if leg[:flight][:flight_number]
+      end
+
+      def add_split_pay_details(post, options)
+        return unless options[:split_pay]
+
+        split_pay = []
+        options[:split_pay].each do |pmnt|
+          split = {}
+
+          split[:linkedAccount] = pmnt[:linked_account]
+          split[:amount] = pmnt[:amount] if pmnt[:amount]
+          split[:percent] = pmnt[:percent] if pmnt[:percent]
+
+          split_pay << split
+        end
+        post[:splitpay] = split_pay
+      end
+
       def parse(body)
         JSON.parse(body)
       end
@@ -218,7 +299,7 @@ module ActiveMerchant #:nodoc:
           success,
           message_from(success, response),
           response,
-          authorization: authorization_from(response),
+          authorization: authorization_from(action, response),
           avs_result: AVSResult.new(code: response['avsResponse']),
           cvv_result: CVVResult.new(response['cvvVerification']),
           test: test?,
@@ -266,8 +347,12 @@ module ActiveMerchant #:nodoc:
         "Error(s)- code:#{response['error']['code']}, message:#{response['error']['message']}"
       end
 
-      def authorization_from(response)
-        response['id']
+      def authorization_from(action, response)
+        if action == 'profiles'
+          response['cards'].first['paymentToken']
+        else
+          response['id']
+        end
       end
 
       def post_data(parameters = {}, options = {})

--- a/test/remote/gateways/remote_paysafe_test.rb
+++ b/test/remote/gateways/remote_paysafe_test.rb
@@ -61,12 +61,55 @@ class RemotePaysafeTest < Test::Unit::TestCase
         version: '1.0.2'
       }
     }
+    @airline_details = {
+      airline_travel_details: {
+        passenger_name: 'Joe Smith',
+        departure_date: '2021-11-30',
+        origin: 'SXF',
+        computerized_reservation_system: 'DATS',
+        ticket: {
+          ticket_number: 9876789,
+          is_restricted_ticket: false
+        },
+        customer_reference_number: 107854099,
+        travel_agency: {
+          name: 'Sally Travel',
+          code: 'AGENTS'
+        },
+        trip_legs: {
+          leg1: {
+            flight: {
+              carrier_code: 'LH',
+              flight_number: '344'
+            },
+            service_class: 'F',
+            is_stop_over_allowed: true,
+            destination: 'ISL',
+            fare_basis: 'VMAY',
+            departure_date: '2021-11-30'
+          },
+          leg2: {
+            flight: {
+              carrier_code: 'TK',
+              flight_number: '999'
+            },
+            service_class: 'F',
+            is_stop_over_allowed: true,
+            destination: 'SOF',
+            fare_basis: 'VMAY',
+            departure_date: '2021-11-30'
+          }
+        }
+      }
+    }
   end
 
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_equal 0, response.params['availableToSettle']
+    assert_not_nil response.params['authCode']
   end
 
   def test_successful_purchase_with_more_options
@@ -78,42 +121,75 @@ class RemotePaysafeTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options.merge(options))
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_equal '127.0.0.1', response.params['customerIp']
+  end
+
+  # Currently, our account is not setup to support split payments
+  #  so we can't test it until it is enabled.
+  # def test_successful_purchase_with_split_payouts
+  #   options = {
+  #     split_pay: [
+  #       {
+  #         linked_account: '1002179730',
+  #         percent: 50
+  #       }
+  #     ]
+  #   }
+
+  #   response = @gateway.purchase(5000, @credit_card, @options.merge(options))
+  #   assert_success response
+  #   assert_equal '987987987', response.params['splitpay'].first['linkedAccount']
+  # end
+
+  def test_successful_purchase_with_airline_details
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(@airline_details))
+    assert_success response
+    assert_equal 'COMPLETED', response.message
+    assert_equal 'LH', response.params['airlineTravelDetails']['tripLegs']['leg1']['flight']['carrierCode']
+    assert_equal 'F', response.params['airlineTravelDetails']['tripLegs']['leg2']['serviceClass']
   end
 
   def test_successful_purchase_with_token
     response = @gateway.purchase(200, @pm_token, @options)
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_equal 0, response.params['availableToSettle']
+    assert_not_nil response.params['authCode']
   end
 
   def test_successful_purchase_with_token_3ds2
     response = @gateway.purchase(200, @pm_token, @options.merge(@visa_three_d_secure_2_options))
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_not_nil response.params['authCode']
   end
 
   def test_successful_purchase_with_mastercard_3ds1
     response = @gateway.purchase(@amount, @mastercard, @options.merge(@mc_three_d_secure_1_options))
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_not_nil response.params['authCode']
   end
 
   def test_successful_purchase_with_mastercard_3ds2
     response = @gateway.purchase(@amount, @mastercard, @options.merge(@mc_three_d_secure_2_options))
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_not_nil response.params['authCode']
   end
 
   def test_successful_purchase_with_visa_3ds1
     response = @gateway.purchase(@amount, @credit_card, @options.merge(@visa_three_d_secure_1_options))
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_not_nil response.params['authCode']
   end
 
   def test_successful_purchase_with_visa_3ds2
     response = @gateway.purchase(@amount, @credit_card, @options.merge(@visa_three_d_secure_2_options))
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_not_nil response.params['authCode']
   end
 
   def test_failed_purchase
@@ -129,6 +205,7 @@ class RemotePaysafeTest < Test::Unit::TestCase
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
     assert_equal 'PENDING', capture.message
+    assert_equal @amount, capture.params['availableToRefund']
   end
 
   def test_successful_authorize_and_capture_with_token
@@ -138,24 +215,28 @@ class RemotePaysafeTest < Test::Unit::TestCase
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
     assert_equal 'PENDING', capture.message
+    assert_equal @amount, capture.params['availableToRefund']
   end
 
   def test_successful_authorize_with_token
     response = @gateway.authorize(250, @pm_token, @options)
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_not_nil response.params['authCode']
   end
 
   def test_successful_authorize_with_token_3ds1
     response = @gateway.authorize(200, @pm_token, @options.merge(@visa_three_d_secure_1_options))
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_not_nil response.params['authCode']
   end
 
   def test_successful_authorize_with_token_3ds2
     response = @gateway.authorize(200, @pm_token, @options.merge(@visa_three_d_secure_2_options))
     assert_success response
     assert_equal 'COMPLETED', response.message
+    assert_not_nil response.params['authCode']
   end
 
   def test_failed_authorize
@@ -244,12 +325,25 @@ class RemotePaysafeTest < Test::Unit::TestCase
   def test_successful_store
     response = @gateway.store(credit_card('4111111111111111'), @profile_options)
     assert_success response
+    assert_equal 'ACTIVE', response.params['status']
+    assert_equal 1979, response.params['dateOfBirth']['year']
+    assert_equal '456 My Street', response.params['addresses'].first['street']
+  end
+
+  def test_successful_store_and_purchase
+    response = @gateway.store(credit_card('4111111111111111'), @profile_options)
+    assert_success response
+    token = response.authorization
+
+    purchase = @gateway.purchase(300, token, @options)
+    assert_success purchase
+    assert_match 'COMPLETED', purchase.message
   end
 
   def test_successful_store_and_redact
     response = @gateway.store(credit_card('4111111111111111'), @profile_options)
     assert_success response
-    id = response.authorization
+    id = response.params['id']
     redact = @gateway.redact(id)
     assert_success redact
   end

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -1,25 +1,18 @@
 require 'test_helper'
 
 class PaysafeTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = PaysafeGateway.new(username: 'username', password: 'password', account_id: 'account_id')
     @credit_card = credit_card
+    @mastercard = credit_card('5186750368967720', brand: 'mastercard')
     @amount = 100
 
     @options = {
       billing_address: address,
       merchant_descriptor: {
         dynamic_descriptor: 'Store Purchase'
-      }
-    }
-
-    @more_options = {
-      phone: '111-222-3456',
-      email: 'profile@memail.com',
-      date_of_birth: {
-        month: 1,
-        year: 1979,
-        day: 1
       }
     }
   end
@@ -32,6 +25,76 @@ class PaysafeTest < Test::Unit::TestCase
 
     assert_equal 'cddbd29d-4983-4719-983a-c6a862895781', response.authorization
     assert response.test?
+  end
+
+  def test_successful_purchase_with_mastercard_3ds2
+    mc_three_d_secure_2_options = {
+      currency: 'EUR',
+      three_d_secure: {
+        eci: 0,
+        cavv: 'AAABBhkXYgAAAAACBxdiENhf7A+=',
+        version: '2.1.0',
+        ds_transaction_id: 'a3a721f3-b6fa-4cb5-84ea-c7b5c39890a2'
+      }
+    }
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @mastercard, mc_three_d_secure_2_options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"threeDSecureVersion":"2.1.0"/, data)
+      assert_match(/"directoryServerTransactionId":"a3a721f3-b6fa-4cb5-84ea-c7b5c39890a2"/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_successful_purchase_with_airline_details
+    airline_details = {
+      airline_travel_details: {
+        passenger_name: 'Joe Smith',
+        departure_date: '2021-11-30',
+        origin: 'SXF',
+        computerized_reservation_system: 'DATS',
+        ticket: {
+          ticket_number: 9876789,
+          is_restricted_ticket: false
+        },
+        customer_reference_number: 107854099,
+        travel_agency: {
+          name: 'Sally Travel',
+          code: 'AGENTS'
+        },
+        trip_legs: {
+          leg1: {
+            flight: {
+              carrier_code: 'LH',
+              flight_number: '344'
+            },
+            service_class: 'F',
+            is_stop_over_allowed: true,
+            departure_date: '2021-11-30'
+          },
+          leg2: {
+            flight: {
+              flight_number: '999'
+            },
+            destination: 'SOF',
+            fare_basis: 'VMAY'
+          }
+        }
+      }
+    }
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, airline_details)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"airlineTravelDetails"/, data)
+      assert_match(/"computerizedReservationSystem":"DATS"/, data)
+      assert_match(/"tripLegs":{"leg1":{"flight":{"carrierCode":"LH"/, data)
+      assert_match(/"leg2":{"flight":{"flightNumber":"999"/, data)
+      assert_match(/"departureDate":"2021-11-30"/, data)
+      assert_match(/"travelAgency":{"name":"Sally Travel","code":"AGENTS"}/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
   end
 
   def test_failed_purchase
@@ -132,13 +195,23 @@ class PaysafeTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    @gateway.expects(:ssl_request).returns(successful_store_response)
+    profile_options = {
+      phone: '111-222-3456',
+      email: 'profile@memail.com',
+      date_of_birth: {
+        month: 1,
+        year: 1979,
+        day: 1
+      }
+    }
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.store(@credit_card, profile_options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"holderName":"Longbob Longsen"/, data)
+      assert_match(/"dateOfBirth":{"year":1979,"month":1,"day":1}/, data)
+    end.respond_with(successful_store_response)
 
-    response = @gateway.store(@credit_card, @more_options)
     assert_success response
-
-    assert_equal '111-222-3456', response.params['phone']
-    assert_equal 'Longbob Longsen', response.params['cards'].first['holderName']
   end
 
   def test_scrub


### PR DESCRIPTION
- Add/edit unit tests to verify field formatting in request data
- Add remote tests to confirm successful transactions for airline merchants
- Add test for store and purchase using new token

Local:
4911 tests, 74270 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
15 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
31 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed