### PR TITLE
PaypalExpress: Test authorization id for delegate mode

### DIFF
--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -624,6 +624,16 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal '9R43552341412482K', response.authorization
   end
 
+  def test_reference_transaction_for_delegate
+    @gateway.expects(:ssl_post).returns(successful_reference_transaction_for_delegate_response)
+
+    response = @gateway.reference_transaction(2000, { reference_id: 'ref_id' })
+
+    assert_equal 'Success', response.params['ack']
+    assert_equal 'Success', response.message
+    assert_equal '416183322E803512C', response.authorization
+  end
+
   def test_reference_transaction_requires_fields
     assert_raise ArgumentError do
       @gateway.reference_transaction(2000, {})
@@ -898,6 +908,66 @@ class PaypalExpressTest < Test::Unit::TestCase
       			</DoReferenceTransactionResponse>
       		</SOAP-ENV:Body>
       	</SOAP-ENV:Envelope>
+    RESPONSE
+  end
+
+  def successful_reference_transaction_for_delegate_response
+    <<~RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <SOAP-ENV:Envelope
+        xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:cc="urn:ebay:apis:CoreComponentTypes"
+        xmlns:wsu="http://schemas.xmlsoap.org/ws/2002/07/utility"
+        xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion"
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+        xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/12/secext"
+        xmlns:ed="urn:ebay:apis:EnhancedDataTypes"
+        xmlns:ebl="urn:ebay:apis:eBLBaseComponents"
+        xmlns:ns="urn:ebay:api:PayPalAPI">
+        <SOAP-ENV:Header>
+          <Security xmlns="http://schemas.xmlsoap.org/ws/2002/12/secext" xsi:type="wsse:SecurityType"></Security>
+          <RequesterCredentials xmlns="urn:ebay:api:PayPalAPI" xsi:type="ebl:CustomSecurityHeaderType">
+            <Credentials xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:UserIdPasswordType">
+              <Username xsi:type="xs:string"></Username>
+              <Password xsi:type="xs:string"></Password>
+              <Signature xsi:type="xs:string"></Signature>
+              <Subject xsi:type="xs:string"></Subject>
+            </Credentials>
+          </RequesterCredentials>
+        </SOAP-ENV:Header>
+        <SOAP-ENV:Body id="_0">
+          <DoReferenceTransactionResponse xmlns="urn:ebay:api:PayPalAPI">
+            <Timestamp xmlns="urn:ebay:apis:eBLBaseComponents">2021-09-27T07:02:45Z</Timestamp>
+            <Ack xmlns="urn:ebay:apis:eBLBaseComponents">Success</Ack>
+            <CorrelationID xmlns="urn:ebay:apis:eBLBaseComponents">141e9fa384657</CorrelationID>
+            <Version xmlns="urn:ebay:apis:eBLBaseComponents">124</Version>
+            <Build xmlns="urn:ebay:apis:eBLBaseComponents">55100925</Build>
+            <DoReferenceTransactionResponseDetails xmlns="urn:ebay:apis:eBLBaseComponents" xsi:type="ebl:DoReferenceTransactionResponseDetailsType">
+              <BillingAgreementID xsi:type="xs:string">B-91K93512S2594031D</BillingAgreementID>
+              <PaymentInfo xsi:type="ebl:PaymentInfoType">
+                <TransactionID>416183322E803512C</TransactionID>
+                <ParentTransactionID xsi:type="ebl:TransactionId">PAYID-MFIWZEI2XE22852XM6623525</ParentTransactionID>
+                <ReceiptID></ReceiptID>
+                <TransactionType xsi:type="ebl:PaymentTransactionCodeType">mercht-pmt</TransactionType>
+                <PaymentType xsi:type="ebl:PaymentCodeType">echeck</PaymentType>
+                <PaymentDate xsi:type="xs:dateTime">2021-09-27T07:02:43Z</PaymentDate>
+                <GrossAmount xsi:type="cc:BasicAmountType" currencyID="USD">12.36</GrossAmount>
+                <TaxAmount xsi:type="cc:BasicAmountType" currencyID="USD">0.00</TaxAmount>
+                <ExchangeRate xsi:type="xs:string"></ExchangeRate>
+                <PaymentStatus xsi:type="ebl:PaymentStatusCodeType">Pending</PaymentStatus>
+                <PendingReason xsi:type="ebl:PendingStatusCodeType">echeck</PendingReason>
+                <ReasonCode xsi:type="ebl:ReversalReasonCodeType">none</ReasonCode>
+                <ProtectionEligibility xsi:type="xs:string">Ineligible</ProtectionEligibility>
+                <ProtectionEligibilityType xsi:type="xs:string">None</ProtectionEligibilityType>
+              </PaymentInfo>
+            </DoReferenceTransactionResponseDetails>
+          </DoReferenceTransactionResponse>
+        </SOAP-ENV:Body>
+      </SOAP-ENV:Envelope>
     RESPONSE
   end
 


### PR DESCRIPTION
Test parsing of authorization id for delegate response in paypal express
implementation.

CE-2213

Unit:
5068 tests, 75103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected