### PR TITLE
Dlocal add three_ds support

### DIFF
--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -19,6 +19,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment, options = {})
         post = {}
         add_auth_purchase_params(post, money, payment, 'purchase', options)
+        add_three_ds(post, options)
 
         commit('purchase', post, options)
       end
@@ -26,6 +27,7 @@ module ActiveMerchant #:nodoc:
       def authorize(money, payment, options = {})
         post = {}
         add_auth_purchase_params(post, money, payment, 'authorize', options)
+        add_three_ds(post, options)
         post[:card][:verify] = true if options[:verify].to_s == 'true'
 
         commit('authorize', post, options)
@@ -162,6 +164,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, parameters, options = {})
+        three_ds_errors = validate_three_ds_params(parameters[:three_dsecure]) if parameters[:three_dsecure].present?
+        return three_ds_errors if three_ds_errors
+
         url = url(action, parameters, options)
         post = post_data(action, parameters)
         begin
@@ -249,6 +254,41 @@ module ActiveMerchant #:nodoc:
 
       def post_data(action, parameters = {})
         parameters.to_json
+      end
+
+      def xid_or_ds_trans_id(three_d_secure)
+        if three_d_secure[:version].to_f >= 2
+          { ds_transaction_id: three_d_secure[:ds_transaction_id] }
+        else
+          { xid: three_d_secure[:xid] }
+        end
+      end
+
+      def add_three_ds(post, options)
+        return unless three_d_secure = options[:three_d_secure]
+
+        post[:three_dsecure] = {
+          mpi: true,
+          three_dsecure_version: three_d_secure[:version],
+          cavv: three_d_secure[:cavv],
+          eci: three_d_secure[:eci],
+          enrollment_response: three_d_secure[:enrolled] == 'true' ? 'Y' : 'N',
+          authentication_response: three_d_secure[:authentication_response_status]
+        }.merge(xid_or_ds_trans_id(three_d_secure))
+      end
+
+      def validate_three_ds_params(three_ds)
+        errors = {}
+        supported_version = %w{1.0 2.0 2.1.0 2.2.0}.include?(three_ds[:three_dsecure_version])
+        supported_enrollment = %w{Y N U}.include?(three_ds[:enrollment_response])
+        supported_auth_response = %w{Y A N U}.include?(three_ds[:authentication_response])
+
+        errors[:three_ds_version] = 'ThreeDs version not supported' unless supported_version
+        errors[:enrollment] = 'Enrollment value not supported' unless supported_enrollment
+        errors[:auth_response] = 'Authentication response value not supported' unless supported_auth_response
+        errors.compact!
+
+        errors.present? ? Response.new(false, 'ThreeDs data is invalid', errors) : nil
       end
     end
   end

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -268,4 +268,32 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:trans_key], transcript)
   end
