### PR TITLE
Worldpay: Adding support for google pay and apple pay

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -15,6 +15,12 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.worldpay.com/'
       self.display_name = 'Worldpay Global'
 
+      NETWORK_TOKEN_TYPE = {
+        apple_pay: 'APPLEPAY',
+        google_pay: 'GOOGLEPAY',
+        network_token: 'NETWORKTOKEN'
+      }
+
       CARD_CODES = {
         'visa'             => 'VISA-SSL',
         'master'           => 'ECMC-SSL',
@@ -441,8 +447,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_network_tokenization_card(xml, payment_method)
+        token_type = NETWORK_TOKEN_TYPE.fetch(payment_method.source, 'NETWORKTOKEN')
+
         xml.paymentDetails do
-          xml.tag! 'EMVCO_TOKEN-SSL', 'type' => 'NETWORKTOKEN' do
+          xml.tag! 'EMVCO_TOKEN-SSL', 'type' => token_type do
             xml.tokenNumber payment_method.number
             xml.expiryDate do
               xml.date(
@@ -450,6 +458,8 @@ module ActiveMerchant #:nodoc:
                 'year' => format(payment_method.year, :four_digits_year)
               )
             end
+            name = card_holder_name(payment_method, options)
+            xml.cardHolderName name if name.present?
             xml.cryptogram payment_method.payment_cryptogram
             xml.eciIndicator format(payment_method.eci, :two_digits)
           end
@@ -477,9 +487,7 @@ module ActiveMerchant #:nodoc:
             'year' => format(payment_method.year, :four_digits_year)
           )
         end
-
-        card_holder_name = test? && options[:execute_threed] && !options[:three_ds_version]&.start_with?('2') ? '3D' : payment_method.name
-        xml.cardHolderName card_holder_name
+        xml.cardHolderName card_holder_name(payment_method, options)
         xml.cvc payment_method.verification_value
 
         add_address(xml, (options[:billing_address] || options[:address]), options)
@@ -771,7 +779,7 @@ module ActiveMerchant #:nodoc:
 
       def payment_details_from(payment_method)
         payment_details = {}
-        if payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :network_token
+        if payment_method.is_a?(NetworkTokenizationCreditCard) && %i{network_token apple_pay google_pay}.include?(payment_method.source)
           payment_details[:payment_type] = :network_token
         elsif payment_method.respond_to?(:number)
           payment_details[:payment_type] = :credit
@@ -812,6 +820,10 @@ module ActiveMerchant #:nodoc:
 
       def eligible_for_0_auth?(payment_method, options = {})
         payment_method.is_a?(CreditCard) && %w(visa master).include?(payment_method.brand) && options[:zero_dollar_auth]
+      end
+
+      def card_holder_name(payment_method, options)
+        test? && options[:execute_threed] && !options[:three_ds_version]&.start_with?('2') ? '3D' : payment_method.name
       end
     end
   end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -43,6 +43,22 @@ class WorldpayTest < Test::Unit::TestCase
         sub_id: '1234567'
       }
     }
+
+    @apple_play_network_token = network_tokenization_credit_card('4895370015293175',
+      month: 10,
+      year: 24,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      source: :apple_pay)
+
+    @google_pay_network_token = network_tokenization_credit_card('4444333322221111',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: Time.new.year + 2,
+      source: :google_pay,
+      transaction_id: '123456789',
+      eci: '05')
   end
 
   def test_successful_authorize
@@ -1161,6 +1177,33 @@ class WorldpayTest < Test::Unit::TestCase
       @gateway.refund(@amount, @options[:order_id], @options)
     end.respond_with(failed_refund_synchronous_response)
     assert_failure response
+  end
+
+  def test_network_token_type_assignation_when_apple_token
+    response = stub_comms do
+      @gateway.authorize(@amount, @apple_play_network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<EMVCO_TOKEN-SSL type="APPLEPAY">), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_network_token_type_assignation_when_network_token
+    response = stub_comms do
+      @gateway.authorize(@amount, @nt_credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<EMVCO_TOKEN-SSL type="NETWORKTOKEN">), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_network_token_type_assignation_when_google_pay
+    response = stub_comms do
+      @gateway.authorize(@amount, @google_pay_network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<EMVCO_TOKEN-SSL type="GOOGLEPAY">), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
   end
 
   private


### PR DESCRIPTION
Summary:
------------------------------
This PR adds support for the apple pay payment method on the Worldpay
adapter by adding a new network token type

Test Execution:
------------------------------
Finished in 149.298941 seconds.
83 tests, 331 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.5904% passed

RuboCop:
------------------------------
723 files inspected, no offenses detected