### PR TITLE
Decidir Plus: Add Gateway Adapter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -71,6 +71,7 @@
 * Orbital: Add `sca_merchant_initiated` operation [ajawadmirza] #4256
 * Cashnet: convert amounts to integers for proper gateway handling [peteroas] #2207
 * PayTrace: Add `unstore` operation [ajawadmirza] #4262
+* Decidir Plus: Add gateway adapter [naashton] #4264
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -1,0 +1,147 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class DecidirPlusGateway < Gateway
+      self.test_url = 'https://developers.decidir.com/api/v2'
+      self.live_url = 'https://live.decidir.com/api/v2'
+
+      self.supported_countries = ['ARG']
+      self.default_currency = 'ARS'
+      self.supported_cardtypes = %i[visa master american_express discover]
+
+      self.homepage_url = 'http://decidir.com.ar/home'
+      self.display_name = 'Decidir Plus'
+
+      def initialize(options = {})
+        requires!(options, :public_key, :private_key)
+        super
+      end
+
+      def purchase(money, payment, options = {})
+        post = {}
+        post[:site_transaction_id] = options[:site_transaction_id] || SecureRandom.hex
+        post[:token] = options[:payment_id].split('|')[0]
+        post[:payment_method_id] = 1
+        post[:bin] = payment.number.to_s[0..5]
+        post[:amount] = money
+        post[:currency] = options[:currency] || self.default_currency
+        post[:installments] = options[:installments] || 1
+        post[:payment_type] = options[:payment_type] || 'single'
+        post[:sub_payments] = []
+
+        commit(:post, 'payments', post)
+      end
+
+      def refund(money, authorization, options = {})
+        post = {}
+        post[:amount] = money
+
+        commit(:post, "payments/#{add_reference(authorization)}/refunds")
+      end
+
+      def store(payment, options = {})
+        post = {}
+        add_payment(post, payment, options)
+
+        commit(:post, 'tokens', post)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Apikey: )\w+), '\1[FILTERED]').
+          gsub(%r(("card_number\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
+          gsub(%r(("security_code\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]')
+      end
+
+      private
+
+      def add_reference(authorization)
+        return unless authorization
+
+        authorization.split('|')[0]
+      end
+
+      def add_payment(post, payment, options = {})
+        post[:card_number] = payment.number
+        post[:card_expiration_month] = payment.month.to_s.rjust(2, '0')
+        post[:card_expiration_year] = payment.year.to_s[-2..-1]
+        post[:security_code] = payment.verification_value.to_s
+        post[:card_holder_name] = payment.name
+        post[:card_holder_identification] = {}
+        post[:card_holder_identification][:type] = options[:dni]
+        post[:card_holder_identification][:number] = options[:card_holder_identification_number]
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def commit(method, endpoint, parameters = {}, options = {})
+        begin
+          raw_response = ssl_request(method, url(endpoint), post_data(parameters), headers(endpoint))
+          response = parse(raw_response)
+        rescue ResponseError => e
+          raw_response = e.response.body
+          response = parse(raw_response)
+        end
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          avs_result: AVSResult.new(code: response['some_avs_response_key']),
+          cvv_result: CVVResult.new(response['some_cvv_response_key']),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def headers(endpoint)
+        {
+          'Content-Type' => 'application/json',
+          'apikey' => endpoint == 'tokens' ? @options[:public_key] : @options[:private_key]
+        }
+      end
+
+      def url(action, options = {})
+        base_url = (test? ? test_url : live_url)
+
+        return "#{base_url}/#{action}"
+      end
+
+      def success_from(response)
+        response.dig('status') == 'approved' || response.dig('status') == 'active'
+      end
+
+      def message_from(response)
+        response.dig('status') || error_message(response) || response.dig('message')
+      end
+
+      def authorization_from(response)
+        return nil unless response.dig('id') || response.dig('bin')
+
+        "#{response.dig('id')}|#{response.dig('bin')}"
+      end
+
+      def post_data(parameters = {})
+        parameters.to_json
+      end
+
+      def error_code_from(response)
+        response.dig('error_type') unless success_from(response)
+      end
+
+      def error_message(response)
+        return error_code_from(response) unless validation_errors = response.dig('validation_errors')
+
+        validation_errors = validation_errors[0]
+
+        "#{validation_errors.dig('code')}: #{validation_errors.dig('param')}"
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -265,6 +265,10 @@ decidir_authorize:
   api_key: 5a15fbc227224edabdb6f2e8219e8b28
   preauth_mode: true
 
+decidir_plus:
+  public_key: SOMECREDENTIAL
+  private_key: SOMECREDENTIAL
+
 decidir_purchase:
   api_key: 5df6b5764c3f4822aecdc82d56f26b9d
 

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+require 'securerandom'
+
+class RemoteDecidirPlusTest < Test::Unit::TestCase
+  def setup
+    @gateway = DecidirPlusGateway.new(fixtures(:decidir_plus))
+
+    @amount = 100
+    @credit_card = credit_card('4484590159923090')
+    @declined_card = credit_card('4000300011112220')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    assert response = @gateway.store(@credit_card)
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(payment_id: response.authorization))
+    assert_success response
+    assert_equal 'approved', response.message
+  end
+
+  def test_failed_purchase
+    assert response = @gateway.store(@credit_card)
+
+    response = @gateway.purchase(@amount, @declined_card, @options.merge(payment_id: response.authorization))
+    assert_failure response
+    assert_equal 'invalid_param: bin', response.message
+  end
+
+  def test_successful_refund
+    response = @gateway.store(@credit_card)
+
+    purchase = @gateway.purchase(@amount, @credit_card, @options.merge(payment_id: response.authorization))
+    assert_success purchase
+    assert_equal 'approved', purchase.message
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'approved', refund.message
+  end
+
+  def test_partial_refund
+    assert response = @gateway.store(@credit_card)
+
+    purchase = @gateway.purchase(@amount, @credit_card, @options.merge(payment_id: response.authorization))
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount - 1, purchase.authorization)
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_equal 'not_found_error', response.message
+  end
+
+  def test_successful_store
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+    assert_equal 'active', response.message
+    assert_equal @credit_card.number[0..5], response.authorization.split('|')[1]
+  end
+
+  def test_invalid_login
+    gateway = DecidirPlusGateway.new(public_key: '12345', private_key: 'abcde')
+
+    response = gateway.store(@credit_card, @options)
+    assert_failure response
+    assert_match %r{Invalid authentication credentials}, response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.store(@credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:public_key], transcript)
+    assert_scrubbed(@gateway.options[:private_key], transcript)
+  end
+end


### PR DESCRIPTION
This is a PR to add the gateway adapter for Decidir Plus

Things to note in this PR:
* No auth/capture or void/cancel transactions
* Payment Method's must be `stored` and the returned third party token
  will be used in combination with other card data in subsequent
`purchase` and `refund` transactions
* The reference token is comprised of the `stored` payment method's `id`
  (returned from Decidir+) and the `bin` of the payment method,
separated by a pipe (`|`)
* Authorization is handled by an `apikey` passed into the headers.
  Either the `public_key` for the tokenization endpoint or `private_key`
for the rest
* Some fields that are stubbed in with defaults ARE REQUIRED in order
  for the transaction to be successful (i.e., `purchase` will fail
without `sub_payments` array)

CE-2145

Unit: 6 tests, 20 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 8 tests, 27 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed