### PR TITLE
Stripe PI: confirm_intent should have add_payment_method_types

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -60,6 +60,7 @@ module ActiveMerchant #:nodoc:
         result = add_payment_method_token(post, payment_method, options)
         return result if result.is_a?(ActiveMerchant::Billing::Response)
 
+        add_payment_method_types(post, options)
         CONFIRM_INTENT_ATTRIBUTES.each do |attribute|
           add_whitelisted_attribute(post, options, attribute)
         end

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -869,6 +869,22 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'requires_confirmation', update_response.params['status']
   end
 
+  def test_create_a_payment_intent_and_confirm_with_different_payment_method
+    options = {
+      currency: 'USD',
+      payment_method_types: %w[afterpay_clearpay],
+      metadata: { key_1: 'value_1', key_2: 'value_2' }
+    }
+    assert create_response = @gateway.setup_purchase(@amount, options)
+    assert_equal 'requires_payment_method', create_response.params['status']
+    intent_id = create_response.params['id']
+    assert_equal 2000, create_response.params['amount']
+    assert_equal 'afterpay_clearpay', create_response.params['payment_method_types'][0]
+
+    assert confirm_response = @gateway.confirm_intent(intent_id, @visa_payment_method, payment_method_types: 'card' )
+    assert_equal 'card', confirm_response.params['payment_method_types'][0]
+  end
+
   def test_create_a_payment_intent_and_void
     options = {
       currency: 'GBP',

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -60,8 +60,9 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert_equal 'requires_confirmation', create.params['status']
     assert create.test?
 
-    assert confirm = @gateway.confirm_intent(create.params['id'], nil, return_url: 'https://example.com/return-to-me')
+    assert confirm = @gateway.confirm_intent(create.params['id'], nil, @options.merge(return_url: 'https://example.com/return-to-me', payment_method_types: 'card'))
     assert_equal 'redirect_to_url', confirm.params.dig('next_action', 'type')
+    assert_equal 'card', confirm.params.dig('payment_method_types')[0]
   end
 
   def test_successful_create_and_capture_intent


### PR DESCRIPTION
Stripe supports passing payment_method_types as an optional parameter for the `confirm_intent` endpoint.
Adding this support allows for users to change the payment method on a transaction
and attempt to complete it in one request.

ECS-2193

Test Summary
Local:
5048 tests, 75004 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
37 tests, 191 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
72 tests, 329 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed