### PR TITLE
Stripe Payment Intents: Add setup_purchase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 == HEAD
 * Wompi: support gateway [therufs] #4173
+* Stripe Payment Intents: Add setup_purchase [aenand] #4178
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/hash/slice'
+require 'active_merchant/billing/gateways/stripe/stripe_payment_intents_response'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -668,8 +669,8 @@ module ActiveMerchant #:nodoc:
         card = card_from_response(response)
         avs_code = AVS_CODE_TRANSLATOR["line1: #{card['address_line1_check']}, zip: #{card['address_zip_check']}"]
         cvc_code = CVC_CODE_TRANSLATOR[card['cvc_check']]
-
-        Response.new(success,
+        response_class = options[:response_class] || Response
+        response_class.new(success,
           message_from(success, response),
           response,
           test: response_is_test?(response),

--- a/lib/active_merchant/billing/gateways/stripe/stripe_payment_intents_response.rb
+++ b/lib/active_merchant/billing/gateways/stripe/stripe_payment_intents_response.rb
@@ -1,0 +1,6 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class StripePaymentIntentsResponse < Response
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -215,6 +215,16 @@ module ActiveMerchant #:nodoc:
         create_setup_intent(payment_method, options.merge!(confirm: true))
       end
 
+      def setup_purchase(money, options = {})
+        requires!(options, :payment_method_types)
+        post = {}
+        add_currency(post, options, money)
+        add_amount(post, money, options)
+        add_payment_method_types(post, options)
+        options[:response_class] = StripePaymentIntentsResponse
+        commit(:post, 'payment_intents', post, options)
+      end
+
       private
 
       def off_session_request?(options = {})
@@ -431,6 +441,10 @@ module ActiveMerchant #:nodoc:
         end
 
         super(response, options)
+      end
+
+      def add_currency(post, options, money)
+        post[:currency] = options[:currency] || currency(money)
       end
     end
   end

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1003,6 +1003,29 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'succeeded', purchase.params['status']
   end
 
+  def test_setup_purchase
+    options = {
+      currency: 'USD',
+      payment_method_types: %w[afterpay_clearpay card]
+    }
+
+    assert response = @gateway.setup_purchase(@amount, options)
+    assert_equal 'requires_payment_method', response.params['status']
+    assert response.params['client_secret'].start_with?('pi')
+    assert_instance_of StripePaymentIntentsResponse, response
+  end
+
+  def test_failed_setup_purchase
+    options = {
+      currency: 'GBP',
+      payment_method_types: %w[afterpay_clearpay card]
+    }
+
+    assert response = @gateway.setup_purchase(@amount, options)
+    assert_failure response
+    assert_match 'The currency provided (gbp) is invalid for one or more payment method types on this PaymentIntent.', response.message
+  end
+
   def test_transcript_scrubbing
     options = {
       currency: 'GBP',

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -450,7 +450,79 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_create_intent_response)
   end
 
+  def test_successful_setup_purchase
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.setup_purchase(@amount, { payment_method_types: %w[afterpay_clearpay card] })
+    end.check_request do |_method, endpoint, data, _headers|
+      assert_match(/payment_method_types\[0\]=afterpay_clearpay&payment_method_types\[1\]=card/, data) if /payment_intents/.match?(endpoint)
+    end.respond_with(successful_setup_purchase)
+  end
+
   private
+
+  def successful_setup_purchase
+    <<-RESPONSE
+    {
+      "id": "pi_3Jr0wXAWOtgoysog2Sp0iKjo",
+      "object": "payment_intent",
+      "amount": 2000,
+      "amount_capturable": 0,
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+
+        ],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges?payment_intent=pi_3Jr0wXAWOtgoysog2Sp0iKjo"
+      },
+      "client_secret": "pi_3Jr0wXAWOtgoysog2Sp0iKjo_secret_1l5cE3MskZ8AMOZaNdpmgZDCn",
+      "confirmation_method": "automatic",
+      "created": 1635774777,
+      "currency": "usd",
+      "customer": null,
+      "description": null,
+      "invoice": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "metadata": {
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": null,
+      "payment_method_options": {
+        "afterpay_clearpay": {
+          "reference": null
+        },
+        "card": {
+          "installments": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "afterpay_clearpay",
+        "card"
+      ],
+      "receipt_email": null,
+      "review": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_payment_method",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+    RESPONSE
+  end
 
   def successful_create_intent_response
     <<-RESPONSE


### PR DESCRIPTION
ECS-2093

In order to add suppport for Stripe alternative payment methods (APMs), the StripePI gateway must support a `setup_purchase` method. This method takes an `amount`, `currency`, and array of `payment_method_types` then submits a post to the `payment_intents` endpoint. It should return a transaction in the `requires_payment_method` status as the user completes the transaction flow for whichever payment method they selected.

Since Stripe APM's are offsite purchases that could be completed at any point, transactions that flow through the `setup_purchase` will have a response of type `StripePaymentIntentsResponse`. This is done to ensure that systems can identify this type of transaction as different from other StripePI transactions, similar to how Paypal Express works.

Test Summary
Local:
4956 tests, 74514 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
31 tests, 171 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
65 tests, 306 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.3846% passed
**There are 3 tests failing on master**