### PR TITLE
Stripe: Add shipping address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Priority Payment Systems - Clean up/refactor gateway file and tests [ali-hassan] #4327
 * SafeCharge: change `verify` to send 0 amount [dsmcclain] #4332
 * DLocal: add support for `force_type` field [dsmcclain] #4336
+* Stripe: add support for `shipping_address` fields [ajawadmirza] #4341
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -388,6 +388,7 @@ module ActiveMerchant #:nodoc:
         end
 
         add_metadata(post, options)
+        add_shipping_address(post, options[:shipping_address]) if options[:shipping_address]
         add_application_fee(post, options)
         add_exchange_rate(post, options)
         add_destination(post, options)
@@ -395,6 +396,23 @@ module ActiveMerchant #:nodoc:
         add_connected_account(post, options)
         add_radar_data(post, options)
         post
+      end
+
+      def add_shipping_address(post, options)
+        requires!(options, :name)
+
+        post[:shipping] = {}
+        post[:shipping][:name] = options[:name] if options[:name]
+        post[:shipping][:carrier] = options[:carrier] if options[:carrier]
+        post[:shipping][:phone] = options[:phone] if options[:phone]
+        post[:shipping][:tracking_number] = options[:tracking_number] if options[:tracking_number]
+        post[:shipping][:address] = {}
+        post[:shipping][:address][:city] = options[:city] if options[:city]
+        post[:shipping][:address][:country] = options[:country] if options[:country]
+        post[:shipping][:address][:line1] = options[:line1] if options[:line1]
+        post[:shipping][:address][:line2] = options[:line2] if options[:line2]
+        post[:shipping][:address][:postal_code] = options[:postal_code] if options[:postal_code]
+        post[:shipping][:address][:state] = options[:state] if options[:state]
       end
 
       def add_amount(post, money, options, include_currency = false)

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -54,6 +54,21 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal 'wow@example.com', response.params['metadata']['email']
   end
 
+  def test_successful_purchase_with_shipping_address
+    shipping = {
+      name: 'John Adam',
+      phone: '+0018313818368',
+      city: 'San Diego',
+      country: 'USA',
+      line1: 'block C',
+      line2: 'street 48',
+      postal_code: '22400',
+      state: 'California'
+    }
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(shipping_address: shipping))
+    assert_success response
+  end
+
   def test_successful_purchase_with_blank_referer
     options = @options.merge({ referrer: '' })
     assert response = @gateway.purchase(@amount, @credit_card, options)

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -463,6 +463,36 @@ class StripeTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_purchase_with_shipping_options
+    shipping = {
+      name: 'John Adam',
+      carrier: 'TEST',
+      phone: '+0018313818368',
+      tracking_number: 'TXNABC123',
+      city: 'San Diego',
+      country: 'USA',
+      line1: 'block C',
+      line2: 'street 48',
+      postal_code: '22400',
+      state: 'California'
+    }
+    options = @options.merge(shipping_address: shipping)
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match('shipping[address][city]=San+Diego', data)
+      assert_match('shipping[address][country]=USA', data)
+      assert_match('shipping[address][line1]=block+C', data)
+      assert_match('shipping[address][line2]=street+48', data)
+      assert_match('shipping[address][postal_code]=22400', data)
+      assert_match('shipping[address][state]=California', data)
+      assert_match('shipping[name]=John+Adam', data)
+      assert_match('shipping[phone]=%2B0018313818368', data)
+      assert_match('shipping[carrier]=TEST', data)
+      assert_match('shipping[tracking_number]=TXNABC123', data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_purchase_with_payment_token
     @gateway.expects(:add_payment_token)
     @gateway.expects(:ssl_request).returns(successful_purchase_response)


### PR DESCRIPTION
Added `shipping_address` in the charge parameters for purchase and
authorize.

CE-2425

Unit:
5070 tests, 75113 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected

Remote:
76 tests, 344 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed