### PR TITLE
EBANX: Change amount for Mexico and Chile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@
 * Litle: Translate google_pay as android_pay [javierpedrozaing] #4331
 * Braintree: Add ACH support for store [cristian] #4285
 * Simetrik: Add support for Simetrik gateway [simetrik-frank] #4339
+* EBANX:  Change amount for Mexico and Chile [flaaviaa] #4337
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -42,8 +42,8 @@ module ActiveMerchant #:nodoc:
         'ar' => 100,
         'co' => 100,
         'pe' => 300,
-        'mx' => 300,
-        'cl' => 5000
+        'mx' => 2000,
+        'cl' => 80000
       }
 
       def initialize(options = {})

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -233,6 +233,26 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_match %r{Accepted}, response.message
   end
 
+  def test_successful_verify_for_mexico
+    options = @options.merge({
+      order_id: generate_unique_id,
+      ip: '127.0.0.1',
+      email: 'joao@example.com.mx',
+      birth_date: '10/11/1980',
+      billing_address: address({
+        address1: '1040 Rua E',
+        city: 'Toluca de Lerdo',
+        state: 'MX',
+        zip: '29269',
+        country: 'MX',
+        phone_number: '8522847035'
+      })
+    })
+    response = @gateway.verify(@credit_card, options)
+    assert_success response
+    assert_match %r{Accepted}, response.message
+  end
+
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response


### PR DESCRIPTION
# Short Summary: 
EBANX: it should change the Mexico and Chile amounts to correspond to one dollar.

# Full Description: 
Merchants using this integration are seeing a big number of transactions being denied at the card verify flow, due to the minimum amount expected by acquires in this type of transaction. So, we increased the value to be accepted by the acquires in the card verify flow. When using local currencies we end up doing the verify using the local currency, and in those cases 100 may be less than the minimum value for a valid transaction in some countries.


# Successful Test Summary 
100% tests passed