### PR TITLE
GlobalCollect: Update Production Endpoint

### DIFF
--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
 
       self.test_url = 'https://eu.sandbox.api-ingenico.com'
       self.preproduction_url = 'https://world.preprod.api-ingenico.com'
-      self.live_url = 'https://api.globalcollect.com'
+      self.live_url = 'https://world.api-ingenico.com'
 
       self.supported_countries = %w[AD AE AG AI AL AM AO AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BW BY BZ CA CC CD CF CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HN HR HT HU ID IE IL IM IN IS IT JM JO JP KE KG KH KI KM KN KR KW KY KZ LA LB LC LI LK LR LS LT LU LV MA MC MD ME MF MG MH MK MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PL PN PS PT PW QA RE RO RS RU RW SA SB SC SE SG SH SI SJ SK SL SM SN SR ST SV SZ TC TD TG TH TJ TL TM TN TO TR TT TV TW TZ UA UG US UY UZ VC VE VG VI VN WF WS ZA ZM ZW]
       self.default_currency = 'USD'

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -9,6 +9,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4567350000427977')
     @declined_card = credit_card('5424180279791732')
+    @preprod_card = credit_card('4111111111111111')
     @accepted_amount = 4005
     @rejected_amount = 2997
     @options = {
@@ -365,7 +366,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
 
   def test_successful_preprod_auth_and_capture
     options = @preprod_options.merge(order_id: rand(1000), requires_approval: true)
-    auth = @gateway_preprod.authorize(@accepted_amount, @credit_card, options)
+    auth = @gateway_preprod.authorize(@accepted_amount, @preprod_card, options)
     assert_success auth
 
     assert capture = @gateway_preprod.capture(@amount, auth.authorization, options)
@@ -374,14 +375,14 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
   end
 
   def test_successful_preprod_purchase
-    options = @preprod_options.merge(order_id: rand(1000), requires_approval: true)
-    assert purchase = @gateway_preprod.purchase(@accepted_amount, @credit_card, options)
+    options = @preprod_options.merge(order_id: rand(1000), requires_approval: false)
+    assert purchase = @gateway_preprod.purchase(@accepted_amount, @preprod_card, options)
     assert_success purchase
   end
 
   def test_successful_preprod_void
     options = @preprod_options.merge(order_id: rand(1000), requires_approval: true)
-    auth = @gateway_preprod.authorize(@amount, @credit_card, options)
+    auth = @gateway_preprod.authorize(@amount, @preprod_card, options)
     assert_success auth
 
     assert void = @gateway_preprod.void(auth.authorization)

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class RemoteGlobalCollectTest < Test::Unit::TestCase
   def setup
     @gateway = GlobalCollectGateway.new(fixtures(:global_collect))
+    @gateway_preprod = GlobalCollectGateway.new(fixtures(:global_collect_preprod))
+    @gateway_preprod.options[:url_override] = 'preproduction'
 
     @amount = 100
     @credit_card = credit_card('4567350000427977')
@@ -12,8 +14,7 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     @options = {
       email: 'example@example.com',
       billing_address: address,
-      description: 'Store Purchase',
-      url_override: 'preproduction'
+      description: 'Store Purchase'
     }
     @long_address = {
       billing_address: {
@@ -23,6 +24,10 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
         zip: '09901',
         country: 'US'
       }
+    }
+    @preprod_options = {
+      email: 'email@example.com',
+      billing_address: address
     }
   end
 
@@ -356,5 +361,31 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
 
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@gateway.options[:secret_api_key], transcript)
+  end
+
+  def test_successful_preprod_auth_and_capture
+    options = @preprod_options.merge(order_id: rand(1000), requires_approval: true)
+    auth = @gateway_preprod.authorize(@accepted_amount, @credit_card, options)
+    assert_success auth
+
+    assert capture = @gateway_preprod.capture(@amount, auth.authorization, options)
+    assert_success capture
+    assert_equal 'CAPTURE_REQUESTED', capture.params['payment']['status']
+  end
+
+  def test_successful_preprod_purchase
+    options = @preprod_options.merge(order_id: rand(1000), requires_approval: true)
+    assert purchase = @gateway_preprod.purchase(@accepted_amount, @credit_card, options)
+    assert_success purchase
+  end
+
+  def test_successful_preprod_void
+    options = @preprod_options.merge(order_id: rand(1000), requires_approval: true)
+    auth = @gateway_preprod.authorize(@amount, @credit_card, options)
+    assert_success auth
+
+    assert void = @gateway_preprod.void(auth.authorization)
+    assert_success void
+    assert_equal 'Succeeded', void.message
   end
 end


### PR DESCRIPTION
The production url for Ingenico (Global Collect) is
https://world.api-ingenico.com. Currently, Ingenico redirects to the
new url but it has been advised that we update the `live_url`.

[Ingenico endpoints](https://epayments-api.developer-ingenico.com/s2sapi/v1/en_US/java/endpoints.html?paymentPlatform=ALL)

CE-2116

Unit: 31 tests, 154 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 29 tests, 72 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.5517% passed