### PR TITLE
PayWay: Update endpoints and response code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@
 * Pin Payments: Add `unstore` support [montdidier] #4276
 * Orbital: Add support for $0 verify [javierpedrozaing] #4275
 * Update inline documentation with all supported cardtypes [ali-hassan] #4283
+* PayWay: Update endpoints, response code [jessiagee] #4281
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/payway_dot_com.rb
+++ b/lib/active_merchant/billing/gateways/payway_dot_com.rb
@@ -1,8 +1,8 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class PaywayDotComGateway < Gateway
-      self.test_url = 'https://devedgilpayway.net/PaywayWS/Payment/CreditCard'
-      self.live_url = 'https://edgilpayway.com/PaywayWS/Payment/CreditCard'
+      self.test_url = 'https://paywaywsdev.com/PaywayWS/Payment/CreditCard'
+      self.live_url = 'https://paywayws.com/PaywayWS/Payment/CreditCard'
 
       self.supported_countries = %w[US CA]
       self.default_currency = 'USD'
@@ -233,7 +233,7 @@ module ActiveMerchant #:nodoc:
 
         return response['paywayCode'] + '-' + 'success' if success
 
-        response['paywayCode'] + '-' + response['paywayMessage']
+        response['paywayCode']
       end
 
       def authorization_from(response)


### PR DESCRIPTION
* updated Production and test endpoint URLs (old ones are deprecated as of Jan 31st 2022
and just return aywayCode only for gateway_specific_response_field message field
* Adds commit from https://github.com/DanAtPayway/active_merchant/pull/1/commits/b96319f41284faba982138d277688e3056141803

Loaded suite test/remote/gateways/remote_payway_dot_com_test

16 tests, 43 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Loaded suite test/unit/gateways/payway_dot_com_test

16 tests, 64 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

bundle exec rake test:local

5038 tests, 74959 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Running RuboCop...

728 files inspected, no offenses detected