### PR TITLE
Stripe: add account_number to scrubbing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * CardStream: Support passing country_code in request [dsmcclain] #4139
 * Adyen: Adjust phone number mapping [aenand] #4138
 * Mit: Change how parameters are converted to JSON [tatsianaclifton] #4140
+* Stripe: Add account_number to scrubbing [aenand] #4145
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -286,7 +286,8 @@ module ActiveMerchant #:nodoc:
           gsub(%r(((\[card\]|card)\[encrypted_pin\]=)[^&]+(&?)), '\1[FILTERED]\3').
           gsub(%r(((\[card\]|card)\[encrypted_pin_key_id\]=)[\w=]+(&?)), '\1[FILTERED]\3').
           gsub(%r(((\[card\]|card)\[number\]=)\d+), '\1[FILTERED]').
-          gsub(%r(((\[card\]|card)\[swipe_data\]=)[^&]+(&?)), '\1[FILTERED]\3')
+          gsub(%r(((\[card\]|card)\[swipe_data\]=)[^&]+(&?)), '\1[FILTERED]\3').
+          gsub(%r(((\[bank_account\]|bank_account)\[account_number\]=)\d+), '\1[FILTERED]')
       end
 
       def supports_network_tokenization?

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -36,6 +36,14 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:login], transcript)
   end
 
+  def test_check_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.store(@check)
+    end
+    transcript = @gateway.scrub(transcript)
+    assert_scrubbed(@check.account_number, transcript)
+  end
+
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -1373,6 +1373,10 @@ class StripeTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed_with_emv_data), post_scrubbed_with_emv_data
   end
 
+  def test_scrubs_account_number
+    assert_equal @gateway.scrub(pre_scrubbed_with_account_number), post_scrubbed_with_account_number
+  end
+
   def test_supports_scrubbing?
     assert @gateway.supports_scrubbing?
   end
@@ -1683,6 +1687,63 @@ class StripeTest < Test::Unit::TestCase
     PRE_SCRUBBED
   end
 
+  def pre_scrubbed_with_account_number
+    <<-PRE_SCRUBBED
+      opening connection to api.stripe.com:443...
+      opened
+      starting SSL for api.stripe.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES128-GCM-SHA256
+      <- "POST /v1/tokens?bank_account[account_number]=000123456789&bank_account[country]=US&bank_account[currency]=usd&bank_account[routing_number]=110000000&bank_account[name]=Jim+Smith&bank_account[account_holder_type]=individual HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic c2tfdGVzdF8zT0Q0VGRLU0lPaERPTDIxNDZKSmNDNzk6\r\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.123.0\r\nStripe-Version: 2015-04-07\r\nX-Stripe-Client-User-Agent: {\"bindings_version\":\"1.123.0\",\"lang\":\"ruby\",\"lang_version\":\"2.6.6 p146 (2020-03-31)\",\"platform\":\"x86_64-darwin20\",\"publisher\":\"active_merchant\"}\r\nX-Stripe-Client-User-Metadata: {\"ip\":null}\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nHost: api.stripe.com\r\nContent-Length: 0\r\n\r\n"
+      <- ""
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Wed, 06 Oct 2021 18:51:30 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 610\r\n"
+      -> "Connection: close\r\n"
+      -> "access-control-allow-credentials: true\r\n"
+      -> "access-control-allow-methods: GET, POST, HEAD, OPTIONS, DELETE\r\n"
+      -> "access-control-allow-origin: *\r\n"
+      -> "access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required\r\n"
+      -> "access-control-max-age: 300\r\n"
+      -> "cache-control: no-cache, no-store\r\n"
+      -> "request-id: req_cueTxQR09SjIOA\r\n"
+      -> "stripe-version: 2015-04-07\r\n"
+      -> "Strict-Transport-Security: max-age=31556926; includeSubDomains; preload\r\n"
+      -> "\r\n"
+      reading 610 bytes...
+      -> "{\n  \"id\": \"btok_1JhfDCAWOtgoysogF0IbYRWH\",\n  \"object\": \"token\",\n  \"bank_account\": {\n    \"id\": \"ba_1JhfDCAWOtgoysogLB5vljcp\",\n    \"object\": \"bank_account\",\n    \"account_holder_name\": \"Jim Smith\",\n    \"account_holder_type\": \"individual\",\n    \"account_type\": null,\n    \"bank_name\": \"STRIPE TEST BANK\",\n    \"country\": \"US\",\n    \"currency\": \"usd\",\n    \"fingerprint\": \"uCkXlMFxqys7GosR\",\n    \"last4\": \"6789\",\n    \"name\": \"Jim Smith\",\n    \"routing_number\": \"110000000\",\n    \"status\": \"new\"\n  },\n  \"client_ip\": \"172.74.90.160\",\n  \"created\": 1633546290,\n  \"livemode\": false,\n  \"type\": \"bank_account\",\n  \"used\": false\n}\n"
+      read 610 bytes
+      Conn close
+      opening connection to api.stripe.com:443...
+      opened
+      starting SSL for api.stripe.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES128-GCM-SHA256
+      <- "POST /v1/customers HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic c2tfdGVzdF8zT0Q0VGRLU0lPaERPTDIxNDZKSmNDNzk6\r\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.123.0\r\nStripe-Version: 2015-04-07\r\nX-Stripe-Client-User-Agent: {\"bindings_version\":\"1.123.0\",\"lang\":\"ruby\",\"lang_version\":\"2.6.6 p146 (2020-03-31)\",\"platform\":\"x86_64-darwin20\",\"publisher\":\"active_merchant\"}\r\nX-Stripe-Client-User-Metadata: {\"ip\":null}\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nHost: api.stripe.com\r\nContent-Length: 36\r\n\r\n"
+      <- "source=btok_1JhfDCAWOtgoysogF0IbYRWH"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Wed, 06 Oct 2021 18:51:31 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 1713\r\n"
+      -> "Connection: close\r\n"
+      -> "access-control-allow-credentials: true\r\n"
+      -> "access-control-allow-methods: GET, POST, HEAD, OPTIONS, DELETE\r\n"
+      -> "access-control-allow-origin: *\r\n"
+      -> "access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required\r\n"
+      -> "access-control-max-age: 300\r\n"
+      -> "cache-control: no-cache, no-store\r\n"
+      -> "request-id: req_CfMAs2B351RDr0\r\n"
+      -> "stripe-version: 2015-04-07\r\n"
+      -> "Strict-Transport-Security: max-age=31556926; includeSubDomains; preload\r\n"
+      -> "\r\n"
+      reading 1713 bytes...
+      -> "{\n  \"id\": \"cus_KMNzQZK4SN7Agn\",\n  \"object\": \"customer\",\n  \"account_balance\": 0,\n  \"address\": null,\n  \"balance\": 0,\n  \"created\": 1633546290,\n  \"currency\": null,\n  \"default_source\": \"ba_1JhfDCAWOtgoysogLB5vljcp\",\n  \"delinquent\": false,\n  \"description\": null,\n  \"discount\": null,\n  \"email\": null,\n  \"invoice_prefix\": \"02D58981\",\n  \"invoice_settings\": {\n    \"custom_fields\": null,\n    \"default_payment_method\": null,\n    \"footer\": null\n  },\n  \"livemode\": false,\n  \"metadata\": {\n  },\n  \"name\": null,\n  \"next_invoice_sequence\": 1,\n  \"phone\": null,\n  \"preferred_locales\": [\n\n  ],\n  \"shipping\": null,\n  \"sources\": {\n    \"object\": \"list\",\n    \"data\": [\n      {\n        \"id\": \"ba_1JhfDCAWOtgoysogLB5vljcp\",\n        \"object\": \"bank_account\",\n        \"account_holder_name\": \"Jim Smith\",\n        \"account_holder_type\": \"individual\",\n        \"account_type\": null,\n        \"bank_name\": \"STRIPE TEST BANK\",\n        \"country\": \"US\",\n        \"currency\": \"usd\",\n        \"customer\": \"cus_KMNzQZK4SN7Agn\",\n        \"fingerprint\": \"uCkXlMFxqys7GosR\",\n        \"last4\": \"6789\",\n        \"metadata\": {\n        },\n        \"name\": \"Jim Smith\",\n        \"routing_number\": \"110000000\",\n        \"status\": \"new\"\n      }\n    ],\n    \"has_more\": false,\n    \"total_count\": 1,\n    \"url\": \"/v1/customers/cus_KMNzQZK4SN7Agn/sources\"\n  },\n  \"subscriptions\": {\n    \"object\": \"list\",\n    \"data\": [\n\n    ],\n    \"has_more\": false,\n    \"total_count\": 0,\n    \"url\": \"/v1/customers/cus_KMNzQZK4SN7Agn/subscriptions\"\n  },\n  \"tax_exempt\": \"none\",\n  \"tax_ids\": {\n    \"object\": \"list\",\n    \"data\": [\n\n    ],\n    \"has_more\": false,\n    \"total_count\": 0,\n    \"url\": \"/v1/customers/cus_KMNzQZK4SN7Agn/tax_ids\"\n  },\n  \"tax_info\": null,\n  \"tax_info_verification\": null\n}\n"
+      read 1713 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
   def post_scrubbed_with_emv_data
     <<-POST_SCRUBBED
       opening connection to api.stripe.com:443...
@@ -1796,6 +1857,63 @@ class StripeTest < Test::Unit::TestCase
       reading 1303 bytes...
       -> "{\n  \"id\": \"ch_155MZJ2gKyKnHxtY1dGqFhSb\",\n  \"object\": \"charge\",\n  \"created\": 1417549457,\n  \"livemode\": false,\n  \"paid\": true,\n  \"amount\": 100,\n  \"currency\": \"usd\",\n  \"refunded\": false,\n  \"captured\": true,\n  \"refunds\": [],\n  \"card\": {\n    \"id\": \"card_155MZJ2gKyKnHxtYihrJ8z94\",\n    \"object\": \"card\",\n    \"last4\": \"4242\",\n    \"brand\": \"Visa\",\n    \"funding\": \"credit\",\n    \"exp_month\": 9,\n    \"exp_year\": 2015,\n    \"fingerprint\": \"944LvWcY01HVTbVc\",\n    \"country\": \"US\",\n    \"name\": \"Longbob Longsen\",\n    \"address_line1\": null,\n    \"address_line2\": null,\n    \"address_city\": null,\n    \"address_state\": null,\n    \"address_zip\": null,\n    \"address_country\": null,\n    \"cvc_check\": \"pass\",\n    \"address_line1_check\": null,\n    \"address_zip_check\": null,\n    \"dynamic_last4\": null,\n    \"customer\": null,\n    \"type\": \"Visa\"\n  },\n  \"balance_transaction\": \"txn_155MZJ2gKyKnHxtYxpYDI5OW\",\n  \"failure_message\": null,\n  \"failure_code\": null,\n  \"amount_refunded\": 0,\n  \"customer\": null,\n  \"invoice\": null,\n  \"description\": \"ActiveMerchant Test Purchase\",\n  \"dispute\": null,\n  \"metadata\": {\n    \"email\": \"wow@example.com\"\n  },\n  \"statement_description\": null,\n  \"fraud_details\": {\n    \"stripe_report\": \"unavailable\",\n    \"user_report\": null\n  },\n  \"receipt_email\": null,\n  \"receipt_number\": null,\n  \"shipping\": null\n}\n"
       read 1303 bytes
+      Conn close
+    POST_SCRUBBED
+  end
+
+  def post_scrubbed_with_account_number
+    <<-POST_SCRUBBED
+      opening connection to api.stripe.com:443...
+      opened
+      starting SSL for api.stripe.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES128-GCM-SHA256
+      <- "POST /v1/tokens?bank_account[account_number]=[FILTERED]&bank_account[country]=US&bank_account[currency]=usd&bank_account[routing_number]=110000000&bank_account[name]=Jim+Smith&bank_account[account_holder_type]=individual HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic [FILTERED]\r\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.123.0\r\nStripe-Version: 2015-04-07\r\nX-Stripe-Client-User-Agent: {\"bindings_version\":\"1.123.0\",\"lang\":\"ruby\",\"lang_version\":\"2.6.6 p146 (2020-03-31)\",\"platform\":\"x86_64-darwin20\",\"publisher\":\"active_merchant\"}\r\nX-Stripe-Client-User-Metadata: {\"ip\":null}\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nHost: api.stripe.com\r\nContent-Length: 0\r\n\r\n"
+      <- ""
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Wed, 06 Oct 2021 18:51:30 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 610\r\n"
+      -> "Connection: close\r\n"
+      -> "access-control-allow-credentials: true\r\n"
+      -> "access-control-allow-methods: GET, POST, HEAD, OPTIONS, DELETE\r\n"
+      -> "access-control-allow-origin: *\r\n"
+      -> "access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required\r\n"
+      -> "access-control-max-age: 300\r\n"
+      -> "cache-control: no-cache, no-store\r\n"
+      -> "request-id: req_cueTxQR09SjIOA\r\n"
+      -> "stripe-version: 2015-04-07\r\n"
+      -> "Strict-Transport-Security: max-age=31556926; includeSubDomains; preload\r\n"
+      -> "\r\n"
+      reading 610 bytes...
+      -> "{\n  \"id\": \"btok_1JhfDCAWOtgoysogF0IbYRWH\",\n  \"object\": \"token\",\n  \"bank_account\": {\n    \"id\": \"ba_1JhfDCAWOtgoysogLB5vljcp\",\n    \"object\": \"bank_account\",\n    \"account_holder_name\": \"Jim Smith\",\n    \"account_holder_type\": \"individual\",\n    \"account_type\": null,\n    \"bank_name\": \"STRIPE TEST BANK\",\n    \"country\": \"US\",\n    \"currency\": \"usd\",\n    \"fingerprint\": \"uCkXlMFxqys7GosR\",\n    \"last4\": \"6789\",\n    \"name\": \"Jim Smith\",\n    \"routing_number\": \"110000000\",\n    \"status\": \"new\"\n  },\n  \"client_ip\": \"172.74.90.160\",\n  \"created\": 1633546290,\n  \"livemode\": false,\n  \"type\": \"bank_account\",\n  \"used\": false\n}\n"
+      read 610 bytes
+      Conn close
+      opening connection to api.stripe.com:443...
+      opened
+      starting SSL for api.stripe.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES128-GCM-SHA256
+      <- "POST /v1/customers HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic [FILTERED]\r\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.123.0\r\nStripe-Version: 2015-04-07\r\nX-Stripe-Client-User-Agent: {\"bindings_version\":\"1.123.0\",\"lang\":\"ruby\",\"lang_version\":\"2.6.6 p146 (2020-03-31)\",\"platform\":\"x86_64-darwin20\",\"publisher\":\"active_merchant\"}\r\nX-Stripe-Client-User-Metadata: {\"ip\":null}\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nHost: api.stripe.com\r\nContent-Length: 36\r\n\r\n"
+      <- "source=btok_1JhfDCAWOtgoysogF0IbYRWH"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Wed, 06 Oct 2021 18:51:31 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 1713\r\n"
+      -> "Connection: close\r\n"
+      -> "access-control-allow-credentials: true\r\n"
+      -> "access-control-allow-methods: GET, POST, HEAD, OPTIONS, DELETE\r\n"
+      -> "access-control-allow-origin: *\r\n"
+      -> "access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required\r\n"
+      -> "access-control-max-age: 300\r\n"
+      -> "cache-control: no-cache, no-store\r\n"
+      -> "request-id: req_CfMAs2B351RDr0\r\n"
+      -> "stripe-version: 2015-04-07\r\n"
+      -> "Strict-Transport-Security: max-age=31556926; includeSubDomains; preload\r\n"
+      -> "\r\n"
+      reading 1713 bytes...
+      -> "{\n  \"id\": \"cus_KMNzQZK4SN7Agn\",\n  \"object\": \"customer\",\n  \"account_balance\": 0,\n  \"address\": null,\n  \"balance\": 0,\n  \"created\": 1633546290,\n  \"currency\": null,\n  \"default_source\": \"ba_1JhfDCAWOtgoysogLB5vljcp\",\n  \"delinquent\": false,\n  \"description\": null,\n  \"discount\": null,\n  \"email\": null,\n  \"invoice_prefix\": \"02D58981\",\n  \"invoice_settings\": {\n    \"custom_fields\": null,\n    \"default_payment_method\": null,\n    \"footer\": null\n  },\n  \"livemode\": false,\n  \"metadata\": {\n  },\n  \"name\": null,\n  \"next_invoice_sequence\": 1,\n  \"phone\": null,\n  \"preferred_locales\": [\n\n  ],\n  \"shipping\": null,\n  \"sources\": {\n    \"object\": \"list\",\n    \"data\": [\n      {\n        \"id\": \"ba_1JhfDCAWOtgoysogLB5vljcp\",\n        \"object\": \"bank_account\",\n        \"account_holder_name\": \"Jim Smith\",\n        \"account_holder_type\": \"individual\",\n        \"account_type\": null,\n        \"bank_name\": \"STRIPE TEST BANK\",\n        \"country\": \"US\",\n        \"currency\": \"usd\",\n        \"customer\": \"cus_KMNzQZK4SN7Agn\",\n        \"fingerprint\": \"uCkXlMFxqys7GosR\",\n        \"last4\": \"6789\",\n        \"metadata\": {\n        },\n        \"name\": \"Jim Smith\",\n        \"routing_number\": \"110000000\",\n        \"status\": \"new\"\n      }\n    ],\n    \"has_more\": false,\n    \"total_count\": 1,\n    \"url\": \"/v1/customers/cus_KMNzQZK4SN7Agn/sources\"\n  },\n  \"subscriptions\": {\n    \"object\": \"list\",\n    \"data\": [\n\n    ],\n    \"has_more\": false,\n    \"total_count\": 0,\n    \"url\": \"/v1/customers/cus_KMNzQZK4SN7Agn/subscriptions\"\n  },\n  \"tax_exempt\": \"none\",\n  \"tax_ids\": {\n    \"object\": \"list\",\n    \"data\": [\n\n    ],\n    \"has_more\": false,\n    \"total_count\": 0,\n    \"url\": \"/v1/customers/cus_KMNzQZK4SN7Agn/tax_ids\"\n  },\n  \"tax_info\": null,\n  \"tax_info_verification\": null\n}\n"
+      read 1713 bytes
       Conn close
     POST_SCRUBBED
   end


### PR DESCRIPTION
For the Stripe and Stripe Payment Intents gateways, when a check/e-check `store` transaction is performed the account_number should be scrubbed.

ECS-2001

Test Summary
Local:
4932 tests, 74350 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
141 tests, 747 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
74 tests, 338 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.6486% passed
The remote test failure returned this message "Account acct_17FRNfIPBJTitsen already has the maximum 200 external accounts attached." I am not sure how to fix this as I believe it is not related to a change I made but rather this account has been tested too much.