### PR TITLE
DLocal: Set API Version

### DIFF
--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -233,6 +233,7 @@ module ActiveMerchant #:nodoc:
           'X-Date' => timestamp,
           'X-Login' => @options[:login],
           'X-Trans-Key' => @options[:trans_key],
+          'X-Version' => '2.1',
           'Authorization' => signature(post, timestamp)
         }
         headers.merge('X-Idempotency-Key' => options[:idempotency_key]) if options[:idempotency_key]

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -210,6 +210,14 @@ class DLocalTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_api_version_param_header 
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, _data, headers|
+      assert_equal '2.1', headers['X-Version']
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
## Summary:

In order to prevent that future releases with breaking changes
 that could potentially affect the current interface of the DLocal adapter,
 this PR set the API version to 2.1.

## Local Tests:

23 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## Remote Tests:

Finished in 172.14121 seconds.
28 tests, 74 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.4286% passed

## RuboCop:

725 files inspected, no offenses detected