### PR TITLE
USA Epay: Add store functionality

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@
 * Wompi: Add support for Authorize and Capture [rachelkirk] #4218
 * Priority: Update source and billing address checks [jessiagee] #4220
 * Pin Payments: Add support for `diners_club`, `discover`, and `jcb` cardtypes [montdidier] #4142
+* USA ePay: Add store method [ajawadmirza] #4224
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -16,7 +16,8 @@ module ActiveMerchant #:nodoc:
         refund: 'cc:refund',
         void: 'cc:void',
         void_release: 'cc:void:release',
-        check_purchase: 'check:sale'
+        check_purchase: 'check:sale',
+        store: 'cc:save'
       }
 
       STANDARD_ERROR_CODE_MAPPING = {
@@ -95,6 +96,12 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money)
         add_test_mode(post, options)
         commit(:refund, post)
+      end
+
+      def store(payment, options = {})
+        post = {}
+        add_payment(post, payment, options)
+        commit(:store, post)
       end
 
       def verify(creditcard, options = {})
@@ -213,6 +220,8 @@ module ActiveMerchant #:nodoc:
         elsif payment.respond_to?(:track_data) && payment.track_data.present?
           post[:magstripe] = payment.track_data
           post[:cardpresent] = true
+        elsif payment.is_a?(String)
+          post[:card]   = payment
         else
           post[:card]   = payment.number
           post[:cvv2]   = payment.verification_value if payment.verification_value?
@@ -299,6 +308,7 @@ module ActiveMerchant #:nodoc:
           status: fields['UMstatus'],
           auth_code: fields['UMauthCode'],
           ref_num: fields['UMrefNum'],
+          card_ref: fields['UMcardRef'],
           batch: fields['UMbatch'],
           avs_result: fields['UMavsResult'],
           avs_result_code: fields['UMavsResultCode'],

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -19,6 +19,16 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+
+    payment_token = response.params['card_ref']
+    assert response = @gateway.purchase(@amount, payment_token, @options)
+    assert_equal 'Success', response.message
+    assert_success response
+  end
+
   def test_successful_purchase_with_track_data
     assert response = @gateway.purchase(@amount, @credit_card_with_track_data, @options)
     assert_equal 'Success', response.message


### PR DESCRIPTION
Added support for `store` method and accept payment token for making
transactions in `usa_epay_transaction` gateway.

CE-2195

Remote:
33 tests, 122 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.9697% passed

Unit:
5004 tests, 74828 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected