### PR TITLE
Moka: add Installment field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@
 * Adyen: Send NTID from stored cred hash [curiousepic] #4164
 * Payflow: use proper case for 3DS 2.x element names [bbraschi] #4113
 * Realex: Add support for stored credentials [dsmcclain] #4170
+* Moka: Add support for InstallmentNumber field [dsmcclain] #4172
 
 == Version 1.123.0 (September 10th, 2021)
 * Paysafe: Add gateway integration [meagabeth] #4085

--- a/lib/active_merchant/billing/gateways/moka.rb
+++ b/lib/active_merchant/billing/gateways/moka.rb
@@ -175,7 +175,8 @@ module ActiveMerchant #:nodoc:
 
       def add_additional_auth_purchase_data(post, options)
         post[:PaymentDealerRequest][:IsPreAuth] = options[:pre_auth]
-        post[:PaymentDealerRequest][:Description] = options[:order_id] if options[:order_id]
+        post[:PaymentDealerRequest][:Description] = options[:description] if options[:description]
+        post[:PaymentDealerRequest][:InstallmentNumber] = options[:installment_number].to_i if options[:installment_number]
         post[:SubMerchantName] = options[:sub_merchant_name] if options[:sub_merchant_name]
         post[:IsPoolPayment] = options[:is_pool_payment] || 0
       end

--- a/test/remote/gateways/remote_moka_test.rb
+++ b/test/remote/gateways/remote_moka_test.rb
@@ -96,6 +96,13 @@ class RemoteMokaTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_installments
+    options = @options.merge(installment_number: 12)
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/moka_test.rb
+++ b/test/unit/gateways/moka_test.rb
@@ -184,6 +184,24 @@ class MokaTest < Test::Unit::TestCase
     end.respond_with(successful_response)
   end
 
+  def test_additional_auth_purchase_fields_are_passed
+    options = @options.merge({
+      description: 'custom purchase',
+      installment_number: 12,
+      sub_merchant_name: 'testco',
+      is_pool_payment: 1
+    })
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      response = JSON.parse(data)
+      assert_equal response['PaymentDealerRequest']['Description'], 'custom purchase'
+      assert_equal response['PaymentDealerRequest']['InstallmentNumber'], 12
+      assert_equal response['SubMerchantName'], 'testco'
+      assert_equal response['IsPoolPayment'], 1
+    end.respond_with(successful_response)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
This PR also fixes the `description` field so that it is passed
correctly.

CE-2086

Rubocop:
716 files inspected, no offenses detected

Local:
4944 tests, 74443 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_moka_test
25 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed