### PR TITLE
Stripe: Add remote tests set up to avoid exceed the max external accounts limit

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -295,6 +295,15 @@ module ActiveMerchant #:nodoc:
         true
       end
 
+      def delete_latest_test_external_account(account)
+        return unless test?
+        auth_header = { 'Authorization': "Bearer #{options[:login]}" }
+        url = "#{live_url}accounts/#{CGI.escape(account)}/external_accounts"
+        accounts_response = JSON.parse(ssl_get("#{url}?limit=100", auth_header))
+        to_delete = accounts_response['data'].reject { |ac| ac['default_for_currency'] }
+        ssl_request(:delete, "#{url}/#{to_delete.first['id']}", nil, auth_header)
+      end
+
       private
 
       class StripePaymentToken < PaymentToken

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -508,10 +508,10 @@ class RemoteStripeTest < Test::Unit::TestCase
   end
 
   def test_successful_store_with_existing_account
-    account = fixtures(:stripe_destination)[:stripe_user_id]
-
+    account = fixtures(:stripe_destination)[:stripe_user_id]    
     assert response = @gateway.store(@debit_card, account: account)
     assert_success response
+    @gateway.delete_latest_test_external_account(account)
     assert_equal 'card', response.params['object']
   end
 


### PR DESCRIPTION
Stripe: Add remote tests set up to avoid exceed the max external accounts limit

Summary:
----------
This PR add the verification of number of external accounts created in stripe and delete accounts
to avoid the error of maximum number of accounts exceeded

Unit tests execution
Finished in 13.744862 seconds.

5010 tests, 74852 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

364.50 tests/s, 5445.82 assertions/s

Remote test execution

remote_stripe_test.rb

Finished in 200.632001 seconds.

74 tests, 339 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

0.37 tests/s, 1.69 assertions/s

remote_stripe_payment_intents_test.rb

Finished in 187.727749 seconds.

66 tests, 313 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

0.35 tests/s, 1.67 assertions/s

Running RuboCop...
Inspecting 725 files

725 files inspected, no offenses detected

RuboCop:
725 files inspected, no offenses detected