### PR TITLE
PayConex: scrub bank account info from transcripts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Routex: Update BIN numbers [rachelkirk] #4123
 * UnionPay: Add Stripe's UnionPay test card to UnionPay BIN range #4122
 * GlobalCollect: Support URL override #4127
+* PayConex: scrub bank account info from transcripts [mbreenlyles] #4128
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/pay_conex.rb
+++ b/lib/active_merchant/billing/gateways/pay_conex.rb
@@ -79,7 +79,9 @@ module ActiveMerchant #:nodoc:
         force_utf8(transcript).
           gsub(%r((api_accesskey=)\w+), '\1[FILTERED]').
           gsub(%r((card_number=)\w+), '\1[FILTERED]').
-          gsub(%r((card_verification=)\w+), '\1[FILTERED]')
+          gsub(%r((card_verification=)\w+), '\1[FILTERED]').
+          gsub(%r((bank_account_number=)\w+), '\1[FILTERED]').
+          gsub(%r((bank_routing_number=)\w+), '\1[FILTERED]')
       end
 
       private

--- a/test/remote/gateways/remote_pay_conex_test.rb
+++ b/test/remote/gateways/remote_pay_conex_test.rb
@@ -29,6 +29,17 @@ class RemotePayConexTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:api_accesskey], transcript)
   end
 
+  def test_transcript_scrubbing_with_check
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @check, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@check.account_number, transcript)
+    assert_scrubbed(@check.routing_number, transcript)
+    assert_scrubbed(@gateway.options[:api_accesskey], transcript)
+  end
+
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/unit/gateways/pay_conex_test.rb
+++ b/test/unit/gateways/pay_conex_test.rb
@@ -171,6 +171,11 @@ class PayConexTest < Test::Unit::TestCase
     assert_equal post_scrubbed, @gateway.scrub(pre_scrubbed)
   end
 
+  def test_scrub_check
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed_check), post_scrubbed_check
+  end
+
   private
 
   def pre_scrubbed
@@ -194,6 +199,18 @@ class PayConexTest < Test::Unit::TestCase
       -> \"?H?f<\u0002\u0000\u0000\"
       D, [2015-03-04T18:13:07.219562 #71589] DEBUG -- : {\"transaction_id\":\"000000002021\",\"tender_type\":\"CARD\",\"transaction_timestamp\":\"2015-03-04 17:13:04\",\"card_brand\":\"VISA\",\"transaction_type\":\"SALE\",\"last4\":\"2224\",\"card_expiration\":\"0916\",\"authorization_code\":\"CVI292\",\"authorization_message\":\"APPROVED\",\"request_amount\":1,\"transaction_amount\":1,\"first_name\":\"Longbob\",\"last_name\":\"Longsen\",\"keyed\":true,\"swiped\":false,\"transaction_approved\":true,\"avs_response\":\"Z\",\"cvv2_response\":\"U\",\"transaction_description\":\"Store Purchase\",\"balance\":1,\"currency\":\"USD\",\"error\":false,\"error_code\":0,\"error_message\":null,\"error_msg\":null}
       {\"transaction_id\":\"000000002021\",\"tender_type\":\"CARD\",\"transaction_timestamp\":\"2015-03-04 17:13:04\",\"card_brand\":\"VISA\",\"transaction_type\":\"SALE\",\"last4\":\"2224\",\"card_expiration\":\"0916\",\"authorization_code\":\"CVI292\",\"authorization_message\":\"APPROVED\",\"request_amount\":1,\"transaction_amount\":1,\"first_name\":\"Longbob\",\"last_name\":\"Longsen\",\"keyed\":true,\"swiped\":false,\"transaction_approved\":true,\"avs_response\":\"Z\",\"cvv2_response\":\"U\",\"transaction_description\":\"Store Purchase\",\"balance\":1,\"currency\":\"USD\",\"error\":false,\"error_code\":0,\"error_message\":null,\"error_msg\":null}
+    POST_SCRUBBED
+  end
+
+  def pre_scrubbed_check
+    <<-PRE_SCRUBBED
+      <- "account_id=220614968961&api_accesskey=69e9c4dd6b8ab9ab47da4e288df78315&tender_type=ACH&first_name=Jim&last_name=Smith&bank_account_number=15378535&bank_routing_number=244183602&check_number=1&ach_account_type=checking&street_address1=456+My+Street&street_address2=Apt+1&city=Ottawa&state=ON&zip=K1C2N6&country=CA&phone=%28555%29555-5555&transaction_description=Store+Purchase&response_format=JSON&transaction_amount=1.00&currency=USD&email=joe%40example.com&transaction_type=SALE"
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed_check
+    <<-POST_SCRUBBED
+      <- "account_id=220614968961&api_accesskey=[FILTERED]&tender_type=ACH&first_name=Jim&last_name=Smith&bank_account_number=[FILTERED]&bank_routing_number=[FILTERED]&check_number=1&ach_account_type=checking&street_address1=456+My+Street&street_address2=Apt+1&city=Ottawa&state=ON&zip=K1C2N6&country=CA&phone=%28555%29555-5555&transaction_description=Store+Purchase&response_format=JSON&transaction_amount=1.00&currency=USD&email=joe%40example.com&transaction_type=SALE"
     POST_SCRUBBED
   end
 


### PR DESCRIPTION
Before changes applied: 
Remote:
24 tests, 38 assertions, 16 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
33.3333% passed

After changes applied:
Remote:
25 tests, 41 assertions, 16 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
36% passed
Unit: 
20 tests, 90 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Local:
4927 tests, 74327 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed