### PR TITLE
IPG: Add redact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,7 @@
 * Stripe: Add support for `radar_options: skip_rules` [dsmcclain] #4250
 * CyberSource: Add `user_po`, `taxable`, `national_tax_indicator`, `tax_amount`, and `national_tax` fields [ajawadmirza] #4251
 * Kushki: Add support for `metadata` [rachelkirk] #4253
+* IPG: Add `unstore` operation [ajawadmirza] #4254
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/ipg.rb
+++ b/lib/active_merchant/billing/gateways/ipg.rb
@@ -16,6 +16,8 @@ module ActiveMerchant #:nodoc:
         'ARS' => '032'
       }
 
+      ACTION_REQUEST_ITEMS = %w(vault unstore)
+
       def initialize(options = {})
         requires!(options, :store_id, :user_id, :password, :pem, :pem_password)
         @credentials = options
@@ -60,6 +62,13 @@ module ActiveMerchant #:nodoc:
         add_storage_item(xml, credit_card, options)
 
         commit('vault', xml)
+      end
+
+      def unstore(hosted_data_id)
+        xml = Builder::XmlMarkup.new(indent: 2)
+        add_unstore_item(xml, hosted_data_id)
+
+        commit('unstore', xml)
       end
 
       def verify(credit_card, options = {})
@@ -129,8 +138,8 @@ module ActiveMerchant #:nodoc:
         xml.tag!('soapenv:Envelope', envelope_namespaces) do
           xml.tag!('soapenv:Header')
           xml.tag!('soapenv:Body') do
-            build_order_request(xml, action, body) if action != 'vault'
-            build_action_request(xml, action, body) if action == 'vault'
+            build_order_request(xml, action, body) unless ACTION_REQUEST_ITEMS.include?(action)
+            build_action_request(xml, action, body) if ACTION_REQUEST_ITEMS.include?(action)
           end
         end
         xml.target!
@@ -149,6 +158,16 @@ module ActiveMerchant #:nodoc:
             add_credit_card(xml, credit_card, {}, 'ns2')
             add_three_d_secure(xml, options[:three_d_secure]) if options[:three_d_secure]
             xml.tag!('ns2:HostedDataID', @hosted_data_id) if @hosted_data_id
+          end
+        end
+      end
+
+      def add_unstore_item(xml, hosted_data_id)
+        requires!({}.merge!({ hosted_data_id: hosted_data_id }), :hosted_data_id)
+        xml.tag!('ns2:StoreHostedData') do
+          xml.tag!('ns2:DataStorageItem') do
+            xml.tag!('ns2:Function', 'delete')
+            xml.tag!('ns2:HostedDataID', hosted_data_id)
           end
         end
       end

--- a/test/remote/gateways/remote_ipg_test.rb
+++ b/test/remote/gateways/remote_ipg_test.rb
@@ -42,6 +42,18 @@ class RemoteIpgTest < Test::Unit::TestCase
     assert_equal 'APPROVED', response.message
   end
 
+  def test_successful_unstore
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal 'true', response.params['successfully']
+    payment_token = response.authorization
+    assert payment_token
+
+    response = @gateway.unstore(payment_token)
+    assert_success response
+    assert_equal 'true', response.params['successfully']
+  end
+
   def test_successful_purchase_with_stored_credential
     @options[:stored_credential] = {
       initial_transaction: true,

--- a/test/unit/gateways/ipg_test.rb
+++ b/test/unit/gateways/ipg_test.rb
@@ -295,6 +295,18 @@ class IpgTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_unstore
+    payment_token = generate_unique_id
+    response = stub_comms do
+      @gateway.unstore(payment_token)
+    end.check_request do |_endpoint, data, _headers|
+      doc = REXML::Document.new(data)
+      assert_match(payment_token, REXML::XPath.first(doc, '//ns2:HostedDataID').text)
+    end.respond_with(successful_store_response)
+
+    assert_success response
+  end
+
   def test_failed_store
     @gateway.expects(:ssl_post).returns(failed_store_response)
 


### PR DESCRIPTION
Added `unstore` method in IPG implementation to delete vaulted payment
method.

CE-2283

Remote:
17 tests, 53 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5021 tests, 74840 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected