### PR TITLE
Orbital Gateway: Add support to $0 verify (updates)

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -220,10 +220,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(creditcard, options = {})
-        amount = allow_0_auth?(creditcard) ? 0 : 100
+        amount = allow_zero_auth?(creditcard) ? 0 : 100
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(amount, creditcard, options) }
-          r.process(:ignore_result) { void(r.authorization) }
+          r.process(:ignore_result) { void(r.authorization) } unless amount == 0
         end
       end
 
@@ -277,7 +277,7 @@ module ActiveMerchant #:nodoc:
         commit(order, :void, options[:retry_logic], options[:trace_number])
       end
 
-      def allow_0_auth?(credit_card)
+      def allow_zero_auth?(credit_card)
         # Discover does not support a $0.00 authorization instead use $1.00
         %w(visa master american_express diners_club jcb).include?(credit_card.brand)
       end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -1501,11 +1501,11 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end
   end
 
-  def test_successful_verify_0_auth_defferent_cards
+  def test_successful_verify_zero_auth_different_cards
     @credit_card.brand = 'master'
     response = stub_comms do
       @gateway.verify(@credit_card, @options)
-    end.respond_with(successful_purchase_response, successful_purchase_response)
+    end.respond_with(successful_purchase_response)
     assert_success response
     assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
     assert_equal 'Approved', response.message
@@ -1524,7 +1524,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     @credit_card.brand = 'discover'
     response = stub_comms do
       @gateway.verify(@credit_card, @options)
-    end.respond_with(successful_purchase_response, successful_purchase_response)
+    end.respond_with(successful_purchase_response, successful_void_response)
     assert_success response
     assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
     assert_equal 'Approved', response.message


### PR DESCRIPTION
DESCRIPTION:
Added verify with $0 amount into Orbital Gateway
Discover card type does not support $0.00 auth instead use $1.00

JIRA TICKET NUMBER:
GWI-71

UNIT TEST OUTPUT:
Finished in 0.72229 seconds.
135 tests, 779 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed8
186.91 tests/s, 1078.51 assertions/s

REMOTE TEST OUTPUT:
Finished in 83.136148 seconds.
80 tests, 355 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
0.96 tests/s, 4.27 assertions/s

RUBOCOP OUTPUT:
Inspecting 729 files
729 files inspected, no offenses detected