### PR TITLE
Decidir Plus: `name_override` option on `store`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@
 * SafeCharge: change `verify` to send 0 amount [dsmcclain] #4332
 * DLocal: add support for `force_type` field [dsmcclain] #4336
 * Barclaycard SmartPay: Support more nonstandard currencies [jherreraa] #4335
+* DecidirPlus: `name_override` option on `store` [naashton] #4338
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -103,7 +103,7 @@ module ActiveMerchant #:nodoc:
           post[:card_expiration_month] = format(payment.month, :two_digits)
           post[:card_expiration_year] = format(payment.year, :two_digits)
           post[:security_code] = payment.verification_value.to_s
-          post[:card_holder_name] = payment.name
+          post[:card_holder_name] = payment.name.empty? ? options[:name_override] : payment.name
           post[:card_holder_identification] = {}
           post[:card_holder_identification][:type] = options[:dni]
           post[:card_holder_identification][:number] = options[:card_holder_identification_number]

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -136,6 +136,15 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
     assert_equal @credit_card.number[0..5], response.authorization.split('|')[1]
   end
 
+  def test_successful_store_name_override
+    @credit_card.name = ''
+    options = { name_override: 'Rick Deckard' }
+    assert response = @gateway_purchase.store(@credit_card, options)
+    assert_success response
+    assert_equal 'active', response.message
+    assert_equal options[:name_override], response.params.dig('cardholder', 'name')
+  end
+
   def test_successful_unstore
     customer = {
       id: 'John',

--- a/test/unit/gateways/decidir_plus_test.rb
+++ b/test/unit/gateways/decidir_plus_test.rb
@@ -98,6 +98,7 @@ class DecidirPlusTest < Test::Unit::TestCase
       @gateway.store(@credit_card, @options)
     end.check_request do |_action, _endpoint, data, _headers|
       assert_match(/#{@credit_card.number}/, data)
+      assert_match(/#{@credit_card.name}/, data)
     end.respond_with(successful_store_response)
 
     assert_success response


### PR DESCRIPTION
Add support to override the payment method name value with one given in
the options hash.

CE-2149

Unit: 1 tests, 5 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 17 tests, 60 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed