### PR TITLE
Orbital: Scrub Payment Cryptogram

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Stripe Payment Intents: Add support for claim_without_transaction_id field [BritneyS] #4111
 * Mit: Add New Gateway [EsporaInfra] #3820
 * Routex: add card type [rachelkirk] #4115
+* Orbital: Scrub Payment Cryptogram [naashton] #4121
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -337,7 +337,8 @@ module ActiveMerchant #:nodoc:
           gsub(%r((<CustomerMerchantID>).+(</CustomerMerchantID>)), '\1[FILTERED]\2').
           gsub(%r((<CustomerProfileMessage>).+(</CustomerProfileMessage>)), '\1[FILTERED]\2').
           gsub(%r((<CheckDDA>).+(</CheckDDA>)), '\1[FILTERED]\2').
-          gsub(%r((<BCRtNum>).+(</BCRtNum>)), '\1[FILTERED]\2')
+          gsub(%r((<BCRtNum>).+(</BCRtNum>)), '\1[FILTERED]\2').
+          gsub(%r((<DigitalTokenCryptogram>).+(</DigitalTokenCryptogram>)), '\1[FILTERED]\2')
       end
 
       private

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -887,6 +887,23 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_scrubbed(@echeck_gateway.options[:merchant_id], transcript)
   end
 
+  def test_transcript_scrubbing_network_card
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      verification_value: '111',
+      brand: 'visa',
+      eci: '5'
+    )
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, network_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(network_card.payment_cryptogram, transcript)
+  end
+
   private
 
   def stored_credential_options(*args, id: nil)


### PR DESCRIPTION
Including a gsub pattern for scrubbing the cryptogram from the
transcript.

CE-1940

Unit: 129 tests, 750 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 72 tests, 328 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed