### PR TITLE
DLocal: Add support for `force_type` field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,8 @@
 * Adyen: Add currencies with three decimals places [gasb150] #4322
 * GlobalCollect: Stregthen success criteria for void action [peteroas] #4324
 * Priority Payment Systems - Clean up/refactor gateway file and tests [ali-hassan] #4327
+* SafeCharge: change `verify` to send 0 amount [dsmcclain] #4332
+* DLocal: add support for `force_type` field [dsmcclain] #4336
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -154,6 +154,7 @@ module ActiveMerchant #:nodoc:
         post[:card][:capture] = (action == 'purchase')
         post[:card][:installments] = options[:installments] if options[:installments]
         post[:card][:installments_id] = options[:installments_id] if options[:installments_id]
+        post[:card][:force_type] = options[:force_type].to_s.upcase if options[:force_type]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -94,6 +94,14 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_match 'The payment was paid', response.message
   end
 
+  def test_successful_purchase_with_force_type_debit
+    options = @options.merge(force_type: 'DEBIT')
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_match 'The payment was paid', response.message
+  end
+
   # You may need dLocal to enable your test account to support individual countries
   def test_successful_purchase_colombia
     response = @gateway.purchase(100000, @credit_card, @options_colombia)

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -54,6 +54,14 @@ class DLocalTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_force_type
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(force_type: 'debit'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'DEBIT', JSON.parse(data)['card']['force_type']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 


### PR DESCRIPTION
CE-2421

Rubocop:
728 files inspected, no offenses detected

Unit:
5069 tests, 75101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_d_local_test
29 tests, 76 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.5517% passed

The following test is failing for reasons unrelated to this change:
`test_successful_purchase_naranja`

As far as I can tell, this test began failing with [this commit](https://github.com/activemerchant/active_merchant/commit/cdfce9fe3a9962f93a0f2a2c7c83ac59042a3656). This test fails with the message "Merchant has no authorization to use this API". My hunch is that resolving this would require contacting dLocal to make adjustments to our Sandbox account.