### PR TITLE
Stripe: Add support for `skip_radar_rules`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,8 @@
 * Cashnet: support multiple itemcodes and amounts [peteroas] #4243
 * IPG: Send default currency in `verify` and two digit `ExpMonth` [ajawadmirza] #4244
 * Stripe: Add remote tests set up to avoid exceed the max external accounts limit [jherreraa] #4239
+* Stripe: Add support for `radar_options: skip_rules` [dsmcclain] #4250
+
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -298,6 +298,7 @@ module ActiveMerchant #:nodoc:
       # Helper method to prevent hitting the external_account limit from remote test runs
       def delete_latest_test_external_account(account)
         return unless test?
+
         auth_header = { 'Authorization': "Bearer #{options[:login]}" }
         url = "#{live_url}accounts/#{CGI.escape(account)}/external_accounts"
         accounts_response = JSON.parse(ssl_get("#{url}?limit=100", auth_header))
@@ -583,11 +584,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_radar_data(post, options = {})
-        return unless options[:radar_session_id]
+        radar_options = {}
+        radar_options[:session] = options[:radar_session_id] if options[:radar_session_id]
+        radar_options[:skip_rules] = ['all'] if options[:skip_radar_rules]
 
-        post[:radar_options] = {
-          session: options[:radar_session_id]
-        }
+        post[:radar_options] = radar_options unless radar_options.empty?
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -209,6 +209,14 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert purchase.params.dig('charges', 'data')[0]['captured']
   end
 
+  def test_successful_purchase_with_skip_radar_rules
+    options = { skip_radar_rules: true }
+    assert purchase = @gateway.purchase(@amount, @visa_card, options)
+
+    assert_equal 'succeeded', purchase.params['status']
+    assert_equal ['all'], purchase.params['charges']['data'][0]['radar_options']['skip_rules']
+  end
+
   def test_successful_authorization_with_external_auth_data_3ds_2
     options = {
       currency: 'GBP',

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -165,6 +165,13 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal 'wow@example.com', response.params['metadata']['email']
   end
 
+  def test_successful_purchase_with_skip_radar_rules
+    options = @options.merge(skip_radar_rules: true)
+    assert purchase = @gateway.purchase(@amount, @credit_card, options)
+    assert_success purchase
+    assert_equal ['all'], purchase.params['radar_options']['skip_rules']
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -279,8 +279,8 @@ class PayeezyGateway < Test::Unit::TestCase
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options.merge(@options_mdd))
     end.check_request do |_endpoint, data, _headers|
-      json = '{"transaction_type":"refund","currency_code":"USD","amount":"100","method":"credit_card","credit_card":{"type":"Visa","cardholder_name":"Longbob Longsen","card_number":"4242424242424242","exp_date":"0922","cvv":"123"},"soft_descriptors":{"dba_name":"Caddyshack","street":"1234 Any Street","city":"Durham","region":"North Carolina","mid":"mid_1234","mcc":"mcc_5678","postal_code":"27701","country_code":"US","merchant_contact_info":"8885551212"},"merchant_ref":null}'
-      assert_match json, data
+      soft_descriptors_regex = %r("soft_descriptors":{"dba_name":"Caddyshack","street":"1234 Any Street","city":"Durham","region":"North Carolina","mid":"mid_1234","mcc":"mcc_5678","postal_code":"27701","country_code":"US","merchant_contact_info":"8885551212"})
+      assert_match soft_descriptors_regex, data
     end.respond_with(successful_refund_response)
 
     assert_success response
@@ -290,8 +290,7 @@ class PayeezyGateway < Test::Unit::TestCase
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options.merge(order_id: 1234))
     end.check_request do |_endpoint, data, _headers|
-      json = '{"transaction_type":"refund","currency_code":"USD","amount":"100","method":"credit_card","credit_card":{"type":"Visa","cardholder_name":"Longbob Longsen","card_number":"4242424242424242","exp_date":"0922","cvv":"123"},"merchant_ref":1234}'
-      assert_match json, data
+      assert_match(/\"merchant_ref\":1234/, data)
     end.respond_with(successful_refund_response)
 
     assert_success response

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -460,6 +460,16 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_create_intent_response)
   end
 
+  def test_successful_authorize_with_skip_radar_rules
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@amount, @credit_card, {
+        skip_radar_rules: true
+      })
+    end.check_request do |_method, endpoint, data, _headers|
+      assert_match(/radar_options\[skip_rules\]\[0\]=all/, data) if /payment_intents/.match?(endpoint)
+    end.respond_with(successful_create_intent_response)
+  end
+
   def test_successful_authorization_with_event_type_metadata
     stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, {

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -1027,6 +1027,16 @@ class StripeTest < Test::Unit::TestCase
     end.respond_with(successful_authorization_response)
   end
 
+  def test_skip_rules_is_submitted_for_purchase
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, {
+        skip_radar_rules: true
+      })
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/radar_options\[skip_rules\]\[0\]=all/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
   def test_client_data_submitted_with_purchase
     stub_comms(@gateway, :ssl_request) do
       updated_options = @options.merge({ description: 'a test customer', ip: '127.127.127.127', user_agent: 'some browser', order_id: '42', email: 'foo@wonderfullyfakedomain.com', receipt_email: 'receipt-receiver@wonderfullyfakedomain.com', referrer: 'http://www.shopify.com' })


### PR DESCRIPTION
Adds the option to pass `skip_radar_rules`, which allows a radar-enabled account to create Charges or Intents without applying any radar screening to the transaction.

Also fixes a rubocop error and two date-specific test failures.

Reviewer should run remote tests for both the Stripe and Stripe Payment Intents gateway adapters.

CE-2234

725 files inspected, no offenses detected

5018 tests, 74825 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_stripe_test
75 tests, 342 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/remote/gateways/remote_stripe_payment_intents_test
68 tests, 318 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed