### PR TITLE
Worldpay: `schemeTransactionIdentifier` field for purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -453,6 +453,7 @@ module ActiveMerchant #:nodoc:
             xml.cryptogram payment_method.payment_cryptogram
             xml.eciIndicator format(payment_method.eci, :two_digits)
           end
+          add_stored_credential_options(xml, options)
         end
       end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -203,7 +203,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_success capture
   end
 
-  def test_authorize_and_purchase_with_instalments
+  def test_authorize_and_purchase_with_installments
     assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(instalment: 3))
     assert_success auth
     assert_equal 'SUCCESS', auth.message


### PR DESCRIPTION
This work adds adds the `schemeTransactionIdentifier` to a purchase via the `storedcredentials` field. The failed remote tests below also fail on `upstream master`.

Local: 4945 tests, 74414 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit: 96 tests, 572 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote: 76 tests, 317 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.3684% passed