+
+  def test_successful_authorize_with_3ds_v1_options
+    @options[:three_d_secure] = {
+      version: '1.0',
+      cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
+      eci: '05',
+      xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_match 'The payment was authorized', auth.message
+  end
+
+  def test_successful_authorize_with_3ds_v2_options
+    @options[:three_d_secure] = {
+      version: '2.2.0',
+      cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
+      eci: '05',
+      ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_match 'The payment was authorized', auth.message
+  end
 end

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -12,6 +12,14 @@ class DLocalTest < Test::Unit::TestCase
       order_id: '1',
       billing_address: address
     }
+    @three_ds_secure = {
+      version: '1.0',
+      cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
+      eci: '05',
+      xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
   end
 
   def test_successful_purchase
@@ -224,6 +232,106 @@ class DLocalTest < Test::Unit::TestCase
     end.check_request do |_endpoint, _data, headers|
       assert_equal '2.1', headers['X-Version']
     end.respond_with(successful_purchase_response)
+  end
+
+  def test_three_ds_v1_object_contruction
+    post = {}
+    @options[:three_d_secure] = @three_ds_secure
+
+    @gateway.send(:add_three_ds, post, @options)
+
+    assert post[:three_dsecure]
+    ds_data = post[:three_dsecure]
+    ds_options = @options[:three_d_secure]
+
+    assert_equal ds_options[:version], ds_data[:three_dsecure_version]
+    assert_equal ds_options[:cavv], ds_data[:cavv]
+    assert_equal ds_options[:eci], ds_data[:eci]
+    assert_equal ds_options[:xid], ds_data[:xid]
+    assert_equal nil, ds_data[:ds_transaction_id]
+    assert_equal 'Y', ds_data[:enrollment_response]
+    assert_equal ds_options[:authentication_response_status], ds_data[:authentication_response]
+  end
+
+  def test_three_ds_v2_object_contruction
+    post = {}
+    @three_ds_secure[:ds_transaction_id] = 'ODUzNTYzOTcwODU5NzY3Qw=='
+    @three_ds_secure[:version] = '2.2.0'
+    @options[:three_d_secure] = @three_ds_secure
+
+    @gateway.send(:add_three_ds, post, @options)
+
+    assert post[:three_dsecure]
+    ds_data = post[:three_dsecure]
+    ds_options = @options[:three_d_secure]
+
+    assert_equal ds_options[:version], ds_data[:three_dsecure_version]
+    assert_equal ds_options[:cavv], ds_data[:cavv]
+    assert_equal ds_options[:eci], ds_data[:eci]
+    assert_equal nil, ds_data[:xid]
+    assert_equal ds_options[:ds_transaction_id], ds_data[:ds_transaction_id]
+    assert_equal 'Y', ds_data[:enrollment_response]
+    assert_equal ds_options[:authentication_response_status], ds_data[:authentication_response]
+  end
+
+  def test_three_ds_version_validation
+    post = {}
+    @options[:three_d_secure] = @three_ds_secure
+    @gateway.send(:add_three_ds, post, @options)
+    resp = @gateway.send(:validate_three_ds_params, post[:three_dsecure])
+
+    assert_equal nil, resp
+    post[:three_dsecure][:three_dsecure_version] = '4.0'
+    resp = @gateway.send(:validate_three_ds_params, post[:three_dsecure])
+
+    assert_equal 'ThreeDs data is invalid', resp.message
+    assert_equal 'ThreeDs version not supported', resp.params['three_ds_version']
+  end
+
+  def test_three_ds_enrollment_validation
+    post = {}
+    @options[:three_d_secure] = @three_ds_secure
+    @gateway.send(:add_three_ds, post, @options)
+    post[:three_dsecure][:enrollment_response] = 'P'
+    resp = @gateway.send(:validate_three_ds_params, post[:three_dsecure])
+
+    assert_equal 'ThreeDs data is invalid', resp.message
+    assert_equal 'Enrollment value not supported', resp.params['enrollment']
+  end
+
+  def test_three_ds_auth_response_validation
+    post = {}
+    @options[:three_d_secure] = @three_ds_secure
+    @gateway.send(:add_three_ds, post, @options)
+    post[:three_dsecure][:authentication_response] = 'P'
+    resp = @gateway.send(:validate_three_ds_params, post[:three_dsecure])
+
+    assert_equal 'ThreeDs data is invalid', resp.message
+    assert_equal 'Authentication response value not supported', resp.params['auth_response']
+  end
+
+  def test_purchase_with_three_ds
+    @options[:three_d_secure] = @three_ds_secure
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      three_ds_params = JSON.parse(data)['three_dsecure']
+      assert_equal '1.0', three_ds_params['three_dsecure_version']
+      assert_equal '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=', three_ds_params['cavv']
+      assert_equal '05', three_ds_params['eci']
+      assert_equal 'ODUzNTYzOTcwODU5NzY3Qw==', three_ds_params['xid']
+      assert_equal 'Y', three_ds_params['enrollment_response']
+      assert_equal 'Y', three_ds_params['authentication_response']
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_unsuccessfully_purchase_with_wrong_three_ds_data
+    @three_ds_secure.delete(:version)
+    @options[:three_d_secure] = @three_ds_secure
+    resp = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_equal 'ThreeDs data is invalid', resp.message
+    assert_equal 'ThreeDs version not supported', resp.params['three_ds_version']
   end
 
   private


### PR DESCRIPTION
### Summary:

This PR adds support for third party three ds authentication
data on the DLocal gateway.

### Test Execution:

**Remote**
Finished in 19.797433 seconds.
31 tests, 79 assertions, 2 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
93.5484% passed

**Unit**
Finished in 30.997677 seconds.
5076 tests, 75140 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100% passed

### RuboCop:
728 files inspected, no offenses detected