### PR TITLE
Litle: fixed refund with custom billing descriptor

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -78,12 +78,12 @@ module ActiveMerchant #:nodoc:
       def refund(money, payment, options = {})
         request = build_xml_request do |doc|
           add_authentication(doc)
-          add_descriptor(doc, options)
           doc.send(refund_type(payment), transaction_attributes(options)) do
             if payment.is_a?(String)
               transaction_id, = split_authorization(payment)
               doc.litleTxnId(transaction_id)
               doc.amount(money) if money
+              add_descriptor(doc, options)
             elsif check?(payment)
               add_echeck_purchase_params(doc, money, payment, options)
             else


### PR DESCRIPTION
Currently, when doing a refund with a  custom billing descriptor the response I get this error

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<litleOnlineResponse xmlns="http://www.litle.com/schema" version="9.14" response="1" message="Error validating xml data against the schema: cvc-complex-type.2.4.a: Invalid content was found starting with element 'customBilling'. One of '{&quot;http://www.litle.com/schema&quot;:transaction, &quot;http://www.litle.com/schema&quot;:recurringTransaction}' is expected." />
```

I checked all other versions of schema, higher versions also, and the problem is that the `customBilling` element is currently a sibling with the `credit` or `echeckCredit`  element , but according to the schema it should be inside the `credit` or `echeckCredit` 

The other methods `add_echeck_purchase_params` and `add_credit_params` already handle the custom billing descriptors correctly 