### PR TITLE
Add metadata to network_tokenization_credit_card

### DIFF
--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -14,7 +14,7 @@ module ActiveMerchant #:nodoc:
       self.require_verification_value = false
       self.require_name = false
 
-      attr_accessor :payment_cryptogram, :eci, :transaction_id
+      attr_accessor :payment_cryptogram, :eci, :transaction_id, :metadata
       attr_writer :source
 
       SOURCES = %i(apple_pay android_pay google_pay network_token)

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -2,27 +2,27 @@ require 'test_helper'
 
 class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
   def setup
-    @tokenized_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+    @tokenized_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       number: '4242424242424242', brand: 'visa',
       month: default_expiration_date.month, year: default_expiration_date.year,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=', eci: '05',
       metadata: { device_manufacturer_id: '1324' }
-    })
-    @tokenized_apple_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+    )
+    @tokenized_apple_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       source: :apple_pay
-    })
-    @tokenized_android_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+    )
+    @tokenized_android_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       source: :android_pay
-    })
-    @tokenized_google_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+    )
+    @tokenized_google_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       source: :google_pay
-    })
-    @existing_network_token = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+    )
+    @existing_network_token = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       source: :network_token
-    })
-    @tokenized_bogus_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+    )
+    @tokenized_bogus_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       source: :bogus_pay
-    })
+    )
   end
 
   def test_type

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -5,7 +5,8 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
     @tokenized_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       number: '4242424242424242', brand: 'visa',
       month: default_expiration_date.month, year: default_expiration_date.year,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=', eci: '05'
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=', eci: '05',
+      metadata: { device_manufacturer_id: '1324' }
     })
     @tokenized_apple_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       source: :apple_pay


### PR DESCRIPTION
Some payment gateways require attributes that cannot currently
be instantiated with network_tokenization_credit_card.

For example - some gateways require `deviceManufacturerIdentifer` and
`paymentDataType` to be passed in for apple pay which can now be stored
in the metadata.

--------------
How `metadata` can be used - I did a quick 📖 and while `eci`, `payment_cryptogram`, `transaction_id` are common across wallets (hence we have these attributes in the model), there are some [apple-pay specific fields](https://developer.apple.com/library/archive/documentation/PassKit/Reference/PaymentTokenJSON/PaymentTokenJSON.html) such as `deviceManufacturerIdentifer` and `paymentDataType` and [google-pay specific fields](https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography) such as `authMethod`, `paymentMethod`. 

With `metadata`, you don't have to dump all these provider specific attributes and you have access to these data if a payment gateway requires them.