### PR TITLE
IPG: Add payment token to make transaction

### DIFF
--- a/test/remote/gateways/remote_ipg_test.rb
+++ b/test/remote/gateways/remote_ipg_test.rb
@@ -5,8 +5,9 @@ class RemoteIpgTest < Test::Unit::TestCase
     @gateway = IpgGateway.new(fixtures(:ipg))
 
     @amount = 100
-    @credit_card = credit_card('5165850000000008', brand: 'mastercard', verification_value: '123', month: '12', year: '2022')
-    @declined_card = credit_card('4000300011112220', brand: 'mastercard', verification_value: '123', month: '12', year: '2022')
+    @credit_card = credit_card('5165850000000008', brand: 'mastercard', verification_value: '652', month: '12', year: '2022')
+    @declined_card = credit_card('4000300011112220', brand: 'mastercard', verification_value: '652', month: '12', year: '2022')
+    @visa_card = credit_card('4704550000000005', brand: 'visa', verification_value: '123', month: '12', year: '2022')
     @options = {
       currency: 'ARS'
     }
@@ -20,11 +21,23 @@ class RemoteIpgTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_store
     payment_token = generate_unique_id
-    response = @gateway.store(@credit_card, @options.merge!({ hosted_data_id: payment_token }))
+    response = @gateway.store(@credit_card, @options.merge({ hosted_data_id: payment_token }))
     assert_success response
     assert_equal 'true', response.params['successfully']
 
-    response = @gateway.purchase(@amount, nil, @options.merge!({ hosted_data_id: payment_token }))
+    response = @gateway.purchase(@amount, payment_token, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+  end
+
+  def test_successful_purchase_with_store_without_passing_hosted
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal 'true', response.params['successfully']
+    payment_token = response.params['hosted_data_id']
+    assert payment_token
+
+    response = @gateway.purchase(@amount, payment_token, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
   end
@@ -50,6 +63,22 @@ class RemoteIpgTest < Test::Unit::TestCase
     assert recurring_purchase = @gateway.purchase(@amount, @credit_card, @options.merge({ order_id: order_id }))
     assert_success recurring_purchase
     assert_equal 'APPROVED', recurring_purchase.message
+  end
+
+  def test_successful_purchase_with_3ds2_options
+    options = @options.merge(
+      three_d_secure: {
+        version: '2.1.0',
+        cavv: 'jEET5Odser3oCRAyNTY5BVgAAAA=',
+        xid: 'jHDMyjJJF9bLBCFT/YUbqMhoQ0s=',
+        directory_response_status: 'Y',
+        authentication_response_status: 'Y',
+        ds_transaction_id: '925a0317-9143-5130-8000-0000000f8742'
+      }
+    )
+    response = @gateway.purchase(@amount, @visa_card, options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
   end
 
   def test_failed_purchase
@@ -133,7 +162,6 @@ class RemoteIpgTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end
     transcript = @gateway.scrub(transcript)
-
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
   end


### PR DESCRIPTION
Added `payment_token` to pass as a payment source for making
transactions to support `third_party_token` and test cases added for 3ds2.

CE-2040

Unit:
19 tests, 88 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
14 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed