### PR TITLE
Wompi: cast error messages to JSON

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * SafeCharge: Add sg_NotUseCVV field [ajawadmirza] #4177
 * PayULatam: Correctly map maestro and condensa card types [dsmcclain] #4182
 * StripePaymentIntents: Refactor response for setup_purchase [aenand] #4183
+* Wompi: cast error messages to JSON [therufs] #4186
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/wompi.rb
+++ b/lib/active_merchant/billing/gateways/wompi.rb
@@ -131,7 +131,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(response)
-        response.dig('data', 'status_message') || response.dig('error', 'reason') || response.dig('error', 'messages')
+        response.dig('data', 'status_message') || response.dig('error', 'reason') || response.dig('error', 'messages').to_json
       end
 
       def authorization_from(response)

--- a/test/remote/gateways/remote_wompi_test.rb
+++ b/test/remote/gateways/remote_wompi_test.rb
@@ -44,7 +44,8 @@ class RemoteWompiTest < Test::Unit::TestCase
   def test_failed_refund
     response = @gateway.refund(@amount, '')
     assert_failure response
-    assert_equal 'transaction_id Debe ser completado', response.message['transaction_id'].first
+    message = JSON.parse(response.message)
+    assert_equal 'transaction_id Debe ser completado', message['transaction_id'].first
   end
 
   def test_successful_void

--- a/test/unit/gateways/wompi_test.rb
+++ b/test/unit/gateways/wompi_test.rb
@@ -69,7 +69,8 @@ class WompiTest < Test::Unit::TestCase
 
     response = @gateway.refund(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal 'transaction_id Debe ser completado', response.message['transaction_id'].first
+    message = JSON.parse(response.message)
+    assert_equal 'transaction_id Debe ser completado', message['transaction_id'].first
   end
 
   def test_successful_void


### PR DESCRIPTION
Remote: 9 tests, 21 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit: 9 tests, 38 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop: 723 files inspected, no offenses detected

CE-1979