### PR TITLE
IPG: Add store error response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -58,6 +58,7 @@
 * Paymentez: Update card mappings [ajawadmirza] #4237
 * Priority: Update parsing for error messages [jessiagee] #4245
 * GlobalCollect: Support for Airline Data [naashton] #4187
+* IPG: Add `tpv_error_code` and `tpv_error_msg` fields [ajawadmirza] #4241
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/ipg.rb
+++ b/lib/active_merchant/billing/gateways/ipg.rb
@@ -343,8 +343,13 @@ module ActiveMerchant #:nodoc:
       def parse(xml)
         reply = {}
         xml = REXML::Document.new(xml)
-        root = REXML::XPath.first(xml, '//ipgapi:IPGApiOrderResponse') || REXML::XPath.first(xml, '//ipgapi:IPGApiActionResponse') || REXML::XPath.first(xml, '//SOAP-ENV:Fault')
+        root = REXML::XPath.first(xml, '//ipgapi:IPGApiOrderResponse') || REXML::XPath.first(xml, '//ipgapi:IPGApiActionResponse') || REXML::XPath.first(xml, '//SOAP-ENV:Fault') || REXML::XPath.first(xml, '//ns4:IPGApiActionResponse')
         reply[:success] = REXML::XPath.first(xml, '//faultcode') ? false : true
+        if REXML::XPath.first(xml, '//ns4:IPGApiActionResponse')
+          reply[:tpv_error_code] = REXML::XPath.first(root, '//ns2:Error').attributes['Code']
+          reply[:tpv_error_msg] = REXML::XPath.first(root, '//ns2:ErrorMessage').text
+          reply[:success] = false
+        end
         root.elements.to_a.each do |node|
           parse_element(reply, node)
         end

--- a/test/remote/gateways/remote_ipg_test.rb
+++ b/test/remote/gateways/remote_ipg_test.rb
@@ -5,7 +5,7 @@ class RemoteIpgTest < Test::Unit::TestCase
     @gateway = IpgGateway.new(fixtures(:ipg))
 
     @amount = 100
-    @credit_card = credit_card('5165850000000008', brand: 'mastercard', verification_value: '652', month: '12', year: '2022')
+    @credit_card = credit_card('5165850000000008', brand: 'mastercard', verification_value: '530', month: '12', year: '2022')
     @declined_card = credit_card('4000300011112220', brand: 'mastercard', verification_value: '652', month: '12', year: '2022')
     @visa_card = credit_card('4704550000000005', brand: 'visa', verification_value: '123', month: '12', year: '2022')
     @options = {

--- a/test/unit/gateways/ipg_test.rb
+++ b/test/unit/gateways/ipg_test.rb
@@ -270,6 +270,15 @@ class IpgTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_failed_store
+    @gateway.expects(:ssl_post).returns(failed_store_response)
+
+    response = @gateway.store(@credit_card, @options.merge!({ hosted_data_id: '123' }))
+    assert_failure response
+    assert_equal response.params['tpv_error_code'], 'SGSDAS-020300'
+    assert !response.params['tpv_error_msg'].nil?
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
@@ -610,6 +619,22 @@ class IpgTest < Test::Unit::TestCase
           </ipgapi:IPGApiActionResponse>
       </SOAP-ENV:Body>
       </SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def failed_store_response
+    <<~RESPONSE
+      <ns4:IPGApiActionResponse xmlns:ns4="http://ipg-online.com/ipgapi/schemas/ipgapi" xmlns:ns2="http://ipg-online.com/ipgapi/schemas/a1" xmlns:ns3="http://ipg-online.com/ipgapi/schemas/v1">
+      <ns4:successfully>true</ns4:successfully>
+        <ns2:Error Code="SGSDAS-020300">
+                          <ns2:ErrorMessage>
+                                Could not store the hosted data id:
+        691c7cb3-a752-4d6d-abde-83cad63de258.
+                                Reason: An internal error has occured while
+                                processing your request
+                          </ns2:ErrorMessage>
+        </ns2:Error>
+      </ns4:IPGApiActionResponse>
     RESPONSE
   end
 


### PR DESCRIPTION
Added `tpv_error_code` and `tpv_error_msg` response fields when store
transaction fails for IPG implementation.

Unit:
5011 tests, 74854 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
16 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed