### PR TITLE
Braintree update gem version to 4.5

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - 2.5
           - 2.6
           - 2.7
         gemfile:
@@ -29,11 +28,9 @@ jobs:
         exclude:
           - version: 2.6
             gemfile: gemfiles/Gemfile.rails_master
-          - version: 2.5
-            gemfile: gemfiles/Gemfile.rails_master
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Set up Ruby ${{ matrix.version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - "lib/active_merchant/billing/gateways/paypal_express.rb"
     - "vendor/**/*"
   ExtraDetails: false
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 # Active Merchant gateways are not amenable to length restrictions
 Metrics/ClassLength:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rubocop', '~> 0.62.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 3.0.0', '<= 3.0.1'
+  gem 'braintree', '>= 4.5.0', '<= 4.5.1'
   gem 'jwe'
   gem 'mechanize'
 end

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = 'tobi@leetsoft.com'
   s.homepage = 'http://activemerchant.org/'
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.6'
 
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'CONTRIBUTORS', 'lib/**/*', 'vendor/**/*']
   s.require_path = 'lib'

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -7,7 +7,7 @@ rescue LoadError
   raise 'Could not load the braintree gem.  Use `gem install braintree` to install it.'
 end
 
-raise 'Need braintree gem >= 2.0.0.' unless Braintree::Version::Major >= 2 && Braintree::Version::Minor >= 0
+raise 'Need braintree gem >= 2.0.0.' unless Braintree::Version::Major >= 4 && Braintree::Version::Minor >= 5
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:


### PR DESCRIPTION
## Summary:

This change updates Braintree gem version to the latest version 4.5 and sets the minimum Ruby version to 2.6 as a consequence.

## Test Execution:

Unit
Finished in 26.188459 seconds.
5067 tests, 75099 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote
Finished in 0.903732 seconds.
86 tests, 194 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

## Rubocop:

Rubocop
728 files inspected, no offenses detected