### PR TITLE
Realex: Add stored credential support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@
 * Adyen: Add application info fields [aenand] #4163
 * Adyen: Send NTID from stored cred hash [curiousepic] #4164
 * Payflow: use proper case for 3DS 2.x element names [bbraschi] #4113
+* Realex: Add support for stored credentials [dsmcclain] #4170
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -151,6 +151,7 @@ module ActiveMerchant
           else
             add_three_d_secure(xml, options)
           end
+          add_stored_credential(xml, options)
           add_comments(xml, options)
           add_address_and_customer_info(xml, options)
         end
@@ -321,6 +322,23 @@ module ActiveMerchant
           xml.tag! 'eci', three_d_secure[:eci]
           xml.tag! 'message_version', version
         end
+      end
+
+      def add_stored_credential(xml, options)
+        return unless stored_credential = options[:stored_credential]
+
+        xml.tag! 'storedcredential' do
+          xml.tag! 'type', stored_credential_type(stored_credential[:reason_type])
+          xml.tag! 'initiator', stored_credential[:initiator]
+          xml.tag! 'sequence', stored_credential[:initial_transaction] ? 'first' : 'subsequent'
+          xml.tag! 'srd', stored_credential[:network_transaction_id]
+        end
+      end
+
+      def stored_credential_type(reason)
+        return 'oneoff' if reason == 'unscheduled'
+
+        reason
       end
 
       def format_address_code(address)


### PR DESCRIPTION
Realex documentation on using Stored Credential/SCA on their API:
https://developer.globalpay.com/api/card-storage#api-credential-on-file

CE-2085

Rubocop:
716 files inspected, no offenses detected

Local:
4943 tests, 74437 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_realex_test
29 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed