### PR TITLE
GWI-68 Allow $0 auth Orbital Gateway

### DIFF
--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -908,7 +908,28 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response
+    assert_equal 'No reason to decline', response.message
+  end
+
+  def test_successful_different_cards
+    @credit_card.brand = 'master'
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal 'No reason to decline', response.message
+  end
+
+  def test_successful_verify_with_discover_brand
+    @credit_card.brand = 'discover'
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
     assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_verify_with_invalid_discover_card
+    @declined_card.brand = 'discover'
+    response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_equal 'Invalid CC Number', response.message
   end
 
   def test_failed_verify


### PR DESCRIPTION
Orbital Gateway: Add support to $0 verify

DESCRIPTION
Added verify with $0 amount into Orbital Gateway
Discover card type does not  support $0.00 auth instead use $1.00

JIRA TICKET NUMBER
GWI-71

UNIT TEST
Finished in 0.661291 seconds.

135 tests, 779 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

129.10 tests/s, 750.16 assertions/s

REMOTE TEST
Finished in 211.728643 seconds.

80 tests, 355 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

0.38 tests/s, 1.68 assertions/s

RUBOCOP
726 files inspected, no offenses detected