### PR TITLE
Stripe Payment Intents: refactor response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,8 @@
 * Worldpay: Adding support for google pay and apple pay [cristian] #4180
 * Worldpay: Adding scrubbing for network token transactions [cristian] #4181
 * SafeCharge: Add sg_NotUseCVV field [ajawadmirza] #4177
-* PayULatam: Correctly map maestro and condensa card types [dsmcclain] $4182
+* PayULatam: Correctly map maestro and condensa card types [dsmcclain] #4182
+* StripePaymentIntents: Refactor response for setup_purchase [aenand] #4183
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -1,5 +1,4 @@
 require 'active_support/core_ext/hash/slice'
-require 'active_merchant/billing/gateways/stripe/stripe_payment_intents_response'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
@@ -669,8 +668,7 @@ module ActiveMerchant #:nodoc:
         card = card_from_response(response)
         avs_code = AVS_CODE_TRANSLATOR["line1: #{card['address_line1_check']}, zip: #{card['address_zip_check']}"]
         cvc_code = CVC_CODE_TRANSLATOR[card['cvc_check']]
-        response_class = options[:response_class] || Response
-        response_class.new(success,
+        Response.new(success,
           message_from(success, response),
           response,
           test: response_is_test?(response),

--- a/lib/active_merchant/billing/gateways/stripe/stripe_payment_intents_response.rb
+++ b/lib/active_merchant/billing/gateways/stripe/stripe_payment_intents_response.rb
@@ -1,6 +1,0 @@
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
-    class StripePaymentIntentsResponse < Response
-    end
-  end
-end

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -221,7 +221,6 @@ module ActiveMerchant #:nodoc:
         add_currency(post, options, money)
         add_amount(post, money, options)
         add_payment_method_types(post, options)
-        options[:response_class] = StripePaymentIntentsResponse
         commit(:post, 'payment_intents', post, options)
       end
 

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1012,7 +1012,6 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert response = @gateway.setup_purchase(@amount, options)
     assert_equal 'requires_payment_method', response.params['status']
     assert response.params['client_secret'].start_with?('pi')
-    assert_instance_of StripePaymentIntentsResponse, response
   end
 
   def test_failed_setup_purchase


### PR DESCRIPTION
In PR #4178 support for a `setup_purchase` transaction was added to the Stripe PI gateway. As part of this, a new `Response class` was added so systems can differentiate that this is an offsite transaction. Creating a new `Response` class is not the best way to implement this and therefore refactoring to remove it.

Test Summary
Local:
4977 tests, 74599 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
31 tests, 171 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
65 tests, 305 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.3846% passed
**There are 3 tests failing on master**