### PR TITLE
SafeCharge: Account for non-fractional currencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Maestro: Allow more card lengths for Luhnless bins [therufs] #4131
 * Paysafe: Update supported countries [meagabeth] #4135
 * Paysafe: Update field mapping for split_pay [meagabeth] #4136
+* SafeCharge: Add handling for non-fractional currencies [dsmcclain] #4137
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -126,9 +126,11 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_transaction_data(trans_type, post, money, options)
+        currency = options[:currency] || currency(money)
+
         post[:sg_TransType] = trans_type
-        post[:sg_Currency] = (options[:currency] || currency(money))
-        post[:sg_Amount] = amount(money)
+        post[:sg_Currency] = currency
+        post[:sg_Amount] = localized_amount(money, currency)
         post[:sg_ClientLoginID] = @options[:client_login_id]
         post[:sg_ClientPassword] = @options[:client_password]
         post[:sg_ResponseFormat] = '4'

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -65,6 +65,15 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_non_fractional_currency
+    options = @options.merge(currency: 'CLP')
+    response = @gateway.purchase(127999, @credit_card, options)
+
+    assert_success response
+    assert_equal 'Success', response.message
+    assert_equal '1279', response.params['requestedamount']
+  end
+
   def test_successful_purchase_with_mpi_options_3ds_1
     options = @options.merge({
       three_d_secure: {


### PR DESCRIPTION
Safe Charge accepts at least one currency (Chilean Peso) that does not
include fractional units. If a request includes a decimal point in the
amount, the gateway will return an error. This PR leverages the `localized_amount`
method to truncate the amount to whole units.

CE-1909

Rubocop:
716 files inspected, no offenses detected

Local:
4928 tests, 74333 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
29 tests, 77 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.5517% passed
You should expect this remote test to fail for reasons not related to this PR:
`test_successful_regular_purchase_through_3ds_flow_with_invalid_pa_res`