### PR TITLE
PayU Latam: send correct card types for maestro and condensa

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Worldpay: Adding support for google pay and apple pay [cristian] #4180
 * Worldpay: Adding scrubbing for network token transactions [cristian] #4181
 * SafeCharge: Add sg_NotUseCVV field [ajawadmirza] #4177
+* PayULatam: Correctly map maestro and condensa card types [dsmcclain] $4182
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -17,6 +17,7 @@ module ActiveMerchant #:nodoc:
       BRAND_MAP = {
         'visa' => 'VISA',
         'master' => 'MASTERCARD',
+        'maestro' => 'MASTERCARD',
         'american_express' => 'AMEX',
         'diners_club' => 'DINERS',
         'naranja' => 'NARANJA',
@@ -278,6 +279,10 @@ module ActiveMerchant #:nodoc:
         Digest::MD5.hexdigest(signature_string)
       end
 
+      def codensa_bin?(number)
+        number.start_with?('590712')
+      end
+
       def add_payment_method(post, payment_method, options)
         if payment_method.is_a?(String)
           brand, token = split_authorization(payment_method)
@@ -295,7 +300,7 @@ module ActiveMerchant #:nodoc:
           credit_card[:name] = payment_method.name.strip
           credit_card[:processWithoutCvv2] = true if add_process_without_cvv2(payment_method, options)
           post[:transaction][:creditCard] = credit_card
-          post[:transaction][:paymentMethod] = BRAND_MAP[payment_method.brand.to_s]
+          post[:transaction][:paymentMethod] = codensa_bin?(payment_method.number) ? 'CODENSA' : BRAND_MAP[payment_method.brand.to_s]
         end
       end
 

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -13,6 +13,8 @@ class PayuLatamTest < Test::Unit::TestCase
     @no_cvv_visa_card = credit_card('4097440000000004', verification_value: ' ')
     @no_cvv_amex_card = credit_card('4097440000000004', verification_value: ' ', brand: 'american_express')
     @cabal_credit_card = credit_card('5896570000000004', verification_value: '123', first_name: 'APPROVED', last_name: '', brand: 'cabal')
+    @maestro_card = credit_card('6759000000000000005', verification_value: '123', first_name: 'APPROVED', brand: 'maestro')
+    @codensa_card = credit_card('5907120000000009', verification_value: '123', first_name: 'APPROVED', brand: 'maestro')
 
     @options = {
       dni_number: '5415668464654',
@@ -208,6 +210,22 @@ class PayuLatamTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
       assert_equal 5555555555, JSON.parse(data)['transaction']['order']['buyer']['contactPhone']
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_card_type_maestro_maps_to_mastercard
+    stub_comms do
+      @gateway.purchase(@amount, @maestro_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'MASTERCARD', JSON.parse(data)['transaction']['paymentMethod']
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_card_type_codensa
+    stub_comms do
+      @gateway.purchase(@amount, @codensa_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'CODENSA', JSON.parse(data)['transaction']['paymentMethod']
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
This PR:
* Maps maestro card type to 'MASTERCARD' in accordance with gateway API.
* Maps a specific maestro BIN (590712) to 'CODENSA' in accordance with the gateway API.
* Updates the expiration dates on some of the test cards to achieve more consistent responses from the gateway sandbox, as advised by the gateway's technical support team.
* Modifies a remote test for `refund` that has been red for quite a while. The test was [originally written to accommodate issues with the gateway's sandbox](https://github.com/activemerchant/active_merchant/pull/2334), but those issues have been resolved and we are able to successfully test `refund` again.

CE-2074 & CE-2080

Rubocop:
720 files inspected, no offenses detected

Local:
4958 tests, 74520 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_payu_latam_test
36 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed