### PR TITLE
Bug: Fixing supported countries method when there is inheritance involved

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -162,7 +162,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def self.supported_countries
-        @supported_countries ||= []
+        @supported_countries ||= (self.superclass.supported_countries || [])
       end
 
       def supported_countries

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -472,6 +472,11 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_setup_purchase)
   end
 
+  def test_supported_countries
+    countries = %w(AE AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK HU IE IN IT JP LT LU LV MT MX MY NL NO NZ PL PT RO SE SG SI SK US)
+    assert_equal countries.sort, StripePaymentIntentsGateway.supported_countries.sort
+  end
+
   private
 
   def successful_setup_purchase


### PR DESCRIPTION
### Summary:

This commit fixes an issue with the supported_countries class method, that prevents a subclass to have the same list of countries of its parent class by inheritance.

### Unit Test Execution:
Finished in 149.298941 seconds.
5000 tests, 74810 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
725 files inspected, no offenses detected