### PR TITLE
Decidir Plus: Fraud Detection Fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -89,6 +89,7 @@
 * PayWay: Update endpoints, response code [jessiagee] #4281
 * CyberSource: Add `line_items` for purchase [ajawadmirza] #4282
 * Payflow Pro: Add `stored_credential` fields [ajawadmirza] #4277
+* Decidir Plus: Add `fraud_detection` fields [naashton] #4289
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -21,6 +21,7 @@ module ActiveMerchant #:nodoc:
 
         add_payment(post, payment, options)
         add_purchase_data(post, money, payment, options)
+        add_fraud_detection(post, options)
 
         commit(:post, 'payments', post)
       end
@@ -98,6 +99,18 @@ module ActiveMerchant #:nodoc:
             amount: sub_payment[:amount]
           }
           post[:sub_payments] << sub_payment_hash
+        end
+      end
+
+      def add_fraud_detection(post, options)
+        return unless fraud_detection = options[:fraud_detection]
+
+        {}.tap do |hsh|
+          hsh[:send_to_cs] = fraud_detection[:send_to_cs] ? true : false # true/false
+          hsh[:channel] = fraud_detection[:channel] if fraud_detection[:channel]
+          hsh[:dispatch_method] = fraud_detection[:dispatch_method] if fraud_detection[:dispatch_method]
+          hsh[:csmdds] = fraud_detection[:csmdds] if fraud_detection[:csmdds]
+          post[:fraud_detection] = hsh
         end
       end
 

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -24,6 +24,17 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
         amount: 1500
       }
     ]
+    @fraud_detection = {
+      send_to_cs: false,
+      channel: 'Web',
+      dispatch_method: 'Store Pick Up',
+      csmdds: [
+        {
+          code: 17,
+          description: 'Campo MDD17'
+        }
+      ]
+    }
   end
 
   def test_successful_purchase
@@ -87,6 +98,17 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, payment_reference, options)
     assert_success response
     assert_equal 'approved', response.message
+  end
+
+  def test_successful_purchase_with_fraud_detection
+    options = @options.merge(fraud_detection: @fraud_detection)
+
+    assert response = @gateway.store(@credit_card)
+    payment_reference = response.authorization
+
+    response = @gateway.purchase(@amount, payment_reference, options)
+    assert_success response
+    assert_equal({ 'status' => nil }, response.params['fraud_detection'])
   end
 
   def test_invalid_login


### PR DESCRIPTION
Add support for fraud detection with Decidir Plus.

This PR includes a method to add `fraud_detection` fields to the post
body of a `purchase` transaction. The `csmdds` subfield of
`fraud_detection` is expected to be given as an array of hashes with a
`code` and `description` value.

CE-2337

Unit: 8 tests, 30 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 10 tests, 33 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed