### PR TITLE
Decidir Plus: Sub Payment Fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -78,6 +78,7 @@
 * CyberSource: Add `line_items` field in authorize method [ajawadmirza] #4268
 * CheckoutV2: Support processing channel and marketplace sub entity ID [AMHOL] #4236
 * Elavon: `third_party_token` bug fix [rachelkirk] #4273
+* Decidir Plus: Add `sub_payments` field [naashton] #4274
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://developers.decidir.com/api/v2'
       self.live_url = 'https://live.decidir.com/api/v2'
 
-      self.supported_countries = ['ARG']
+      self.supported_countries = ['AR']
       self.default_currency = 'ARS'
       self.supported_cardtypes = %i[visa master american_express discover]
 
@@ -82,7 +82,23 @@ module ActiveMerchant #:nodoc:
         post[:currency] = options[:currency] || self.default_currency
         post[:installments] = options[:installments] || 1
         post[:payment_type] = options[:payment_type] || 'single'
+        add_sub_payments(post, options)
+      end
+
+      def add_sub_payments(post, options)
+        # sub_payments field is required for purchase transactions, even if empty
         post[:sub_payments] = []
+
+        return unless sub_payments = options[:sub_payments]
+
+        sub_payments.each do |sub_payment|
+          sub_payment_hash = {
+            site_id: sub_payment[:site_id],
+            installments: sub_payment[:installments],
+            amount: sub_payment[:amount]
+          }
+          post[:sub_payments] << sub_payment_hash
+        end
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -12,6 +12,18 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase'
     }
+    @sub_payments = [
+      {
+        site_id: '04052018',
+        installments: 1,
+        amount: 1500
+      },
+      {
+        site_id: '04052018',
+        installments: 1,
+        amount: 1500
+      }
+    ]
   end
 
   def test_successful_purchase
@@ -64,6 +76,17 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'active', response.message
     assert_equal @credit_card.number[0..5], response.authorization.split('|')[1]
+  end
+
+  def test_successful_purchase_with_options
+    options = @options.merge(sub_payments: @sub_payments)
+
+    assert response = @gateway.store(@credit_card)
+    payment_reference = response.authorization
+
+    response = @gateway.purchase(@amount, payment_reference, options)
+    assert_success response
+    assert_equal 'approved', response.message
   end
 
   def test_invalid_login


### PR DESCRIPTION
Add `sub_payment` fields to `purchase` transactions. This field needs to
be set in the post body, regardless of whether or not it is populated
with data.

Fix country code for this gateway.

CE-2145

Unit: 7 tests, 25 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 9 tests, 30 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed