### PR TITLE
add skip_response option on request check fro commit stubs

### DIFF
--- a/test/comm_stub.rb
+++ b/test/comm_stub.rb
@@ -8,17 +8,29 @@ module CommStub
       @check = nil
     end
 
-    def check_request(&block)
-      @check = block
-      self
+    def check_request(skip_response: false, &block)
+      if skip_response
+        @complete = true
+        overwrite_gateway_method do |*args|
+          block&.call(*args) || ''
+        end
+        @action.call
+      else
+        @check = block
+        self
+      end
+    end
+
+    def overwrite_gateway_method(&block)
+      singleton_class = (class << @gateway; self; end)
+      singleton_class.send(:undef_method, @method_to_stub)
+      singleton_class.send(:define_method, @method_to_stub, &block)
     end
 
     def respond_with(*responses)
       @complete = true
       check = @check
-      singleton_class = (class << @gateway; self; end)
-      singleton_class.send(:undef_method, @method_to_stub)
-      singleton_class.send(:define_method, @method_to_stub) do |*args|
+      overwrite_gateway_method do |*args|
         check&.call(*args)
         (responses.size == 1 ? responses.last : responses.shift)
       end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1205,30 +1205,27 @@ class WorldpayTest < Test::Unit::TestCase
   end
 
   def test_network_token_type_assignation_when_apple_token
-    response = stub_comms do
+    stub_comms do
       @gateway.authorize(@amount, @apple_play_network_token, @options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
       assert_match %r(<EMVCO_TOKEN-SSL type="APPLEPAY">), data
-    end.respond_with(successful_authorize_response)
-    assert_success response
+    end
   end
 
   def test_network_token_type_assignation_when_network_token
-    response = stub_comms do
+    stub_comms do
       @gateway.authorize(@amount, @nt_credit_card, @options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
       assert_match %r(<EMVCO_TOKEN-SSL type="NETWORKTOKEN">), data
-    end.respond_with(successful_authorize_response)
-    assert_success response
+    end
   end
 
   def test_network_token_type_assignation_when_google_pay
-    response = stub_comms do
+    stub_comms do
       @gateway.authorize(@amount, @google_pay_network_token, @options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
       assert_match %r(<EMVCO_TOKEN-SSL type="GOOGLEPAY">), data
-    end.respond_with(successful_authorize_response)
-    assert_success response
+    end
   end
 
   def test_order_id_crop_and_clean


### PR DESCRIPTION
### Summary
---
Currently is mandatory to add a "respond_with" to a CommStub instance in order to be able to check the content of a request, this change makes that optional.

The main point of this change si that doesn't make sense to test the validity of a response that is not affected by the input, no matter how bad the request is is not going to affect the response, it is basically an 'assert true'.

### Test Local
---
5004 tests, 74825 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
294.40 tests/s, 4402.22 assertions/s

### Test RuboCop
---
725 files inspected, no offenses detected