### PR TITLE
CyberSource: Add line_item for purchase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@
 * Pin Payments: Add `unstore` support [montdidier] #4276
 * Orbital: Add support for $0 verify [javierpedrozaing] #4275
 * Update inline documentation with all supported cardtypes [ali-hassan] #4283
+* CyberSource: Add `line_items` for purchase [ajawadmirza] #4282
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -290,7 +290,7 @@ module ActiveMerchant #:nodoc:
       def build_auth_request(money, creditcard_or_reference, options)
         xml = Builder::XmlMarkup.new indent: 2
         add_customer_id(xml, options)
-        add_payment_method_or_subscription(xml, money, creditcard_or_reference, options, true)
+        add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
         add_threeds_2_ucaf_data(xml, creditcard_or_reference, options)
         add_decision_manager_fields(xml, options)
         add_mdd_fields(xml, options)
@@ -881,7 +881,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_payment_method_or_subscription(xml, money, payment_method_or_reference, options, include_items = false)
+      def add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
         if payment_method_or_reference.is_a?(String)
           add_purchase_data(xml, money, true, options)
           add_installments(xml, options)
@@ -894,7 +894,7 @@ module ActiveMerchant #:nodoc:
         else
           add_address(xml, payment_method_or_reference, options[:billing_address], options)
           add_address(xml, payment_method_or_reference, options[:shipping_address], options, true)
-          add_line_item_data(xml, options) if include_items
+          add_line_item_data(xml, options)
           add_purchase_data(xml, money, true, options)
           add_installments(xml, options)
           add_creditcard(xml, payment_method_or_reference)

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -48,14 +48,8 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
           code: 'default',
           description: 'Giant Walrus',
           sku: 'WA323232323232323',
-          tax_amount: 5,
-          national_tax: 10
-        },
-        {
-          declared_value: 100,
-          quantity: 2,
-          description: 'Marble Snowcone',
-          sku: 'FAKE1232132113123'
+          tax_amount: 10,
+          national_tax: 5
         }
       ],
       currency: 'USD',


### PR DESCRIPTION
Added `line_items` field to be passed in purchase method also for cyber
source implementation.

CE-2240

Unit:
5044 tests, 74980 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected

Remote:
101 tests, 520 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.0594% passed