### PR TITLE
BlueSnap: Update refund

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Ebanx: Add support for `order_number` field [ali-hassan] #4304
 * BlueSnap: Add support for  `idempotency_key` field [drkjc] #4305
 * Paymentez: Update `capture` method to verify by otp for pending transactions [ajawadmirza] #4267
+* BlueSnap: Update refund request and endpoint along with merchant transaction support [ajawadmirza] #4307
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -376,11 +376,59 @@ class BlueSnapTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    @gateway.expects(:raw_ssl_request).returns(successful_refund_response)
+    options = {
+      reason: 'Refund for order #1992',
+      cancel_subscription: 'false',
+      tax_amount: 0.05,
+      transaction_meta_data: [
+        {
+          meta_key: 'refundedItems',
+          meta_value: '1552,8832',
+          meta_description: 'Refunded Items',
+          meta_is_visible: 'false'
+        },
+        {
+          meta_key: 'Number2',
+          meta_value: 'KTD',
+          meta_description: 'Metadata 2',
+          meta_is_visible: 'true'
+        }
+      ]
+    }
+    transaction_id = '1286'
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.refund(@amount, transaction_id, options)
+    end.check_request do |_action, endpoint, data, _headers|
+      doc = REXML::Document.new(data)
 
-    response = @gateway.refund(@amount, 'Authorization')
+      assert_includes endpoint, "/refund/#{transaction_id}"
+      assert_match(/<amount>1.00<\/amount>/, data)
+      assert_match(/<tax-amount>0.05<\/tax-amount>/, data)
+      assert_match(/<cancel-subscription>false<\/cancel-subscription>/, data)
+      assert_match(/<reason>Refund for order #1992<\/reason>/, data)
+      assert_match(/<meta-key>refundedItems<\/meta-key>/, data)
+      assert_match(/<meta-value>KTD<\/meta-value>/, data)
+      assert_match(/<meta-description>Metadata 2<\/meta-description>/, data)
+      transaction_meta_data = doc.root.elements['transaction-meta-data'].elements.to_a
+      transaction_meta_data.each_with_index do |item, index|
+        assert_match item.elements['meta-key'].text, options[:transaction_meta_data][index][:meta_key]
+        assert_match item.elements['meta-value'].text, options[:transaction_meta_data][index][:meta_value]
+        assert_match item.elements['meta-description'].text, options[:transaction_meta_data][index][:meta_description]
+        assert_match item.elements['is-visible'].text, options[:transaction_meta_data][index][:meta_is_visible]
+      end
+    end.respond_with(successful_refund_response)
     assert_success response
     assert_equal '1012082907', response.authorization
+  end
+
+  def test_successful_refund_with_merchant_id
+    merchant_transaction_id = '12678'
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.refund(@amount, '', @options.merge({ merchant_transaction_id: merchant_transaction_id }))
+    end.check_request do |_action, endpoint, _data, _headers|
+      assert_includes endpoint, "/refund/merchant/#{merchant_transaction_id}"
+    end.respond_with(successful_refund_response)
+    assert_success response
   end
 
   def test_failed_refund


### PR DESCRIPTION
Updated `refund` method to include transaction id in its url for blue
snap implementation

CE-2351

Unit:
5052 tests, 75025 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected

Remote:
48 tests, 163 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed