### PR TITLE
Revert "Remove YAML warning on load_fixtures_method"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,7 +46,6 @@
 * Pin Payments: Add support for `diners_club`, `discover`, and `jcb` cardtypes [montdidier] #4142
 * USA ePay: Add store method [ajawadmirza] #4224
 * IPG: Quick fix to remove warning [ajawadmirza] #4225
-* Remove YAML warning on load_fixtures_method [jherreraa] #4226
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -281,7 +281,7 @@ module ActiveMerchant
     def load_fixtures
       [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
         if File.exist?(file_name)
-          yaml_data = YAML.safe_load(File.read(file_name), aliases: true)
+          yaml_data = YAML.safe_load(File.read(file_name), [], [], true)
           credentials.merge!(symbolize_keys(yaml_data))
         end
         credentials


### PR DESCRIPTION
This reverts commit 653116444dd926d6d5172563c11ed9a000301103.

Unit:
5009 tests, 74848 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected