### PR TITLE
CardStream: Support passing country_code in request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * Paysafe: Update supported countries [meagabeth] #4135
 * Paysafe: Update field mapping for split_pay [meagabeth] #4136
 * SafeCharge: Add handling for non-fractional currencies [dsmcclain] #4137
+* CardStream: Support passing country_code in request [dsmcclain] #4139
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -246,6 +246,16 @@ class CardStreamTest < Test::Unit::TestCase
     assert_equal 'APPROVED', response.message
   end
 
+  def test_adding_country_code
+    %i[authorize purchase refund].each do |action|
+      stub_comms do
+        @gateway.send(action, 142, @visacreditcard, @visacredit_options.merge(country_code: 'US'))
+      end.check_request do |_endpoint, data, _headers|
+        assert_match(/&countryCode=US/, data)
+      end.respond_with(successful_purchase_response)
+    end
+  end
+
   def test_hmac_signature_added_to_post
     post_params = "action=SALE&amount=10000&captureDelay=0&cardCVV=356&cardExpiryMonth=12&cardExpiryYear=14&cardNumber=4929421234600821&countryCode=GB&currencyCode=826&customerAddress=Flat+6%2C+Primrose+Rise+347+Lavender+Road&customerCountryCode=GB&customerName=Longbob+Longsen&customerPostCode=NN17+8YG+&merchantID=login&orderRef=AM+test+purchase&remoteAddress=1.1.1.1&threeDSRequired=N&transactionUnique=#{@visacredit_options[:order_id]}&type=1"
     expected_signature = Digest::SHA512.hexdigest("#{post_params}#{@gateway.options[:shared_secret]}")


### PR DESCRIPTION
This PR makes it possible to specify a `country_code` in the request (not to be confused with `customerCountryCode`).
Previously it was simply defaulting to 'GB' every time.

CE-1960

Rubocop:
716 files inspected, no offenses detected

Local:
4929 tests, 74340 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
31 tests, 200 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.5484% passed
You should expect to see both of the following tests fail with the message "ERROR CODE (RC_IP_BLOCKED_PRIMARY)":
`test_successful_amex_purchase_and_refund_with_force_refund`
`test_successful_amex_authorization_and_capture`
This is the result of cnfigurations for AMEX cards on our test account, which I am unable to change.