### PR TITLE
Payflow: include AuthenticationStatus with 3DS 2.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@
 * Payflow: use proper case for 3DS 2.x element names [bbraschi] #4113
 * Realex: Add support for stored credentials [dsmcclain] #4170
 * Moka: Add support for InstallmentNumber field [dsmcclain] #4172
+* Payflow: include AuthenticationStatus for 3DS 2.x [bbraschi] #4168
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/payflow.rb
+++ b/lib/active_merchant/billing/gateways/payflow.rb
@@ -296,11 +296,19 @@ module ActiveMerchant #:nodoc:
       end
 
       def authentication_status(three_d_secure, xml)
-        if three_d_secure[:authentication_response_status].present?
-          xml.tag! 'Status', three_d_secure[:authentication_response_status]
-        elsif three_d_secure[:directory_response_status].present?
-          xml.tag! 'Status', three_d_secure[:directory_response_status]
+        status = if three_d_secure[:authentication_response_status].present?
+                   three_d_secure[:authentication_response_status]
+                 elsif three_d_secure[:directory_response_status].present?
+                   three_d_secure[:directory_response_status]
         end
+        if status.present?
+          xml.tag! 'Status', status
+          xml.tag! 'AuthenticationStatus', status if version_2_or_newer?(three_d_secure)
+        end
+      end
+
+      def version_2_or_newer?(three_d_secure)
+        three_d_secure[:version]&.start_with?('2')
       end
 
       def credit_card_type(credit_card)


### PR DESCRIPTION
Payflow 3DS 2.x: add missing `AuthenticationStatus`, as per latest guidance from PayPal:

> we added these two fields [~ThreeDSVersion and AuthenticationStatus~] to XMLPay. Here is the schema.

```xml 
<element name = "BuyerAuthResult">
    <complexType content = "elementOnly">
        <sequence>
            <element name = "Status" type = "BuyerAuthStatusEnum"/>
            <element name = "AuthenticationId" type = "Base64Sha1StringType" minOccurs="0" maxOccurs="1"/>
            <element name = "PAReq" type = "BuyerAuthMesgType" minOccurs="0" maxOccurs="1" />
            <element name = "ACSUrl" type = "uriReference" minOccurs="0" maxOccurs="1" />
            <element name = "ECI" type = "ECIType" minOccurs="0" maxOccurs="1" />
            <element name = "CAVV" type = "Base64Sha1StringType" minOccurs="0" maxOccurs="1" />
            <element name = "XID" type = "Base64Sha1StringType" minOccurs="0" maxOccurs="1" />
            <element name = "DSTransactionID" type = "DSTransactionIDType" minOccurs="0" maxOccurs="1" />
            <element name = "`ThreeDSVersion`" type = "ThreeDSVersionType" minOccurs="0" maxOccurs="1" />
            <element name = "AuthenticationStatus" type = "BuyerAuthStatusEnum"/>
        </sequence>
    </complexType>
</element>
```

For 3DS 2.x, `Status` is redundant with `AuthenticationStatus`. Decided to keep it as it has not been reported as being a problem. 