### PR TITLE
Worldpay: Add transaction identifier to `store`

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -303,8 +303,19 @@ module ActiveMerchant #:nodoc:
                   add_card(xml, credit_card, options)
                 end
               end
+              add_transaction_identifier(xml, options) if network_transaction_id(options)
             end
           end
+        end
+      end
+
+      def network_transaction_id(options)
+        options[:stored_credential_transaction_id] || options.dig(:stored_credential, :network_transaction_id)
+      end
+
+      def add_transaction_identifier(xml, options)
+        xml.storedCredentials 'usage' => 'FIRST' do
+          xml.schemeTransactionIdentifier network_transaction_id(options)
         end
       end
 
@@ -743,6 +754,7 @@ module ActiveMerchant #:nodoc:
       def commit(action, request, *success_criteria, options)
         xml = ssl_post(url, request, headers(options))
         raw = parse(action, xml)
+
         if options[:execute_threed]
           raw[:cookie] = @cookie if defined?(@cookie)
           raw[:session_id] = options[:session_id]

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -858,6 +858,26 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_match @store_options[:customer], response.authorization
   end
 
+  def test_successful_store_with_transaction_identifier_using_gateway_specific_field
+    transaction_identifier = 'ABC123'
+    options_with_transaction_id = @store_options.merge(stored_credential_transaction_id: transaction_identifier)
+    assert response = @gateway.store(@credit_card, options_with_transaction_id)
+
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+    assert_match transaction_identifier, response.params['transaction_identifier']
+  end
+
+  def test_successful_store_with_transaction_identifier_using_normalized_fields
+    transaction_identifier = 'CDE456'
+    options_with_transaction_id = @store_options.merge(stored_credential: { network_transaction_id: transaction_identifier })
+    assert response = @gateway.store(@credit_card, options_with_transaction_id)
+
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+    assert_match transaction_identifier, response.params['transaction_identifier']
+  end
+
   def test_successful_purchase_with_statement_narrative
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(statement_narrative: 'Merchant Statement Narrative'))
     assert_success response


### PR DESCRIPTION
Makes it possible to tokenize a payment method at Worldpay with a
stored credential transaction id attached to it.

CE-2176

Rubocop:
725 files inspected, no offenses detected

Unit:
5009 tests, 74848 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_worldpay_test
94 tests, 390 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.8723% passed

Remote tests failing on master for unrelated reasons:
`test_3ds_version_2_parameters_pass_thru`
`test_3ds_version_1_parameters_pass_thru`