### PR TITLE
Moka: Remove additional transaction data from subsequent calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,8 +15,9 @@
 * PayArc: Fix billing address nil and phone_number issues [dsmcclain] #4114
 * Routex: Update BIN numbers [rachelkirk] #4123
 * UnionPay: Add Stripe's UnionPay test card to UnionPay BIN range #4122
-* GlobalCollect: Support URL override #4127
+* GlobalCollect: Support URL override [naashton] #4127
 * PayConex: scrub bank account info from transcripts [mbreenlyles] #4128
+* Moka: Remove additional transaction data from subsequent calls [naashton] #4129
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/moka.rb
+++ b/lib/active_merchant/billing/gateways/moka.rb
@@ -77,7 +77,6 @@ module ActiveMerchant #:nodoc:
         post[:PaymentDealerRequest] = {}
         add_payment_dealer_authentication(post)
         add_transaction_reference(post, authorization)
-        add_additional_transaction_data(post, options)
 
         commit('capture', post)
       end
@@ -87,7 +86,6 @@ module ActiveMerchant #:nodoc:
         post[:PaymentDealerRequest] = {}
         add_payment_dealer_authentication(post)
         add_transaction_reference(post, authorization)
-        add_additional_transaction_data(post, options)
         add_void_refund_reason(post)
         add_amount(post, money)
 
@@ -99,7 +97,6 @@ module ActiveMerchant #:nodoc:
         post[:PaymentDealerRequest] = {}
         add_payment_dealer_authentication(post)
         add_transaction_reference(post, authorization)
-        add_additional_transaction_data(post, options)
         add_void_refund_reason(post)
 
         commit('void', post)


### PR DESCRIPTION
Moka returns an error when `OrderTrxCode` is given on subsequent calls;
`capture`, `void`, and `refund`. Removing the method call from those
transactions should resolve the issue.

CE-1990

Unit: 16 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 22 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed