### PR TITLE
Orbital: Add googlepay payment tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@
 * Element (Vantiv Express): Add support for general credit [dsmcclain] #4203
 * Worldpay: Update supported countries list, currencies [jherreraa] #4207
 * StripePI: Adding countries available. [gasb150] #4208
+* Orbital: Adding google pay payment tests for Orbital. [ajawadmirza] #4205
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147


### PR DESCRIPTION
Added google pay purchase and auth capture remote tests on orbital
gateway for end to end testing.

[CE-1819](https://spreedly.atlassian.net/browse/CE-1819)

Unit:
4999 tests, 74808 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
76 tests, 345 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed