### PR TITLE
Paysafe: Update field mapping for split_pay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 * Moka: Ensure CvcNumber can be an empty string [jessiagee] #4130
 * Maestro: Allow more card lengths for Luhnless bins [therufs] #4131
 * Paysafe: Update supported countries [meagabeth] #4135
+* Paysafe: Update field mapping for split_pay [meagabeth] #4136
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -276,8 +276,8 @@ module ActiveMerchant #:nodoc:
           split = {}
 
           split[:linkedAccount] = pmnt[:linked_account]
-          split[:amount] = pmnt[:amount] if pmnt[:amount]
-          split[:percent] = pmnt[:percent] if pmnt[:percent]
+          split[:amount] = pmnt[:amount].to_i if pmnt[:amount]
+          split[:percent] = pmnt[:percent].to_i if pmnt[:percent]
 
           split_pay << split
         end


### PR DESCRIPTION
- The gateway expects the amount and percent fields to be integers when they reach the gateway. This was not originally discovered when writing unit and remote tests, but popped up as an error when writing integration tests.

Local:
4928 tests, 74333 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Rubocop:
716 files inspected, no offenses detected
Unit:
15 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
30 tests, 90 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed