### PR TITLE
Add bank account info scrubbing tests for multiple gateways

### DIFF
--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -827,6 +827,15 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:password], transcript)
   end
 
+  def test_account_number_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @check, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+    
+    assert_scrubbed(@check.account_number, clean_transcript)
+  end
+
   def test_verify_credentials
     assert @gateway.verify_credentials
 

--- a/test/remote/gateways/remote_blue_pay_test.rb
+++ b/test/remote/gateways/remote_blue_pay_test.rb
@@ -207,4 +207,13 @@ class BluePayTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, clean_transcript)
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
   end
+
+  def test_account_number_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, check, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(check.account_number, clean_transcript)
+  end
 end

--- a/test/remote/gateways/remote_bridge_pay_test.rb
+++ b/test/remote/gateways/remote_bridge_pay_test.rb
@@ -142,4 +142,13 @@ class RemoteBridgePayTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
   end
+
+  def test_account_number_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(150, @check, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@check.account_number, clean_transcript)
+  end
 end

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -234,6 +234,16 @@ class RemoteForteTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
   end
 
+  def test_account_number_scrubbing
+    transcript = capture_transcript(@gateway) do 
+      @gateway.purchase(@amount, @check, @options)
+    end
+
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@check.account_number, clean_transcript)
+  end
+
   private
 
   def wait_for_authorization_to_clear

--- a/test/remote/gateways/remote_hps_test.rb
+++ b/test/remote/gateways/remote_hps_test.rb
@@ -374,6 +374,15 @@ class RemoteHpsTest < Test::Unit::TestCase
     assert_scrubbed(credit_card.payment_cryptogram, transcript)
   end
 
+  def test_account_number_scrubbing
+    options = @options.merge(company_name: 'Hot Buttered Toast Incorporated')
+    transcript = capture_transcript(@check_gateway) do
+      @check_gateway.purchase(@check_amount, @check, options)
+    end
+    clean_transcript = @check_gateway.scrub(transcript)
+    assert_scrubbed(@check.account_number, clean_transcript)
+  end
+
   def test_successful_purchase_with_apple_pay_raw_cryptogram_with_eci
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',

--- a/test/remote/gateways/remote_vanco_test.rb
+++ b/test/remote/gateways/remote_vanco_test.rb
@@ -97,6 +97,15 @@ class RemoteVancoTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:password], transcript)
   end
 
+  def test_account_number_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @check, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@check.account_number, clean_transcript)
+  end
+
   def test_invalid_login
     gateway = VancoGateway.new(
       user_id: 'unknown_id',

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -281,6 +281,11 @@ class HpsTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrub), post_scrub
   end
 
+  def test_account_number_scrubbing
+    assert_equal @gateway.scrub(pre_scrubbed_account_number),  post_scrubbed_account_number
+  end
+
+
   def test_successful_purchase_with_apple_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
@@ -1345,5 +1350,59 @@ reading 1067 bytes...
 read 1067 bytes
 Conn close
     }
+  end
+
+  def pre_scrubbed_account_number
+    <<~PRE_SCRUBBED
+      opening connection to posgateway.secureexchange.net:443...
+      opened
+      starting SSL for posgateway.secureexchange.net:443...
+      SSL established, protocol: TLSv1.2, cipher: DHE-RSA-AES256-SHA256
+      <- "POST /Hps.Exchange.PosGateway/PosGatewayService.asmx?wsdl HTTP/1.1\r\nContent-Type: text/xml\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: posgateway.secureexchange.net\r\nContent-Length: 1029\r\n\r\n"
+      <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP:Envelope xmlns:SOAP=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:hps=\"http://Hps.Exchange.PosGateway\"><SOAP:Body><hps:PosRequest><hps:Ver1.0><hps:Header><hps:SecretAPIKey/></hps:Header><hps:Transaction><hps:CheckSale><hps:Block1><hps:CheckAction>SALE</hps:CheckAction><hps:AccountInfo><hps:RoutingNumber>122000030</hps:RoutingNumber><hps:AccountNumber>1357902468</hps:AccountNumber><hps:CheckNumber>1234</hps:CheckNumber><hps:AccountType>SAVINGS</hps:AccountType></hps:AccountInfo><hps:CheckType>PERSONAL</hps:CheckType><hps:Amt>20.00</hps:Amt><hps:SECCode>WEB</hps:SECCode><hps:ConsumerInfo><hps:FirstName>Jim</hps:FirstName><hps:LastName>Smith</hps:LastName><hps:CheckName>Hot Buttered Toast Incorporated</hps:CheckName></hps:ConsumerInfo><hps:AdditionalTxnFields><hps:Description>Store Purchase</hps:Description><hps:InvoiceNbr>1</hps:InvoiceNbr></hps:AdditionalTxnFields></hps:Block1></hps:CheckSale></hps:Transaction></hps:Ver1.0></hps:PosRequest></SOAP:Body></SOAP:Envelope>"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Cache-Control: no-cache,no-store\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "Content-Type: text/xml; charset=utf-8\r\n"
+      -> "Expires: -1\r\n"
+      -> "X-Frame-Options: DENY\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains;\r\n"
+      -> "Date: Tue, 12 Oct 2021 15:17:29 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Content-Length: 543\r\n"
+      -> "\r\n"
+      reading 543 bytes...
+      -> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><PosResponse rootUrl=\"https://posgateway.secureexchange.net/Hps.Exchange.PosGateway\" xmlns=\"http://Hps.Exchange.PosGateway\"><Ver1.0><Header><GatewayTxnId>1589181322</GatewayTxnId><GatewayRspCode>-2</GatewayRspCode><GatewayRspMsg>Authentication Error</GatewayRspMsg></Header></Ver1.0></PosResponse></soap:Body></soap:Envelope>"
+      read 543 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed_account_number
+    <<~POST_SCRUBBED
+      opening connection to posgateway.secureexchange.net:443...
+      opened
+      starting SSL for posgateway.secureexchange.net:443...
+      SSL established, protocol: TLSv1.2, cipher: DHE-RSA-AES256-SHA256
+      <- "POST /Hps.Exchange.PosGateway/PosGatewayService.asmx?wsdl HTTP/1.1\r\nContent-Type: text/xml\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: posgateway.secureexchange.net\r\nContent-Length: 1029\r\n\r\n"
+      <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP:Envelope xmlns:SOAP=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:hps=\"http://Hps.Exchange.PosGateway\"><SOAP:Body><hps:PosRequest><hps:Ver1.0><hps:Header><hps:SecretAPIKey/></hps:Header><hps:Transaction><hps:CheckSale><hps:Block1><hps:CheckAction>SALE</hps:CheckAction><hps:AccountInfo><hps:RoutingNumber>[FILTERED]</hps:RoutingNumber><hps:AccountNumber>[FILTERED]</hps:AccountNumber><hps:CheckNumber>1234</hps:CheckNumber><hps:AccountType>SAVINGS</hps:AccountType></hps:AccountInfo><hps:CheckType>PERSONAL</hps:CheckType><hps:Amt>20.00</hps:Amt><hps:SECCode>WEB</hps:SECCode><hps:ConsumerInfo><hps:FirstName>Jim</hps:FirstName><hps:LastName>Smith</hps:LastName><hps:CheckName>Hot Buttered Toast Incorporated</hps:CheckName></hps:ConsumerInfo><hps:AdditionalTxnFields><hps:Description>Store Purchase</hps:Description><hps:InvoiceNbr>1</hps:InvoiceNbr></hps:AdditionalTxnFields></hps:Block1></hps:CheckSale></hps:Transaction></hps:Ver1.0></hps:PosRequest></SOAP:Body></SOAP:Envelope>"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Cache-Control: no-cache,no-store\r\n"
+      -> "Pragma: no-cache\r\n"
+      -> "Content-Type: text/xml; charset=utf-8\r\n"
+      -> "Expires: -1\r\n"
+      -> "X-Frame-Options: DENY\r\n"
+      -> "X-Content-Type-Options: nosniff\r\n"
+      -> "Strict-Transport-Security: max-age=31536000; includeSubDomains;\r\n"
+      -> "Date: Tue, 12 Oct 2021 15:17:29 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Content-Length: 543\r\n"
+      -> "\r\n"
+      reading 543 bytes...
+      -> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><PosResponse rootUrl=\"https://posgateway.secureexchange.net/Hps.Exchange.PosGateway\" xmlns=\"http://Hps.Exchange.PosGateway\"><Ver1.0><Header><GatewayTxnId>1589181322</GatewayTxnId><GatewayRspCode>-2</GatewayRspCode><GatewayRspMsg>Authentication Error</GatewayRspMsg></Header></Ver1.0></PosResponse></soap:Body></soap:Envelope>"
+      read 543 bytes
+      Conn close
+    POST_SCRUBBED
   end
 end


### PR DESCRIPTION
Add bank account info scrubbing tests for Authorize.net, BluePay, BridgePay, Forte, Heartland Payment Services, Vanco

The scrub methods for these gateways do include scrubbing bank account info but do not have unit and remote tests to ensure the info is filtered out.
Test Summary
Local:

Authorize_net Unit:
108 tests, 640 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Authorize_net Remote:
74 tests, 270 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

BluePay Unit:
30 tests, 142 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
BluePay Remote:
19 tests, 90 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

BridgePay Unit:
15 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
BridgePay Remote:
18 tests, 40 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Forte unit:
22 tests, 85 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Forte Remote:
24 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Heartland Payment Services Unit:
61 tests, 295 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Heartland Payment Services Remote:
58 tests, 155 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.5517% passed
**I had 2 failures due to authentication errors. These are unrelated to changes I made**

Vanco Unit:
10 tests, 46 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Vanco Remote:
3 tests, 29 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.3077% passed
**1 test failed due to incorrect error message. This is unrelated to changes I made**
Vanco Unit: