### PR TITLE
Elavon: `third_party_token` bug fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,6 +77,7 @@
 * Paysafe: Update redact method [meagabeth] #4269
 * CyberSource: Add `line_items` field in authorize method [ajawadmirza] #4268
 * CheckoutV2: Support processing channel and marketplace sub entity ID [AMHOL] #4236
+* Elavon: `third_party_token` bug fix [rachelkirk] #4273
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -251,17 +251,23 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert_equal 'APPROVAL', purchase.message
   end
 
+  # This test is essentially replicating a test on line 373 in order to get it passing.
+  # This test was part of the work to enable recurring transactions for Elavon. Recurring
+  # transactions aren't possible with Elavon unless cards are stored there as well. This work
+  # will be removed in a later cleanup ticket.
   def test_successful_purchase_with_ssl_token
+    store_response = @tokenization_gateway.store(@credit_card, @options)
+    token = store_response.params['token']
     options = {
       email: 'paul@domain.com',
       description: 'Test Transaction',
       billing_address: address,
       ip: '203.0.113.0',
       merchant_initiated_unscheduled: 'Y',
-      ssl_token: '4000000000000002'
+      ssl_token: token
     }
 
-    purchase = @gateway.purchase(@amount, @credit_card, options)
+    purchase = @tokenization_gateway.purchase(@amount, token, options)
 
     assert_success purchase
     assert_equal 'APPROVAL', purchase.message
@@ -373,6 +379,7 @@ class RemoteElavonTest < Test::Unit::TestCase
     assert response = @tokenization_gateway.purchase(@amount, token, @options)
     assert_success response
     assert response.test?
+    assert_not_empty response.params['token']
     assert_equal 'APPROVAL', response.message
   end
 


### PR DESCRIPTION
CE-2242

Line 301 in add_auth_purchase_params was causing an extra ssl_token field with a nil value to be added to the request. The changes remove the extra ssl_token, which has eliminated the invalid card errors. I’ve added some logic in the commit method and the authorization_from method to handle the third_party_token coming from the store call.

Unit Tests:
47 tests, 243 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
37 tests, 172 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.2973% passed

test_successful_special_character_encoding_truncation(RemoteElavonTest) is failing currently on master and on my branch. (the remote test results have been a bit inconsistent for me yesterday and today)

Local:
5035 tests, 74943 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed