### PR TITLE
CyberSource: Add national tax indicator field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -93,6 +93,7 @@
 * CyberSource: Add `line_items` for purchase [ajawadmirza] #4282
 * Payflow Pro: Add `stored_credential` fields [ajawadmirza] #4277
 * Decidir Plus: Add `fraud_detection` fields [naashton] #4289
+* CyberSource: Add `national_tax_indicator` fields in authorize and purchase [ajawadmirza] #4299
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -291,6 +291,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new indent: 2
         add_customer_id(xml, options)
         add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
+        add_other_tax(xml, options)
         add_threeds_2_ucaf_data(xml, creditcard_or_reference, options)
         add_decision_manager_fields(xml, options)
         add_mdd_fields(xml, options)
@@ -349,6 +350,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new indent: 2
         add_customer_id(xml, options)
         add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
+        add_other_tax(xml, options)
         add_threeds_2_ucaf_data(xml, payment_method_or_reference, options)
         add_decision_manager_fields(xml, options)
         add_mdd_fields(xml, options)

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -57,8 +57,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       ignore_cvv: 'true',
       commerce_indicator: 'internet',
       user_po: 'ABC123',
-      taxable: true,
-      national_tax_indicator: 1
+      taxable: true
     }
 
     @subscription_options = {
@@ -248,7 +247,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(authorize)
     assert adjust = @gateway_latam.adjust(@amount * 2, authorize.authorization, @options)
     assert_success adjust
-    assert capture = @gateway_latam.capture(@amount, authorize.authorization, @options)
+    assert capture = @gateway_latam.capture(@amount, authorize.authorization, @options.merge({ national_tax_indicator: 1 }))
     assert_successful_response(capture)
   end
 
@@ -262,7 +261,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   def test_capture_and_void
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(auth)
-    assert capture = @gateway.capture(@amount, auth.authorization, @options)
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge({ national_tax_indicator: 1 }))
     assert_successful_response(capture)
     assert void = @gateway.void(capture.authorization, @options)
     assert_successful_response(void)
@@ -271,7 +270,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   def test_capture_and_void_with_elo
     assert auth = @gateway.authorize(@amount, @elo_credit_card, @options)
     assert_successful_response(auth)
-    assert capture = @gateway.capture(@amount, auth.authorization, @options)
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge({ national_tax_indicator: 1 }))
     assert_successful_response(capture)
     assert void = @gateway.void(capture.authorization, @options)
     assert_successful_response(void)
@@ -317,6 +316,11 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_successful_response(response)
+  end
+
+  def test_successful_purchase_with_national_tax_indicator
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options.merge(national_tax_indicator: 1))
+    assert_successful_response(purchase)
   end
 
   def test_successful_purchase_with_issuer_additional_data
@@ -384,6 +388,11 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     options = @options.merge(customer_id: '7500BB199B4270EFE05348D0AFCAD')
     assert response = @gateway.authorize(@amount, @credit_card, options)
     assert_successful_response(response)
+  end
+
+  def test_authorize_with_national_tax_indicator
+    assert authorize = @gateway.authorize(@amount, @credit_card, @options.merge(national_tax_indicator: 1))
+    assert_successful_response(authorize)
   end
 
   def test_successful_purchase_with_customer_id
@@ -510,7 +519,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(auth)
 
-    assert response = @gateway.capture(@amount, auth.authorization, @options)
+    assert response = @gateway.capture(@amount, auth.authorization, @options.merge({ national_tax_indicator: 1 }))
     assert_successful_response(response)
     assert !response.authorization.blank?
   ensure
@@ -521,14 +530,14 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(auth)
 
-    assert capture = @gateway.capture(@amount + 10, auth.authorization, @options)
+    assert capture = @gateway.capture(@amount + 10, auth.authorization, @options.merge({ national_tax_indicator: 1 }))
     assert_failure capture
     assert_equal 'The requested amount exceeds the originally authorized amount', capture.message
   end
 
   def test_failed_capture_bad_auth_info
     assert @gateway.authorize(@amount, @credit_card, @options)
-    assert capture = @gateway.capture(@amount, 'a;b;c', @options)
+    assert capture = @gateway.capture(@amount, 'a;b;c', @options.merge({ national_tax_indicator: 1 }))
     assert_failure capture
   end
 
@@ -601,7 +610,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(auth)
 
     (1..20).each { |e| @options["mdd_field_#{e}".to_sym] = "value #{e}" }
-    assert capture = @gateway.capture(@amount, auth.authorization, @options)
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge({ national_tax_indicator: 1 }))
     assert_successful_response(capture)
   end
 
@@ -624,7 +633,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(auth)
 
-    capture_options = @options.merge(local_tax_amount: '0.17', national_tax_amount: '0.05')
+    capture_options = @options.merge(local_tax_amount: '0.17', national_tax_amount: '0.05', national_tax_indicator: 1)
     assert capture = @gateway.capture(@amount, auth.authorization, capture_options)
     assert_successful_response(capture)
   end

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -64,6 +64,24 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_national_tax_indicator
+    national_tax_indicator = 1
+    stub_comms do
+      @gateway.purchase(100, @credit_card, @options.merge(national_tax_indicator: national_tax_indicator))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<otherTax>\s+<nationalTaxIndicator>#{national_tax_indicator}<\/nationalTaxIndicator>\s+<\/otherTax>/m, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_successful_authorize_with_national_tax_indicator
+    national_tax_indicator = 1
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(national_tax_indicator: national_tax_indicator))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<otherTax>\s+<nationalTaxIndicator>#{national_tax_indicator}<\/nationalTaxIndicator>\s+<\/otherTax>/m, data)
+    end.respond_with(successful_authorization_response)
+  end
+
   def test_successful_credit_card_purchase_with_elo
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 


### PR DESCRIPTION
Added `national_tax_indicator` in purchase and authorize calls for cyber
source implementation.

CE-2338

Unit:
5050 tests, 75009 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected

Remote:
103 tests, 520 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.2039% passed