### PR TITLE
DecidirPlus: Add `unstore` method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * Orbital: Indicate support for network tokenization [dsmcclain] #4309
 * IPG: remove `uruguay` from supported countries [ajawadmirza] #4311
 * Decidir: Add sub_payments sub-fields to gateway [meagabeth] #4315
+* DecidirPlus: Added `unstore` method [ajawadmirza] #4317
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -136,6 +136,25 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
     assert_equal @credit_card.number[0..5], response.authorization.split('|')[1]
   end
 
+  def test_successful_unstore
+    customer = {
+      id: 'John',
+      email: 'decidir@decidir.com'
+    }
+
+    assert response = @gateway_purchase.store(@credit_card)
+    payment_reference = response.authorization
+
+    response = @gateway_purchase.purchase(@amount, payment_reference, @options.merge({ customer: customer }))
+    assert_success response
+
+    assert_equal 'approved', response.message
+    token_id = response.authorization
+
+    assert unstore_response = @gateway_purchase.unstore(token_id)
+    assert_success unstore_response
+  end
+
   def test_successful_purchase_with_options
     options = @options.merge(sub_payments: @sub_payments)
 

--- a/test/unit/gateways/decidir_plus_test.rb
+++ b/test/unit/gateways/decidir_plus_test.rb
@@ -94,6 +94,18 @@ class DecidirPlusTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_unstore
+    token_id = '132141|123|3d5992f9-90f8-4ac4-94dd-6baa7306941f'
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.unstore(token_id)
+    end.check_request do |_action, endpoint, data, _headers|
+      assert_includes endpoint, "cardtokens/#{token_id.split('|')[2]}"
+      assert_empty JSON.parse(data)
+    end.respond_with(successful_unstore_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_options
     options = @options.merge(sub_payments: @sub_payments)
     options[:installments] = 4
@@ -217,6 +229,8 @@ class DecidirPlusTest < Test::Unit::TestCase
       {\"id\":\"cd4ba1c0-4b41-4c5c-8530-d0c757df8603\",\"status\":\"active\",\"card_number_length\":16,\"date_created\":\"2022-01-07T17:37Z\",\"bin\":\"448459\",\"last_four_digits\":\"3090\",\"security_code_length\":3,\"expiration_month\":9,\"expiration_year\":23,\"date_due\":\"2022-01-07T17:52Z\",\"cardholder\":{\"identification\":{\"type\":\"\",\"number\":\"\"},\"name\":\"Longbob Longsen\"}}
     }
   end
+
+  def successful_unstore_response; end
 
   def successful_purchase_response
     %{


### PR DESCRIPTION
Added `unstore` method along with its required changes in purchase to
receive valid token in decidir plus implementation.

CE-2144

Remote:
16 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5064 tests, 75089 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected