### PR TITLE
Mundipagg: Fix unit test

### DIFF
--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -371,16 +371,16 @@ class MundipaggTest < Test::Unit::TestCase
   end
 
   def test_gateway_id_fallback
-    gateway = MundipaggGateway.new(api_key: 'my_api_key', gateway_id: 'abc123')
+    @gateway = MundipaggGateway.new(api_key: 'my_api_key', gateway_id: 'abcd123')
     options = {
       order_id: '1',
       billing_address: address,
       description: 'Store Purchase'
     }
     stub_comms do
-      gateway.purchase(@amount, @credit_card, options)
+      @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/"gateway_affiliation_id":"abc123"/, data)
+      assert_match(/"gateway_affiliation_id":"abcd123"/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Fixed unit test case for gateway id that was sending remote call to
gateway in mundipagg implementation.

CE-2206

Unit:
5022 tests, 74850 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
41 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed