### PR TITLE
Moka: send correct amount in refund

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Paysafe: Remove invalid code [meagabeth] #4156
 * NMI: Add descriptor fields [ajawadmirza] #4157
 * Authorize.net: Add tests for scrubbing banking account info (in addition to BluePay, BridgePay, Forte, HPS, and Vanco Gateways)[aenand] #4159
+* Moka: Send refund amount with decimal [dsmcclain] #4160
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/moka.rb
+++ b/lib/active_merchant/billing/gateways/moka.rb
@@ -170,7 +170,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_amount(post, money)
-        post[:PaymentDealerRequest][:Amount] = money || 0
+        post[:PaymentDealerRequest][:Amount] = amount(money) || 0
       end
 
       def add_additional_auth_purchase_data(post, options)

--- a/test/unit/gateways/moka_test.rb
+++ b/test/unit/gateways/moka_test.rb
@@ -83,6 +83,14 @@ class MokaTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_partial_refund
+    stub_comms do
+      @gateway.refund(50, 'Test-9732c2ce-08d9-4ff6-a89f-bd3fa345811c')
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal '0.50', JSON.parse(data)['PaymentDealerRequest']['Amount']
+    end.respond_with(successful_refund_response)
+  end
+
   def test_failed_refund
     @gateway.expects(:ssl_post).returns(failed_refund_response)
 


### PR DESCRIPTION
Previously, refund was sending the amount in cents instead of converting
it to dollar format.

CE-2065

Rubocop:
716 files inspected, no offenses detected

Unit:
4940 tests, 74385 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_moka_test
24 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed