### PR TITLE
CyberSource: Add tax fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -64,7 +64,7 @@
 * IPG: Send default currency in `verify` and two digit `ExpMonth` [ajawadmirza] #4244
 * Stripe: Add remote tests set up to avoid exceed the max external accounts limit [jherreraa] #4239
 * Stripe: Add support for `radar_options: skip_rules` [dsmcclain] #4250
-
+* CyberSource: Add `user_po`, `taxable`, `national_tax_indicator`, `tax_amount`, and `national_tax` fields [ajawadmirza] #4251
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -507,6 +507,8 @@ module ActiveMerchant #:nodoc:
             xml.tag! 'productCode', value[:code] || 'shipping_only'
             xml.tag! 'productName', value[:description]
             xml.tag! 'productSKU', value[:sku]
+            xml.tag! 'taxAmount', value[:tax_amount] if value[:tax_amount]
+            xml.tag! 'nationalTax', value[:national_tax] if value[:national_tax]
           end
         end
       end
@@ -522,10 +524,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_merchant_descriptor(xml, options)
-        return unless options[:merchant_descriptor]
+        return unless options[:merchant_descriptor] || options[:user_po] || options[:taxable]
 
         xml.tag! 'invoiceHeader' do
-          xml.tag! 'merchantDescriptor', options[:merchant_descriptor]
+          xml.tag! 'merchantDescriptor', options[:merchant_descriptor] if options[:merchant_descriptor]
+          xml.tag! 'userPO', options[:user_po] if options[:user_po]
+          xml.tag! 'taxable', options[:taxable] if options[:taxable]
         end
       end
 
@@ -628,11 +632,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_other_tax(xml, options)
-        return unless options[:local_tax_amount] || options[:national_tax_amount]
+        return unless options[:local_tax_amount] || options[:national_tax_amount] || options[:national_tax_indicator]
 
         xml.tag! 'otherTax' do
           xml.tag! 'localTaxAmount', options[:local_tax_amount] if options[:local_tax_amount]
           xml.tag! 'nationalTaxAmount', options[:national_tax_amount] if options[:national_tax_amount]
+          xml.tag! 'nationalTaxIndicator', options[:national_tax_indicator] if options[:national_tax_indicator]
         end
       end
 

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -47,7 +47,9 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
           quantity: 2,
           code: 'default',
           description: 'Giant Walrus',
-          sku: 'WA323232323232323'
+          sku: 'WA323232323232323',
+          tax_amount: 5,
+          national_tax: 10
         },
         {
           declared_value: 100,
@@ -59,7 +61,10 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       currency: 'USD',
       ignore_avs: 'true',
       ignore_cvv: 'true',
-      commerce_indicator: 'internet'
+      commerce_indicator: 'internet',
+      user_po: 'ABC123',
+      taxable: true,
+      national_tax_indicator: 1
     }
 
     @subscription_options = {


### PR DESCRIPTION
Added `userPO`, `taxable`, `nationalTaxIndicator`, `taxAmount`, and
`nationalTax` in the cyber source implementation.

CE-2240

Remote:
101 tests, 520 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.0594% passed

Unit:
5020 tests, 74836 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected