### PR TITLE
Global Collect: Support URL override

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * PayArc: Fix billing address nil and phone_number issues [dsmcclain] #4114
 * Routex: Update BIN numbers [rachelkirk] #4123
 * UnionPay: Add Stripe's UnionPay test card to UnionPay BIN range #4122
+* GlobalCollect: Support URL override #4127
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -1,10 +1,13 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class GlobalCollectGateway < Gateway
+      class_attribute :preproduction_url
+
       self.display_name = 'GlobalCollect'
       self.homepage_url = 'http://www.globalcollect.com/'
 
       self.test_url = 'https://eu.sandbox.api-ingenico.com'
+      self.preproduction_url = 'https://world.preprod.api-ingenico.com'
       self.live_url = 'https://api.globalcollect.com'
 
       self.supported_countries = %w[AD AE AG AI AL AM AO AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BW BY BZ CA CC CD CF CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HN HR HT HU ID IE IL IM IN IS IT JM JO JP KE KG KH KI KM KN KR KW KY KZ LA LB LC LI LK LR LS LT LU LV MA MC MD ME MF MG MH MK MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PL PN PS PT PW QA RE RO RS RU RW SA SB SC SE SG SH SI SJ SK SL SM SN SR ST SV SZ TC TD TG TH TJ TL TM TN TO TR TT TV TW TZ UA UG US UY UZ VC VE VG VI VN WF WS ZA ZM ZW]
@@ -260,6 +263,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def url(action, authorization)
+        return preproduction_url if @options[:url_override].to_s == 'preproduction'
+
         (test? ? test_url : live_url) + uri(action, authorization)
       end
 

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -12,7 +12,8 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     @options = {
       email: 'example@example.com',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      url_override: 'preproduction'
     }
     @long_address = {
       billing_address: {

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -47,6 +47,21 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_preproduction_url
+    @gateway = GlobalCollectGateway.new(
+      merchant_id: '1234',
+      api_key_id: '39u4193urng12',
+      secret_api_key: '109H/288H*50Y18W4/0G8571F245KA=',
+      url_override: 'preproduction'
+    )
+
+    stub_comms do
+      @gateway.authorize(@accepted_amount, @credit_card)
+    end.check_request do |endpoint, _data, _headers|
+      assert_match(/world\.preprod\.api-ingenico\.com/, endpoint)
+    end.respond_with(successful_authorize_response)
+  end
+
   # When requires_approval is true (or not present),
   # a `purchase` makes two calls (`auth` and `capture`).
   def test_successful_purchase_with_requires_approval_true


### PR DESCRIPTION
Global Collect has a pre-production url endpoint that we need to make
available.

This endpoint can be enabled by setting `url_override` to
`preproduction` when initializing the gateway.

CE-1964

Unit: 53 tests, 227 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 25 tests, 61 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96% passed