### PR TITLE
Adyen: Adjust phone number mapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Paysafe: Update field mapping for split_pay [meagabeth] #4136
 * SafeCharge: Add handling for non-fractional currencies [dsmcclain] #4137
 * CardStream: Support passing country_code in request [dsmcclain] #4139
+* Adyen: Adjust phone number mapping [aenand] #4138
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -217,7 +217,7 @@ module ActiveMerchant #:nodoc:
       }
 
       def add_extra_data(post, payment, options)
-        post[:telephoneNumber] = options[:billing_address][:phone] if options.dig(:billing_address, :phone)
+        post[:telephoneNumber] = (options[:billing_address][:phone_number] if options.dig(:billing_address, :phone_number)) || (options[:billing_address][:phone] if options.dig(:billing_address, :phone)) || ''
         post[:fraudOffset] = options[:fraud_offset] if options[:fraud_offset]
         post[:selectedBrand] = options[:selected_brand] if options[:selected_brand]
         post[:selectedBrand] ||= NETWORK_TOKENIZATION_CARD_SOURCE[payment.source.to_s] if payment.is_a?(NetworkTokenizationCreditCard)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1190,6 +1190,19 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_authorize_phone
+    @options[:billing_address][:phone] = '1234567890'
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_authorize_phone_number
+    @options[:billing_address].delete(:phone)
+    @options[:billing_address][:phone_number] = '0987654321'
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+  end
+
   def test_purchase_using_stored_credential_recurring_cit
     initial_options = stored_credential_options(:cardholder, :recurring, :initial)
     assert auth = @gateway.authorize(@amount, @credit_card, initial_options)

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -881,6 +881,26 @@ class AdyenTest < Test::Unit::TestCase
     assert_equal @options[:shipping_address][:country], post[:deliveryAddress][:country]
   end
 
+  def test_successful_auth_phone
+    options = @options.merge(billing_address: { phone: 1234567890 })
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 1234567890, JSON.parse(data)['telephoneNumber']
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_successful_auth_phone_number
+    options = @options.merge(billing_address: { phone_number: 987654321, phone: 1234567890 })
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 987654321, JSON.parse(data)['telephoneNumber']
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_purchase_with_long_order_id
     options = @options.merge({ order_id: @long_order_id })
     response = stub_comms do


### PR DESCRIPTION
Adds a bit of logic to the way the Adyen gateway passes phone numbers so that if a payment method has a phone number saved to it that will be mapped first (`billing_address[:phone]`), otherwise if the transaction has (`billing_address[phone_number]`) that will be mapped. If neither are available we will map an empty string. Similar to [#4005](https://github.com/activemerchant/active_merchant/pull/4005).

CE-1908

Test Summary:

There were 17 test errors due to not having monei api_key
Local:
4930 tests, 74297 assertions, 0 failures, 17 errors, 0 pendings, 0 omissions, 0 notifications
99.6552% passed

Unit:
88 tests, 450 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
119 tests, 441 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed