### PR TITLE
Worldpay: Add support for Visa Direct Fast Funds Credit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@
 * Orbital: Adding google pay payment tests for Orbital. [ajawadmirza] #4205
 * Bug: Fixing supported countries method when there is inheritance involved [cristian] #4211
 * Mundipagg: Update success method [ajawadmirza] #4210
+* Worldpay: Add support for Visa Direct Fast Funds Credit [dsmcclain] #4212
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -699,6 +699,33 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', credit.message
   end
 
+  def test_successful_fast_fund_credit_on_cft_gateway
+    options = @options.merge({ fast_fund_credit: true })
+
+    credit = @cftgateway.credit(@amount, @credit_card, options)
+    assert_success credit
+    assert_equal 'SUCCESS', credit.message
+  end
+
+  def test_successful_fast_fund_credit_with_token_on_cft_gateway
+    assert store = @gateway.store(@credit_card, @store_options)
+    assert_success store
+
+    options = @options.merge({ fast_fund_credit: true })
+    assert credit = @gateway.credit(@amount, store.authorization, options)
+    assert_success credit
+  end
+
+  def test_failed_fast_fund_credit_on_cft_gateway
+    options = @options.merge({ fast_fund_credit: true })
+    refused_card = credit_card('4917300800000000', name: 'REFUSED') # 'magic' value for testing failures, provided by Worldpay
+
+    credit = @cftgateway.credit(@amount, refused_card, options)
+    assert_failure credit
+    assert_equal '01', credit.params['action_code']
+    assert_equal "A transaction status of 'ok' or 'PUSH_APPROVED' is required.", credit.message
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
This PR contains two commits for ease of reviewing.

The first commit decomposes some complex methods in the Worldpay adapter in order to make the code easier to maintain and to allow us to reuse some of the logic.

The second commit adds support for the Visa Direct Fast Funds Credit feature, using a switch called `fast_fund_credit`. Current documentation for this feature can be found [here](https://developer.worldpay.com/docs/wpg/manage/fastaccess/#disbursement). This feature will be available for visa credit cards as well as tokenized visa credit cards.

Unit:
5001 tests, 74815 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
Loaded suite test/remote/gateways/remote_worldpay_test
90 tests, 375 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.7778% passed

Failing remote tests that are unrelated to this change:
`test_3ds_version_1_parameters_pass_thru`
`test_3ds_version_2_parameters_pass_thru`

