### PR TITLE
NMI: omit initial_transaction_id for CIT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * PayULatam: Correctly map maestro and condensa card types [dsmcclain] #4182
 * StripePaymentIntents: Refactor response for setup_purchase [aenand] #4183
 * Wompi: cast error messages to JSON [therufs] #4186
+* NMI: Omit initial_transaction_id for CIT [aenand] #4189
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -206,7 +206,8 @@ module ActiveMerchant #:nodoc:
           post[:stored_credential_indicator] = 'stored'
         else
           post[:stored_credential_indicator] = 'used'
-          post[:initial_transaction_id] = stored_credential[:network_transaction_id]
+          # should only send :initial_transaction_id if it is a MIT
+          post[:initial_transaction_id] = stored_credential[:network_transaction_id] if post[:initiated_by] == 'merchant'
         end
       end
 

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -499,7 +499,7 @@ class NmiTest < Test::Unit::TestCase
       assert_match(/initiated_by=customer/, data)
       assert_match(/stored_credential_indicator=used/, data)
       assert_match(/billing_method=recurring/, data)
-      assert_match(/initial_transaction_id=abc123/, data)
+      refute_match(/initial_transaction_id/, data)
     end.respond_with(successful_authorization_response)
 
     assert_success response
@@ -555,7 +555,7 @@ class NmiTest < Test::Unit::TestCase
       assert_match(/initiated_by=customer/, data)
       assert_match(/stored_credential_indicator=used/, data)
       assert_match(/billing_method=installment/, data)
-      assert_match(/initial_transaction_id=abc123/, data)
+      refute_match(/initial_transaction_id/, data)
     end.respond_with(successful_authorization_response)
 
     assert_success response
@@ -611,7 +611,7 @@ class NmiTest < Test::Unit::TestCase
       assert_match(/initiated_by=customer/, data)
       assert_match(/stored_credential_indicator=used/, data)
       refute_match(/billing_method/, data)
-      assert_match(/initial_transaction_id=abc123/, data)
+      refute_match(/initial_transaction_id/, data)
     end.respond_with(successful_authorization_response)
 
     assert_success response


### PR DESCRIPTION
ECS-1833

For client initiated transactions on the NMI gateway, we should not be sending the `:initial_transaction_id`. Please see [NMI Docs](https://secure.networkmerchants.com/gw/merchants/resources/integration/integration_portal.php#credential_on_file_information) for more information.

Test Summary
Local:
4979 tests, 74605 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
48 tests, 375 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
43 tests, 161 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed