### PR TITLE
IPG: Add support for params &  gateway specific fields

### DIFF
--- a/test/remote/gateways/remote_ipg_test.rb
+++ b/test/remote/gateways/remote_ipg_test.rb
@@ -5,8 +5,8 @@ class RemoteIpgTest < Test::Unit::TestCase
     @gateway = IpgGateway.new(fixtures(:ipg))
 
     @amount = 100
-    @credit_card = credit_card('5165850000000008', brand: 'mastercard', verification_value: '123', month: '12', year: '22')
-    @declined_card = credit_card('4000300011112220', brand: 'mastercard', verification_value: '123', month: '12', year: '22')
+    @credit_card = credit_card('5165850000000008', brand: 'mastercard', verification_value: '123', month: '12', year: '2022')
+    @declined_card = credit_card('4000300011112220', brand: 'mastercard', verification_value: '123', month: '12', year: '2022')
     @options = {
       currency: 'ARS'
     }
@@ -78,7 +78,7 @@ class RemoteIpgTest < Test::Unit::TestCase
   end
 
   def test_failed_capture
-    response = @gateway.capture(@amount, { order_id: '' }, @options)
+    response = @gateway.capture(@amount, '', @options)
     assert_failure response
     assert_equal 'FAILED', response.message
     assert_equal 'SGS-005001', response.error_code
@@ -95,7 +95,7 @@ class RemoteIpgTest < Test::Unit::TestCase
   end
 
   def test_failed_void
-    response = @gateway.void({ order_id: '' }, @options)
+    response = @gateway.void('', @options)
     assert_failure response
   end
 
@@ -109,7 +109,7 @@ class RemoteIpgTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    response = @gateway.refund(@amount, { order_id: '' }, @options)
+    response = @gateway.refund(@amount, '', @options)
     assert_failure response
     assert_equal 'FAILED', response.message
     assert_equal 'SGS-005001', response.error_code


### PR DESCRIPTION
Accept 4 digit payment year (as per the standard credit card options)
Return single order id string in authorization
Add submerchant gateway specific fields
Required changes in test cases

CE-2038

Unit:
4979 tests, 74611 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
14 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
722 files inspected, no offenses detected