### PR TITLE
Adyen: send original NTID when it exists

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -425,7 +425,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_network_transaction_reference(post, options)
-        return unless ntid = options[:network_transaction_id] || options.dig(:stored_credential, :network_transaction_id)
+        stored_ntid = options.dig(:stored_credential, :original_network_transaction_id) || options.dig(:stored_credential, :network_transaction_id)
+        return unless ntid = options[:network_transaction_id] || stored_ntid
 
         post[:additionalData] = {} unless post[:additionalData]
         post[:additionalData][:networkTxReference] = ntid

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1228,7 +1228,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success capture
     assert_equal '[capture-received]', capture.message
 
-    used_options = stored_credential_options(:recurring, :cardholder, ntid: auth.network_transaction_id)
+    used_options = stored_credential_options(:recurring, :cardholder, ntid: auth.network_transaction_id, original_ntid: auth.network_transaction_id)
     assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
     assert_success purchase
   end
@@ -1242,7 +1242,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success capture
     assert_equal '[capture-received]', capture.message
 
-    used_options = stored_credential_options(:recurring, :cardholder, ntid: auth.network_transaction_id)
+    used_options = stored_credential_options(:recurring, :cardholder, ntid: auth.network_transaction_id, original_ntid: auth.network_transaction_id)
     assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
     assert_success purchase
   end
@@ -1256,7 +1256,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success capture
     assert_equal '[capture-received]', capture.message
 
-    used_options = stored_credential_options(:unscheduled, :cardholder, ntid: auth.network_transaction_id)
+    used_options = stored_credential_options(:unscheduled, :cardholder, ntid: auth.network_transaction_id, original_ntid: auth.network_transaction_id)
     assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
     assert_success purchase
   end
@@ -1270,7 +1270,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success capture
     assert_equal '[capture-received]', capture.message
 
-    used_options = stored_credential_options(:unscheduled, :cardholder, ntid: auth.network_transaction_id)
+    used_options = stored_credential_options(:unscheduled, :cardholder, ntid: auth.network_transaction_id, original_ntid: auth.network_transaction_id)
     assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
     assert_success purchase
   end
@@ -1386,9 +1386,9 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
   private
 
-  def stored_credential_options(*args, ntid: nil)
+  def stored_credential_options(*args, ntid: nil, original_ntid: nil)
     @options.merge(order_id: generate_unique_id,
-                   stored_credential: stored_credential(*args, network_transaction_id: ntid))
+                   stored_credential: stored_credential(*args, original_network_transaction_id: original_ntid, network_transaction_id: ntid))
   end
 
   def assert_void_references_original_authorization(void, auth)


### PR DESCRIPTION
We were previously only sending the most recent network_transaction_id from the stored credential hash. This change prioritizes the `original_network_transaction_id`, if it is present in the stored credential hash, to be sent as the `networkTxReference`, while remaining backward-compatible. There is a new unit test and changes to remote tests to mimic the new stored credential hash and `networkTxReference` field prioritization.

Unit:
91 tests, 470 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
121 tests, 442 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed