### PR TITLE
Priority: Cleaning up refund method

### DIFF
--- a/lib/active_merchant/billing/gateways/priority.rb
+++ b/lib/active_merchant/billing/gateways/priority.rb
@@ -68,12 +68,12 @@ module ActiveMerchant #:nodoc:
         commit('purchase', params: params, jwt: options)
       end
 
-      def refund(amount, credit_card, options)
+      def refund(amount, authorization, options)
         params = {}
+        params['merchantId'] = @options[:merchant_id]
+        params['paymentToken'] = get_hash(authorization)['payment_token'] || options[:payment_token]
         # refund amounts must be negative
         params['amount'] = ('-' + localized_amount(amount.to_f, options[:currency])).to_f
-        add_credit_card(params, credit_card, 'refund', options) unless options[:auth_code]
-        add_type_merchant_refund(params, options)
         commit('refund', params: params, jwt: options)
       end
 
@@ -182,42 +182,6 @@ module ActiveMerchant #:nodoc:
         params['sourceZip'] = options[:billing_address][:zip] if options[:billing_address]
         params['taxExempt'] = false
         params['tenderType'] = 'Card'
-      end
-
-      def add_type_merchant_refund(params, options)
-        params['cardPresent'] = options[:card_present]
-        params['clientReference'] = options[:client_ref]
-        params['created'] = options[:created]
-        params['creatorName'] = options[:creator_name]
-        params['currency'] = options[:currency]
-        params['customerCode'] = options[:customer_code]
-        params['enteredAmount'] = options[:amount]
-        params['id'] = 0
-        params['invoice'] = options[:invoice]
-        params['isDuplicate'] = false
-        params['merchantId'] = @options[:merchant_id]
-        params['paymentToken'] = options[:payment_token]
-
-        params['posData'] = add_pos_data(options[:pos_data]) if options[:pos_data]
-
-        params['purchases'] = add_purchases_data(options[:purchases][0]) if options[:purchases]
-
-        params['reference'] = options[:reference]
-        params['requireSignature'] = false
-
-        params['risk'] = add_risk_data(options[:risk]) if options[:risk]
-
-        params['settledAmount'] = options[:settled_amt]
-        params['settledCurrency'] = options[:settled_currency]
-        params['settledDate'] = options[:created]
-        params['shipToCountry'] = options[:ship_to_country]
-        params['shouldGetCreditCardLevel'] = options[:should_get_credit_card_level]
-        params['source'] = options[:source]
-        params['status'] = options[:status]
-        params['tax'] = options[:tax]
-        params['taxExempt'] = options[:tax_exempt]
-        params['tenderType'] = 'Card'
-        params['type'] = options[:type]
       end
 
       def commit(action, params: '', iid: '', card_number: nil, jwt: '')

--- a/test/remote/gateways/remote_priority_test.rb
+++ b/test/remote/gateways/remote_priority_test.rb
@@ -22,10 +22,7 @@ class RemotePriorityTest < Test::Unit::TestCase
     @faulty_credit_card = credit_card('12345', month: '01', year: '2029', first_name: 'Marcus', last_name: 'Rashford', verification_value: '999')
 
     @option_spr = {
-      billing_address: address(),
-      avs_street: '666',
-      avs_zip: '55044',
-      tender_type: 'Card'
+      billing_address: address()
     }
 
     # purchase params fail inavalid card number
@@ -241,7 +238,7 @@ class RemotePriorityTest < Test::Unit::TestCase
       @gateway.close_batch(response.params['batchId'], @option_spr)
       refund_params = @option_spr.merge(response.params).deep_transform_keys { |key| key.to_s.underscore }.transform_keys(&:to_sym)
 
-      refund = @gateway.refund(response.params['amount'].to_f * 100, @credit_card, refund_params)
+      refund = @gateway.refund(response.params['amount'].to_f * 100, response.authorization.to_s, refund_params)
       assert_success refund
       assert refund.params['status'] == 'Approved'
 


### PR DESCRIPTION
* Refund was currently using blind credit instead of refund
* Removed unused params updates

bundle exec rake test:local

5009 tests, 74781 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

725 files inspected, no offenses detected

Loaded suite test/unit/gateways/priority_test

11 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_priority_test

20 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed