### PR TITLE
GlobalCollect: Add support for Naranja and Cabal card types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* GlobalCollect: Improve support for Naranja and Cabal card types [dsmcclain] #4286
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -87,7 +87,9 @@ module ActiveMerchant #:nodoc:
         'master' => '3',
         'discover' => '128',
         'jcb' => '125',
-        'diners_club' => '132'
+        'diners_club' => '132',
+        'cabal' => '135',
+        'naranja' => '136'
       }
 
       def add_order(post, money, options, capture: false)
@@ -248,7 +250,6 @@ module ActiveMerchant #:nodoc:
         month = format(payment.month, :two_digits)
         expirydate = "#{month}#{year}"
         pre_authorization = options[:pre_authorization] ? 'PRE_AUTHORIZATION' : 'FINAL_AUTHORIZATION'
-
         post['cardPaymentMethodSpecificInput'] = {
           'paymentProductId' => BRAND_MAP[payment.brand],
           'skipAuthentication' => 'true', # refers to 3DSecure


### PR DESCRIPTION
Also fixes an issue in the remote tests that caused intermittent
failures.

CE-2319

unit
5035 tests, 74943 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

rubocop
728 files inspected, no offenses detected

remote
Loaded suite test/remote/gateways/remote_global_collect_test
31 tests, 78 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.7742% passed

The following test is failing on master for unrelated reasons (it looks as though installments was never implemented correctly): 
`test_successful_purchase_with_installments`