### PR TITLE
Adyen application id external platform

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -462,12 +462,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_external_platform(post, options)
+        options.update(externalPlatform: application_id) if application_id
+
         return unless options[:externalPlatform]
 
         post[:applicationInfo][:externalPlatform] = {
           name: options[:externalPlatform][:name],
-          version: options[:externalPlatform][:version],
-          integrator: options[:externalPlatform][:integrator]
+          version: options[:externalPlatform][:version]
         }
       end
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -902,12 +902,9 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_application_info
+    ActiveMerchant::Billing::AdyenGateway.application_id = { name: 'Acme', version: '1.0' }
+
     options = @options.merge!(
-      externalPlatform: {
-        name: 'Acme',
-        version: '1',
-        integrator: 'abc'
-      },
       merchantApplication: {
         name: 'Acme Inc.',
         version: '2'
@@ -917,8 +914,7 @@ class AdyenTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'Acme', JSON.parse(data)['applicationInfo']['externalPlatform']['name']
-      assert_equal '1', JSON.parse(data)['applicationInfo']['externalPlatform']['version']
-      assert_equal 'abc', JSON.parse(data)['applicationInfo']['externalPlatform']['integrator']
+      assert_equal '1.0', JSON.parse(data)['applicationInfo']['externalPlatform']['version']
       assert_equal 'Acme Inc.', JSON.parse(data)['applicationInfo']['merchantApplication']['name']
       assert_equal '2', JSON.parse(data)['applicationInfo']['merchantApplication']['version']
     end.respond_with(successful_authorize_response)


### PR DESCRIPTION
Adds application_id to all Adyen transactions if available. Stores application id info under `externalPlatform` in the transaction data.