### PR TITLE
Mercado Pago: Update verify for custom amount

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@
 * Worldpay: Set default eCommerce indicator for EMVCO network tokens [shasum] #4215
 * Update handling routing numbers for Canadian banks [therufs] #4217
 * Stripe: API version updated [jherreraa] #4209
+* Mercado Pago: Update verify method [ajawadmirza] #4219
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -53,8 +53,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options = {})
+        verify_amount = 100
+        verify_amount = options[:amount].to_i if options[:amount]
         MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
+          r.process { authorize(verify_amount, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
         end
       end

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -307,6 +307,13 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     assert_match %r{pending_capture}, response.message
   end
 
+  def test_successful_verify_with_amount
+    @options[:amount] = 200
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{pending_capture}, response.message
+  end
+
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -252,6 +252,17 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_verify_with_custom_amount
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options.merge({ amount: 200 }))
+    end.check_request do |endpoint, data, _headers|
+      params = JSON.parse(data)
+      assert_equal 2.0, params['transaction_amount'] if endpoint.include? 'payment'
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+  end
+
   def test_successful_verify_with_failed_void
     @gateway.expects(:ssl_request).at_most(3).returns(failed_void_response)
 


### PR DESCRIPTION
Updated `verify` method to allow custom amount in options to support card
validation rules.

CE-2136

Remote:

36 tests, 102 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.6667% passed

Unit:
5004 tests, 74828 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected