### PR TITLE
Decidir & Decidir Plus: Revise handling of sub_payment sub-fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * Decidir: Add sub_payments sub-fields to gateway [meagabeth] #4315
 * Priority: Add additional fields to purchase and capture requests [dsmcclain] #4301
 * DecidirPlus: Added `unstore` method [ajawadmirza] #4317
+* Decidir & Decidir Plus: Revise handling of `sub_payment` sub-fields [meagabeth] #4318
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -219,8 +219,8 @@ module ActiveMerchant #:nodoc:
         sub_payments.each do |sub_payment|
           sub_payment_hash = {
             site_id: sub_payment[:site_id],
-            installments: sub_payment[:installments],
-            amount: sub_payment[:amount]
+            installments: sub_payment[:installments].to_i,
+            amount: sub_payment[:amount].to_i
           }
           post[:sub_payments] << sub_payment_hash
         end

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -143,8 +143,8 @@ module ActiveMerchant #:nodoc:
         sub_payments.each do |sub_payment|
           sub_payment_hash = {
             site_id: sub_payment[:site_id],
-            installments: sub_payment[:installments],
-            amount: sub_payment[:amount]
+            installments: sub_payment[:installments].to_i,
+            amount: sub_payment[:amount].to_i
           }
           post[:sub_payments] << sub_payment_hash
         end

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -21,8 +21,8 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
       },
       {
         site_id: '04052018',
-        installments: 1,
-        amount: 1500
+        installments: '1',
+        amount: '1500'
       }
     ]
     @fraud_detection = {

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -21,8 +21,8 @@ class RemoteDecidirTest < Test::Unit::TestCase
     @sub_payments = [
       {
         site_id: '04052018',
-        installments: 1,
-        amount: 1500
+        installments: '1',
+        amount: '1500'
       },
       {
         site_id: '04052018',


### PR DESCRIPTION
The gateway expects the `sub_payments` sub-fields `installments` and `amount` to be integers instead of strings

CE-2361

Local:
5063 tests, 75084 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Rubocop:
728 files inspected, no offenses detected

Decidir Tests
Unit:
38 tests, 184 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
24 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Decidir Plus Tests
Unit:
11 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
15 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed