### PR TITLE
Priority: update parsing for error messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,6 +56,7 @@
 * Wompi: Update authorization in `capture` method. [rachelkirk] #4238
 * IPG: Update authorization to support `store` method token. [ajawadmirza] #4233
 * Paymentez: Update card mappings [ajawadmirza] #4237
+* Priority: Update parsing for error messages [jessiagee] #4245
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/priority.rb
+++ b/lib/active_merchant/billing/gateways/priority.rb
@@ -68,7 +68,7 @@ module ActiveMerchant #:nodoc:
         commit('purchase', params: params, jwt: options)
       end
 
-      def refund(amount, authorization, options)
+      def refund(amount, authorization, options = {})
         params = {}
         params['merchantId'] = @options[:merchant_id]
         params['paymentToken'] = get_hash(authorization)['payment_token'] || options[:payment_token]
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
         commit('capture', params: params, jwt: options)
       end
 
-      def void(authorization, options)
+      def void(authorization, options = {})
         commit('void', iid: get_hash(authorization)['id'], jwt: options)
       end
 
@@ -189,13 +189,13 @@ module ActiveMerchant #:nodoc:
           begin
             case action
             when 'void'
-              ssl_request(:delete, url(action, params, ref_number: iid), nil, request_headers)
+              parse(ssl_request(:delete, url(action, params, ref_number: iid), nil, request_headers))
             when 'verify'
               parse(ssl_get(url(action, params, credit_card_number: card_number), request_verify_headers(jwt)))
             when 'get_payment_status', 'create_jwt'
               parse(ssl_get(url(action, params, ref_number: iid), request_headers))
             when 'close_batch'
-              ssl_request(:put, url(action, params, ref_number: iid), nil, request_headers)
+              parse(ssl_request(:put, url(action, params, ref_number: iid), nil, request_headers))
             else
               parse(ssl_post(url(action, params), post_data(params), request_headers))
             end
@@ -206,10 +206,10 @@ module ActiveMerchant #:nodoc:
         response = { 'code' => '204' } if response == ''
         Response.new(
           success,
-          message_from(success, response),
+          message_from(response),
           response,
-          authorization: success && response['code'] != '204' ? authorization_from(response) : nil,
-          error_code: success || response['code'] == '204' || response == '' ? nil : error_from(response),
+          authorization: success ? authorization_from(response) : nil,
+          error_code: success || response == '' ? nil : error_from(response),
           test: test?
         )
       end
@@ -256,6 +256,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
+        return body if body['code'] == '204'
+
         JSON.parse(body)
       rescue JSON::ParserError
         message = 'Invalid JSON response received from Priority Gateway. Please contact Priority Gateway if you continue to receive this message.'
@@ -272,12 +274,10 @@ module ActiveMerchant #:nodoc:
         success
       end
 
-      def message_from(succeeded, response)
-        if succeeded
-          response['status']
-        else
-          response['authMessage']
-        end
+      def message_from(response)
+        return response['details'][0] if response['details'] && response['details'][0]
+
+        response['authMessage'] || response['message'] || response['status']
       end
 
       def authorization_from(response)
@@ -288,7 +288,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def error_from(response)
-        response['errorCode']
+        response['errorCode'] || response['status']
       end
 
       def post_data(params)

--- a/test/remote/gateways/remote_priority_test.rb
+++ b/test/remote/gateways/remote_priority_test.rb
@@ -50,7 +50,7 @@ class RemotePriorityTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount_purchase, @credit_card_purchase_fail_invalid_number, @option_spr)
     assert_failure response
 
-    assert_equal 'Invalid card number', response.params['authMessage']
+    assert_equal 'Invalid card number', response.message
     assert_equal 'Declined', response.params['status']
   end
 
@@ -59,9 +59,9 @@ class RemotePriorityTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount_purchase, @credit_card_purchase_fail_missing_month, @option_spr)
     assert_failure response
 
-    assert_equal 'ValidationError', response.params['errorCode']
+    assert_equal 'ValidationError', response.error_code
     assert_equal 'Validation error happened', response.params['message']
-    assert_equal 'Missing expiration month and / or year', response.params['details'][0]
+    assert_equal 'Missing expiration month and / or year', response.message
   end
 
   # Missing card verification number
@@ -69,7 +69,7 @@ class RemotePriorityTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount_purchase, @credit_card_purchase_fail_missing_verification, @option_spr)
     assert_failure response
 
-    assert_equal 'CVV is required based on merchant fraud settings', response.params['authMessage']
+    assert_equal 'CVV is required based on merchant fraud settings', response.message
     assert_equal 'Declined', response.params['status']
   end
 
@@ -85,7 +85,7 @@ class RemotePriorityTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount_purchase, @credit_card_purchase_fail_invalid_number, @option_spr)
     assert_failure response
 
-    assert_equal 'Invalid card number', response.params['authMessage']
+    assert_equal 'Invalid card number', response.message
     assert_equal 'Declined', response.params['status']
   end
 
@@ -94,9 +94,9 @@ class RemotePriorityTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount_purchase, @credit_card_purchase_fail_missing_month, @option_spr)
     assert_failure response
 
-    assert_equal 'ValidationError', response.params['errorCode']
+    assert_equal 'ValidationError', response.error_code
     assert_equal 'Validation error happened', response.params['message']
-    assert_equal 'Missing expiration month and / or year', response.params['details'][0]
+    assert_equal 'Missing expiration month and / or year', response.message
   end
 
   # Missing card verification number
@@ -104,7 +104,7 @@ class RemotePriorityTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount_purchase, @credit_card_purchase_fail_missing_verification, @option_spr)
     assert_failure response
 
-    assert_equal 'CVV is required based on merchant fraud settings', response.params['authMessage']
+    assert_equal 'CVV is required based on merchant fraud settings', response.message
     assert_equal 'Declined', response.params['status']
   end
 
@@ -117,7 +117,7 @@ class RemotePriorityTest < Test::Unit::TestCase
 
     capture = @gateway.capture(@amount_authorize, auth_obj.authorization.to_s, @option_spr)
     assert_success capture
-    assert_equal 'Approved', capture.params['authMessage']
+    assert_equal 'Approved', capture.message
     assert_equal 'Approved', capture.params['status']
   end
 
@@ -128,7 +128,7 @@ class RemotePriorityTest < Test::Unit::TestCase
     capture = @gateway.capture(@amount_authorize, { 'payment_token' => 'bogus' }.to_s, @option_spr)
     assert_failure capture
 
-    assert_equal 'Original Transaction Not Found', capture.params['authMessage']
+    assert_equal 'Original Transaction Not Found', capture.message
     assert_equal 'Declined', capture.params['status']
   end
 
@@ -152,9 +152,8 @@ class RemotePriorityTest < Test::Unit::TestCase
   def test_failed_void
     assert void = @gateway.void({ 'id' => 123456 }.to_s, @option_spr)
     assert_failure void
-    assert_equal 'Unauthorized', void.params['errorCode']
-    assert_equal 'Unauthorized', void.params['message']
-    assert_equal 'Original Payment Not Found Or You Do Not Have Access.', void.params['details'][0]
+    assert_equal 'Unauthorized', void.error_code
+    assert_equal 'Original Payment Not Found Or You Do Not Have Access.', void.message
   end
 
   def test_success_get_payment_status
@@ -242,7 +241,7 @@ class RemotePriorityTest < Test::Unit::TestCase
       assert_success refund
       assert refund.params['status'] == 'Approved'
 
-      assert_equal 'Approved', refund.message
+      assert_equal 'Approved or completed successfully', refund.message
     else
       assert_failure response
     end


### PR DESCRIPTION
* Return more useful error and success messages from parsing
* Tests are now looking at response.message, response.error_code instead of response['message'], response['errorCode'] etc.

bundle exec rake test:local

5009 tests, 74782 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

725 files inspected, no offenses detected

Loaded suite test/unit/gateways/priority_test

11 tests, 60 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_priority_test

20 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed