### PR TITLE
CheckoutV2: Add support for Apple Pay and Google Pay tokens

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -110,17 +110,16 @@ module ActiveMerchant #:nodoc:
       def add_payment_method(post, payment_method, options)
         post[:source] = {}
         if payment_method.is_a?(NetworkTokenizationCreditCard)
+          token_type = token_type_from(payment_method)
+          cryptogram = payment_method.payment_cryptogram
+          eci = payment_method.eci || options[:eci]
+          eci ||= '05' if token_type == 'vts'
+
           post[:source][:type] = 'network_token'
           post[:source][:token] = payment_method.number
-          post[:source][:token_type] = token_type_from(payment_method)
-
-          if cryptogram = payment_method.payment_cryptogram
-            post[:source][:cryptogram] = cryptogram
-          end
-
-          if eci = payment_method.eci || options[:eci]
-            post[:source][:eci] = eci
-          end
+          post[:source][:token_type] = token_type
+          post[:source][:cryptogram] = cryptogram if cryptogram
+          post[:source][:eci] = eci if eci
         else
           post[:source][:type] = 'card'
           post[:source][:name] = payment_method.name

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -11,7 +11,6 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @threeds_card = credit_card('4485040371536584', verification_value: '100', month: '12', year: '2020')
 
     @vts_network_token = network_tokenization_credit_card('4242424242424242',
-      eci:                '05',
       payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
       month:              '10',
       year:               '2025',

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -10,11 +10,52 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @declined_card = credit_card('42424242424242424', verification_value: '234', month: '6', year: '2025')
     @threeds_card = credit_card('4485040371536584', verification_value: '100', month: '12', year: '2020')
 
-    @network_token = network_tokenization_credit_card('4242424242424242',
+    @vts_network_token = network_tokenization_credit_card('4242424242424242',
+      eci:                '05',
       payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
       month:              '10',
       year:               '2025',
       source:             :network_token,
+      brand:              'visa',
+      verification_value: nil)
+
+    @mdes_network_token = network_tokenization_credit_card('5436031030606378',
+      eci:                '02',
+      payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+      month:              '10',
+      year:               '2025',
+      source:             :network_token,
+      brand:              'master',
+      verification_value: nil)
+
+    @google_pay_visa_cryptogram_3ds_network_token = network_tokenization_credit_card('4242424242424242',
+      eci:                '05',
+      payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+      month:              '10',
+      year:               '2025',
+      source:             :google_pay,
+      verification_value: nil)
+
+    @google_pay_master_cryptogram_3ds_network_token = network_tokenization_credit_card('5436031030606378',
+      payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+      month:              '10',
+      year:               '2025',
+      source:             :google_pay,
+      brand:              'master',
+      verification_value: nil)
+
+    @google_pay_pan_only_network_token = network_tokenization_credit_card('4242424242424242',
+      month:              '10',
+      year:               '2025',
+      source:             :google_pay,
+      verification_value: nil)
+
+    @apple_pay_network_token = network_tokenization_credit_card('4242424242424242',
+      eci:                '05',
+      payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+      month:              '10',
+      year:               '2025',
+      source:             :apple_pay,
       verification_value: nil)
 
     @options = {
@@ -66,11 +107,42 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
-  def test_successful_purchase_with_network_token
-    response = @gateway.purchase(100, @network_token, @options)
+  def test_successful_purchase_with_vts_network_token
+    response = @gateway.purchase(100, @vts_network_token, @options)
     assert_success response
     assert_equal 'Succeeded', response.message
     assert_not_nil response.params['source']['payment_account_reference']
+  end
+
+  def test_successful_purchase_with_mdes_network_token
+    response = @gateway.purchase(100, @mdes_network_token, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_not_nil response.params['source']['payment_account_reference']
+  end
+
+  def test_successful_purchase_with_google_pay_visa_cryptogram_3ds_network_token
+    response = @gateway.purchase(100, @google_pay_visa_cryptogram_3ds_network_token, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_google_pay_master_cryptogram_3ds_network_token
+    response = @gateway.purchase(100, @google_pay_master_cryptogram_3ds_network_token, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_google_pay_pan_only_network_token
+    response = @gateway.purchase(100, @google_pay_pan_only_network_token, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_apple_pay_network_token
+    response = @gateway.purchase(100, @apple_pay_network_token, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
   end
 
   def test_successful_purchase_with_additional_options

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -41,10 +41,131 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Y', response.cvv_result['code']
   end
 
-  def test_successful_purchase_using_network_token
-    network_token = network_tokenization_credit_card({ source: :network_token })
+  def test_successful_purchase_using_vts_network_token
+    network_token = network_tokenization_credit_card(
+      '4242424242424242',
+      { source: :network_token, brand: 'visa', eci: '05' }
+    )
     response = stub_comms do
       @gateway.purchase(@amount, network_token)
+    end.check_request do |_endpoint, data, _headers|
+      request_data = JSON.parse(data)
+
+      assert_equal(request_data['source']['type'], 'network_token')
+      assert_equal(request_data['source']['token'], network_token.number)
+      assert_equal(request_data['source']['token_type'], 'vts')
+      assert_equal(request_data['source']['eci'], '05')
+      assert_equal(request_data['source']['cryptogram'], network_token.payment_cryptogram)
+    end.respond_with(successful_purchase_with_network_token_response)
+
+    assert_success response
+    assert_equal '2FCFE326D92D4C27EDD699560F484', response.params['source']['payment_account_reference']
+    assert response.test?
+  end
+
+  def test_successful_purchase_using_mdes_network_token
+    network_token = network_tokenization_credit_card(
+      '5436031030606378',
+      { source: :network_token, brand: 'master' }
+    )
+    response = stub_comms do
+      @gateway.purchase(@amount, network_token)
+    end.check_request do |_endpoint, data, _headers|
+      request_data = JSON.parse(data)
+
+      assert_equal(request_data['source']['type'], 'network_token')
+      assert_equal(request_data['source']['token'], network_token.number)
+      assert_equal(request_data['source']['token_type'], 'mdes')
+      assert_equal(request_data['source']['eci'], nil)
+      assert_equal(request_data['source']['cryptogram'], network_token.payment_cryptogram)
+    end.respond_with(successful_purchase_with_network_token_response)
+
+    assert_success response
+    assert_equal '2FCFE326D92D4C27EDD699560F484', response.params['source']['payment_account_reference']
+    assert response.test?
+  end
+
+  def test_successful_purchase_using_apple_pay_network_token
+    network_token = network_tokenization_credit_card(
+      '4242424242424242',
+      { source: :apple_pay, eci: '05', payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA' }
+    )
+    response = stub_comms do
+      @gateway.purchase(@amount, network_token)
+    end.check_request do |_endpoint, data, _headers|
+      request_data = JSON.parse(data)
+
+      assert_equal(request_data['source']['type'], 'network_token')
+      assert_equal(request_data['source']['token'], network_token.number)
+      assert_equal(request_data['source']['token_type'], 'applepay')
+      assert_equal(request_data['source']['eci'], '05')
+      assert_equal(request_data['source']['cryptogram'], network_token.payment_cryptogram)
+    end.respond_with(successful_purchase_with_network_token_response)
+
+    assert_success response
+    assert_equal '2FCFE326D92D4C27EDD699560F484', response.params['source']['payment_account_reference']
+    assert response.test?
+  end
+
+  def test_successful_purchase_using_android_pay_network_token
+    network_token = network_tokenization_credit_card(
+      '4242424242424242',
+      { source: :android_pay, eci: '05', payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA' }
+    )
+    response = stub_comms do
+      @gateway.purchase(@amount, network_token)
+    end.check_request do |_endpoint, data, _headers|
+      request_data = JSON.parse(data)
+
+      assert_equal(request_data['source']['type'], 'network_token')
+      assert_equal(request_data['source']['token'], network_token.number)
+      assert_equal(request_data['source']['token_type'], 'googlepay')
+      assert_equal(request_data['source']['eci'], '05')
+      assert_equal(request_data['source']['cryptogram'], network_token.payment_cryptogram)
+    end.respond_with(successful_purchase_with_network_token_response)
+
+    assert_success response
+    assert_equal '2FCFE326D92D4C27EDD699560F484', response.params['source']['payment_account_reference']
+    assert response.test?
+  end
+
+  def test_successful_purchase_using_google_pay_network_token
+    network_token = network_tokenization_credit_card(
+      '4242424242424242',
+      { source: :google_pay, eci: '05', payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA' }
+    )
+    response = stub_comms do
+      @gateway.purchase(@amount, network_token)
+    end.check_request do |_endpoint, data, _headers|
+      request_data = JSON.parse(data)
+
+      assert_equal(request_data['source']['type'], 'network_token')
+      assert_equal(request_data['source']['token'], network_token.number)
+      assert_equal(request_data['source']['token_type'], 'googlepay')
+      assert_equal(request_data['source']['eci'], '05')
+      assert_equal(request_data['source']['cryptogram'], network_token.payment_cryptogram)
+    end.respond_with(successful_purchase_with_network_token_response)
+
+    assert_success response
+    assert_equal '2FCFE326D92D4C27EDD699560F484', response.params['source']['payment_account_reference']
+    assert response.test?
+  end
+
+  def test_successful_purchase_using_google_pay_pan_only_network_token
+    network_token = network_tokenization_credit_card(
+      '4242424242424242',
+      { source: :google_pay }
+    )
+    response = stub_comms do
+      @gateway.purchase(@amount, network_token)
+    end.check_request do |_endpoint, data, _headers|
+      request_data = JSON.parse(data)
+
+      assert_equal(request_data['source']['type'], 'network_token')
+      assert_equal(request_data['source']['token'], network_token.number)
+      assert_equal(request_data['source']['token_type'], 'googlepay')
+      assert_equal(request_data['source']['eci'], nil)
+      assert_equal(request_data['source']['cryptogram'], nil)
     end.respond_with(successful_purchase_with_network_token_response)
 
     assert_success response


### PR DESCRIPTION
# Description
Adds support for `applepay` and `googlepay` network tokens via the `CheckoutV2Gateway`.

Also removes the default `eci` value of `05` for `mdes` tokens, `05` only seems to be valid for `Visa` - see https://support.midtrans.com/hc/en-us/articles/204161150-What-is-ECI-on-3DS-protocol-

# Test Summary

## Unit
5016 tests, 74917 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## Rubocop
725 files inspected, no offenses detected

## Remote
43 tests, 110 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed