### PR TITLE
PayFlow Pro: Add Stored Credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 == HEAD
 * GlobalCollect: Improve support for Naranja and Cabal card types [dsmcclain] #4286
+* Payflow: Add support for stored credentials [ajawadmirza] #4277
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173
@@ -87,6 +88,7 @@
 * Update inline documentation with all supported cardtypes [ali-hassan] #4283
 * PayWay: Update endpoints, response code [jessiagee] #4281
 * CyberSource: Add `line_items` for purchase [ajawadmirza] #4282
+* Payflow Pro: Add `stored_credential` fields [ajawadmirza] #4277
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -62,6 +62,28 @@ class RemotePayflowTest < Test::Unit::TestCase
     assert !response.fraud_review?
   end
 
+  def test_successful_purchase_with_stored_credential
+    @options[:stored_credential] = {
+      initial_transaction: true,
+      reason_type: 'recurring',
+      initiator: 'cardholder',
+      network_transaction_id: nil
+    }
+    assert response = @gateway.purchase(100000, @credit_card, @options)
+    assert_equal 'Approved', response.message
+    assert_success response
+
+    @options[:stored_credential] = {
+      initial_transaction: false,
+      reason_type: 'recurring',
+      initiator: 'merchant',
+      network_transaction_id: response.authorization
+    }
+    assert response = @gateway.purchase(100000, @credit_card, @options)
+    assert_equal 'Approved', response.message
+    assert_success response
+  end
+
   def test_successful_purchase_with_extra_options
     assert response = @gateway.purchase(100000, @credit_card, @options.merge(@extra_options))
     assert_equal 'Approved', response.message


### PR DESCRIPTION
Added support for `stored_credential` to allow recurring payments of
cardholder and merchant in payflow pro implementation.

CE-2244

Closes #4277

Remote:
39 tests, 169 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
74.359% passed

Unit:
5036 tests, 74956 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected