### PR TITLE
IPG: Update authorization for store

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@
 * Add skip_response option on request check for commit stubs [cristian] #4223
 * Pin Payments: Add support for `void` and New Zealand to supported countries. [montdidier] #4144
 * Wompi: Update authorization in `capture` method. [rachelkirk] #4238
+* IPG: Update authorization to support `store` method token. [ajawadmirza] #4233
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/ipg.rb
+++ b/lib/active_merchant/billing/gateways/ipg.rb
@@ -332,7 +332,7 @@ module ActiveMerchant #:nodoc:
           response[:success],
           message_from(response),
           response,
-          authorization: authorization_from(response),
+          authorization: authorization_from(action, response),
           avs_result: AVSResult.new(code: response[:AVSResponse]),
           cvv_result: CVVResult.new(response[:ProcessorCCVResponse]),
           test: test?,
@@ -370,8 +370,8 @@ module ActiveMerchant #:nodoc:
         response[:TransactionResult]
       end
 
-      def authorization_from(response)
-        response[:OrderId]
+      def authorization_from(action, response)
+        return (action == 'vault' ? response[:hosted_data_id] : response[:OrderId])
       end
 
       def error_code_from(response)

--- a/test/remote/gateways/remote_ipg_test.rb
+++ b/test/remote/gateways/remote_ipg_test.rb
@@ -34,7 +34,7 @@ class RemoteIpgTest < Test::Unit::TestCase
     response = @gateway.store(@credit_card, @options)
     assert_success response
     assert_equal 'true', response.params['successfully']
-    payment_token = response.params['hosted_data_id']
+    payment_token = response.authorization
     assert payment_token
 
     response = @gateway.purchase(@amount, payment_token, @options)


### PR DESCRIPTION
Updated authorization for IPG so that `hosted_data_id` is sent for store
and `OrderId` for other

CE-2231

Unit:
5010 tests, 74852 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
14 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed