### PR TITLE
USA ePay: Update implementation to send valid authorization

### DIFF
--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -331,7 +331,7 @@ module ActiveMerchant #:nodoc:
         error_code = (STANDARD_ERROR_CODE_MAPPING[response[:error_code]] || STANDARD_ERROR_CODE[:processing_error]) unless approved
         Response.new(approved, message_from(response), response,
           test: test?,
-          authorization: response[:ref_num],
+          authorization: authorization_from(action, response),
           cvv_result: response[:cvv2_result_code],
           avs_result: { code: response[:avs_result_code] },
           error_code: error_code)
@@ -345,6 +345,10 @@ module ActiveMerchant #:nodoc:
 
           return response[:error]
         end
+      end
+
+      def authorization_from(action, response)
+        return (action == :store ? response[:card_ref] : response[:ref_num])
       end
 
       def post_data(action, parameters = {})

--- a/test/unit/gateways/usa_epay_transaction_test.rb
+++ b/test/unit/gateways/usa_epay_transaction_test.rb
@@ -280,6 +280,15 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_store_request
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    expected_auth = response.params['card_ref']
+    assert_equal expected_auth, response.authorization
+  end
+
   def test_successful_capture_passing_extra_info
     response = stub_comms do
       @gateway.capture(@amount, '65074409', @options)
@@ -604,6 +613,10 @@ class UsaEpayTransactionTest < Test::Unit::TestCase
 
   def successful_void_response_echeck
     'UMversion=2.9&UMstatus=Approved&UMauthCode=TM80A5&UMrefNum=133134971&UMavsResult=No%20AVS%20response%20%28Typically%20no%20AVS%20data%20sent%20or%20swiped%20transaction%29&UMavsResultCode=&UMcvv2Result=No%20CVV2%2FCVC%20data%20available%20for%20transaction.&UMcvv2ResultCode=&UMresult=A&UMvpasResultCode=&UMerror=&UMerrorcode=00000&UMcustnum=&UMbatch=&UMbatchRefNum=&UMisDuplicate=N&UMconvertedAmount=&UMconvertedAmountCurrency=840&UMconversionRate=&UMcustReceiptResult=No%20Receipt%20Sent&UMprocRefNum=&UMcardLevelResult=&UMauthAmount=&UMfiller=filled'
+  end
+
+  def successful_store_response
+    'UMversion=2.9&UMstatus=Approved&UMauthCode=&UMrefNum=&UMavsResult=No%20AVS%20response%20%28Typically%20no%20AVS%20data%20sent%20or%20swiped%20transaction%29&UMavsResultCode=&UMcvv2Result=No%20CVV2%2FCVC%20data%20available%20for%20transaction.&UMcvv2ResultCode=&UMresult=A&UMvpasResultCode=&UMerror=&UMerrorcode=00000&UMcustnum=&UMbatch=&UMbatchRefNum=&UMisDuplicate=N&UMconvertedAmount=&UMconvertedAmountCurrency=840&UMconversionRate=&UMcustReceiptResult=No%20Receipt%20Sent&UMprocRefNum=&UMcardLevelResult=&UMauthAmount=&UMcardRef=whx6-fvz2-24l1-39a8&UMcardType=Visa&UMmaskedCardNum=XXXXXXXXXXXX2224&UMfiller=filled'
   end
 
   def pre_scrubbed


### PR DESCRIPTION
Updated USA ePay implementation to send valid authorization for store
and other transactions.

CE-2195

Unit:
5010 tests, 74852 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
33 tests, 122 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.9697% passed