### PR TITLE
[GWI-7] Worldpay: Adding appley pay payment method

### DIFF
--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -14,11 +14,11 @@ class WorldpayTest < Test::Unit::TestCase
     @token = '|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8'
     @elo_credit_card = credit_card('4514 1600 0000 0008',
       month: 10,
-      year: 2020,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'elo')
+       year: 2020,
+       first_name: 'John',
+       last_name: 'Smith',
+       verification_value: '737',
+       brand: 'elo')
     @nt_credit_card = network_tokenization_credit_card('4895370015293175',
       brand: 'visa',
       eci: '07',
@@ -43,6 +43,14 @@ class WorldpayTest < Test::Unit::TestCase
         sub_id: '1234567'
       }
     }
+
+    @apple_play_network_token = network_tokenization_credit_card('4895370015293175',
+      month: 10,
+      year: 24,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      source: :apple_pay)
   end
 
   def test_successful_authorize
@@ -1161,6 +1169,24 @@ class WorldpayTest < Test::Unit::TestCase
       @gateway.refund(@amount, @options[:order_id], @options)
     end.respond_with(failed_refund_synchronous_response)
     assert_failure response
+  end
+
+  def test_network_token_type_assignation_when_apple_token
+    response = stub_comms do
+      @gateway.authorize(@amount, @apple_play_network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<EMVCO_TOKEN-SSL type="APPLEPAY">), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_network_token_type_assignation_when_network_token
+    response = stub_comms do
+      @gateway.authorize(@amount, @nt_credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<EMVCO_TOKEN-SSL type="NETWORKTOKEN">), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
   end
 
   private


### PR DESCRIPTION
### Related Issues
[GWI-7](https://spreedly.atlassian.net/jira/software/c/projects/GWI/boards/105/backlog?view=detail&selectedIssue=GWI-7&issueLimit=100#:~:text=GWI-1-,GWI-7,-1)

### Description

This PR adds support for the apple pay payment method on the Worldpay adapter by adding a new network token type

### Test Scenarios covered:

- [ ] 1. successful authorize without cardholder name
- [ ] 2. successful authorize with cardholder name
- [ ] 3. successful authorize with cardholder name as empty string
- [ ] 4. unsuccessful authorize without token number
- [ ] 5. unsuccessful authorize with token number as empty string
- [ ] 6. successful authorize with token number
- [ ] 7. unsuccessful authorize with invalid token number
- [ ] 8. unsuccessful authorize without expire date
- [ ] 9. successful authorize with valid expire date
- [ ] 10. unsuccessful authorize without cryptogram
- [ ] 11. unsuccessful authorize with invalid cryptogram
- [ ] 12. successful authorize with valid cryptogram
- [ ] 13. successful purchase with valid card
- [ ] 14. successful purchase with valid card and specific store credentials

explanations:

3) if emoty it will not be included, so is covered by (1).
10, 11, 12) we can only simulate declined transactions like in the (7) case, but validate
            real cryptogram seems that is not possible agains the test environment.
14) given how apple pay works stored credentilas doesnt make much sense, apple tokens
    are translated into real pan numbers at the schema/acquire level.




### TestSuite execution
Finished in 149.298941 seconds.
83 tests, 331 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.5904% passed