### PR TITLE
Add UnionPay test card to BIN range

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Stripe and Stripe PI: Add Radar Session Option [tatsianaclifton] #4119
 * PayArc: Fix billing address nil and phone_number issues [dsmcclain] #4114
 * Routex: Update BIN numbers [rachelkirk] #4123
+* UnionPay: Add Stripe's UnionPay test card to UnionPay BIN range #4122
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -199,7 +199,7 @@ module ActiveMerchant #:nodoc:
 
       # https://www.discoverglobalnetwork.com/content/dam/discover/en_us/dgn/pdfs/IPP-VAR-Enabler-Compliance.pdf
       UNIONPAY_RANGES = [
-        62212600..62379699, 62400000..62699999, 62820000..62889999,
+        620000..620000, 62212600..62379699, 62400000..62699999, 62820000..62889999,
         81000000..81099999, 81100000..81319999, 81320000..81519999, 81520000..81639999, 81640000..81719999
       ]
 

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -228,6 +228,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
 
   def test_should_detect_vr_card
     assert_equal 'vr', CreditCard.brand?('6370364495764400')
+    assert_equal 'vr', CreditCard.brand?('6274160000000001')
   end
 
   def test_should_detect_elo_card
@@ -366,6 +367,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
       6046220312312312
       6393889871239871
       5022751231231231
+      6275350000000001
     ]
     numbers.each do |num|
       assert_equal 16, num.length


### PR DESCRIPTION
Revises [Pull UnionPay's 62* BIN ranges out of Discover's #4103](https://github.com/activemerchant/active_merchant/pull/4103)

I ran into issues while testing payment processing using [Stripe's test UnionPay card](https://stripe.com/docs/testing) (6200000000000005) as it wasn't previously included in ActiveMerchant's UnionPay's BIN range. This PR simply adds it to the existing BIN range.

I also added some additional tests for Vr and Carnet to ensure that their 627* range cards are getting classified correctly (Elo also has 627* cards but there was already an existing test). 

------------
**Unit tests**:
4926 tests, 74323 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
