### PR TITLE
CE-2343 Bluesnap Idempotency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * NMI: Update gateway credentials to accept security_key [javierpedrozaing] #4302
 * PaySafe: Fix commit for `unstore` method [ajawadmirza] #4303
 * Ebanx: Add support for `order_number` field [ali-hassan] #4304
+* BlueSnap: Add support for  `idempotency_key` field [drkjc] #4305
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -573,4 +573,10 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert_scrubbed(@check.routing_number, transcript)
     assert_scrubbed(@gateway.options[:api_password], transcript)
   end
+
+  def test_successful_purchase_with_idempotency_key
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(idempotency_key: 'test123'))
+    assert_success response
+    assert_equal 'Success', response.message
+  end
 end

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -543,6 +543,14 @@ class BlueSnapTest < Test::Unit::TestCase
     end
   end
 
+  def test_optional_idempotency_key_header
+    stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({ idempotency_key: 'test123' }))
+    end.check_request do |_method, _url, _data, headers|
+      assert_equal 'test123', headers['Idempotency-Key']
+    end.respond_with(successful_authorize_response)
+  end
+
   private
 
   def check_amount_registered(amount, currency)


### PR DESCRIPTION
Bluesnap: Add support for optional Idempotency Key field on purchase, authorize, capture, refund, and void. Idempotency Key is passed as a header.

Unit tests:
41 tests, 237 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:
49 tests, 166 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed