### PR TITLE
Stripe update api version

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -25,7 +25,7 @@ module ActiveMerchant #:nodoc:
 
       DEFAULT_API_VERSION = '2015-04-07'
 
-      self.supported_countries = %w(AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MT MX NL NO NZ PL PT RO SE SG SI SK US)
+      self.supported_countries = %w(AE AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK HU IE IN IT JP LT LU LV MT MX MY NL NO NZ PL PT RO SE SG SI SK US)
       self.default_currency = 'USD'
       self.money_format = :cents
       self.supported_cardtypes = %i[visa master american_express discover jcb diners_club maestro unionpay]

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
         'unchecked' => 'P'
       }
 
-      DEFAULT_API_VERSION = '2015-04-07'
+      DEFAULT_API_VERSION = '2020-08-27'
 
       self.supported_countries = %w(AE AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK HU IE IN IT JP LT LU LV MT MX MY NL NO NZ PL PT RO SE SG SI SK US)
       self.default_currency = 'USD'
@@ -222,10 +222,12 @@ module ActiveMerchant #:nodoc:
             r.process { commit(:post, "customers/#{CGI.escape(options[:customer])}/cards", params, options) }
 
             post[:default_card] = r.params['id'] if options[:set_default] && r.success? && !r.params['id'].blank?
+            post[:expand] = [:sources]
 
             r.process { update_customer(options[:customer], post) } if post.count > 0
           end
         else
+          post[:expand] = [:sources]
           commit(:post, 'customers', post.merge(params), options)
         end
       end
@@ -762,7 +764,7 @@ module ActiveMerchant #:nodoc:
             country: 'US',
             currency: 'usd',
             routing_number: bank_account.routing_number,
-            name: bank_account.name,
+            account_holder_name: bank_account.name,
             account_holder_type: account_holder_type
           }
         }

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -5,8 +5,6 @@ module ActiveMerchant #:nodoc:
     # This gateway uses the current Stripe {Payment Intents API}[https://stripe.com/docs/api/payment_intents].
     # For the legacy API, see the Stripe gateway
     class StripePaymentIntentsGateway < StripeGateway
-      self.supported_countries = %w(AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MT MX NL NO NZ PL PT RO SE SG SI SK US)
-
       ALLOWED_METHOD_STATES = %w[automatic manual].freeze
       ALLOWED_CANCELLATION_REASONS = %w[duplicate fraudulent requested_by_customer abandoned].freeze
       CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor_suffix statement_descriptor receipt_email save_payment_method]

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
       CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor_suffix statement_descriptor receipt_email save_payment_method]
       CONFIRM_INTENT_ATTRIBUTES = %i[receipt_email return_url save_payment_method setup_future_usage off_session]
       UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor_suffix statement_descriptor receipt_email setup_future_usage]
-      DEFAULT_API_VERSION = '2019-05-16'
+      DEFAULT_API_VERSION = '2020-08-27'
 
       def create_intent(money, payment_method, options = {})
         post = {}
@@ -192,6 +192,7 @@ module ActiveMerchant #:nodoc:
             post[:description] = options[:description] if options[:description]
             post[:email] = options[:email] if options[:email]
             options = format_idempotency_key(options, 'customer')
+            post[:expand] = [:sources]
             customer = commit(:post, 'customers', post, options)
             customer_id = customer.params['id']
           end

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -8,10 +8,14 @@ module ActiveMerchant #:nodoc:
 
       self.default_currency = 'GBP'
       self.money_format = :cents
-      self.supported_countries = %w(HK GB AU AD AR BE BR CA CH CN CO CR CY CZ DE DK ES FI FR GI GR HU IE IN IT JP LI LU MC MT MY MX NL NO NZ PA PE PL PT SE SG SI SM TR UM VA)
+      self.supported_countries = %w(AX AL DZ AS AO AI AG AM AW AZ BS BH BD BB BY BZ BJ BM BT BO BA BW IO BN BF BI KH CM CV KY CF TD CN CX CC KM CK DJ DO EC EG GQ ET FK FJ GF PF
+                                    TF GA GM GE GH GL GD GP GU GN GW GY HT HM ID IL JM JO KZ KE KI KW KG LS MK MG MW MV ML MH MQ MR MU YT FM MD MC MN ME MS MA MZ NA NR NP NC NE
+                                    NG NU NF MP OM PK PW PY PE PH PN PR QA RE RU RW KN LC WS SM ST SA SN RS SC SL SB ZA KR LK SZ TW TJ TZ TH TG TK TO TT TM TC TV UG UA AE UY UZ
+                                    VU VE VN EH YE ZM AD AR AU AT BE BR BG CA CL CO CR HR CY CZ DK SV EE FO FI FR DE GI GR GT GG HN HK HU IS IN IE IM IT JP JE LV LI LT LU MY MT
+                                    MX NL NZ NI NO PA PL PT RO SG SK SI ES SE CH TR GB US)
       self.supported_cardtypes = %i[visa master american_express discover jcb maestro elo naranja cabal unionpay]
-      self.currencies_without_fractions = %w(HUF IDR ISK JPY KRW)
-      self.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
+      self.currencies_without_fractions = %w(HUF IDR JPY KRW BEF XOF XAF XPF GRD GNF ITL LUF MGA MGF PYG PTE RWF ESP TRL VND KMF)
+      self.currencies_with_three_decimal_places = %w(BHD KWD OMR TND LYD JOD IQD)
       self.homepage_url = 'http://www.worldpay.com/'
       self.display_name = 'Worldpay Global'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -281,7 +281,7 @@ module ActiveMerchant
     def load_fixtures
       [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
         if File.exist?(file_name)
-          yaml_data = YAML.safe_load(File.read(file_name), [], [], true)
+          yaml_data = YAML.safe_load(File.read(file_name), aliases: true)
           credentials.merge!(symbolize_keys(yaml_data))
         end
         credentials


### PR DESCRIPTION
Summary:
This PR changes the API version to the latest version available (2020-08-27), also includes the update of the use of method YAML.safe_load to avoid a warning on test helper

Test Execution:
test/remote/gateways/remote_stripe_test.rb
Finished in 122.237642 seconds.

74 tests, 338 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.6486% passed

test/remote/gateways/remote_stripe_payment_intents_test.rb
Finished in 164.5804 seconds.

66 tests, 313 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
725 files inspected, no offenses detected