### PR TITLE
Make "set" `require`d by credit_card_methods.rb

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     # Convenience methods that can be included into a custom Credit Card object, such as an ActiveRecord based Credit Card object.


### PR DESCRIPTION
Nondeterministic `require` loading was occasionally
causing this file to raise a `NameError` when
loaded by itself. Sometimes it would succeed,
when a different file that `require 'set'`ed  would
load first.

> `uninitialized constant ActiveMerchant::Billing::CreditCardMethods::Set (NameError)`

Local tests:
4928 tests, 74333 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
716 files inspected, no offenses detected
