### PR TITLE
EBANX: Added `processing_type` Gateway Specific Field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Stripe PI: add support for `fulfillment_date` and `event_type` [dsmcclain] #4193
 * Paysafe: Adjust logic for sending 3DS field [meagabeth] #4194
 * Priority: Fix unit test cases [ajawadmirza] #4195
+* EBANX: New Gateway Specific Receiver [spreedly-kledoux] #4198
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -214,6 +214,7 @@ module ActiveMerchant #:nodoc:
         post[:metadata] = options[:metadata] if options[:metadata]
         post[:metadata] = {} if post[:metadata].nil?
         post[:metadata][:merchant_payment_code] = options[:order_id] if options[:order_id]
+        post[:processing_type] = options[:processing_type] if options[:processing_type]
       end
 
       def parse(body)
@@ -222,7 +223,8 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, parameters)
         url = url_for((test? ? test_url : live_url), action, parameters)
-        response = parse(ssl_request(HTTP_METHOD[action], url, post_data(action, parameters), { 'x-ebanx-client-user-agent': "ActiveMerchant/#{ActiveMerchant::VERSION}" }))
+
+        response = parse(ssl_request(HTTP_METHOD[action], url, post_data(action, parameters), headers(parameters)))
 
         success = success_from(action, response)
 
@@ -234,6 +236,19 @@ module ActiveMerchant #:nodoc:
           test: test?,
           error_code: error_code_from(response, success)
         )
+      end
+
+      def headers(params)
+        processing_type = params[:processing_type]
+        commit_headers = { 'x-ebanx-client-user-agent': "ActiveMerchant/#{ActiveMerchant::VERSION}" }
+
+        add_processing_type_to_commit_headers(commit_headers, processing_type) if processing_type == 'local'
+
+        commit_headers
+      end
+
+      def add_processing_type_to_commit_headers(commit_headers, processing_type)
+        commit_headers['x-ebanx-api-processing-type'] = processing_type
       end
 
       def success_from(action, response)

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -46,6 +46,13 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_equal 'Accepted', response.message
   end
 
+  def test_successful_purchase_passing_processing_type_in_header
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ processing_type: 'local' }))
+
+    assert_success response
+    assert_equal 'Accepted', response.message
+  end
+
   def test_successful_purchase_as_brazil_business_with_responsible_fields
     options = @options.update(document: '32593371000110',
                               person_type: 'business',

--- a/test/unit/gateways/ebanx_test.rb
+++ b/test/unit/gateways/ebanx_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class EbanxTest < Test::Unit::TestCase
+  include CommStub
+
   def setup
     @gateway = EbanxGateway.new(integration_key: 'key')
     @credit_card = credit_card
@@ -17,10 +19,21 @@ class EbanxTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(successful_purchase_response)
 
     response = @gateway.purchase(@amount, @credit_card, @options)
+
     assert_success response
 
     assert_equal '592db57ad6933455efbb62a48d1dfa091dd7cd092109db99', response.authorization
     assert response.test?
+  end
+
+  def test_successful_purchase_with_optional_processing_type_header
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@accepted_amount, @credit_card, @options.merge(processing_type: 'local'))
+    end.check_request do |_method, _endpoint, _data, headers|
+      assert_equal 'local', headers['x-ebanx-api-processing-type']
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
   end
 
   def test_failed_purchase


### PR DESCRIPTION
The headers that are generated for the `commit` method are now generated via a helper method. This method will look for a gateway specific field `processing_type`; if the field is present with a value of `local`, an additional header will be added to the gateway request: `x-ebanx-api-processing-type`.

CE-2113

Rubocop:
725 files inspected, no offenses detected

Local:
4995 tests, 74785 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_ebanx_test
25 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed