### PR TITLE
Adyen: Add currencies with three decimals places

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -9,6 +9,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w(AT AU BE BG BR CH CY CZ DE DK EE ES FI FR GB GI GR HK HU IE IS IT LI LT LU LV MC MT MX NL NO PL PT RO SE SG SK SI US)
       self.default_currency = 'USD'
       self.currencies_without_fractions = %w(CVE DJF GNF IDR JPY KMF KRW PYG RWF UGX VND VUV XAF XOF XPF)
+      self.currencies_with_three_decimal_places = %w(BHD IQD JOD KWD LYD OMR TND)
       self.supported_cardtypes = %i[visa master american_express diners_club jcb dankort maestro discover elo naranja cabal unionpay]
 
       self.money_format = :cents

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -1146,6 +1146,14 @@ class AdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_three_decimal_places_currency_handling
+    stub_comms do
+      @gateway.authorize(1000, @credit_card, @options.merge(currency: 'JOD'))
+    end.check_request(skip_response: true) do |_endpoint, data|
+      assert_match(/"amount\":{\"value\":\"1000\",\"currency\":\"JOD\"}/, data)
+    end
+  end
+
   private
 
   def stored_credential_options(*args, ntid: nil)


### PR DESCRIPTION
Summary:
---------------------------------------
In order to add currencies with three decimal places, this commit include
for currencies_with_three_decimal_places: Bahraini Dinar, Iraqi Dinar,
Jordanian Dinar, Kuwaiti Dinar, Libyan Dinar, Rial Omani, and Tunisian Dinar.

Local Tests:
---------------------------------------
90 tests, 464 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
---------------------------------------
Note: This need an Spreedly member with an IP added to the whitelist for testing.

RuboCop:
728 files inspected, no offenses detected