### PR TITLE
PaySafe: Update unstore method to support profile id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -92,6 +92,7 @@
 * CyberSource: Add `line_items` for purchase [ajawadmirza] #4282
 * Payflow Pro: Add `stored_credential` fields [ajawadmirza] #4277
 * Decidir Plus: Add `fraud_detection` fields [naashton] #4289
+* PaySafe: Update `unstore` method and authorization for redact [ajawadmirza] #4294
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def unstore(pm_profile_id)
-        commit_for_unstore(:delete, "profiles/#{pm_profile_id}", nil, nil)
+        commit_for_unstore(:delete, "profiles/#{get_id_from_store_auth(pm_profile_id)}", nil, nil)
       end
 
       def supports_scrubbing?
@@ -179,7 +179,7 @@ module ActiveMerchant #:nodoc:
       def add_payment(post, payment)
         if payment.is_a?(String)
           post[:card] = {}
-          post[:card][:paymentToken] = payment
+          post[:card][:paymentToken] = get_pm_from_store_auth(payment)
         else
           post[:card] = { cardExpiry: {} }
           post[:card][:cardNum] = payment.number
@@ -384,10 +384,19 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(action, response)
         if action == 'profiles'
-          response['cards'].first['paymentToken']
+          pm = response['cards'].first['paymentToken']
+          "#{pm}|#{response['id']}"
         else
           response['id']
         end
+      end
+
+      def get_pm_from_store_auth(authorization)
+        authorization.split('|')[0]
+      end
+
+      def get_id_from_store_auth(authorization)
+        authorization.split('|')[1]
       end
 
       def post_data(parameters = {}, options = {})

--- a/test/remote/gateways/remote_paysafe_test.rb
+++ b/test/remote/gateways/remote_paysafe_test.rb
@@ -367,7 +367,7 @@ class RemotePaysafeTest < Test::Unit::TestCase
   def test_successful_store_and_unstore
     response = @gateway.store(credit_card('4111111111111111'), @profile_options)
     assert_success response
-    id = response.params['id']
+    id = response.authorization
     unstore = @gateway.unstore(id)
     assert_success unstore
   end


### PR DESCRIPTION
Updated `unstore` method so that profile id can be sent from
authorization in paysafe implementation.

[CE-2285](https://spreedly.atlassian.net/browse/CE-2285)

Unit:
5048 tests, 75003 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected

Remote:
31 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed