### PR TITLE
PayTrace: Add unstore method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -70,6 +70,7 @@
 * Wompi: Update sandbox and production endpoints [rachelkirk] #4255
 * Orbital: Add `sca_merchant_initiated` operation [ajawadmirza] #4256
 * Cashnet: convert amounts to integers for proper gateway handling [peteroas] #2207
+* PayTrace: Add `unstore` operation [ajawadmirza] #4262
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/pay_trace.rb
+++ b/lib/active_merchant/billing/gateways/pay_trace.rb
@@ -118,7 +118,7 @@ module ActiveMerchant #:nodoc:
         check_token_response(response, ENDPOINTS[:store], post, options)
       end
 
-      def redact(customer_id)
+      def unstore(customer_id)
         post = {}
         post[:customer_id] = customer_id
         response = commit(ENDPOINTS[:redact], post)

--- a/test/remote/gateways/remote_pay_trace_test.rb
+++ b/test/remote/gateways/remote_pay_trace_test.rb
@@ -322,7 +322,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
     response = @gateway.store(@mastercard, @options)
     assert_success response
     customer_id = response.params['customer_id']
-    redact = @gateway.redact(customer_id)
+    redact = @gateway.unstore(customer_id)
     assert_success redact
     assert_equal true, redact.success?
   end


### PR DESCRIPTION
Added `unstore` method to redact store token in paytrace implementation
along with its remote test.

CE-2286

Remote:
27 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5022 tests, 74849 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected