### PR TITLE
IPG: Quick fix to remove warning

### DIFF
--- a/lib/active_merchant/billing/gateways/ipg.rb
+++ b/lib/active_merchant/billing/gateways/ipg.rb
@@ -19,6 +19,7 @@ module ActiveMerchant #:nodoc:
       def initialize(options = {})
         requires!(options, :store_id, :user_id, :password, :pem, :pem_password)
         @credentials = options
+        @hosted_data_id = nil
         super
       end
 


### PR DESCRIPTION
Initialized `hosted_data_id` to remove warning from IPG

Unit:
5009 tests, 74848 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
16 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed