### PR TITLE
Pin Payments: add NZ as supported country

### DIFF
--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
 
       self.default_currency = 'AUD'
       self.money_format = :cents
-      self.supported_countries = ['AU']
+      self.supported_countries = %w(AU NZ)
       self.supported_cardtypes = %i[visa master american_express]
       self.homepage_url = 'http://www.pinpayments.com/'
       self.display_name = 'Pin Payments'

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -52,7 +52,7 @@ class PinTest < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal ['AU'], PinGateway.supported_countries
+    assert_equal %w(AU NZ), PinGateway.supported_countries
   end
 
   def test_supported_cardtypes


### PR DESCRIPTION
Pin Payments now supports New Zealand merchants.

# Test Summary

## Unit

4931 tests, 74348 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## Remote

17 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## Rubocop

716 files inspected, no offenses detected
