### PR TITLE
Paysafe: Adjust logic for sending 3DS field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * IPG: Add support for sub-merchant and recurring type fields [ajawadmirza] # 4188
 * Wompi: Support `installments` option [therufs] #4192
 * Stripe PI: add support for `fulfillment_date` and `event_type` [dsmcclain] #4193
+* Paysafe: Adjust logic for sending 3DS field [meagabeth] #4194
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -203,7 +203,7 @@ module ActiveMerchant #:nodoc:
         post[:authentication][:cavv] = three_d_secure[:cavv]
         post[:authentication][:xid] = three_d_secure[:xid] if three_d_secure[:xid]
         post[:authentication][:threeDSecureVersion] = three_d_secure[:version]
-        post[:authentication][:directoryServerTransactionId] = three_d_secure[:ds_transaction_id] unless payment.is_a?(String) || payment.brand != 'mastercard'
+        post[:authentication][:directoryServerTransactionId] = three_d_secure[:ds_transaction_id] unless payment.is_a?(String) || !mastercard?(payment)
       end
 
       def add_airline_travel_details(post, options)
@@ -282,6 +282,12 @@ module ActiveMerchant #:nodoc:
           split_pay << split
         end
         post[:splitpay] = split_pay
+      end
+
+      def mastercard?(payment)
+        return false unless payment.respond_to?(:brand)
+
+        payment.brand == 'master'
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_paysafe_test.rb
+++ b/test/remote/gateways/remote_paysafe_test.rb
@@ -6,7 +6,7 @@ class RemotePaysafeTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4037111111000000')
-    @mastercard = credit_card('5200400000000009', brand: 'mastercard')
+    @mastercard = credit_card('5200400000000009', brand: 'master')
     @pm_token = 'Ci3S9DWyOP9CiJ5'
     @options = {
       billing_address: address,

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -6,7 +6,7 @@ class PaysafeTest < Test::Unit::TestCase
   def setup
     @gateway = PaysafeGateway.new(username: 'username', password: 'password', account_id: 'account_id')
     @credit_card = credit_card
-    @mastercard = credit_card('5186750368967720', brand: 'mastercard')
+    @mastercard = credit_card('5454545454545454', brand: 'master')
     @amount = 100
 
     @options = {


### PR DESCRIPTION
Change credit card brand to be `master` instead of `mastercard` to adhere to existing pattern and reflect value received when interacting with Spreedly's core API.
This change ensures that the `ds_transaction_id` is included for Mastercard 3DS2 transactions.

CE-2133

Local
4994 tests, 74763 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop
725 files inspected, no offenses detected

Unit
15 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote
30 tests, 90 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed