### PR TITLE
CyberSource: Add line_items for authorize method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -73,6 +73,7 @@
 * PayTrace: Add `unstore` operation [ajawadmirza] #4262
 * Decidir Plus: Add gateway adapter [naashton] #4264
 * CheckoutV2: Add support for Apple Pay and Google Pay tokens [AMHOL] #4235
+* CyberSource: Add `line_items` field in authorize method [ajawadmirza] #4268
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -290,7 +290,7 @@ module ActiveMerchant #:nodoc:
       def build_auth_request(money, creditcard_or_reference, options)
         xml = Builder::XmlMarkup.new indent: 2
         add_customer_id(xml, options)
-        add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
+        add_payment_method_or_subscription(xml, money, creditcard_or_reference, options, true)
         add_threeds_2_ucaf_data(xml, creditcard_or_reference, options)
         add_decision_manager_fields(xml, options)
         add_mdd_fields(xml, options)
@@ -500,6 +500,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_line_item_data(xml, options)
+        return unless options[:line_items]
+
         options[:line_items].each_with_index do |value, index|
           xml.tag! 'item', { 'id' => index } do
             xml.tag! 'unitPrice', localized_amount(value[:declared_value].to_i, options[:currency] || default_currency)
@@ -879,7 +881,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
+      def add_payment_method_or_subscription(xml, money, payment_method_or_reference, options, include_items = false)
         if payment_method_or_reference.is_a?(String)
           add_purchase_data(xml, money, true, options)
           add_installments(xml, options)
@@ -892,6 +894,7 @@ module ActiveMerchant #:nodoc:
         else
           add_address(xml, payment_method_or_reference, options[:billing_address], options)
           add_address(xml, payment_method_or_reference, options[:shipping_address], options, true)
+          add_line_item_data(xml, options) if include_items
           add_purchase_data(xml, money, true, options)
           add_installments(xml, options)
           add_creditcard(xml, payment_method_or_reference)


### PR DESCRIPTION
Added `line_items` field to be passed in for authorize method in cyber
source implementation.

CE-2240

Remote:
101 tests, 520 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.0594% passed

Unit:
5023 tests, 74856 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
725 files inspected, no offenses detected