### PR TITLE
Safe Charge: Support string for Add sg_NotUseCVV field

### DIFF
--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -147,7 +147,7 @@ module ActiveMerchant #:nodoc:
         post[:sg_MerchantPhoneNumber] = options[:merchant_phone_number] if options[:merchant_phone_number]
         post[:sg_MerchantName] = options[:merchant_name] if options[:merchant_name]
         post[:sg_ProductID] = options[:product_id] if options[:product_id]
-        post[:sg_NotUseCVV] = options[:not_use_cvv] ? 1 : 0 if options[:not_use_cvv]
+        post[:sg_NotUseCVV] = options[:not_use_cvv].to_s == 'true' ? 1 : 0 unless options[:not_use_cvv].nil?
       end
 
       def add_payment(post, payment, options = {})

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -135,6 +135,24 @@ class SafeChargeTest < Test::Unit::TestCase
       assert_match(/sg_NotUseCVV=1/, data)
     end.respond_with(successful_authorize_response)
 
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ not_use_cvv: 'true' }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/sg_NotUseCVV=1/, data)
+    end.respond_with(successful_authorize_response)
+
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ not_use_cvv: false }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/sg_NotUseCVV=0/, data)
+    end.respond_with(successful_authorize_response)
+
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ not_use_cvv: 'false' }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/sg_NotUseCVV=0/, data)
+    end.respond_with(successful_authorize_response)
+
     assert_success response
     assert response.test?
   end


### PR DESCRIPTION
String parameter support is added for sg_NotUseCVV field

CE-2084

Rubocop:
723 files inspected, no offenses detected

Unit:
4977 tests, 74599 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
30 tests, 81 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.6667% passed