### PR TITLE
Paymentez: Add verify order functionality

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * PaySafe: Fix commit for `unstore` method [ajawadmirza] #4303
 * Ebanx: Add support for `order_number` field [ali-hassan] #4304
 * BlueSnap: Add support for  `idempotency_key` field [drkjc] #4305
+* Paymentez: Update `capture` method to verify by otp for pending transactions [ajawadmirza] #4267
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -34,6 +34,8 @@ module ActiveMerchant #:nodoc:
         28 => :card_declined
       }.freeze
 
+      SUCCESS_STATUS = ['success', 'pending', 1, 0]
+
       CARD_MAPPING = {
         'visa' => 'vi',
         'master' => 'mc',
@@ -77,13 +79,21 @@ module ActiveMerchant #:nodoc:
         commit_transaction('authorize', post)
       end
 
-      def capture(money, authorization, _options = {})
+      def capture(money, authorization, options = {})
         post = {
           transaction: { id: authorization }
         }
-        post[:order] = { amount: amount(money).to_f } if money
+        verify_flow = options[:type] && options[:value]
 
-        commit_transaction('capture', post)
+        if verify_flow
+          add_customer_data(post, options)
+          add_verify_value(post, options)
+        elsif money
+          post[:order] = { amount: amount(money).to_f }
+        end
+
+        action = verify_flow ? 'verify' : 'capture'
+        commit_transaction(action, post)
       end
 
       def refund(money, authorization, options = {})
@@ -139,10 +149,10 @@ module ActiveMerchant #:nodoc:
       private
 
       def add_customer_data(post, options)
-        requires!(options, :user_id, :email)
+        requires!(options, :user_id)
         post[:user] ||= {}
         post[:user][:id] = options[:user_id]
-        post[:user][:email] = options[:email]
+        post[:user][:email] = options[:email] if options[:email]
         post[:user][:ip_address] = options[:ip] if options[:ip]
         post[:user][:fiscal_number] = options[:fiscal_number] if options[:fiscal_number]
         if phone = options[:phone] || options.dig(:billing_address, :phone)
@@ -177,6 +187,11 @@ module ActiveMerchant #:nodoc:
           post[:card][:cvc] = payment.verification_value
           post[:card][:type] = CARD_MAPPING[payment.brand]
         end
+      end
+
+      def add_verify_value(post, options)
+        post[:type] = options[:type] if options[:type]
+        post[:value] = options[:value] if options[:value]
       end
 
       def add_extra_params(post, options)
@@ -262,7 +277,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(response)
-        !response.include?('error') && (response['status'] || response['transaction']['status']) == 'success'
+        return false if response.include?('error')
+
+        SUCCESS_STATUS.include?(response['status'] || response['transaction']['status'])
       end
 
       def card_success_from(response)
@@ -278,7 +295,7 @@ module ActiveMerchant #:nodoc:
         if !success_from(response) && response['error']
           response['error'] && response['error']['type']
         else
-          response['transaction'] && response['transaction']['message']
+          (response['transaction'] && response['transaction']['message']) || (response['message'])
         end
       end
 

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -766,6 +766,10 @@ paymentez:
   application_code: APPCODE
   app_key: APPKEY
 
+paymentez_ecuador:
+  application_code: APPCODE
+  app_key: APPKEY
+
 paymill:
   private_key: a9580be4a7b9d0151a3da88c6c935ce0
   public_key: 57313835619696ac361dc591bc973626

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -3,9 +3,11 @@ require 'test_helper'
 class RemotePaymentezTest < Test::Unit::TestCase
   def setup
     @gateway = PaymentezGateway.new(fixtures(:paymentez))
+    @ecuador_gateway = PaymentezGateway.new(fixtures(:paymentez_ecuador))
 
     @amount = 100
     @credit_card = credit_card('4111111111111111', verification_value: '666')
+    @otp_card = credit_card('36417002140808', verification_value: '666')
     @elo_credit_card = credit_card('6362970000457013',
       month: 10,
       year: 2022,
@@ -195,6 +197,14 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_equal 'Response by mock', capture.message
   end
 
+  def test_successful_authorize_and_capture_with_nil_amount
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert capture = @gateway.capture(nil, auth.authorization)
+    assert_success capture
+    assert_equal 'Response by mock', capture.message
+  end
+
   def test_successful_authorize_and_capture_with_elo
     auth = @gateway.authorize(@amount, @elo_credit_card, @options)
     assert_success auth
@@ -253,6 +263,18 @@ class RemotePaymentezTest < Test::Unit::TestCase
     response = @gateway.capture(@amount, '')
     assert_failure response
     assert_equal 'The modification of the amount is not supported by carrier', response.message
+  end
+
+  def test_successful_capture_with_otp
+    @options[:vat] = 0.1
+    response = @ecuador_gateway.purchase(@amount, @otp_card, @options)
+    assert_success response
+    assert_equal 'pending', response.params['transaction']['status']
+
+    transaction_id = response.params['transaction']['id']
+    options = @options.merge({ type: 'BY_OTP', value: '012345' })
+    response = @ecuador_gateway.capture(nil, transaction_id, options)
+    assert_success response
   end
 
   def test_store


### PR DESCRIPTION
Added verify order functionality to approve pending transaction to
perform otp transaction flow in paymentez gateway. Tests to be performed with `ecaudor` fixtures.

CE-1920

Unit:
5022 tests, 74850 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected

Remote:
33 tests, 82 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
87.8788% passed