### PR TITLE
Pin Payments: add diners_club, discover, jcb as supported cardtypes

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'AUD'
       self.money_format = :cents
       self.supported_countries = ['AU']
-      self.supported_cardtypes = %i[visa master american_express]
+      self.supported_cardtypes = %i[visa master american_express diners_club discover jcb]
       self.homepage_url = 'http://www.pinpayments.com/'
       self.display_name = 'Pin Payments'
 

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -56,7 +56,7 @@ class PinTest < Test::Unit::TestCase
   end
 
   def test_supported_cardtypes
-    assert_equal %i[visa master american_express], PinGateway.supported_cardtypes
+    assert_equal %i[visa master american_express diners_club discover jcb], PinGateway.supported_cardtypes
   end
 
   def test_display_name


### PR DESCRIPTION
Pin Payments now supports diners_club, discover and jcb.

# Test Summary

## Local

4931 tests, 74348 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
716 files inspected, no offenses detected

## Unit

4931 tests, 74348 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## Remote

17 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
