### PR TITLE
MIT: Change how parameters are converted to JSON

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * SafeCharge: Add handling for non-fractional currencies [dsmcclain] #4137
 * CardStream: Support passing country_code in request [dsmcclain] #4139
 * Adyen: Adjust phone number mapping [aenand] #4138
+* Mit: Change how parameters are converted to JSON [tatsianaclifton] #4140
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/mit.rb
+++ b/lib/active_merchant/billing/gateways/mit.rb
@@ -219,7 +219,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, parameters)
-        json_str = parameters.to_json
+        json_str = JSON.generate(parameters)
         cleaned_str = json_str.gsub('\n', '')
         raw_response = ssl_post(live_url, cleaned_str, { 'Content-type' => 'application/json' })
         response = JSON.parse(decrypt(raw_response, @options[:key_session]))


### PR DESCRIPTION
When Active Merchant is used in rails application that uses module ActiveSupport to_json method will be overwritten and `<` and `>` will be encoded. This commit includes the change that to_json from ActiveSupport is not used when converting parameters to json string.

bundle exec rake test:local
716 files inspected, no offenses detected

Unit:
9 tests, 33 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
8 tests, 22 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed