### PR TITLE
DLocal: Implement $0 Verify

### DIFF
--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -26,6 +26,7 @@ module ActiveMerchant #:nodoc:
       def authorize(money, payment, options = {})
         post = {}
         add_auth_purchase_params(post, money, payment, 'authorize', options)
+        post[:card][:verify] = true if options[:verify].to_s == 'true'
 
         commit('authorize', post, options)
       end
@@ -52,10 +53,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options = {})
-        MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
-        end
+        authorize(0, credit_card, options.merge(verify: 'true'))
       end
 
       def supports_scrubbing?
@@ -191,7 +189,7 @@ module ActiveMerchant #:nodoc:
       def success_from(action, response)
         return false unless response['status_code']
 
-        %w[100 200 400 600].include? response['status_code'].to_s
+        %w[100 200 400 600 700].include? response['status_code'].to_s
       end
 
       def message_from(action, response)

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -224,13 +224,15 @@ class RemoteDLocalTest < Test::Unit::TestCase
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response
-    assert_match %r{The payment was authorized}, response.message
+    assert_equal 0, response.params['amount']
+    assert_match %r{The payment was verified}, response.message
   end
 
   def test_successful_verify_with_cabal
     response = @gateway.verify(@cabal_credit_card, @options)
     assert_success response
-    assert_match %r{The payment was authorized}, response.message
+    assert_equal 0, response.params['amount']
+    assert_match %r{The payment was verified}, response.message
   end
 
   def test_failed_verify

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -189,29 +189,20 @@ class DLocalTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    @gateway.expects(:ssl_request).times(2).returns(successful_authorize_response, successful_void_response)
+    @gateway.expects(:ssl_post).returns(successful_verify_response)
 
     response = @gateway.verify(@credit_card, @options)
     assert_success response
 
-    assert_equal 'D-15104-be03e883-3e6b-497d-840e-54c8b6209bc3', response.authorization
-  end
-
-  def test_successful_verify_with_failed_void
-    @gateway.expects(:ssl_request).times(2).returns(successful_authorize_response, failed_void_response)
-
-    response = @gateway.verify(@credit_card, @options)
-    assert_success response
-
-    assert_equal 'D-15104-be03e883-3e6b-497d-840e-54c8b6209bc3', response.authorization
+    assert_equal 'T-15104-bb204de6-2708-4398-955f-2b16cf633687', response.authorization
   end
 
   def test_failed_verify
-    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+    @gateway.expects(:ssl_post).returns(failed_verify_response)
 
     response = @gateway.verify(@credit_card, @options)
     assert_failure response
-    assert_equal '309', response.error_code
+    assert_equal '315', response.error_code
   end
 
   def test_scrub
@@ -285,6 +276,14 @@ class DLocalTest < Test::Unit::TestCase
 
   def failed_capture_response
     '{"code":4000,"message":"Payment not found"}'
+  end
+
+  def successful_verify_response
+    '{"id":"T-15104-bb204de6-2708-4398-955f-2b16cf633687","amount":0,"currency":"BRL","payment_method_id":"CARD","payment_method_type":"CARD","payment_method_flow":"DIRECT","country":"BR","card":{"holder_name":"Longbob Longsen", "expiration_month":9, "expiration_year":2022, "brand":"VI", "last4":"1111", "verify":true},"three_dsecure":{},"created_date":"2021-11-05T19:54:34.000+0000","approved_date":"2021-11-05T19:54:35.000+0000","status":"VERIFIED","status_detail":"The payment was verified.","status_code":"700","order_id":"e3ec1f40e9cb06b2d9c61f35bd5115e9"}'
+  end
+
+  def failed_verify_response
+    '{"id":"T-15104-585b4fb0-8fc5-4ae2-bb87-41218b744ca0","amount":0,"currency":"BRL","payment_method_id":"CARD","payment_method_type":"CARD","payment_method_flow":"DIRECT","country":"BR","card":{"holder_name":"Longbob Longsen", "expiration_month":9, "expiration_year":2022, "brand":"VI", "last4":"1111", "verify":true},"three_dsecure":{},"created_date":"2021-11-05T19:54:34.000+0000","status":"REJECTED","status_detail":"Invalid security code.","status_code":"315","order_id":"e013030bd5a7330a5d490247a9ca2bf47","description":"315"}'
   end
 
   def successful_refund_response


### PR DESCRIPTION
Previously this adapter was doing an auth followed by a void. DLocal
supports performing `verify` by passing an amount of 0 on
authorizations. The gateway returns a status code of 700 to signify
success when performing this action.

CE-2064

Rubocop:
723 files inspected, no offenses detected

Local:
4978 tests, 74601 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_d_local_test
28 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed