### PR TITLE
Stripe PI: add name on card to billing details & do some refactoring

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,11 @@
 * CardStream: Support passing country_code in request [dsmcclain] #4139
 * Adyen: Adjust phone number mapping [aenand] #4138
 * Mit: Change how parameters are converted to JSON [tatsianaclifton] #4140
+<<<<<<< HEAD
 * Stripe: Add account_number to scrubbing [aenand] #4145
+=======
+* Stripe PI: add name on card to billing_details [dsmcclain] #4146
+>>>>>>> 28760c2b (Stripe PI: refactor `add_payment_method_token` method)
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -10,6 +10,10 @@ module ActiveMerchant #:nodoc:
         @success
       end
 
+      def failure?
+        !success?
+      end
+
       def test?
         @test
       end

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -593,6 +593,19 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'Ottawa', billing['city']
   end
 
+  def test_create_payment_intent_with_name_if_billing_address_absent
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      confirm: true
+    }
+    name_on_card = [@visa_card.first_name, @visa_card.last_name].join(' ')
+
+    assert response = @gateway.create_intent(@amount, @visa_card, options)
+    assert_success response
+    assert_equal name_on_card, response.params.dig('charges', 'data')[0].dig('billing_details', 'name')
+  end
+
   def test_create_payment_intent_with_connected_account
     transfer_group = 'XFERGROUP'
     application_fee = 100


### PR DESCRIPTION
This PR contains two commits.

The first commit includes logic for adding the name attached to a credit card to `billing_details.name` in cases where no other `billing_address` exists.

The second commit is optional, and represents a refactoring of the `add_payment_method_token` method within the gateway adapter. This file is becoming difficult to maintain, and this proposal is a small step toward making it a little easier to read and modify.

Full test suite was run on each commit separately, both achieving 100% passing.

Local:
4931 tests, 74348 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
716 files inspected, no offenses detected

Remote:
Loaded suite test/remote/gateways/remote_stripe_payment_intents_test
63 tests, 302 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
