### PR TITLE
Paymentez: Fix authorize for core

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * BlueSnap: Add support for  `idempotency_key` field [drkjc] #4305
 * Paymentez: Update `capture` method to verify by otp for pending transactions [ajawadmirza] #4267
 * BlueSnap: Update refund request and endpoint along with merchant transaction support [ajawadmirza] #4307
+* Paymentez: Fix `authorize` to call `purchase` for otp flow [ajawadmirza] #4310
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -69,6 +69,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorize(money, payment, options = {})
+        return purchase(money, payment, options) if options[:otp_flow]
+
         post = {}
 
         add_invoice(post, money, options)

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -267,7 +267,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
 
   def test_successful_capture_with_otp
     @options[:vat] = 0.1
-    response = @ecuador_gateway.purchase(@amount, @otp_card, @options)
+    response = @ecuador_gateway.authorize(@amount, @otp_card, @options.merge({ otp_flow: true }))
     assert_success response
     assert_equal 'pending', response.params['transaction']['status']
 


### PR DESCRIPTION
Fixed `authorize` to call `purchase` so that capture can be made on core for paymentez implementation.

CE-1920

Remote:
33 tests, 83 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
87.8788% passed

Unit:
5057 tests, 75059 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected