### PR TITLE
SafeCharge: Change Verify to send 0 amount

### DIFF
--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -107,10 +107,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options = {})
-        MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
-        end
+        authorize(0, credit_card, options)
       end
 
       def supports_scrubbing?

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -52,9 +52,7 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
   def test_successful_regular_purchase_through_3ds_flow_with_invalid_pa_res
     response = @three_ds_gateway.purchase(@amount, @three_ds_invalid_pa_res_card, @three_ds_options)
     assert_success response
-    assert !response.params['acsurl'].blank?
-    assert !response.params['pareq'].blank?
-    assert !response.params['xid'].blank?
+    assert_equal 'Attempted But Card Not Enrolled', response.params['threedreason']
     assert response.params['threedflow'] = 1
     assert_equal 'Success', response.message
   end

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -248,31 +248,13 @@ class SafeChargeTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_verify
-    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response, successful_void_response)
-
-    response = @gateway.verify(@credit_card, @options)
-    assert_success response
-
-    assert_equal '111534|101508189855|MQBVAG4ASABkAEgAagB3AEsAbgAtACoAWgAzAFwAW' \
-                 'wBNAF8ATQBUAD0AegBQAGwAQAAtAD0AXAB5AFkALwBtAFAALABaAHoAOgBFAE' \
-                 'wAUAA1AFUAMwA=|%02d|%d|1.00|USD' % [@credit_card.month, @credit_card.year.to_s[-2..-1]], response.authorization
-    assert response.test?
-  end
-
-  def test_successful_verify_with_failed_void
-    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response, failed_void_response)
-
-    response = @gateway.verify(@credit_card, @options)
-    assert_success response
-  end
-
-  def test_failed_verify
-    @gateway.expects(:ssl_post).returns(failed_authorize_response)
-
-    response = @gateway.verify(@credit_card, @options)
-    assert_failure response
-    assert_equal '0', response.error_code
+  def test_verify_sends_zero_amount
+    stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/sg_TransType=Auth/, data)
+      assert_match(/sg_Amount=0.00/, data)
+    end.respond_with(successful_authorize_response)
   end
 
   def test_scrub


### PR DESCRIPTION
Also updates tests to reflect new `verify` flow.

CE-190

Rubocop:
728 files inspected, no offenses detected

Unit:
5068 tests, 75098 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_safe_charge_test
30 tests, 83 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed