### PR TITLE
Add rexml as a dependency

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('nokogiri', '~> 1.4')
+  s.add_dependency('rexml')
 
   s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('pry')


### PR DESCRIPTION
Starting with Ruby 3, rexml is no longer a default gem. It is now a
bundled gem. This means that when installed with bundler.

More details here:
https://nts.strzibny.name/ruby-stdlib-default-bundled-gems/

The important bit:

> Bundled gems are regular gems that ship with the default Ruby
> installation. These libraries are maintained outside the Ruby core
> team and can be uninstalled if necessary. As with other 3rd-party
> gems, you have to include them into gemspec or gemfile.

So for Ruby 3 compatibility, the dependency should be specified.

Fixes #3851