### PR TITLE
Update Canadian institution number handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Worldpay: Adding missing countries to supported countries [cristian] #4213
 * Update institution numbers for Canadian banks [therufs] #4216
 * Worldpay: Set default eCommerce indicator for EMVCO network tokens [shasum] #4215
+* Update handling routing numbers for Canadian banks [therufs] #4217
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -71,11 +71,8 @@ module ActiveMerchant #:nodoc:
             (7 * (digits[1] + digits[4] + digits[7])) +
             (digits[2] + digits[5] + digits[8])) % 10
 
-          return checksum == 0
+          return checksum == 0 || CAN_INSTITUTION_NUMBERS.include?(routing_number[1..3])
         end
-
-        return CAN_INSTITUTION_NUMBERS.include?(routing_number[0..2]) if digits.size == 8
-
         false
       end
     end

--- a/test/unit/check_test.rb
+++ b/test/unit/check_test.rb
@@ -4,7 +4,7 @@ class CheckTest < Test::Unit::TestCase
   VALID_ABA     = '111000025'
   INVALID_ABA   = '999999999'
   MALFORMED_ABA = 'I like fish'
-  VALID_CBA = '00194611'
+  VALID_CBA = '000194611'
   INVALID_NINE_DIGIT_CBA = '012345678'
   INVALID_SEVEN_DIGIT_ROUTING_NUMBER = '0123456'
 
@@ -92,7 +92,7 @@ class CheckTest < Test::Unit::TestCase
     )
   end
 
-  def test_invalid_nine_digit_canada_routing_number
+  def test_invalid_canada_routing_number
     errors = assert_not_valid Check.new(
       name: 'Tim Horton',
       routing_number: INVALID_NINE_DIGIT_CBA,


### PR DESCRIPTION
Canadian routing numbers are typically handled either in print/MICR format or
electronic format (see https://en.wikipedia.org/wiki/Routing_number_(Canada)#Format).
Update check validation to handle checks with a valid Canadian institution number, presented in the standard electronic format.

Unit tests:
5002 tests, 74820 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected