### PR TITLE
NMI: Add descriptors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@
 * dLocal: Update supported countries list [mbreenlyles] #4155
 * SafeCharge: Add support for email field in capture [rachelkirk] #4153
 * Paysafe: Remove invalid code [meagabeth] #4156
+* NMI: Add descriptor fields [ajawadmirza] #4157
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -236,6 +236,19 @@ module ActiveMerchant #:nodoc:
           post[:shipping_zip] = shipping_address[:zip]
           post[:shipping_phone] = shipping_address[:phone]
         end
+
+        if (descriptor = options[:descriptors])
+          post[:descriptor] = descriptor[:descriptor]
+          post[:descriptor_phone] = descriptor[:descriptor_phone]
+          post[:descriptor_address] = descriptor[:descriptor_address]
+          post[:descriptor_city] = descriptor[:descriptor_city]
+          post[:descriptor_state] = descriptor[:descriptor_state]
+          post[:descriptor_postal] = descriptor[:descriptor_postal]
+          post[:descriptor_country] = descriptor[:descriptor_country]
+          post[:descriptor_mcc] = descriptor[:descriptor_mcc]
+          post[:descriptor_merchant_id] = descriptor[:descriptor_merchant_id]
+          post[:descriptor_url] = descriptor[:descriptor_url]
+        end
       end
 
       def add_vendor_data(post, options)

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -24,6 +24,18 @@ class RemoteNmiTest < Test::Unit::TestCase
     @level3_options = {
       tax: 5.25, shipping: 10.51, ponumber: 1002
     }
+    @descriptor_options = {
+      descriptor: 'test',
+      descriptor_phone: '123',
+      descriptor_address: 'address',
+      descriptor_city: 'city',
+      descriptor_state: 'state',
+      descriptor_postal: 'postal',
+      descriptor_country: 'country',
+      descriptor_mcc: 'mcc',
+      descriptor_merchant_id: '120',
+      descriptor_url: 'url'
+    }
   end
 
   def test_invalid_login
@@ -125,6 +137,16 @@ class RemoteNmiTest < Test::Unit::TestCase
 
     assert response = @gateway.authorize(@amount, @credit_card, options)
     assert_success response
+    assert_equal 'Succeeded', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_descriptors
+    options = @options.merge({ descriptors: @descriptor_options })
+
+    assert response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert response.test?
     assert_equal 'Succeeded', response.message
     assert response.authorization
   end

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -16,6 +16,18 @@ class NmiTest < Test::Unit::TestCase
       recurring: true, order_id: '#1001', description: 'AM test', currency: 'GBP', dup_seconds: 15,
       customer: '123', tax: 5.25, shipping: 10.51, ponumber: 1002
     }
+    @descriptor_options = {
+      descriptor: 'test',
+      descriptor_phone: '123',
+      descriptor_address: 'address',
+      descriptor_city: 'city',
+      descriptor_state: 'state',
+      descriptor_postal: 'postal',
+      descriptor_country: 'country',
+      descriptor_mcc: 'mcc',
+      descriptor_merchant_id: '120',
+      descriptor_url: 'url'
+    }
   end
 
   def test_successful_purchase
@@ -156,6 +168,27 @@ class NmiTest < Test::Unit::TestCase
     assert_success response
     assert response.test?
     assert_equal 'Succeeded', response.message
+  end
+
+  def test_purchase_with_descriptor_options
+    options = @transaction_options.merge({ descriptors: @descriptor_options })
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/descriptor=test/, data)
+      assert_match(/descriptor_phone=123/, data)
+      assert_match(/descriptor_address=address/, data)
+      assert_match(/descriptor_city=city/, data)
+      assert_match(/descriptor_state=state/, data)
+      assert_match(/descriptor_postal=postal/, data)
+      assert_match(/descriptor_country=country/, data)
+      assert_match(/descriptor_mcc=mcc/, data)
+      assert_match(/descriptor_merchant_id=120/, data)
+      assert_match(/descriptor_url=url/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
   end
 
   def test_authorize_with_options


### PR DESCRIPTION
Added `descriptors` gateway specific fields to the
NMI gateway along with unit and remote tests.

CE-1970
Unit:
4938 tests, 74380 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
43 tests, 161 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Rubocop:
716 files inspected, no offenses detected