### PR TITLE
Stripe Payment Intents: Add support for fulfillment_date and event_type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * GlobalCollect: Support for Lodging Data [naashton] #4190
 * IPG: Add support for sub-merchant and recurring type fields [ajawadmirza] # 4188
 * Wompi: Support `installments` option [therufs] #4192
+* Stripe PI: add support for `fulfillment_date` and `event_type` [dsmcclain] #4193
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -534,7 +534,6 @@ module ActiveMerchant #:nodoc:
         post[:metadata].merge!(options[:metadata]) if options[:metadata]
         post[:metadata][:email] = options[:email] if options[:email]
         post[:metadata][:order_id] = options[:order_id] if options[:order_id]
-        post.delete(:metadata) if post[:metadata].empty?
       end
 
       def add_emv_metadata(post, creditcard)

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -35,6 +35,7 @@ module ActiveMerchant #:nodoc:
         add_ntid(post, options)
         add_claim_without_transaction_id(post, options)
         add_error_on_requires_action(post, options)
+        add_fulfillment_date(post, options)
         request_three_d_secure(post, options)
 
         CREATE_INTENT_ATTRIBUTES.each do |attribute|
@@ -56,6 +57,7 @@ module ActiveMerchant #:nodoc:
         CONFIRM_INTENT_ATTRIBUTES.each do |attribute|
           add_whitelisted_attribute(post, options, attribute)
         end
+
         commit(:post, "payment_intents/#{intent_id}/confirm", post, options)
       end
 
@@ -91,6 +93,7 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_shipping_address(post, options)
         add_connected_account(post, options)
+        add_fulfillment_date(post, options)
 
         UPDATE_INTENT_ATTRIBUTES.each do |attribute|
           add_whitelisted_attribute(post, options, attribute)
@@ -106,6 +109,7 @@ module ActiveMerchant #:nodoc:
 
         add_metadata(post, options)
         add_return_url(post, options)
+        add_fulfillment_date(post, options)
         post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
         post[:usage] = options[:usage] if %w(on_session off_session).include?(options[:usage])
         post[:description] = options[:description] if options[:description]
@@ -252,6 +256,16 @@ module ActiveMerchant #:nodoc:
       def add_customer(post, options)
         customer = options[:customer].to_s
         post[:customer] = customer if customer.start_with?('cus_')
+      end
+
+      def add_fulfillment_date(post, options)
+        post[:fulfillment_date] = options[:fulfillment_date].to_i if options[:fulfillment_date]
+      end
+
+      def add_metadata(post, options = {})
+        super
+
+        post[:metadata][:event_type] = options[:event_type] if options[:event_type]
       end
 
       def add_return_url(post, options)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -30,7 +30,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     @three_ds_external_data_card = credit_card('4000002760003184',
       verification_value: '737',
       month: 10,
-      year: 2021)
+      year: 2031)
     @visa_card = credit_card('4242424242424242',
       verification_value: '737',
       month: 10,
@@ -303,13 +303,15 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       receipt_email: 'test@example.com',
       statement_descriptor: 'Statement Descriptor',
       statement_descriptor_suffix: suffix,
-      metadata: { key_1: 'value_1', key_2: 'value_2' }
+      metadata: { key_1: 'value_1', key_2: 'value_2' },
+      event_type: 'concert'
     }
 
     assert response = @gateway.create_intent(@amount, nil, options)
 
     assert_success response
     assert_equal 'value_1', response.params['metadata']['key_1']
+    assert_equal 'concert', response.params['metadata']['event_type']
     assert_equal 'ActiveMerchant Test Purchase', response.params['description']
     assert_equal 'test@example.com', response.params['receipt_email']
     assert_equal 'Statement Descriptor', response.params['statement_descriptor']
@@ -628,6 +630,16 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal transfer_group, response.params['transfer_group']
     assert_equal @destination_account, response.params['on_behalf_of']
     assert_equal @destination_account, response.params.dig('transfer_data', 'destination')
+  end
+
+  def test_create_payment_intent_with_fulfillment_date
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      fulfillment_date: 1636756194
+    }
+    assert response = @gateway.authorize(@amount, @visa_payment_method, options)
+    assert_success response
   end
 
   def test_create_a_payment_intent_and_confirm

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -450,6 +450,20 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_create_intent_response)
   end
 
+  def test_successful_authorization_with_event_type_metadata
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@amount, @credit_card, {
+        email: 'wow@example.com',
+        event_type: 'concert'
+      })
+    end.check_request do |_method, endpoint, data, _headers|
+      if /payment_intents/.match?(endpoint)
+        assert_match(/metadata\[email\]=wow%40example.com/, data)
+        assert_match(/metadata\[event_type\]=concert/, data)
+      end
+    end.respond_with(successful_create_intent_response)
+  end
+
   def test_successful_setup_purchase
     stub_comms(@gateway, :ssl_request) do
       @gateway.setup_purchase(@amount, { payment_method_types: %w[afterpay_clearpay card] })


### PR DESCRIPTION
`fulfillment_date` is a root field while `event_type` belongs in the `metadata` object.

Any reviewer should run the remote tests for both the Stripe PI and regular Stripe gateways, as this PR makes changes to both files.

CE-2101

Local:
4980 tests, 74615 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
722 files inspected, no offenses detected

Remote:

Loaded suite test/remote/gateways/remote_stripe_payment_intents_test
66 tests, 311 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_stripe_test
74 tests, 338 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed