### PR TITLE
Paysafe: Concatenate credentials for headers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+
 = ActiveMerchant CHANGELOG
 
 == HEAD
@@ -21,6 +22,7 @@
 * EBANX: New Gateway Specific Receiver [spreedly-kledoux] #4198
 * Wompi: Don't send CVV field if no CVV provided [therufs] #4199
 * Worldpay: cleaning order_id according to worldpay rules [cristian] #4197
+* Paysafe: Concatenate credentials for headers [meagabeth] #4201
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -326,7 +326,7 @@ module ActiveMerchant #:nodoc:
       def headers
         {
           'Content-Type' => 'application/json',
-          'Authorization' => "Basic #{Base64.strict_encode64(@options[:api_key].to_s)}"
+          'Authorization' => 'Basic ' + Base64.strict_encode64("#{@options[:username]}:#{@options[:password]}")
         }
       end
 


### PR DESCRIPTION
Paysafe gateway requires an API key be sent in with the headers for each request. The API key is a concatenated version of the account's username and password. This PR takes the concatenation responsibility off of the user and does it automatically.

Rubocop:
725 files inspected, no offenses detected

Local:
4996 tests, 74789 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
15 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
30 tests, 90 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed