### PR TITLE
DecidirPlus: `debit` and `payment_method_id` fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@
 * Priority: Update `add_purchases_data` to return if `options[:purchases]` is empty [drkjc] #4349
 * Stripe PI: update `shipping` field to `shipping_address` [ajawadmirza] #4347
 * DecidirPlus: Handle `payment_method_id` by `card_brand` [naashton] #4350
+* DecidirPlus: `debit` and `payment_method_id` fields [naashton] #4351
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -145,31 +145,38 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment_method_id(options)
-        return 1 unless options[:card_brand]
+        return options[:payment_method_id].to_i if options[:payment_method_id]
 
-        case options[:card_brand]
-        when 'visa'
-          1
-        when 'master'
-          104
-        when 'american_express'
-          65
-        when 'american_express_prisma'
-          111
-        when 'cabal'
-          63
-        when 'diners_club'
-          8
-        when 'visa_debit'
-          31
-        when 'master_debit'
-          105
-        when 'maestro_debit'
-          106
-        when 'cabal_debit'
-          108
+        if options[:debit]
+          case options[:card_brand]
+          when 'visa'
+            31
+          when 'master'
+            105
+          when 'maestro'
+            106
+          when 'cabal'
+            108
+          else
+            31
+          end
         else
-          1
+          case options[:card_brand]
+          when 'visa'
+            1
+          when 'master'
+            104
+          when 'american_express'
+            65
+          when 'american_express_prisma'
+            111
+          when 'cabal'
+            63
+          when 'diners_club'
+            8
+          else
+            1
+          end
         end
       end
 

--- a/test/unit/gateways/decidir_plus_test.rb
+++ b/test/unit/gateways/decidir_plus_test.rb
@@ -120,6 +120,8 @@ class DecidirPlusTest < Test::Unit::TestCase
     options = @options.merge(sub_payments: @sub_payments)
     options[:installments] = 4
     options[:payment_type] = 'distributed'
+    options[:debit] = 'true'
+    options[:card_brand] = 'visa_debit'
 
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @payment_reference, options)
@@ -127,6 +129,7 @@ class DecidirPlusTest < Test::Unit::TestCase
       assert_equal(@sub_payments, JSON.parse(data, symbolize_names: true)[:sub_payments])
       assert_match(/#{options[:installments]}/, data)
       assert_match(/#{options[:payment_type]}/, data)
+      assert_match(/\"payment_method_id\":31/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response


### PR DESCRIPTION
Add support for `debit` and `payment_method_id` gateway fields. Decidir+
requires that transactions after `store` need to contain a
`payment_method_id` that corresponds to the `payment_method` tokenized
on the initial `store` call. `payment_method_id`'s are also different
for debit and credit cards, so the `debit` option allows for users to
pass that value manually.

CE-2424

Unit: 13 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 22 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed