### PR TITLE
IPG: Remove Uruguay from supported countries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * DecidirPlus: Added `authorize`, `capture`, `void`, and `verify` methods [ajawadmirza] #4284
 * Paymentez: Fix `authorize` to call `purchase` for otp flow [ajawadmirza] #4310
 * Orbital: Indicate support for network tokenization [dsmcclain] #4309
+* IPG: remove `uruguay` from supported countries [ajawadmirza] #4311
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/ipg.rb
+++ b/lib/active_merchant/billing/gateways/ipg.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://test.ipg-online.com/ipgapi/services'
       self.live_url = 'https://www5.ipg-online.com'
 
-      self.supported_countries = %w(UY AR)
+      self.supported_countries = %w(AR)
       self.default_currency = 'ARS'
       self.supported_cardtypes = %i[visa master american_express discover]
 
@@ -12,7 +12,6 @@ module ActiveMerchant #:nodoc:
       self.display_name = 'IPG'
 
       CURRENCY_CODES = {
-        'UYU' => '858',
         'ARS' => '032'
       }
 

--- a/test/unit/gateways/ipg_test.rb
+++ b/test/unit/gateways/ipg_test.rb
@@ -261,10 +261,10 @@ class IpgTest < Test::Unit::TestCase
 
   def test_successful_verify_with_currency_code
     response = stub_comms do
-      @gateway.verify(@credit_card, { currency: 'UYU' })
+      @gateway.verify(@credit_card, { currency: 'ARS' })
     end.check_request do |_endpoint, data, _headers|
       doc = REXML::Document.new(data)
-      assert_match('858', REXML::XPath.first(doc, '//v1:Payment//v1:Currency').text) if REXML::XPath.first(doc, '//v1:CreditCardTxType//v1:Type')&.text == 'preAuth'
+      assert_match('032', REXML::XPath.first(doc, '//v1:Payment//v1:Currency').text) if REXML::XPath.first(doc, '//v1:CreditCardTxType//v1:Type')&.text == 'preAuth'
     end.respond_with(successful_authorize_response, successful_void_response)
     assert_success response
   end


### PR DESCRIPTION
Removed `uruguay` from supported countries along with its currency code
and test case changes in ipg implementation.

CE-2374

Unit:
5057 tests, 75059 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected

Remote:
17 tests, 53 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed