### PR TITLE
Maestro: allow card lengths for non-validated cards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * PayConex: scrub bank account info from transcripts [mbreenlyles] #4128
 * Moka: Remove additional transaction data from subsequent calls [naashton] #4129
 * Moka: Ensure CvcNumber can be an empty string [jessiagee] #4130
+* Maestro: Allow more card lengths for Luhnless bins [therufs] #4131
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -19,7 +19,7 @@ module ActiveMerchant #:nodoc:
             MAESTRO_BINS.any? { |bin| num.slice(0, bin.size) == bin }
           )
         },
-        'maestro_no_luhn'    => ->(num) { num =~ /^(501080|501081|501082)\d{10}$/ },
+        'maestro_no_luhn'    => ->(num) { num =~ /^(501080|501081|501082)\d{6,13}$/ },
         'forbrugsforeningen' => ->(num) { num =~ /^600722\d{10}$/ },
         'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818)\d{10}$/ },
         'alia'               => ->(num) { num =~ /^(504997|505878|601030|601073|505874)\d{10}$/ },

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -208,6 +208,8 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'maestro_no_luhn', CreditCard.brand?('5010800000000000')
     assert_equal 'maestro_no_luhn', CreditCard.brand?('5010810000000000')
     assert_equal 'maestro_no_luhn', CreditCard.brand?('5010820000000000')
+    assert_equal 'maestro_no_luhn', CreditCard.brand?('501082000000')
+    assert_equal 'maestro_no_luhn', CreditCard.brand?('5010820000000000000')
   end
 
   def test_maestro_no_luhn_number_not_validated


### PR DESCRIPTION
rake test:local
4928 tests, 74332 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
716 files inspected, no offenses detected