### PR TITLE
Kushki: Add support for `metadata`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,6 +65,7 @@
 * Stripe: Add remote tests set up to avoid exceed the max external accounts limit [jherreraa] #4239
 * Stripe: Add support for `radar_options: skip_rules` [dsmcclain] #4250
 * CyberSource: Add `user_po`, `taxable`, `national_tax_indicator`, `tax_amount`, and `national_tax` fields [ajawadmirza] #4251
+* Kushki: Add support for `metadata` [rachelkirk] #4253
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -82,6 +82,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(action, post, amount, options)
         add_payment_method(post, payment_method, options)
         add_full_response(post, options)
+        add_metadata(post, options)
 
         commit(action, post)
       end
@@ -94,6 +95,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(action, post, amount, options)
         add_contact_details(post, options[:contact_details]) if options[:contact_details]
         add_full_response(post, options)
+        add_metadata(post, options)
 
         commit(action, post)
       end
@@ -105,6 +107,7 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization, options)
         add_invoice(action, post, amount, options)
         add_full_response(post, options)
+        add_metadata(post, options)
 
         commit(action, post)
       end
@@ -175,6 +178,10 @@ module ActiveMerchant #:nodoc:
 
       def add_full_response(post, options)
         post[:fullResponse] = options[:full_response].to_s.casecmp('true').zero? if options[:full_response]
+      end
+
+      def add_metadata(post, options)
+        post[:metadata] = options[:metadata] if options[:metadata]
       end
 
       ENDPOINT = {

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -32,6 +32,10 @@ class RemoteKushkiTest < Test::Unit::TestCase
         last_name: 'Dis',
         second_last_name: 'Buscemi',
         phone_number: '+13125556789'
+      },
+      metadata: {
+        productos: 'bananas',
+        nombre_apellido: 'Kirk'
       }
     }
 

--- a/test/unit/gateways/kushki_test.rb
+++ b/test/unit/gateways/kushki_test.rb
@@ -37,6 +37,10 @@ class KushkiTest < Test::Unit::TestCase
         last_name: 'Dis',
         second_last_name: 'Buscemi',
         phone_number: '+13125556789'
+      },
+      metadata: {
+        productos: 'bananas',
+        nombre_apellido: 'Kirk'
       }
     }
 
@@ -50,7 +54,12 @@ class KushkiTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_charge_response)
     @gateway.expects(:ssl_post).returns(successful_token_response)
 
-    response = @gateway.purchase(amount, @credit_card, options)
+    response = stub_comms do
+      @gateway.purchase(amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_includes data, 'metadata'
+    end.respond_with(successful_token_response, successful_charge_response)
+
     assert_success response
     assert_equal 'Succeeded', response.message
     assert_match %r(^\d+$), response.authorization


### PR DESCRIPTION
CE-2246

Remote:
14 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
16 tests, 104 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Local:
5020 tests, 74837 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed