### PR TITLE
PayU Latam: Refactor/fix failing remote tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * Decidir & Decidir Plus: Revise handling of `sub_payment` sub-fields [meagabeth] #4318
 * DecidirPlus: Update `unstore` implementation to get token from params [ajawadmirza] #4320
 * CyberSource: Add option for zero amount verify [gasb150] #4313
+* PayU Latam: Refactor `message_from` method, fix failing remote tests [rachelkirk] #4326
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173


### PR DESCRIPTION
CE-586

This PR has some refactoring of the `message_from` method. It also updates several tests that were failing due to changes in the gateway's response. PayU Latam now supports `capture` so tests that were added by a previous contributor were uncommented out.

Local:
5057 tests, 75059 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
38 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
37 tests, 146 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed