### PR TITLE
GlobalCollect: Append URI to the URL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * NMI: Add descriptor fields [ajawadmirza] #4157
 * Authorize.net: Add tests for scrubbing banking account info (in addition to BluePay, BridgePay, Forte, HPS, and Vanco Gateways)[aenand] #4159
 * Moka: Send refund amount with decimal [dsmcclain] #4160
+* GlobalCollect: Append URI to the URL [naashton] #4162
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -263,7 +263,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def url(action, authorization)
-        return preproduction_url if @options[:url_override].to_s == 'preproduction'
+        return preproduction_url + uri(action, authorization) if @options[:url_override].to_s == 'preproduction'
 
         (test? ? test_url : live_url) + uri(action, authorization)
       end

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -58,7 +58,7 @@ class GlobalCollectTest < Test::Unit::TestCase
     stub_comms do
       @gateway.authorize(@accepted_amount, @credit_card)
     end.check_request do |endpoint, _data, _headers|
-      assert_match(/world\.preprod\.api-ingenico\.com/, endpoint)
+      assert_match(/world\.preprod\.api-ingenico\.com\/v1\/#{@gateway.options[:merchant_id]}/, endpoint)
     end.respond_with(successful_authorize_response)
   end
 


### PR DESCRIPTION
For preproduction, the resource needed to be appended to the URL

CE-2076

Unit: 29 tests, 140 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 25 tests, 61 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96% passed