### PR TITLE
Worldpay cleaning order

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -235,7 +235,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def order_tag_attributes(options)
-        { 'orderCode' => options[:order_id], 'installationId' => options[:inst_id] || @options[:inst_id] }.reject { |_, v| !v.present? }
+        { 'orderCode' => clean_order_id(options[:order_id]), 'installationId' => options[:inst_id] || @options[:inst_id] }.reject { |_, v| !v.present? }
+      end
+
+      def clean_order_id(order_id)
+        order_id.to_s.gsub(/(\s|\||<|>|'|")/, '')[0..64]
       end
 
       def build_capture_request(money, authorization, options)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1210,6 +1210,16 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_order_id_crop_and_clean
+    @options[:order_id] = "abc1234 abc1234 'abc1234' <abc1234> \"abc1234\" | abc1234 abc1234 abc1234 abc1234 abc1234"
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<order orderCode="abc1234abc1234abc1234abc1234abc1234abc1234abc1234abc1234abc1234ab">), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   private
 
   def assert_date_element(expected_date_hash, date_element)


### PR DESCRIPTION
### Description:

According with Worldpay documentation the order_id param can't be longer that 64 characters and (<>|""'') chars are not allowed.

[Worldpay Docs](https://developer.worldpay.com/docs/wpg/directintegration/paymentrequests#ordercode-attribute)

### Test suite results:

#### Unit Test:
Finished in 14.508438 seconds.
4996 tests, 74772 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications

#### Remote Test:
Finished in 155.882857 seconds.
88 tests, 370 assertions, 2 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
97.7273% passed

#### RuboCop:
725 files inspected, no offenses detected