### PR TITLE
LITLE:  Translate or unify :google_pay and android_pay

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -386,7 +386,7 @@ module ActiveMerchant #:nodoc:
           doc.orderSource(order_source)
         elsif payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :apple_pay
           doc.orderSource('applepay')
-        elsif payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :android_pay
+        elsif payment_method.is_a?(NetworkTokenizationCreditCard) && [:google_pay, :android_pay].include?(payment_method.source)
           doc.orderSource('androidpay')
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
           doc.orderSource('retail')
@@ -394,6 +394,7 @@ module ActiveMerchant #:nodoc:
           doc.orderSource('ecommerce')
         end
       end
+
 
       def order_source(options = {})
         return options[:order_source] unless options[:stored_credential]

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -65,6 +65,17 @@ class RemoteLitleTest < Test::Unit::TestCase
         payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
       }
     )
+
+    @decrypted_google_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        source: :google_pay,
+        month: '01',
+        year: '2021',
+        brand: 'visa',
+        number:  '4457000300000007',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    )
     @check = check(
       name: 'Tom Black',
       routing_number:  '011075150',
@@ -214,6 +225,12 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_android_pay
     assert response = @gateway.purchase(10000, @decrypted_android_pay)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_google_pay
+    assert response = @gateway.purchase(10000, @decrypted_google_pay)
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -32,6 +32,16 @@ class LitleTest < Test::Unit::TestCase
         payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
       }
     )
+    @decrypted_google_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        source: :google_pay,
+        month: '01',
+        year: '2021',
+        brand: 'visa',
+        number:  '4457000300000007',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    )
     @amount = 100
     @options = {}
     @check = check(
@@ -253,6 +263,14 @@ class LitleTest < Test::Unit::TestCase
   def test_add_android_pay_order_source
     stub_comms do
       @gateway.purchase(@amount, @decrypted_android_pay)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<orderSource>androidpay</orderSource>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_add_google_pay_order_source
+    stub_comms do
+      @gateway.purchase(@amount, @decrypted_google_pay)
     end.check_request do |_endpoint, data, _headers|
       assert_match '<orderSource>androidpay</orderSource>', data
     end.respond_with(successful_purchase_response)


### PR DESCRIPTION
Description
-------------------------
we need unify the source  as :andorid_pay if the network token
 is google_pay or android_pay

JIRA ticket number
-------------------------
GWI-96

Unit test
-------------------------
Finished in 0.137911 seconds.

54 tests, 230 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

391.56 tests/s, 1667.74 assertions/s

Remote test
-------------------------
Finished in 35.502618 seconds.

50 tests, 209 assertions, 13 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
74% passed

1.41 tests/s, 5.89 assertions/s

Rubocop
-------------------------
729 files inspected, no offenses detected


Some remote test was fixed in this PR => [https://github.com/activemerchant/active_merchant/pull/4340](https://github.com/activemerchant/active_merchant/pull/4340) 