### PR TITLE
Paysafe: Fix commit method for unstore operation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * CyberSource: Add `national_tax_indicator` fields in authorize and purchase [ajawadmirza] #4299
 * Credorax: Update `OpCode` for credit transactions [dsmcclain] #4279
 * Credorax: Revert update made to `OpCode` [dsmcclain] #4306
+* PaySafe: Fix commit for `unstore` method [ajawadmirza] #4303
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def unstore(pm_profile_id)
-        commit_for_unstore(:delete, "profiles/#{get_id_from_store_auth(pm_profile_id)}", nil, nil)
+        commit(:delete, "profiles/#{get_id_from_store_auth(pm_profile_id)}", nil, nil)
       end
 
       def supports_scrubbing?
@@ -321,6 +321,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(body)
+        return {} if body.empty?
+
         JSON.parse(body)
       end
 
@@ -339,17 +341,6 @@ module ActiveMerchant #:nodoc:
           cvv_result: CVVResult.new(response['cvvVerification']),
           test: test?,
           error_code: success ? nil : error_code_from(response)
-        )
-      end
-
-      def commit_for_unstore(method, action, parameters, options)
-        url = url(action)
-        response = raw_ssl_request(method, url, post_data(parameters, options), headers)
-        success = true if response.code == '200'
-
-        Response.new(
-          success,
-          message: response.message
         )
       end
 


### PR DESCRIPTION
Fixed commit method for `unstore` operation in paysafe implementation to
parse the response correctly for empty strings.

CE-2285

Unit:
5052 tests, 75017 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected

Remote:
31 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed