### PR TITLE
Paysafe: Update redact method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -74,6 +74,7 @@
 * Decidir Plus: Add gateway adapter [naashton] #4264
 * CheckoutV2: Add support for Apple Pay and Google Pay tokens [AMHOL] #4235
 * Decidir Plus: Update payment reference [naashton] #4271
+* Paysafe: Update redact method [meagabeth] #4269
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -94,8 +94,8 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'profiles', post, options)
       end
 
-      def redact(pm_profile_id)
-        commit_for_redact(:delete, "profiles/#{pm_profile_id}", nil, nil)
+      def unstore(pm_profile_id)
+        commit_for_unstore(:delete, "profiles/#{pm_profile_id}", nil, nil)
       end
 
       def supports_scrubbing?
@@ -342,7 +342,7 @@ module ActiveMerchant #:nodoc:
         )
       end
 
-      def commit_for_redact(method, action, parameters, options)
+      def commit_for_unstore(method, action, parameters, options)
         url = url(action)
         response = raw_ssl_request(method, url, post_data(parameters, options), headers)
         success = true if response.code == '200'

--- a/test/remote/gateways/remote_paysafe_test.rb
+++ b/test/remote/gateways/remote_paysafe_test.rb
@@ -364,12 +364,12 @@ class RemotePaysafeTest < Test::Unit::TestCase
     assert_match 'COMPLETED', purchase.message
   end
 
-  def test_successful_store_and_redact
+  def test_successful_store_and_unstore
     response = @gateway.store(credit_card('4111111111111111'), @profile_options)
     assert_success response
     id = response.params['id']
-    redact = @gateway.redact(id)
-    assert_success redact
+    unstore = @gateway.unstore(id)
+    assert_success unstore
   end
 
   def test_invalid_login


### PR DESCRIPTION
-`redact` method changed to `unstore`

CE-2285

Remote:
31 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
16 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Local:
5034 tests, 74935 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Rubocop:
728 files inspected, no offenses detected