### PR TITLE
Add 4CS gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/four_cs_online.rb
+++ b/lib/active_merchant/billing/gateways/four_cs_online.rb
@@ -20,12 +20,12 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment, options = {})
         soap = do_authorization_and_post(money, payment, options)
-        commit('AuthOnly', soap)
+        commit('AuthAndPost', soap)
       end
 
       def authorize(money, payment, options = {})
         soap = do_authorization(money, payment, options)
-        commit('AuthAndPost', soap)
+        commit('AuthOnly', soap)
       end
 
       private

--- a/lib/active_merchant/billing/gateways/four_cs_online.rb
+++ b/lib/active_merchant/billing/gateways/four_cs_online.rb
@@ -1,0 +1,160 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class FourCsOnlineGateway < Gateway
+      self.test_url = 'https://merchants.4csonline.com/DevTranSvcs/Ssis.asmx'
+      self.live_url = 'https://merchants.4csonline.com/TranSvcs/Ssis.asmx'
+
+      self.supported_countries = ['MS']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = %i[visa master]
+
+      self.money_format = :dollars
+
+      self.homepage_url = 'https://www.4csonline.com/'
+      self.display_name = '4CS'
+
+      def initialize(options = {})
+        requires!(options, :merchant_key)
+        super
+      end
+
+      def purchase(money, payment, options = {})
+        soap = do_authorization_and_post(money, payment, options)
+        commit('AuthOnly', soap)
+      end
+
+      def authorize(money, payment, options = {})
+        soap = do_authorization(money, payment, options)
+        commit('AuthAndPost', soap)
+      end
+
+      private
+
+      def do_authorization(money, card, options)
+        build_soap do |soap|
+          add_credentials(soap, options)
+          add_transaction_type(soap, 'AuthOnly')
+          add_order_info(soap, money, options)
+          add_customer_data(soap, card, options)
+          add_address(soap, options)
+          add_payment(soap, card)
+        end
+      end
+
+      def do_authorization_and_post(money, card, options)
+        build_soap do |soap|
+          add_credentials(soap, options)
+          add_transaction_type(soap, 'AuthAndPost')
+          add_order_info(soap, money, options)
+          add_customer_data(soap, card, options)
+          add_address(soap, options)
+          add_payment(soap, card)
+        end
+      end
+
+      def add_credentials(soap, options)
+        soap.tag!('MerchantKey', @options[:merchant_key].to_s)
+      end
+
+      def add_transaction_type(soap, transaction_type)
+        soap.tag!('TranType', transaction_type)
+      end
+
+      def add_order_info(soap, money, options)
+        soap.tag!('Amount', amount(money).to_s)
+        soap.tag!('Currency', (options[:currency] || currency(money).to_s))
+        soap.tag!('Invoice', options[:invoice].to_s)
+        soap.tag!('TranId', options[:transaction_id].to_s)
+      end
+
+      def add_customer_data(soap, card, options)
+        soap.tag!('CardholderName', card.name)
+      end
+
+      def add_address(soap, options)
+        address = options[:billing_address] || options[:address]
+        if address.present?
+          address.delete(:name)
+          address.delete(:company)
+          address.delete(:phone)
+          address.delete(:fax)
+          soap.tag!('Address', address.values.join(', '))
+        end
+      end
+
+      def add_payment(soap, card)
+        month = card.month.to_s.rjust(2, '0')
+        year = card.year.to_s[-2, 2]
+
+        soap.tag!('CardNumber', card.number.to_s)
+        soap.tag!('ExpiryMMYY', "#{month}#{year}")
+        soap.tag!('VerificationValue', card.verification_value.to_s)
+      end
+
+      def parse(response, action)
+        result = {}
+        document = REXML::Document.new(response)
+        response_element = document.root.get_elements("//response").first
+        response_element.elements.each do |element|
+          result[element.name.underscore] = element.text
+        end
+        result
+      end
+
+      def commit(soap_action, soap)
+        headers = {
+          'Content-Type' => 'text/xml; charset=utf-8'
+        }
+
+        response_string = ssl_post(test? ? self.test_url : self.live_url, soap, headers)
+        response = parse(response_string, soap_action)
+
+        return Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def build_soap
+        retval = Builder::XmlMarkup.new(indent: 2)
+        retval.instruct!(:xml, version: '1.0', encoding: 'utf-8')
+        retval.tag!('soap:Envelope', {
+          'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+          'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+          'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/'
+        }) do
+          retval.tag!('soap:Body') do
+            retval.tag!('SSISProcessTransaction', { 'xmlns' => 'http://equament.com/Schemas/Fmx/ssis' }) do
+              retval.tag!('request') do
+                yield retval
+              end
+            end
+          end
+        end
+        retval.target!
+      end
+
+      def success_from(response)
+        response['financial_result_code'] == 'Approved'
+      end
+
+      def message_from(response)
+        response['financial_result_code']
+      end
+
+      def authorization_from(response)
+        response['approval_code']
+      end
+
+      def error_code_from(response)
+        unless success_from(response)
+          response['error_message']
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/four_cs_online.rb
+++ b/lib/active_merchant/billing/gateways/four_cs_online.rb
@@ -94,7 +94,7 @@ module ActiveMerchant #:nodoc:
       def parse(response, action)
         result = {}
         document = REXML::Document.new(response)
-        response_element = document.root.get_elements("//response").first
+        response_element = document.root.get_elements('//response').first
         response_element.elements.each do |element|
           result[element.name.underscore] = element.text
         end
@@ -151,9 +151,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def error_code_from(response)
-        unless success_from(response)
-          response['error_message']
-        end
+        response['error_message'] unless success_from(response)
       end
     end
   end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -391,6 +391,9 @@ forte:
   api_key: "f087a90f00f0ae57050c937ed3815c9f"
   secret: "d793d64064e3113a74fa72035cfc3a1d"
 
+four_cs_online:
+  merchant_key: your_merchant_key
+
 garanti:
   login: "PROVAUT"
   terminal_id: 30691300

--- a/test/remote/gateways/remote_four_cs_online_test.rb
+++ b/test/remote/gateways/remote_four_cs_online_test.rb
@@ -10,7 +10,7 @@ class RemoteFourCsOnlineTest < Test::Unit::TestCase
     @incomplete_card = credit_card('4444111122225551')
     @expired_card = credit_card('4444111122223333', year: Time.now.year - 1)
     @options = {
-      invoice: '12345',
+      invoice: Time.now.to_i,
       transaction_id: Time.now.to_i,
       billing_address: address,
       description: 'Store Purchase'
@@ -24,8 +24,8 @@ class RemoteFourCsOnlineTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_more_options
-    invoice = '98765'
-    transaction_id = Time.now.to_i.to_s
+    invoice = Time.now.to_i.to_s
+    transaction_id = invoice
 
     options = {
       invoice: invoice,

--- a/test/remote/gateways/remote_four_cs_online_test.rb
+++ b/test/remote/gateways/remote_four_cs_online_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class RemoteFourCsOnlineTest < Test::Unit::TestCase
+  def setup
+    @gateway = FourCsOnlineGateway.new(fixtures(:four_cs_online))
+
+    @amount = 100
+    @credit_card = credit_card('4444111122223333')
+    @declined_card = credit_card('4444111122221113')
+    @incomplete_card = credit_card('4444111122225551')
+    @expired_card = credit_card('4444111122223333', year: Time.now.year - 1)
+    @options = {
+      invoice: '12345',
+      transaction_id: Time.now.to_i,
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    invoice = '98765'
+    transaction_id = Time.now.to_i.to_s
+
+    options = {
+      invoice: invoice,
+      transaction_id: transaction_id
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal invoice, response.params['invoice']
+    assert_equal transaction_id, response.params['tran_id']
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Declined', response.message
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Declined', response.message
+  end
+
+  def test_expired_card
+    response = @gateway.authorize(@amount, @expired_card, @options)
+    assert_failure response
+    assert_equal 'Incomplete', response.message
+    assert_equal 'ParameterError', response.params['result_code']
+    assert_equal 'Bad Parameter: ExpiryMMYY', response.error_code
+  end
+
+  def test_invalid_login
+    gateway = FourCsOnlineGateway.new(merchant_key: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Incomplete', response.message
+    assert_equal 'Bad Parameter: MerchantKey', response.error_code
+  end
+end

--- a/test/unit/gateways/four_cs_online_test.rb
+++ b/test/unit/gateways/four_cs_online_test.rb
@@ -1,0 +1,183 @@
+require 'test_helper'
+
+class FourCsOnlineTest < Test::Unit::TestCase
+  def setup
+    @gateway = FourCsOnlineGateway.new(merchant_key: 'some_key')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal '000025', response.authorization
+    assert_equal 'Approved', response.message
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Declined', response.message
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal '000093', response.authorization
+    assert_equal 'Approved', response.message
+    assert response.test?
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal nil, response.authorization
+    assert_equal 'Declined', response.message
+    assert response.test?
+  end
+
+  def test_expired_card
+    @gateway.expects(:ssl_post).returns(expired_card_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal nil, response.authorization
+    assert_equal 'ParameterError', response.params['result_code']
+    assert_equal 'Bad Parameter: ExpiryMMYY', response.error_code
+    assert response.test?
+  end
+
+  private
+
+  def successful_purchase_response
+    %(
+      <?xml version="1.0" encoding="utf-8"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+              <SSISProcessTransactionResponse xmlns="http://equament.com/Schemas/Fmx/ssis">
+                  <SSISProcessTransactionResult>OK</SSISProcessTransactionResult>
+                  <response>
+                      <Invoice>12345</Invoice>
+                      <TranId>202109251234</TranId>
+                      <ResultCode>OK</ResultCode>
+                      <FinancialResultCode>Approved</FinancialResultCode>
+                      <Amount>10.00</Amount>
+                      <Currency>USD</Currency>
+                      <ApprovalCode>000025</ApprovalCode>
+                      <HostReference>2123219664647905</HostReference>
+                      <BatchId>2123210300203853</BatchId>
+                      <AVSResult />
+                  </response>
+              </SSISProcessTransactionResponse>
+          </soap:Body>
+      </soap:Envelope>
+    )
+  end
+
+  def failed_purchase_response
+    %(
+      <?xml version="1.0" encoding="utf-8"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+              <SSISProcessTransactionResponse xmlns="http://equament.com/Schemas/Fmx/ssis">
+                  <SSISProcessTransactionResult>OK</SSISProcessTransactionResult>
+                  <response>
+                      <Invoice>12345</Invoice>
+                      <TranId>202109251357</TranId>
+                      <ResultCode>OK</ResultCode>
+                      <FinancialResultCode>Declined</FinancialResultCode>
+                      <Amount>10.00</Amount>
+                      <Currency>USD</Currency>
+                      <ApprovalCode />
+                      <HostReference>2123219856480907</HostReference>
+                      <BatchId>2123210300203853</BatchId>
+                      <AVSResult />
+                  </response>
+              </SSISProcessTransactionResponse>
+          </soap:Body>
+      </soap:Envelope>
+    )
+  end
+
+  def successful_authorize_response
+    %(
+      <?xml version="1.0" encoding="utf-8"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+              <SSISProcessTransactionResponse xmlns="http://equament.com/Schemas/Fmx/ssis">
+                  <SSISProcessTransactionResult>OK</SSISProcessTransactionResult>
+                  <response>
+                      <Invoice>12345</Invoice>
+                      <TranId>202109251401</TranId>
+                      <ResultCode>OK</ResultCode>
+                      <FinancialResultCode>Approved</FinancialResultCode>
+                      <Amount>10.00</Amount>
+                      <Currency>USD</Currency>
+                      <ApprovalCode>000093</ApprovalCode>
+                      <HostReference>2123220080160908</HostReference>
+                      <AVSResult />
+                  </response>
+              </SSISProcessTransactionResponse>
+          </soap:Body>
+      </soap:Envelope>
+    )
+  end
+
+  def failed_authorize_response
+    %(
+    <?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <soap:Body>
+            <SSISProcessTransactionResponse xmlns="http://equament.com/Schemas/Fmx/ssis">
+                <SSISProcessTransactionResult>OK</SSISProcessTransactionResult>
+                <response>
+                    <Invoice>12345</Invoice>
+                    <TranId>202109251403</TranId>
+                    <ResultCode>OK</ResultCode>
+                    <FinancialResultCode>Declined</FinancialResultCode>
+                    <Amount>10.00</Amount>
+                    <Currency>USD</Currency>
+                    <ApprovalCode />
+                    <HostReference>2123220186990909</HostReference>
+                    <AVSResult />
+                </response>
+            </SSISProcessTransactionResponse>
+        </soap:Body>
+    </soap:Envelope>
+    )
+  end
+
+  def expired_card_response
+    %(
+      <?xml version="1.0" encoding="utf-8"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+              <SSISProcessTransactionResponse xmlns="http://equament.com/Schemas/Fmx/ssis">
+                  <SSISProcessTransactionResult>OK</SSISProcessTransactionResult>
+                  <response>
+                      <ErrorMessage>Bad Parameter: ExpiryMMYY</ErrorMessage>
+                      <ResultCode>ParameterError</ResultCode>
+                      <FinancialResultCode>Incomplete</FinancialResultCode>
+                      <Amount>0</Amount>
+                  </response>
+              </SSISProcessTransactionResponse>
+          </soap:Body>
+      </soap:Envelope>
+    )
+  end
+end


### PR DESCRIPTION
FourCsOnlineGateway: Integration of new 4CS (Caribbean Credit Card Corporation) Gateway

Integrate FourCsOnlineGateway with the following methods: purchase and authorize.

Test Summary
4931 tests, 74344 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit: 5 tests, 24 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote: 6 tests, 16 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed