### PR TITLE
Orbital: Add SCA Merchant Initiated field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,7 @@
 * CyberSource: Add `user_po`, `taxable`, `national_tax_indicator`, `tax_amount`, and `national_tax` fields [ajawadmirza] #4251
 * Kushki: Add support for `metadata` [rachelkirk] #4253
 * IPG: Add `redact` operation [ajawadmirza] #4254
+* Orbital: Add `sca_merchant_initiated` operation [ajawadmirza] #4256
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -632,6 +632,14 @@ module ActiveMerchant #:nodoc:
         xml.tag!(:SCARecurringPayment, parameters[:sca_recurring]) if valid_eci
       end
 
+      def add_mc_sca_merchant_initiated(xml, creditcard, parameters, three_d_secure)
+        return unless parameters && parameters[:sca_merchant_initiated] && creditcard.brand == 'master'
+
+        valid_eci = three_d_secure && three_d_secure[:eci] && three_d_secure[:eci] == '7'
+
+        xml.tag!(:SCAMerchantInitiatedTransaction, parameters[:sca_merchant_initiated]) if valid_eci
+      end
+
       def add_dpanind(xml, creditcard)
         return unless creditcard.is_a?(NetworkTokenizationCreditCard)
 
@@ -900,6 +908,7 @@ module ActiveMerchant #:nodoc:
             add_card_indicators(xml, parameters)
             add_stored_credentials(xml, parameters)
             add_pymt_brand_program_code(xml, payment_source, three_d_secure)
+            add_mc_sca_merchant_initiated(xml, payment_source, parameters, three_d_secure)
             add_mc_scarecurring(xml, payment_source, parameters, three_d_secure)
             add_mc_program_protocol(xml, payment_source, three_d_secure)
             add_mc_directory_trans_id(xml, payment_source, three_d_secure)

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -227,6 +227,27 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_false response.authorization.blank?
   end
 
+  def test_successful_purchase_with_sca_merchant_initiated_master_card
+    cc = credit_card('5555555555554444', first_name: 'Joe', last_name: 'Smith',
+                     month: '12', year: '2022', brand: 'master', verification_value: '999')
+    options_local = {
+      three_d_secure: {
+        eci: '7',
+        xid: 'TESTXID',
+        cavv: 'AAAEEEDDDSSSAAA2243234',
+        ds_transaction_id: '97267598FAE648F28083C23433990FBC',
+        version: '2.2.0'
+      },
+      sca_merchant_initiated: 'Y'
+    }
+
+    assert response = @three_ds_gateway.purchase(100, cc, @options.merge(options_local))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
   def test_successful_purchase_with_american_express_network_tokenization_credit_card
     network_card = network_tokenization_credit_card('4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -312,6 +312,30 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_three_d_secure_data_on_sca_merchant_initiated_master_card
+    options_local = {
+      three_d_secure: {
+        eci: '7',
+        xid: 'TESTXID',
+        cavv: 'AAAEEEDDDSSSAAA2243234',
+        ds_transaction_id: '97267598FAE648F28083C23433990FBC',
+        version: '2.2.0'
+      },
+      sca_merchant_initiated: 'Y'
+    }
+
+    stub_comms do
+      @gateway.purchase(50, credit_card(nil, brand: 'master'), @options.merge(options_local))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %{<AuthenticationECIInd>7</AuthenticationECIInd>}, data
+      assert_match %{<AAV>AAAEEEDDDSSSAAA2243234</AAV>}, data
+      assert_match %{<MCProgramProtocol>2</MCProgramProtocol>}, data
+      assert_match %{<MCDirectoryTransID>97267598FAE648F28083C23433990FBC</MCDirectoryTransID>}, data
+      assert_match %{<SCAMerchantInitiatedTransaction>Y</SCAMerchantInitiatedTransaction>}, data
+      assert_match %{<UCAFInd>4</UCAFInd>}, data
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_three_d_secure_data_on_master_sca_recurring_with_invalid_eci
     options_local = {
       three_d_secure: {


### PR DESCRIPTION
Added `sca_merchant_initiated` field in orbital implementation to
support master card eci 7 to exempt from SCA when flag is set.

CE-2236

Remote:
77 tests, 349 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5022 tests, 74849 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected