### PR TITLE
Cashnet: Transforms amounts into integers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -68,6 +68,7 @@
 * Kushki: Add support for `metadata` [rachelkirk] #4253
 * IPG: Add `redact` operation [ajawadmirza] #4254
 * Wompi: Update sandbox and production endpoints [rachelkirk] #4255
+* Cashnet: convert amounts to integers for proper gateway handling [peteroas] #2207
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -117,11 +117,11 @@ module ActiveMerchant #:nodoc:
           codes_and_amounts = options[:item_codes].transform_keys { |key| key.to_s.delete('_') }
           codes_and_amounts.each do |key, value|
             post[key] = value if key.start_with?('itemcode')
-            post[key] = amount(value) if key.start_with?('amount')
+            post[key] = amount(value.to_i) if key.start_with?('amount')
           end
         else
           post[:itemcode] = (options[:item_code] || @options[:default_item_code])
-          post[:amount] = amount(money)
+          post[:amount] = amount(money.to_i)
         end
       end
 


### PR DESCRIPTION
This covers an edge-case where the list of `amounts` within the `item_codes` option is coverted into a string