### PR TITLE
Stripe PI: test shipping address

### DIFF
--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -88,6 +88,30 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert purchase.params.dig('charges', 'data')[0]['captured']
   end
 
+  def test_successful_purchase_with_shipping_address
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      shipping: {
+        name: 'John Adam',
+        carrier: 'TEST',
+        phone: '+0018313818368',
+        tracking_number: 'TXNABC123',
+        address: {
+          city: 'San Diego',
+          country: 'USA',
+          line1: 'block C',
+          line2: 'street 48',
+          postal_code: '22400',
+          state: 'California'
+        }
+      }
+    }
+    assert response = @gateway.purchase(@amount, @visa_payment_method, options)
+    assert_success response
+    assert_equal 'succeeded', response.params['status']
+  end
+
   def test_unsuccessful_purchase_google_pay_with_invalid_card_number
     options = {
       currency: 'GBP'

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -370,6 +370,41 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_create_intent_response)
   end
 
+  def test_purchase_with_shipping_options
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      shipping: {
+        name: 'John Adam',
+        carrier: 'TEST',
+        phone: '+0018313818368',
+        tracking_number: 'TXNABC123',
+        address: {
+          city: 'San Diego',
+          country: 'USA',
+          line1: 'block C',
+          line2: 'street 48',
+          postal_code: '22400',
+          state: 'California'
+        }
+      }
+    }
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @visa_token, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match('shipping[address][city]=San+Diego', data)
+      assert_match('shipping[address][country]=USA', data)
+      assert_match('shipping[address][line1]=block+C', data)
+      assert_match('shipping[address][line2]=street+48', data)
+      assert_match('shipping[address][postal_code]=22400', data)
+      assert_match('shipping[address][state]=California', data)
+      assert_match('shipping[name]=John+Adam', data)
+      assert_match('shipping[phone]=%2B0018313818368', data)
+      assert_match('shipping[carrier]=TEST', data)
+      assert_match('shipping[tracking_number]=TXNABC123', data)
+    end.respond_with(successful_create_intent_response)
+  end
+
   def test_authorize_with_apple_pay
     options = {
       currency: 'GBP'


### PR DESCRIPTION
Tested shipping address field to be passed in to the stripe pi gateway.

CE-2425

Remote:
73 tests, 327 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.5205% passed

Unit:
5070 tests, 75113 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected