### PR TITLE
Moka: Ensure CvcNumber can be an empty string

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * GlobalCollect: Support URL override [naashton] #4127
 * PayConex: scrub bank account info from transcripts [mbreenlyles] #4128
 * Moka: Remove additional transaction data from subsequent calls [naashton] #4129
+* Moka: Ensure CvcNumber can be an empty string [jessiagee] #4130
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/moka.rb
+++ b/lib/active_merchant/billing/gateways/moka.rb
@@ -165,7 +165,7 @@ module ActiveMerchant #:nodoc:
         post[:PaymentDealerRequest][:CardNumber] = card.number
         post[:PaymentDealerRequest][:ExpMonth] = card.month.to_s.rjust(2, '0')
         post[:PaymentDealerRequest][:ExpYear] = card.year
-        post[:PaymentDealerRequest][:CvcNumber] = card.verification_value
+        post[:PaymentDealerRequest][:CvcNumber] = card.verification_value || ''
       end
 
       def add_amount(post, money)

--- a/test/remote/gateways/remote_moka_test.rb
+++ b/test/remote/gateways/remote_moka_test.rb
@@ -87,6 +87,15 @@ class RemoteMokaTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_nil_cvv
+    test_card = credit_card('5269111122223332')
+    test_card.verification_value = nil
+
+    response = @gateway.purchase(@amount, test_card, @options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response


### PR DESCRIPTION
bundle exec rake test:local

4926 tests, 74324 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

716 files inspected, no offenses detected

Loaded suite test/unit/gateways/moka_test

16 tests, 73 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_moka_test

23 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed