### PR TITLE
Wompi: update authorization in capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,8 @@
 * USA ePay: Add store test, update authorize param [jessiagee] #4232
 * Stripe: Update destination test account [jherreraa] #4234
 * Add skip_response option on request check for commit stubs [cristian] #4223
+* Pin Payments: Add support for `void` and New Zealand to supported countries. [montdidier] #4144
+* Wompi: Update authorization in `capture` method. [rachelkirk] #4238
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/wompi.rb
+++ b/lib/active_merchant/billing/gateways/wompi.rb
@@ -54,10 +54,9 @@ module ActiveMerchant #:nodoc:
         post = {
           reference: options[:reference] || generate_reference,
           public_key: public_key,
-          payment_source_id: authorization
+          payment_source_id: authorization.to_i
         }
         add_invoice(post, money, options)
-
         commit('capture', post, '/transactions_sync')
       end
 

--- a/test/unit/gateways/wompi_test.rb
+++ b/test/unit/gateways/wompi_test.rb
@@ -76,8 +76,9 @@ class WompiTest < Test::Unit::TestCase
   def test_failed_capture
     @gateway.expects(:ssl_post).returns(failed_capture_response)
 
-    response = @gateway.capture(@amount, @credit_card, @options)
+    response = @gateway.capture(@amount, '')
     assert_failure response
+
     assert_equal 'La transacción fue rechazada (Sandbox)', response.message
   end
 


### PR DESCRIPTION
CE-2013

Local Tests:
5010 tests, 74852 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit Tests:
12 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
14 tests, 36 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed