### PR TITLE
Worldpay: Adding missing countries to supported countries

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -8,11 +8,14 @@ module ActiveMerchant #:nodoc:
 
       self.default_currency = 'GBP'
       self.money_format = :cents
-      self.supported_countries = %w(AX AL DZ AS AO AI AG AM AW AZ BS BH BD BB BY BZ BJ BM BT BO BA BW IO BN BF BI KH CM CV KY CF TD CN CX CC KM CK DJ DO EC EG GQ ET FK FJ GF PF
-                                    TF GA GM GE GH GL GD GP GU GN GW GY HT HM ID IL JM JO KZ KE KI KW KG LS MK MG MW MV ML MH MQ MR MU YT FM MD MC MN ME MS MA MZ NA NR NP NC NE
-                                    NG NU NF MP OM PK PW PY PE PH PN PR QA RE RU RW KN LC WS SM ST SA SN RS SC SL SB ZA KR LK SZ TW TJ TZ TH TG TK TO TT TM TC TV UG UA AE UY UZ
-                                    VU VE VN EH YE ZM AD AR AU AT BE BR BG CA CL CO CR HR CY CZ DK SV EE FO FI FR DE GI GR GT GG HN HK HU IS IN IE IM IT JP JE LV LI LT LU MY MT
-                                    MX NL NZ NI NO PA PL PT RO SG SK SI ES SE CH TR GB US)
+      self.supported_countries = %w(AD AE AG AI AL AM AO AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BM BN BO BR BS BT BW
+                                    BY BZ CA CC CF CH CK CL CM CN CO CR CV CX CY CZ DE DJ DK DO DZ EC EE EG EH ES ET FI FJ FK
+                                    FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GT GU GW GY HK HM HN HR HT HU ID IE IL
+                                    IM IN IO IS IT JE JM JO JP KE KG KH KI KM KN KR KW KY KZ LA LC LI LK LS LT LU LV MA MC MD
+                                    ME MG MH MK ML MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ
+                                    OM PA PE PF PH PK PL PN PR PT PW PY QA RE RO RS RU RW SA SB SC SE SG SI SK SL SM SN ST SV
+                                    SZ TC TD TF TG TH TJ TK TM TO TR TT TV TW TZ UA UG US UY UZ VA VC VE VI VN VU WF WS YE YT
+                                    ZA ZM)
       self.supported_cardtypes = %i[visa master american_express discover jcb maestro elo naranja cabal unionpay]
       self.currencies_without_fractions = %w(HUF IDR JPY KRW BEF XOF XAF XPF GRD GNF ITL LUF MGA MGF PYG PTE RWF ESP TRL VND KMF)
       self.currencies_with_three_decimal_places = %w(BHD KWD OMR TND LYD JOD IQD)


### PR DESCRIPTION
### Summary:

This PR adds 7 missing countries to the supported countries list for Worldpay gateway, ending with a 212
supported countries.

### Test Execution:

Finished in 17.827146 seconds.
4999 tests, 74808 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
725 files inspected, no offenses detected