### PR TITLE
Decidir Plus: Add supported methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * BlueSnap: Add support for  `idempotency_key` field [drkjc] #4305
 * Paymentez: Update `capture` method to verify by otp for pending transactions [ajawadmirza] #4267
 * BlueSnap: Update refund request and endpoint along with merchant transaction support [ajawadmirza] #4307
+* DecidirPlus: Added `authorize`, `capture`, `void`, and `verify` methods [ajawadmirza] #4284
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -269,6 +269,10 @@ decidir_plus:
   public_key: SOMECREDENTIAL
   private_key: SOMECREDENTIAL
 
+decidir_plus_preauth:
+  public_key: SOMECREDENTIAL
+  private_key: SOMECREDENTIAL
+
 decidir_purchase:
   api_key: 5df6b5764c3f4822aecdc82d56f26b9d
 

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -3,7 +3,8 @@ require 'securerandom'
 
 class RemoteDecidirPlusTest < Test::Unit::TestCase
   def setup
-    @gateway = DecidirPlusGateway.new(fixtures(:decidir_plus))
+    @gateway_purchase = DecidirPlusGateway.new(fixtures(:decidir_plus))
+    @gateway_auth = DecidirPlusGateway.new(fixtures(:decidir_plus_preauth))
 
     @amount = 100
     @credit_card = credit_card('4484590159923090')
@@ -25,12 +26,12 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
       }
     ]
     @fraud_detection = {
-      send_to_cs: false,
+      send_to_cs: 'false',
       channel: 'Web',
       dispatch_method: 'Store Pick Up',
       csmdds: [
         {
-          code: 17,
+          code: '17',
           description: 'Campo MDD17'
         }
       ]
@@ -38,52 +39,98 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    assert response = @gateway.store(@credit_card)
+    assert response = @gateway_purchase.store(@credit_card)
     payment_reference = response.authorization
 
-    response = @gateway.purchase(@amount, payment_reference, @options)
+    response = @gateway_purchase.purchase(@amount, payment_reference, @options)
     assert_success response
     assert_equal 'approved', response.message
   end
 
   def test_failed_purchase
-    assert @gateway.store(@credit_card)
+    assert @gateway_purchase.store(@credit_card)
 
-    response = @gateway.purchase(@amount, '', @options)
+    response = @gateway_purchase.purchase(@amount, '', @options)
     assert_failure response
     assert_equal 'invalid_param: token', response.message
   end
 
-  def test_successful_refund
-    response = @gateway.store(@credit_card)
+  def test_successful_authorize_and_capture
+    options = @options.merge(fraud_detection: @fraud_detection)
 
-    purchase = @gateway.purchase(@amount, response.authorization, @options)
+    assert response = @gateway_auth.store(@credit_card, options)
+    payment_reference = response.authorization
+
+    response = @gateway_auth.authorize(@amount, payment_reference, options)
+    assert_success response
+
+    assert capture_response = @gateway_auth.capture(@amount, response.authorization, options)
+    assert_success capture_response
+  end
+
+  def test_successful_refund
+    response = @gateway_purchase.store(@credit_card)
+
+    purchase = @gateway_purchase.purchase(@amount, response.authorization, @options)
     assert_success purchase
     assert_equal 'approved', purchase.message
 
-    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert refund = @gateway_purchase.refund(@amount, purchase.authorization)
     assert_success refund
     assert_equal 'approved', refund.message
   end
 
   def test_partial_refund
-    assert response = @gateway.store(@credit_card)
+    assert response = @gateway_purchase.store(@credit_card)
 
-    purchase = @gateway.purchase(@amount, response.authorization, @options)
+    purchase = @gateway_purchase.purchase(@amount, response.authorization, @options)
     assert_success purchase
 
-    assert refund = @gateway.refund(@amount - 1, purchase.authorization)
+    assert refund = @gateway_purchase.refund(@amount - 1, purchase.authorization)
     assert_success refund
   end
 
   def test_failed_refund
-    response = @gateway.refund(@amount, '')
+    response = @gateway_purchase.refund(@amount, '')
     assert_failure response
     assert_equal 'not_found_error', response.message
   end
 
+  def test_successful_void
+    options = @options.merge(fraud_detection: @fraud_detection)
+
+    assert response = @gateway_auth.store(@credit_card, options)
+    payment_reference = response.authorization
+
+    response = @gateway_auth.authorize(@amount, payment_reference, options)
+    assert_success response
+    assert_equal 'pre_approved', response.message
+    authorization = response.authorization
+
+    assert void_response = @gateway_auth.void(authorization)
+    assert_success void_response
+  end
+
+  def test_failed_void
+    assert response = @gateway_auth.void('')
+    assert_failure response
+    assert_equal 'not_found_error', response.message
+  end
+
+  def test_successful_verify
+    assert response = @gateway_auth.verify(@credit_card, @options.merge(fraud_detection: @fraud_detection))
+    assert_success response
+    assert_equal 'active', response.message
+  end
+
+  def test_failed_verify
+    assert response = @gateway_auth.verify(@declined_card, @options)
+    assert_failure response
+    assert_equal 'rejected', response.message
+  end
+
   def test_successful_store
-    assert response = @gateway.store(@credit_card)
+    assert response = @gateway_purchase.store(@credit_card)
     assert_success response
     assert_equal 'active', response.message
     assert_equal @credit_card.number[0..5], response.authorization.split('|')[1]
@@ -92,10 +139,10 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
   def test_successful_purchase_with_options
     options = @options.merge(sub_payments: @sub_payments)
 
-    assert response = @gateway.store(@credit_card)
+    assert response = @gateway_purchase.store(@credit_card)
     payment_reference = response.authorization
 
-    response = @gateway.purchase(@amount, payment_reference, options)
+    response = @gateway_purchase.purchase(@amount, payment_reference, options)
     assert_success response
     assert_equal 'approved', response.message
   end
@@ -103,10 +150,10 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
   def test_successful_purchase_with_fraud_detection
     options = @options.merge(fraud_detection: @fraud_detection)
 
-    assert response = @gateway.store(@credit_card)
+    assert response = @gateway_purchase.store(@credit_card)
     payment_reference = response.authorization
 
-    response = @gateway.purchase(@amount, payment_reference, options)
+    response = @gateway_purchase.purchase(@amount, payment_reference, options)
     assert_success response
     assert_equal({ 'status' => nil }, response.params['fraud_detection'])
   end
@@ -120,14 +167,14 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
   end
 
   def test_transcript_scrubbing
-    transcript = capture_transcript(@gateway) do
-      @gateway.store(@credit_card, @options)
+    transcript = capture_transcript(@gateway_purchase) do
+      @gateway_purchase.store(@credit_card, @options)
     end
-    transcript = @gateway.scrub(transcript)
+    transcript = @gateway_purchase.scrub(transcript)
 
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
-    assert_scrubbed(@gateway.options[:public_key], transcript)
-    assert_scrubbed(@gateway.options[:private_key], transcript)
+    assert_scrubbed(@gateway_purchase.options[:public_key], transcript)
+    assert_scrubbed(@gateway_purchase.options[:private_key], transcript)
   end
 end


### PR DESCRIPTION
Added `authorize`, `capture`, `void`, `verify` methods for decidir plus
along with its test cases.

CE-2159

Remote:
15 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5059 tests, 75068 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected