### PR TITLE
Paysafe: Add support for stored credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@
 * Bug: Fixing supported countries method when there is inheritance involved [cristian] #4211
 * Mundipagg: Update success method [ajawadmirza] #4210
 * Worldpay: Add support for Visa Direct Fast Funds Credit [dsmcclain] #4212
+* Paysafe: Add support for stored credentials [meagabeth] #4214
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/test/remote/gateways/remote_paysafe_test.rb
+++ b/test/remote/gateways/remote_paysafe_test.rb
@@ -64,7 +64,7 @@ class RemotePaysafeTest < Test::Unit::TestCase
     @airline_details = {
       airline_travel_details: {
         passenger_name: 'Joe Smith',
-        departure_date: '2021-11-30',
+        departure_date: '2026-11-30',
         origin: 'SXF',
         computerized_reservation_system: 'DATS',
         ticket: {
@@ -86,7 +86,7 @@ class RemotePaysafeTest < Test::Unit::TestCase
             is_stop_over_allowed: true,
             destination: 'ISL',
             fare_basis: 'VMAY',
-            departure_date: '2021-11-30'
+            departure_date: '2026-11-30'
           },
           leg2: {
             flight: {
@@ -97,7 +97,7 @@ class RemotePaysafeTest < Test::Unit::TestCase
             is_stop_over_allowed: true,
             destination: 'SOF',
             fare_basis: 'VMAY',
-            departure_date: '2021-11-30'
+            departure_date: '2026-11-30'
           }
         }
       }
@@ -189,6 +189,31 @@ class RemotePaysafeTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'COMPLETED', response.message
     assert_not_nil response.params['authCode']
+  end
+
+  def test_successful_purchase_with_stored_credentials
+    initial_options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring'
+      }
+    )
+
+    initial_response = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success initial_response
+    assert_not_nil initial_response.params['storedCredential']
+    network_transaction_id = initial_response.params['id']
+
+    stored_options = @options.merge(
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'installment',
+        network_transaction_id: network_transaction_id
+      }
+    )
+    response = @gateway.purchase(@amount, @credit_card, stored_options)
+    assert_success response
+    assert_equal 'COMPLETED', response.message
   end
 
   def test_failed_purchase

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -97,6 +97,24 @@ class PaysafeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_stored_credentials
+    stored_credential_options = {
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring',
+        initiator: 'merchant'
+      }
+    }
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential_options))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(%r{"type":"RECURRING"}, data)
+      assert_match(%r{"occurrence":"INITIAL"}, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_request).returns(failed_purchase_response)
 


### PR DESCRIPTION
[Paysafe stored credential API docs](https://developer.paysafe.com/en/cards/api/#/introduction/complex-json-objects/storedcredential)

CE-1569

Local:
5001 tests, 74815 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
16 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
31 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Rubocop:
725 files inspected, no offenses detected