### PR TITLE
Orbital: Quick fix for brand correction

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -570,7 +570,7 @@ module ActiveMerchant #:nodoc:
         # - http://download.chasepaymentech.com/docs/orbital/orbital_gateway_xml_specification.pdf
         unless creditcard.nil?
           if creditcard.verification_value?
-            xml.tag! :CardSecValInd, '1' if %w(visa mastercard discover).include?(creditcard.brand)
+            xml.tag! :CardSecValInd, '1' if %w(visa master discover).include?(creditcard.brand)
             xml.tag! :CardSecVal, creditcard.verification_value
           end
         end


### PR DESCRIPTION
Fix for brand name correction for `master` in orbital gateway.

CE-2232

Unit:
5010 tests, 74849 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
76 tests, 345 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed