### PR TITLE
Change Eway Rapid param naming

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -16,7 +16,7 @@ module ActiveMerchant #:nodoc:
       class_attribute :partner_id
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, :api_key, :password)
         super
       end
 
@@ -306,7 +306,7 @@ module ActiveMerchant #:nodoc:
 
       def commit(url, params)
         headers = {
-          'Authorization' => ('Basic ' + Base64.strict_encode64(@options[:login].to_s + ':' + @options[:password].to_s).chomp),
+          'Authorization' => ('Basic ' + Base64.strict_encode64(@options[:api_key].to_s + ':' + @options[:password].to_s).chomp),
           'Content-Type' => 'application/json'
         }
         request = params.to_json

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -6,7 +6,7 @@ class EwayRapidTest < Test::Unit::TestCase
   def setup
     ActiveMerchant::Billing::EwayRapidGateway.partner_id = nil
     @gateway = EwayRapidGateway.new(
-      login: 'login',
+      api_key: 'api_key',
       password: 'password'
     )
 


### PR DESCRIPTION
According to [Eway Rapid documentation](https://eway.io/api-v3/#authentication), they have API key and password for authentication.
```
4926 tests, 74320 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```
