### PR TITLE
Stripe PI: Update `shipping` to `shipping_address`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@
 * Barclaycard SmartPay: Support more nonstandard currencies [jherreraa] #4335
 * DecidirPlus: `name_override` option on `store` [naashton] #4338
 * Priority: Update `add_purchases_data` to return if `options[:purchases]` is empty [drkjc] #4349
+* Stripe PI: update `shipping` field to `shipping_address` [ajawadmirza] #4347
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -471,7 +471,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_shipping_address(post, options = {})
-        return unless shipping = options[:shipping]
+        return unless shipping = options[:shipping_address]
 
         post[:shipping] = {}
         post[:shipping][:address] = {}

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -92,7 +92,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     options = {
       currency: 'GBP',
       customer: @customer,
-      shipping: {
+      shipping_address: {
         name: 'John Adam',
         carrier: 'TEST',
         phone: '+0018313818368',
@@ -676,7 +676,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     options = {
       currency: 'USD',
       customer: @customer,
-      shipping: {
+      shipping_address: {
         address: {
           line1: '1 Test Ln',
           city: 'Durham'

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -374,7 +374,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     options = {
       currency: 'GBP',
       customer: @customer,
-      shipping: {
+      shipping_address: {
         name: 'John Adam',
         carrier: 'TEST',
         phone: '+0018313818368',


### PR DESCRIPTION
Updated field name from `shipping` to `shipping_address` to make it
consistent with other gateways.

CE-2425

Unit:
5070 tests, 75114 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected

Remote:
74 tests, 330 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.5946% passed