### PR TITLE
USAePay: Add store test, update authorize param

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@
 * IPG: Quick fix to remove warning [ajawadmirza] #4225
 * Worldpay: Add support for tokenizing payment methods with transaction identifiers [dsmcclain] #4227
 * USA ePay: Update implementation to send valid authorization [ajawadmirza] #4231
+* USA ePay: Add store test, update authorize param [jessiagee] #4232
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -44,14 +44,14 @@ module ActiveMerchant #:nodoc:
         super
       end
 
-      def authorize(money, credit_card, options = {})
+      def authorize(money, payment, options = {})
         post = {}
 
         add_amount(post, money)
         add_invoice(post, options)
-        add_payment(post, credit_card)
-        unless credit_card.track_data.present?
-          add_address(post, credit_card, options)
+        add_payment(post, payment)
+        unless payment.is_a?(CreditCard) && payment.track_data.present?
+          add_address(post, payment, options)
           add_customer_data(post, options)
         end
         add_split_payments(post, options)

--- a/test/remote/gateways/remote_usa_epay_transaction_test.rb
+++ b/test/remote/gateways/remote_usa_epay_transaction_test.rb
@@ -23,8 +23,18 @@ class RemoteUsaEpayTransactionTest < Test::Unit::TestCase
     response = @gateway.store(@credit_card, @options)
     assert_success response
 
-    payment_token = response.params['card_ref']
+    payment_token = response.authorization
     assert response = @gateway.purchase(@amount, payment_token, @options)
+    assert_equal 'Success', response.message
+    assert_success response
+  end
+
+  def test_successful_authorize_with_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+
+    payment_token = response.authorization
+    assert response = @gateway.authorize(@amount, payment_token, @options)
     assert_equal 'Success', response.message
     assert_success response
   end


### PR DESCRIPTION
* Added a store test for authorize with a third party token
* Updated authorize param to use 'payment' instead of 'credit card'

bundle exec rake test:local

5010 tests, 74852 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

725 files inspected, no offenses detected

Loaded suite test/unit/gateways/usa_epay_transaction_test

51 tests, 307 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_usa_epay_transaction_test

34 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
