### PR TITLE
Paymentez: Update card mappings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,6 +55,7 @@
 * Pin Payments: Add support for `void` and New Zealand to supported countries. [montdidier] #4144
 * Wompi: Update authorization in `capture` method. [rachelkirk] #4238
 * IPG: Update authorization to support `store` method token. [ajawadmirza] #4233
+* Paymentez: Update card mappings [ajawadmirza] #4237
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w[MX EC CO BR CL PE]
       self.default_currency = 'USD'
-      self.supported_cardtypes = %i[visa master american_express diners_club elo alia olimpica]
+      self.supported_cardtypes = %i[visa master american_express diners_club elo alia olimpica discover maestro sodexo carnet unionpay jcb]
 
       self.homepage_url = 'https://secure.paymentez.com/'
       self.display_name = 'Paymentez'
@@ -39,7 +39,14 @@ module ActiveMerchant #:nodoc:
         'master' => 'mc',
         'american_express' => 'ax',
         'diners_club' => 'di',
-        'elo' => 'el'
+        'elo' => 'el',
+        'discover' => 'dc',
+        'maestro' => 'ms',
+        'sodexo' => 'sx',
+        'olimpica' => 'ol',
+        'carnet' => 'ct',
+        'unionpay' => 'up',
+        'jcb' => 'jc'
       }.freeze
 
       def initialize(options = {})


### PR DESCRIPTION
Updated card mappings for the paymentez implementation

CE-2167

Remote:
31 tests, 66 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
80.6452% passed

Unit:
5010 tests, 74852 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected