### PR TITLE
Priority: Remove bank account tender type

### DIFF
--- a/lib/active_merchant/billing/gateways/priority.rb
+++ b/lib/active_merchant/billing/gateways/priority.rb
@@ -72,7 +72,6 @@ module ActiveMerchant #:nodoc:
         params = {}
         # refund amounts must be negative
         params['amount'] = ('-' + localized_amount(amount.to_f, options[:currency])).to_f
-        add_bank(params, options[:auth_code])
         add_credit_card(params, credit_card, 'refund', options) unless options[:auth_code]
         add_type_merchant_refund(params, options)
         commit('refund', params: params, jwt: options)
@@ -86,7 +85,7 @@ module ActiveMerchant #:nodoc:
         params['paymentToken'] = get_hash(authorization)['payment_token']
         params['shouldGetCreditCardLevel'] = true
         params['source'] = options[:source]
-        params['tenderType'] = options[:tender_type]
+        params['tenderType'] = 'Card'
 
         commit('capture', params: params, jwt: options)
       end
@@ -121,12 +120,6 @@ module ActiveMerchant #:nodoc:
           gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
           gsub(%r((number\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
           gsub(%r((cvv\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]')
-      end
-
-      def add_bank(params, auth_code)
-        params['authCode'] = auth_code
-        params['authOnly'] = false
-        params['availableAuthAmount'] = 0
       end
 
       def add_credit_card(params, credit_card, action, options)
@@ -188,7 +181,7 @@ module ActiveMerchant #:nodoc:
         params['source'] = options[:source]
         params['sourceZip'] = options[:billing_address][:zip] if options[:billing_address]
         params['taxExempt'] = false
-        params['tenderType'] = options[:tender_type]
+        params['tenderType'] = 'Card'
       end
 
       def add_type_merchant_refund(params, options)
@@ -223,7 +216,7 @@ module ActiveMerchant #:nodoc:
         params['status'] = options[:status]
         params['tax'] = options[:tax]
         params['taxExempt'] = options[:tax_exempt]
-        params['tenderType'] = options[:tender_type]
+        params['tenderType'] = 'Card'
         params['type'] = options[:type]
       end
 

--- a/test/remote/gateways/remote_priority_test.rb
+++ b/test/remote/gateways/remote_priority_test.rb
@@ -181,7 +181,7 @@ class RemotePriorityTest < Test::Unit::TestCase
 
   # Must enter 6 to 10 numbers from start of card to test
   def test_successful_verify
-    # Generate jwt token from key and secret. Pass generated jwt to verify function. The verify function requries a jwt for header authorization.
+    # Generate jwt token from key and secret. Pass generated jwt to verify function. The verify function requires a jwt for header authorization.
     jwt_response = @gateway.create_jwt(@option_spr)
     response = @gateway.verify(@credit_card, { jwt_token: jwt_response.params['jwtToken'] })
     assert_success response
@@ -190,7 +190,7 @@ class RemotePriorityTest < Test::Unit::TestCase
 
   # Must enter 6 to 10 numbers from start of card to test
   def test_failed_verify
-    # Generate jwt token from key and secret. Pass generated jwt to verify function. The verify function requries a jwt for header authorization.
+    # Generate jwt token from key and secret. Pass generated jwt to verify function. The verify function requires a jwt for header authorization.
     jwt_response = @gateway.create_jwt(@option_spr)
     @gateway.verify(@invalid_credit_card, { jwt_token: jwt_response.params['jwtToken'] })
   rescue StandardError => e
@@ -203,7 +203,7 @@ class RemotePriorityTest < Test::Unit::TestCase
   end
 
   def test_failed_verify_must_be_6_to_10_digits
-    # Generate jwt token from key and secret. Pass generated jwt to verify function. The verify function requries a jwt for header authorization.
+    # Generate jwt token from key and secret. Pass generated jwt to verify function. The verify function requires a jwt for header authorization.
     jwt_response = @gateway.create_jwt(@option_spr)
     @gateway.verify(@faulty_credit_card, { jwt_token: jwt_response.params['jwtToken'] })
   rescue StandardError => e


### PR DESCRIPTION
* The existing add_bank method did not actually set the bank information
appropriately so removed it until further information if necessary

bundle exec rake test:local

5009 tests, 74848 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

725 files inspected, no offenses detected

Loaded suite test/unit/gateways/priority_test

12 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_priority_test

20 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed