### PR TITLE
Nuvei (SafeCharge): Add support for `email` field in capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@
 * TransFirst: Scrub account number [aenand] #4152
 * Paysafe: Update supported countries list [meagabeth] #4154
 * dLocal: Update supported countries list [mbreenlyles] #4155
+* SafeCharge: Add support for email field in capture [rachelkirk] #4153
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -62,6 +62,7 @@ module ActiveMerchant #:nodoc:
         post[:sg_CCToken] = token
         post[:sg_ExpMonth] = exp_month
         post[:sg_ExpYear] = exp_year
+        post[:sg_Email] = options[:email]
 
         commit(post)
       end

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -200,7 +200,7 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, extra)
     assert_success auth
 
-    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert capture = @gateway.capture(@amount, auth.authorization, extra)
     assert_success capture
     assert_equal 'Success', capture.message
   end

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -148,6 +148,16 @@ class SafeChargeTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_capture_with_options
+    capture = stub_comms do
+      @gateway.capture(@amount, 'auth|transaction_id|token|month|year|amount|currency', @options.merge(email: 'slowturtle86@aol.com'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/sg_Email/, data)
+    end.respond_with(successful_capture_response)
+
+    assert_success capture
+  end
+
   def test_failed_capture
     @gateway.expects(:ssl_post).returns(failed_capture_response)
 


### PR DESCRIPTION
[CE-1992](https://spreedly.atlassian.net/browse/CE-1992)

Note: You will need to be connected to the VPN to run remote tests for this gateway.
Unit:
25 tests, 136 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
29 tests, 77 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.5517% passed
test_successful_regular_purchase_through_3ds_flow_with_invalid_pa_res(RemoteSafeChargeTest) - This test was failing before my changes.

Local:
4932 tests, 74352 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed