### PR TITLE
Cybersource: add processor response message

### DIFF
--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -59,6 +59,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Successful transaction', response.message
+    assert_equal 'Approved and completed successfully', response.params['processorMessage']
     assert_success response
     assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;", response.authorization
     assert response.test?


### PR DESCRIPTION
Cybersource: adds constant for mapping `processorResponse` to processor error codes.

_Note:_ there is no remote test coverage for the processor response mapping because Cybersource sandbox does not return `processorResponse` error codes (not that I can find, at least).

_Second Note:_ submitted as a draft PR awaiting further information from Cybersource on whether these processor response messages can be trusted. Do not merge until further notice.

CE-2271

Unit:
5046 tests, 74997 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected

Remote:
101 tests, 512 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.0693% passed

The following tests are failing on master for reasons unrelated to this change:
```
test_successful_validate_pinless_debit_card
test_successful_tax_calculation
test_successful_pinless_debit_card_purchase
test_successful_authorization_and_failed_capture
 test_successful_asynchronous_adjust
test_successful_3ds_validate_purchase_request
test_successful_3ds_validate_authorize_request
```