### PR TITLE
CyberSource: Add option to target 0 verify

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -158,9 +158,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(payment, options = {})
+        amount = eligible_for_zero_auth?(payment, options) ? 0 : 100
         MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, payment, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
+          r.process { authorize(amount, payment, options) }
+          r.process(:ignore_result) { void(r.authorization, options) } unless amount == 0
         end
       end
 
@@ -1078,6 +1079,10 @@ module ActiveMerchant #:nodoc:
         else
           response[:message]
         end
+      end
+
+      def eligible_for_zero_auth?(payment_method, options = {})
+        payment_method.is_a?(CreditCard) && options[:zero_amount_auth]
       end
     end
   end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -10,6 +10,11 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
     @credit_card = credit_card('4111111111111111', verification_value: '987')
     @declined_card = credit_card('801111111111111')
+    @master_credit_card = credit_card('5555555555554444',
+      verification_value: '321',
+      month: '12',
+      year: (Time.now.year + 2).to_s,
+      brand: :master)
     @pinless_debit_card = credit_card('4002269999999999')
     @elo_credit_card = credit_card('5067310000000010',
       verification_value: '321',
@@ -1007,6 +1012,29 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
     gateway = CyberSourceGateway.new(login: 'an_unknown_login', password: 'unknown_password')
     assert !gateway.verify_credentials
+  end
+
+  def test_successful_verify
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match '1.00', response.params['amount']
+    assert_equal 'Successful transaction', response.message
+  end
+
+  def test_successful_verify_zero_amount_visa
+    @options[:zero_amount_auth] = true
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match '0.00', response.params['amount']
+    assert_equal 'Successful transaction', response.message
+  end
+
+  def test_successful_verify_zero_amount_master
+    @options[:zero_amount_auth] = true
+    response = @gateway.verify(@master_credit_card, @options)
+    assert_success response
+    assert_match '0.00', response.params['amount']
+    assert_equal 'Successful transaction', response.message
   end
 
   private

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -737,6 +737,23 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_verify_zero_amount_request
+    @options[:zero_amount_auth] = true
+    stub_comms(@gateway, :ssl_post) do
+      @gateway.verify(@credit_card, @options)
+    end.check_request(skip_response: true) do |_endpoint, data|
+      assert_match %r(<grandTotalAmount>0.00<\/grandTotalAmount>), data
+    end
+  end
+
+  def test_successful_verify_request
+    stub_comms(@gateway, :ssl_post) do
+      @gateway.verify(@credit_card, @options)
+    end.check_request(skip_response: true) do |_endpoint, data|
+      assert_match %r(<grandTotalAmount>1.00<\/grandTotalAmount>), data
+    end
+  end
+
   def test_successful_verify_with_elo
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.verify(@elo_credit_card, @options)


### PR DESCRIPTION
Summary:
---------------------------------------
In order to be able to use $0 authorizations this PR add
the gateway specific field "zero_dollar_auth" as an option, so
I can verify my customers Credit Cards, depending on the acquiring bank,
without making any charges to them.

Local Tests:
---------------------------------------
115 tests, 562 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
---------------------------------------
105 tests, 526 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.3333% passed

RuboCop:
---------------------------------------
728 files inspected, no offenses detected