### PR TITLE
Decidir Plus: Update payment reference

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -73,6 +73,7 @@
 * PayTrace: Add `unstore` operation [ajawadmirza] #4262
 * Decidir Plus: Add gateway adapter [naashton] #4264
 * CheckoutV2: Add support for Apple Pay and Google Pay tokens [AMHOL] #4235
+* Decidir Plus: Update payment reference [naashton] #4271
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -16,24 +16,25 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
 
   def test_successful_purchase
     assert response = @gateway.store(@credit_card)
+    payment_reference = response.authorization
 
-    response = @gateway.purchase(@amount, @credit_card, @options.merge(payment_id: response.authorization))
+    response = @gateway.purchase(@amount, payment_reference, @options)
     assert_success response
     assert_equal 'approved', response.message
   end
 
   def test_failed_purchase
-    assert response = @gateway.store(@credit_card)
+    assert @gateway.store(@credit_card)
 
-    response = @gateway.purchase(@amount, @declined_card, @options.merge(payment_id: response.authorization))
+    response = @gateway.purchase(@amount, '', @options)
     assert_failure response
-    assert_equal 'invalid_param: bin', response.message
+    assert_equal 'invalid_param: token', response.message
   end
 
   def test_successful_refund
     response = @gateway.store(@credit_card)
 
-    purchase = @gateway.purchase(@amount, @credit_card, @options.merge(payment_id: response.authorization))
+    purchase = @gateway.purchase(@amount, response.authorization, @options)
     assert_success purchase
     assert_equal 'approved', purchase.message
 
@@ -45,7 +46,7 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
   def test_partial_refund
     assert response = @gateway.store(@credit_card)
 
-    purchase = @gateway.purchase(@amount, @credit_card, @options.merge(payment_id: response.authorization))
+    purchase = @gateway.purchase(@amount, response.authorization, @options)
     assert_success purchase
 
     assert refund = @gateway.refund(@amount - 1, purchase.authorization)

--- a/test/unit/gateways/decidir_plus_test.rb
+++ b/test/unit/gateways/decidir_plus_test.rb
@@ -6,10 +6,10 @@ class DecidirPlusTest < Test::Unit::TestCase
   def setup
     @gateway = DecidirPlusGateway.new(public_key: 'public_key', private_key: 'private_key')
     @credit_card = credit_card
+    @payment_reference = '2bf7bffb-1257-4b45-8d42-42d090409b8a|448459'
     @amount = 100
 
     @options = {
-      payment_id: '2bf7bffb-1257-4b45-8d42-42d090409b8a|448459',
       billing_address: address,
       description: 'Store Purchase'
     }
@@ -17,7 +17,7 @@ class DecidirPlusTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, @options)
+      @gateway.purchase(@amount, @payment_reference, @options)
     end.check_request do |_action, _endpoint, data, _headers|
       assert_match(/2bf7bffb-1257-4b45-8d42-42d090409b8a/, data)
     end.respond_with(successful_purchase_response)
@@ -35,7 +35,7 @@ class DecidirPlusTest < Test::Unit::TestCase
 
   def test_successful_refund
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.refund(@amount, @options[:payment_id])
+      @gateway.refund(@amount, @payment_reference)
     end.respond_with(successful_refund_response)
 
     assert_success response
@@ -43,7 +43,7 @@ class DecidirPlusTest < Test::Unit::TestCase
 
   def test_failed_refund
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.refund(@amount, @options[:payment_id])
+      @gateway.refund(@amount, @payment_reference)
     end.respond_with(failed_purchase_response)
 
     assert_failure response


### PR DESCRIPTION
**What changed?**

* Refactored purchase method to pass arguments to other methods that are
  responsible for appending the `post` hash with data for a `purchase`
transaction
* `token` and `bin` are parsed from a `payment` of String type instead
  of a `payment_id` in the `options` hash

CE-2145

Unit: 6 tests, 20 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 8 tests, 27 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed