### PR TITLE
Worldpay: Set default eCommerce indicator for EMVCO network tokens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@
 * Paysafe: Add support for stored credentials [meagabeth] #4214
 * Worldpay: Adding missing countries to supported countries [cristian] #4213
 * Update institution numbers for Canadian banks [therufs] #4216
+* Worldpay: Set default eCommerce indicator for EMVCO network tokens [shasum] #4215
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -516,9 +516,10 @@ module ActiveMerchant #:nodoc:
               )
             end
             name = card_holder_name(payment_method, options)
+            eci = format(payment_method.eci, :two_digits)
             xml.cardHolderName name if name.present?
             xml.cryptogram payment_method.payment_cryptogram
-            xml.eciIndicator format(payment_method.eci, :two_digits)
+            xml.eciIndicator eci.empty? ? '07' : eci
           end
         end
       end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -30,6 +30,9 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       eci: '07',
       source: :network_token,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+    @nt_credit_card_without_eci = network_tokenization_credit_card('4895370015293175',
+      source: :network_token,
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
 
     @options = {
       order_id: generate_unique_id,
@@ -81,6 +84,12 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_network_token
     assert response = @gateway.purchase(@amount, @nt_credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_purchase_with_network_token_without_eci
+    assert response = @gateway.purchase(@amount, @nt_credit_card_without_eci, @options)
     assert_success response
     assert_equal 'SUCCESS', response.message
   end


### PR DESCRIPTION
    Unit:
    5004 tests, 74828 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed
    
    RuboCop:
    725 files inspected, no offenses detected
    
    Remote:
    91 tests, 379 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    97.8022% passed
    
    Failing remote tests unrelated to this change:
    test_3ds_version_1_parameters_pass_thru
    test_3ds_version_2_parameters_pass_thru
