### PR TITLE
Fixup PR #4122 Add UnionPay test card to BIN range

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -199,7 +199,7 @@ module ActiveMerchant #:nodoc:
 
       # https://www.discoverglobalnetwork.com/content/dam/discover/en_us/dgn/pdfs/IPP-VAR-Enabler-Compliance.pdf
       UNIONPAY_RANGES = [
-        620000..620000, 62212600..62379699, 62400000..62699999, 62820000..62889999,
+        62000000..62000000, 62212600..62379699, 62400000..62699999, 62820000..62889999,
         81000000..81099999, 81100000..81319999, 81320000..81519999, 81520000..81639999, 81640000..81719999
       ]
 

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -281,6 +281,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'unionpay', CreditCard.brand?('814400000000000000')
     assert_equal 'unionpay', CreditCard.brand?('8171999927660000')
     assert_equal 'unionpay', CreditCard.brand?('8171999900000000021')
+    assert_equal 'unionpay', CreditCard.brand?('6200000000000005')
   end
 
   def test_should_detect_synchrony_card


### PR DESCRIPTION
Amends #4122 

Errors occurred during payment process testing using Stripe's test UnionPay card (6200000000000005) as it wasn't previously included in ActiveMerchant's CUP range.

In #4122, I mistakenly added the wrong number of 0's for the test BIN 😔 and therefore the test card was still not getting classified correctly. I've updated this and added an additional test.

________

4928 tests, 74331 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
716 files inspected, no offenses detected