### PR TITLE
DecidirPlus: Handle `payment_method_id` by `card_brand`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@
 * DecidirPlus: `name_override` option on `store` [naashton] #4338
 * Priority: Update `add_purchases_data` to return if `options[:purchases]` is empty [drkjc] #4349
 * Stripe PI: update `shipping` field to `shipping_address` [ajawadmirza] #4347
+* DecidirPlus: Handle `payment_method_id` by `card_brand` [naashton] #4350
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = ['AR']
       self.default_currency = 'ARS'
-      self.supported_cardtypes = %i[visa master american_express discover]
+      self.supported_cardtypes = %i[visa master american_express discover diners_club naranja cabal]
 
       self.homepage_url = 'http://decidir.com.ar/home'
       self.display_name = 'Decidir Plus'
@@ -120,7 +120,7 @@ module ActiveMerchant #:nodoc:
 
       def add_purchase_data(post, money, payment, options = {})
         post[:site_transaction_id] = options[:site_transaction_id] || SecureRandom.hex
-        post[:payment_method_id] = 1
+        post[:payment_method_id] = add_payment_method_id(options)
         post[:amount] = money
         post[:currency] = options[:currency] || self.default_currency
         post[:installments] = options[:installments] || 1
@@ -141,6 +141,35 @@ module ActiveMerchant #:nodoc:
             amount: sub_payment[:amount].to_i
           }
           post[:sub_payments] << sub_payment_hash
+        end
+      end
+
+      def add_payment_method_id(options)
+        return 1 unless options[:card_brand]
+
+        case options[:card_brand]
+        when 'visa'
+          1
+        when 'master'
+          104
+        when 'american_express'
+          65
+        when 'american_express_prisma'
+          111
+        when 'cabal'
+          63
+        when 'diners_club'
+          8
+        when 'visa_debit'
+          31
+        when 'master_debit'
+          105
+        when 'maestro_debit'
+          106
+        when 'cabal_debit'
+          108
+        else
+          1
         end
       end
 

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -8,10 +8,13 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4484590159923090')
+    @american_express = credit_card('376414000000009')
+    @cabal = credit_card('5896570000000008')
     @declined_card = credit_card('4000300011112220')
     @options = {
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      card_brand: 'visa'
     }
     @sub_payments = [
       {
@@ -184,6 +187,17 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
     response = @gateway_purchase.purchase(@amount, payment_reference, options)
     assert_success response
     assert_equal({ 'status' => nil }, response.params['fraud_detection'])
+  end
+
+  def test_successful_purchase_with_card_brand
+    options = @options.merge(card_brand: 'cabal')
+
+    assert response = @gateway_purchase.store(@cabal)
+    payment_reference = response.authorization
+
+    response = @gateway_purchase.purchase(@amount, payment_reference, options)
+    assert_success response
+    assert_equal 63, response.params['payment_method_id']
   end
 
   def test_invalid_login


### PR DESCRIPTION
Determine `payment_method_id` based on `card_brand` passed in the
options hash for auth and purchase transactions

CE-2424

Unit: 13 tests, 53 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote0: 17 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed