### PR TITLE
CE- 2403 Priority: Add GSF `replay_id`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * DecidirPlus: Handle `payment_method_id` by `card_brand` [naashton] #4350
 * DecidirPlus: `debit` and `payment_method_id` fields [naashton] #4351
 * Adyen: Include Application ID in adyen authorize and purchase transactions [peteroas] #4343
+* Priority: Add support for `replay_id` field [drkjc] #4352
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173


### PR DESCRIPTION
`replay_id` can be thought of like an `idempotency_key`. When `replay_id` is sent the expected behavior is that if the gateway can find a duplicate` replay_id` attached to previous transaction they return that original response. This only works with `purchase` and `authorize`. `voids` and `refund` should be sent w/ out `replay_id`. 

CE-2403

Local:
5070 tests, 75112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
13 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
24 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed