### PR TITLE
Safe Charge: Add sg_NotUseCVV field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Ipg: Add new gateway [ajawadmirza] #4171
 * Worldpay: Adding support for google pay and apple pay [cristian] #4180
 * Worldpay: Adding scrubbing for network token transactions [cristian] #4181
+* SafeCharge: Add sg_NotUseCVV field [ajawadmirza] #4177
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -147,6 +147,7 @@ module ActiveMerchant #:nodoc:
         post[:sg_MerchantPhoneNumber] = options[:merchant_phone_number] if options[:merchant_phone_number]
         post[:sg_MerchantName] = options[:merchant_name] if options[:merchant_name]
         post[:sg_ProductID] = options[:product_id] if options[:product_id]
+        post[:sg_NotUseCVV] = options[:not_use_cvv] ? 1 : 0 if options[:not_use_cvv]
       end
 
       def add_payment(post, payment, options = {})

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -205,6 +205,16 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     assert_equal 'Success', capture.message
   end
 
+  def test_successful_authorize_and_capture_with_not_use_cvv
+    @credit_card.verification_value = nil
+    auth = @gateway.authorize(@amount, @credit_card, @options.merge!({ not_use_cvv: true }))
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal 'Success', capture.message
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -128,6 +128,17 @@ class SafeChargeTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_authorize_with_not_use_cvv
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ not_use_cvv: true }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/sg_NotUseCVV=1/, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert response.test?
+  end
+
   def test_failed_authorize
     @gateway.expects(:ssl_post).returns(failed_authorize_response)
 


### PR DESCRIPTION
Added sg_NotUseCVV gateway specific field to the
safe charge gateway along with unit and remote tests.

CE-2084

Remote:
30 tests, 81 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.6667% passed

Rubocop:
719 files inspected, no offenses detected

Unit:
4956 tests, 74516 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed