### PR TITLE
IPG: verify method bug fixes for core

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -61,6 +61,7 @@
 * IPG: Add `tpv_error_code` and `tpv_error_msg` fields [ajawadmirza] #4241
 * StripePI: Set restriction for Apple/Google Pay [jherreraa] #4247
 * Cashnet: support multiple itemcodes and amounts [peteroas] #4243
+* IPG: Send default currency in `verify` and two digit `ExpMonth` [ajawadmirza] #4244
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/ipg.rb
+++ b/lib/active_merchant/billing/gateways/ipg.rb
@@ -63,6 +63,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options = {})
+        options[:currency] = self.default_currency unless options[:currency] && !options[:currency].empty?
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -165,7 +166,7 @@ module ActiveMerchant #:nodoc:
 
           xml.tag!("#{credit_envelope}:CreditCardData") do
             xml.tag!('v1:CardNumber', payment.number) if payment.number
-            xml.tag!('v1:ExpMonth', payment.month) if payment.month
+            xml.tag!('v1:ExpMonth', format(payment.month, :two_digits)) if payment.month
             xml.tag!('v1:ExpYear', format(payment.year, :two_digits)) if payment.year
             xml.tag!('v1:CardCodeValue', payment.verification_value) if payment.verification_value
             xml.tag!('v1:Brand', options[:brand]) if options[:brand]

--- a/test/unit/gateways/ipg_test.rb
+++ b/test/unit/gateways/ipg_test.rb
@@ -24,6 +24,18 @@ class IpgTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_transaction_with_single_digit_card
+    @credit_card.month = 3
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      doc = REXML::Document.new(data)
+      assert_match('03', REXML::XPath.first(doc, '//v1:CreditCardData//v1:ExpMonth').text)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_stored_credentials
     stored_credential = {
       initial_transaction: true,
@@ -239,7 +251,20 @@ class IpgTest < Test::Unit::TestCase
 
   def test_successful_verify
     response = stub_comms do
-      @gateway.verify(@credit_card, @options)
+      @gateway.verify(@credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      doc = REXML::Document.new(data)
+      assert_match('032', REXML::XPath.first(doc, '//v1:Payment//v1:Currency').text) if REXML::XPath.first(doc, '//v1:CreditCardTxType//v1:Type')&.text == 'preAuth'
+    end.respond_with(successful_authorize_response, successful_void_response)
+    assert_success response
+  end
+
+  def test_successful_verify_with_currency_code
+    response = stub_comms do
+      @gateway.verify(@credit_card, { currency: 'UYU' })
+    end.check_request do |_endpoint, data, _headers|
+      doc = REXML::Document.new(data)
+      assert_match('858', REXML::XPath.first(doc, '//v1:Payment//v1:Currency').text) if REXML::XPath.first(doc, '//v1:CreditCardTxType//v1:Type')&.text == 'preAuth'
     end.respond_with(successful_authorize_response, successful_void_response)
     assert_success response
   end


### PR DESCRIPTION
Send default `currency` for verify method and allow two digit string in
`ExpMonth` in IPG request.

CE-2249
CE-2250

Unit:
5010 tests, 74849 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
16 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed