### PR TITLE
Moka: Pass Currency on Capture transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/moka.rb
+++ b/lib/active_merchant/billing/gateways/moka.rb
@@ -77,6 +77,7 @@ module ActiveMerchant #:nodoc:
         post[:PaymentDealerRequest] = {}
         add_payment_dealer_authentication(post)
         add_transaction_reference(post, authorization)
+        add_invoice(post, money, options)
 
         commit('capture', post)
       end

--- a/test/remote/gateways/remote_moka_test.rb
+++ b/test/remote/gateways/remote_moka_test.rb
@@ -112,6 +112,16 @@ class RemoteMokaTest < Test::Unit::TestCase
     assert_equal 'Success', capture.message
   end
 
+  def test_successful_authorize_and_capture_using_non_default_currency
+    options = @options.merge(currency: 'USD')
+    auth = @gateway.authorize(@amount, @credit_card, options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization, currency: 'USD')
+    assert_success capture
+    assert_equal 'Success', capture.message
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response


### PR DESCRIPTION
Moka's default currency is 'TL'. We discovered that if you create an
authorization for a different currency (say 'USD'), you still must pass
that currency on the capture, otherwise Moka will default to 'TL' and
the response will be a `CurrencyDoesntMatch` error.

CE-1999

Rubocop:
716 files inspected, no offenses detected

Local:
4928 tests, 74333 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_moka_test
24 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed