### PR TITLE
Adyen: Add external platform information

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@
 * Authorize.net: Add tests for scrubbing banking account info (in addition to BluePay, BridgePay, Forte, HPS, and Vanco Gateways)[aenand] #4159
 * Moka: Send refund amount with decimal [dsmcclain] #4160
 * GlobalCollect: Append URI to the URL [naashton] #4162
+* Adyen: Add application info fields [aenand] #4163
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -60,6 +60,7 @@ module ActiveMerchant #:nodoc:
         add_splits(post, options)
         add_recurring_contract(post, options)
         add_network_transaction_reference(post, options)
+        add_application_info(post, options)
         commit('authorise', post, options)
       end
 
@@ -449,6 +450,31 @@ module ActiveMerchant #:nodoc:
         }
 
         post[:recurring] = recurring
+      end
+
+      def add_application_info(post, options)
+        post[:applicationInfo] ||= {}
+        add_external_platform(post, options)
+        add_merchant_application(post, options)
+      end
+
+      def add_external_platform(post, options)
+        return unless options[:externalPlatform]
+
+        post[:applicationInfo][:externalPlatform] = {
+          name: options[:externalPlatform][:name],
+          version: options[:externalPlatform][:version],
+          integrator: options[:externalPlatform][:integrator]
+        }
+      end
+
+      def add_merchant_application(post, options)
+        return unless options[:merchantApplication]
+
+        post[:applicationInfo][:merchantApplication] = {
+          name: options[:merchantApplication][:name],
+          version: options[:merchantApplication][:version]
+        }
       end
 
       def add_installments(post, options)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1190,6 +1190,22 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_auth_application_info
+    options = @options.merge!(
+      externalPlatform: {
+        name: 'Acme',
+        version: '1',
+        integrator: 'abc'
+      },
+      merchantApplication: {
+        name: 'Acme Inc.',
+        version: '2'
+      }
+    )
+    response = @gateway.authorize(@amount, @credit_card, options)
+    assert_success response
+  end
+
   def test_successful_authorize_phone
     @options[:billing_address][:phone] = '1234567890'
     response = @gateway.authorize(@amount, @credit_card, @options)

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -901,6 +901,30 @@ class AdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_auth_application_info
+    options = @options.merge!(
+      externalPlatform: {
+        name: 'Acme',
+        version: '1',
+        integrator: 'abc'
+      },
+      merchantApplication: {
+        name: 'Acme Inc.',
+        version: '2'
+      }
+    )
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'Acme', JSON.parse(data)['applicationInfo']['externalPlatform']['name']
+      assert_equal '1', JSON.parse(data)['applicationInfo']['externalPlatform']['version']
+      assert_equal 'abc', JSON.parse(data)['applicationInfo']['externalPlatform']['integrator']
+      assert_equal 'Acme Inc.', JSON.parse(data)['applicationInfo']['merchantApplication']['name']
+      assert_equal '2', JSON.parse(data)['applicationInfo']['merchantApplication']['version']
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_purchase_with_long_order_id
     options = @options.merge({ order_id: @long_order_id })
     response = stub_comms do


### PR DESCRIPTION
For external platforms to track usage metrics in Adyen they need to be able to pass external platform information via application info. [Adyen documentation](https://docs.adyen.com/api-explorer/#/Payment/v64/post/authorise__reqParam_applicationInfo-externalPlatform)

ECS-2090

Test Summary
Local:
4941 tests, 74390 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
716 files inspected, no offenses detected
Unit:
89 tests, 455 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
120 tests, 408 assertions, 15 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
87.5% passed
**There are remote test failures with a message 3D not authenticated. Not sure why these are failing**