### PR TITLE
Stripe PI: add_metadata to setup_purchase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * Wompi: Don't send CVV field if no CVV provided [therufs] #4199
 * Worldpay: cleaning order_id according to worldpay rules [cristian] #4197
 * Paysafe: Concatenate credentials for headers [meagabeth] #4201
+* Stripe Payment Intents: Add metadata to setup_purchase [aenand] #4202
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -225,6 +225,7 @@ module ActiveMerchant #:nodoc:
         add_currency(post, options, money)
         add_amount(post, money, options)
         add_payment_method_types(post, options)
+        add_metadata(post, options)
         commit(:post, 'payment_intents', post, options)
       end
 

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -840,7 +840,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'You cannot cancel this PaymentIntent because ' \
       'it has a status of succeeded. Only a PaymentIntent with ' \
       'one of the following statuses may be canceled: ' \
-      'requires_payment_method, requires_capture, requires_confirmation, requires_action.', cancel_response.message
+      'requires_payment_method, requires_capture, requires_confirmation, requires_action, processing.', cancel_response.message
   end
 
   def test_refund_a_payment_intent
@@ -1018,11 +1018,14 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
   def test_setup_purchase
     options = {
       currency: 'USD',
-      payment_method_types: %w[afterpay_clearpay card]
+      payment_method_types: %w[afterpay_clearpay card],
+      metadata: { key_1: 'value_1', key_2: 'value_2' }
     }
 
     assert response = @gateway.setup_purchase(@amount, options)
     assert_equal 'requires_payment_method', response.params['status']
+    assert_equal 'value_1', response.params['metadata']['key_1']
+    assert_equal 'value_2', response.params['metadata']['key_2']
     assert response.params['client_secret'].start_with?('pi')
   end
 


### PR DESCRIPTION
ECS-2122

Adding a call to `add_metadata` when making a `setup_purchase` to ensure that any metadata sent to AM is sent to Stripe. Also added a quick fix to one of the remote tests that were failing.

Test Summary
Local:
996 tests, 74789 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
32 tests, 175 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
66 tests, 311 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed