### PR TITLE
Addition of invalid_amount for amount_too_small Stripe error handler

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -95,7 +95,8 @@ module ActiveMerchant #:nodoc:
         pickup_card: 'pick_up_card',
         config_error: 'config_error',
         test_mode_live_card: 'test_mode_live_card',
-        unsupported_feature: 'unsupported_feature'
+        unsupported_feature: 'unsupported_feature',
+        invalid_amount: 'invalid_amount'
       }
 
       cattr_reader :implementations

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -48,7 +48,8 @@ module ActiveMerchant #:nodoc:
         'processing_error' => STANDARD_ERROR_CODE[:processing_error],
         'incorrect_pin' => STANDARD_ERROR_CODE[:incorrect_pin],
         'test_mode_live_card' => STANDARD_ERROR_CODE[:test_mode_live_card],
-        'pickup_card' => STANDARD_ERROR_CODE[:pickup_card]
+        'pickup_card' => STANDARD_ERROR_CODE[:pickup_card],
+        'amount_too_small' => STANDARD_ERROR_CODE[:invalid_amount]
       }
 
       BANK_ACCOUNT_HOLDER_TYPE_MAPPING = {


### PR DESCRIPTION
# Summary: #####################

We have a requirement to display a better message to merchants for Stripe's `amount_too_small` error. This will raise our `amount_invalid` error message suggesting an amount error instead of the default error informing the buyer to try again in a few minutes.

# Successful Test Summary

`rake test:units TEST=test/unit/gateways/stripe_test.rb`
```
....................................................................................
Finished in 0.048985 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------
142 tests, 750 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------
2898.85 tests/s, 15310.81 assertions/s
```
