### PR TITLE
[PROPOSAL] Adding and configure VCR to be used on remote tests

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -31,6 +31,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry')
   s.add_development_dependency('pry-byebug')
   s.add_development_dependency('rake')
+  s.add_development_dependency('rexml', '3.1.9')
   s.add_development_dependency('test-unit', '~> 3')
   s.add_development_dependency('thor')
+  s.add_development_dependency('vcr')
+  s.add_development_dependency('webmock')
 end

--- a/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
+++ b/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
@@ -23,6 +23,7 @@ module BraintreeCommon
       gsub(%r((<payment-method-nonce>)[^<]+(</payment-method-nonce>)), '\1[FILTERED]\2').
       gsub(%r((<payment-method-token>)[^<]+(</payment-method-token>)), '\1[FILTERED]\2').
       gsub(%r((<value>)[^<]{100,}(</value>)), '\1[FILTERED]\2').
-      gsub(%r((<token>)[^<]+(</token>)), '\1[FILTERED]\2')
+      gsub(%r((<token>)[^<]+(</token>)), '\1[FILTERED]\2').
+      gsub(%r((tokenusbankacct_bc)\w*), '\1[FILTERED]')
   end
 end

--- a/test/remote/gateways/remote_braintree_token_nonce_test.rb
+++ b/test/remote/gateways/remote_braintree_token_nonce_test.rb
@@ -1,8 +1,10 @@
 require 'test_helper'
 
 class RemoteBraintreeTokenNonceTest < Test::Unit::TestCase
+  prepend VCRRemote
+
   def setup
-    @gateway = BraintreeGateway.new(fixtures(:braintree_blue))
+    @gateway = BraintreeGateway.new(fixtures(:braintree_blue).merge({ merchant_id: 'sk2db46gz3spmcb2' }))
     @braintree_backend = @gateway.instance_eval { @braintree_gateway }
 
     ach_mandate = 'By clicking ["Checkout"], I authorize Braintree, a service of PayPal, ' \

--- a/test/support/vcr_module.rb
+++ b/test/support/vcr_module.rb
@@ -1,0 +1,38 @@
+# Given the remote tests state the VCR gem will be initially disabled and
+# is only going to be available on test classes that enables the VCRModule, for
+# that the only needed step is to add VCRModule with as a prepend keyword.
+
+module VCRRemote
+  def setup
+    class_name = self.name.match(/\((\w*)\)/)[1]
+
+    unless config_already_defined?
+      VCR.configure do |conf|
+        conf.before_record do |interaction|
+          if @gateway.supports_scrubbing
+            interaction.request.body = @gateway.scrub(interaction.request.body)
+            interaction.response.body = @gateway.scrub(interaction.response.body)
+          end
+        end
+      end
+    end
+
+    VCR.turn_on!
+    VCR.insert_cassette([class_name, method_name].compact.join('/').underscore)
+    super
+  end
+
+  def teardown
+    VCR.eject_cassette
+    VCR.turn_off!
+    super
+  end
+
+  private
+
+  def config_already_defined?
+    VCR.configuration.hooks[:before_record].any? do |hook|
+      hook.hook.source_location.first =~ /vcr_module/
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,8 @@ require 'yaml'
 require 'json'
 require 'active_merchant'
 require 'comm_stub'
+require 'vcr'
+require 'support/vcr_module'
 
 require 'active_support/core_ext/integer/time'
 require 'active_support/core_ext/numeric/time'
@@ -354,3 +356,30 @@ class MockResponse
     @headers[header]
   end
 end
+
+# Given the remote tests state the VCR gem will be initially disabled and
+# is only going to be available on test classes that enables the VCRModule, for
+# that the only needed step is to add VCRModule with as a prepend keyword.
+VCR.configure do |config|
+  config.cassette_library_dir = 'test/vcr_cassettes'
+  config.allow_http_connections_when_no_cassette = true
+  config.hook_into :webmock
+  config.default_cassette_options = {
+    record: :once,
+    update_content_length_header: true, # Enables response body modification and prevent errors/bugs with some libraries
+    allow_unused_http_interactions: false # Behaves like a mock object
+  }
+
+  # filter out any Basic and Bearer headers on request
+  config.filter_sensitive_data('<AUTH_DATA>') do |interaction|
+    (interaction.request.headers['Authorization'] || ['']).first.split(' ').last
+  end
+
+  # extend the indentification of a unique request
+  config.default_cassette_options = {
+    match_requests_on: %i[method host path]
+  }
+end
+
+VCR.turn_off!
+WebMock.allow_net_connect!

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_client_token_generation.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_client_token_generation.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/sk2db46gz3spmcb2/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 3.0.1 (ActiveMerchant 1.125.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Mar 2022 20:27:48 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1593'
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - eb9fb09b904c4
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKVWXZObuBJ9z6/IW55ylw8zN66aZGs9AxiNwUGABHpDiBk+JMzENgZ+/TaeySapnd26VffB5bJodZ8+53Tj299HJd8P5bdjfeg+f9D/o314X3bFQdTd0+cPSex8/PTh9y/vbgtZl93p4+nQlt2Xd+/f3w65PJdfygkZLEVzTtdnrzlMuztUiRQfuIn6Ujnaco6VPDODTMUW9bwL632NZJkcLoxUmzxZ91F7oj5x+tgOHnIXbTNDfs2T3iVpj/zE6qM0QDzFF9oGKGjlc5SKgLjCjFuM/FZPaIobv2U6bcWDUOT+Gk/Hm8yUS/wpv9+0kY1uYqNdCSmzsNv4vLUOmdKjnHozMwnjbX/ISKH7bnAiasz9NrtQWbW5S+KA9rXfbHom7TNL5QN3iRdSwNgmE2BofNt6juLNPldijqh+8V0njmKG8tYeY004AZE3NCY+0eUqlvibsK0tjgnLY+cQx2ifJ2PC3FOA3aqPCT7k9tqmsfM11CTks/Y+kf2SDzBPMQXMiWVTZcm8tW4yrRhzCZxQ6Ydaf8nmILhyqtZt5CAzM/tBtJcJd6JKZnJDocdcl6d9jH2e9BYl4igo9iLomRj4wGxBfV1mOXDiN1KDvGZOUUo6yXxVAWcWhvznwpBN5LA+a8Uxl08Td08oV+s+m9Fckn678MFpaMRxsBcGSmMlAde1n5wDx9zVJWnkMyXVQ64/TVFDMl+iI1W661PkJcAvJ6BJW+25y2IB9UDTc5ZUUQkeKFyEOPAHGrpc9nQfI0YdNjPwELPH+6jrF/wmleAZKayoDRqesAvgjwBfSmJGeZKNkB/npFry177mXcADlqCBBXxLf7atnWKecFCUJajmXTJm2tMcy82QGrqLaYB9ujLCWTxTdQqTWA4iJZuww6uMemPYhnPYiG3YovugI37eiccg0i1s4GPYFhdBRRoSNBKDHakjj9RGDww08+pLnRnrM1OyIyk6wlzV+RZrxda/2U3rqnBb4N85MxcN5Z1VF8qBucITo6TLUiyF4QDuYODxQQvu/YFTMmVGVUHMvDODb77CdXDPurIJ5sLVm6zxhswYe0YtLTWcSx6tDT9aN9ywVE6FXrzO8YKLmQjqVzi+825g9uHZZZnng9jiSzEfhp25qUqqy2utLqg41OLm0znrUJVD/kIRuaNLDQvya8NrvpHfeUdP4Uq4CeTzJv/eXu3iP3T4rK51FanElkws9eu9PNbCXX8DvLBjyGNmIslcCdiDqlB49qS+hj3UcFcuODaFK8nfcF77tOaMWm2m1qudQlNG5VlsIRcVgIOYWdqeQYfTvgk1f1qfYM81uetAjD8UxnFirqcFStz4ZnDhNKj9ev295mOWbvorbmoZeYoGrhZOrrvvr5rL85+0QQw49bo39amXvVqY4ORt8FYvc2EQrZj+xQvRwq+jC7d66z6cP51hd545/fS/eWvJ1zEJfQ2LP7nB1ItvoRd3hHMhi8m7oboGcfiw6I6dQGYmaJiQc0bRkVHgA3ILmizY4Gy0hCub5d6b3jLWE/ix57UOvnKOZYr7zPRPV7x3/6BlpF/nZdHxH7xfP0aXunAdCz5HTK0qU6NctID7Ovvpmdf0//UUvMPcsYf+Nmzx3avX37r3q/Z4zzUL9BNDoY71XrGKbwMJuuoceIQeJbN1WajgAH1oUEsBH/OSB76P3BTewgOca0VHlnttnoLvAFusnBOLwDsyuCw8M3e0XrR4memIXn23SfTsgunJJ4ZTs6RXQVy1/ixUkji4hAVUNmxKGukmxqmnCdOxPc6JoVkJXceh4cScyhVVwZZIMpRNuyqpvBOt3JVKt0h7ksSWz0QXX4urNzZTnrIK3sG/+G1ffxpYCh5JN0f2ugOK7R+Lv3Xw8BRSsXjttOD+ZffdL/oT2Ks69Jy86okH8Ap4B2bDIP/PXLzE6WTiywyqShPbzbxgBT/LzDjBXg/P333w4x7uge9G2D/VV5bO3Qs8IzBPcoIdeu3l+4zAfjiz692fPJoEx5xCvC3baxx1Ztg/03f9/GuPP7wRUniXmT/iC3Oz9NXybbvw2IgUwW+rKeF9y7VgYNedikiihfVjqn2+/e3lv9u7299+/Vf3J4CdJoAMCgAA
+  recorded_at: Tue, 15 Mar 2022 20:27:48 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_successfully_create_token_nonce_for_bank_account.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_successfully_create_token_nonce_for_bank_account.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/sk2db46gz3spmcb2/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 3.0.1 (ActiveMerchant 1.125.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Mar 2022 20:27:49 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1592'
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 4882e4dead844
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKVWXZObuBJ9z6/IW572Lh/D3Lhqkq14xmCIhWOBJNAbQmT4kDATY/Px67fxTDZJ3dlbW7UPlMtC6j59zukWd3+MWr29FN9O1bH98M78j/HubdHmR1m1jx/ekdj97f27Pz6+uctVVbT9b/2xKdqPb96+vbtk6lx8LKbA4kkwZ2x19uvjtLsPSpngo7CDrtCusaxjrc7colO+DTrRHqp9FaiCHAdOy3VGVl3U9AxRt4s34efMC7appb5kpPNo0gWIOF2UhIFI8MCaMAgb9RQlMqSetOMGB6gxCUtwjRpuskZ+lpo+XPez8Ta11bK/zx7WTbQJbmOruZFKpYd2jUTjHFNtRhnzZ25TLprumNLcRF7YUz1mqEkHpsom82gcsq5C9brjanPmifosPOofGGBsyAQYarRxnqJ4vc90P0fMHJDnxlHMg0wpOzYkR2SVYN0hagbHuA4CuXE2JJFfyOx2TMF5MpLMU3tsUodRzCHeLUtUdjAUxHP2iKpuiQeYp5gBZuJsmHZU1ji3qZGPkOcpYgodjG5I5zC8cqpXTeQGdmp3F9kME25lSWZ6y6DGzFT9PsZIkA7yyZNk2I+gZmrhI99IhkyVZsAJqpUBce2MBQltFUe6BM4cDPHPuaXqyOVd2shTph4n4fVBplddOgdzQbvtwodgByuOw720giTWCnBd68kEcCw8U9FaPTFafs7MxymqaYpUcGLa9BALfAL8CgqaNOVeeDyWkA80PaekjArwQO4FgYjdRUNPqI7t44Azl88cPMQ340PUdgt+mynwjJJO1IS1IHwA/BHgS2jMmSDpCPFxRsslfoUMfwAPOJKFDvCt0Lxxdo0MEvPTmOpxTVxqkKY/FER6cTP0yDoOsTFO3HPHkOEmtDpSeCuXJ6UiVndGc2nsPXNPYtpGluOhbW5I972NPPwUbiTiMZ4OetXHBv6GDEyIi0ahOfaroUqt1Zlr1dIkOEFfVdkWG/kW3e6mVZl7DfDvnrkXXIp7p8q1C32FJ85omyZYSct1djq8iPhohA/oIhidUqssYc+8s8NvSOMqfOBtUYdz7pl1WvuX1Bo7zhwjsdwhi1YWila1sBydMWnmL3284OJ2APlLHN/7t9D78G5Y+vkot3jI5+NlZ6/LgpnqmqsNSwG5hP14TtugzCB+rqnasSWHA/GNy0u8Udz7J1/jUnoE4vkTetjc7OJPJjw317yalnJLJ56gaq9OlfRW3wAvzBj6NbUDxT0F2MMy13j2lbmCOVQLTy041rmn6P/gvNbpzClzmlSvbnY6mFKmznILsZgEHNROk+YMOvT7+mCgadXDnKszz4U96JJbJ9DdN0Itb5EdDoKFFapW33N+TZN1d8XNHCtLgovQCyfX2fdXzuX9T9oEHDj121f1qZa5mtvg5G34Wi1zblEjn/6PF6KFX9eUXvnaeVh/PMPsPAv2/p95a4nXcgV1XRZ/CovrZ99CLd4I61Llk3/LTAP24eOiO3ZDldqgIaHnlAUnzoAPiC0ZWbDB2uhIT9XLuVe9Za0m8GMnKhN85Z6KBHepjfor3vu/0TIyr/2y6Pg33q++RkOVe64Dzwkzp4ReV4sWcN7kP73z6+6/voY7zBs7qG/NF9+9eP21c79qj/fCcEA/ecn1qdprXoptqEBXUwCPUKPiG1PlOjxCHQbk0sDHvMSB35Owpb/wAOtG3tLlXJMl4DvAFmu35xF4R4XDwjP3RudZi+eejtjVd2tipgNmPaKWW3HS6TAuGzRLDYMHF8xVRc0nUiuPWH3HCDfxZpyJZTiEreKD5caCqRumwy1V9FLUzU3B1L1s1K7QpkObXtGNeqKm/JJfvbGesoSXcAf/4rd99f4C87EUyfrEX2ZAvv20+NsED08HJhev9QvuX2bfw6I/vUnhfhUeedETX8Ar4B3oDYv+m7543mfSSSw9qEtDbtfzghX8rFKrv8jkcP7ugx/ncAd813LzU37tmMIb4B2FflITzNBrLd97BObDmV/P/uRREp4yBvs3qrnuY+4M82f6rh+61vjDGwcGd5n9Y39ur5e6GrFtFh5rmQTw36kLuG+FEV74daYGlBiH6mtifLj7/fnb7c3d779+1f0JuihsdgwKAAA=
+  recorded_at: Tue, 15 Mar 2022 20:27:49 GMT
+- request:
+    method: post
+    uri: https://payments.sandbox.braintree-api.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"clientSdkMetadata":{"platform":"web","source":"client","integration":"custom","sessionId":"ae7962ce-1c32-4ed7-8f21-b36a1e70ec62","version":"3.83.0"},"query":"        mutation
+        TokenizeUsBankAccount($input: TokenizeUsBankAccountInput!) {\n          tokenizeUsBankAccount(input:
+        $input) {\n            paymentMethod {\n              id\n              details
+        {\n                ... on UsBankAccountDetails {\n                  last4\n                }\n              }\n            }\n          }\n        }\n","variables":{"input":{"usBankAccount":{"achMandate":"By
+        clicking [\"Checkout\"], I authorize Braintree, a service of PayPal, on behalf
+        of My Company (i) to verify my bank account information using bank information
+        and consumer reports and (ii) to debit my bank account.","routingNumber":"011000015","accountNumber":"4012000033330125","accountType":"CHECKING","billingAddress":{"streetAddress":"96706
+        Onie Plains","extendedAddress":"01897 Alysa Lock","city":"Miami","state":"FL","zipCode":"32191"},"individualOwner":{"firstName":"Jim","lastName":"Smith"}}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <AUTH_DATA>
+      Braintree-Version:
+      - '2018-05-10'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Mar 2022 20:27:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '205'
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Accept-Encoding
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - d6f6b77b51ad4
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"data":{"tokenizeUsBankAccount":{"paymentMethod":{"id":"tokenusbankacct_bc[FILTERED]","details":{"last4":"0125"}}}},"extensions":{"requestId":"ccdf1f33-c4b6-409a-8a46-056fe3a8a535"}}'
+  recorded_at: Tue, 15 Mar 2022 20:27:49 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_unsucesfull_create_token_with_invalid_state.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_unsucesfull_create_token_with_invalid_state.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/sk2db46gz3spmcb2/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 3.0.1 (ActiveMerchant 1.125.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Mar 2022 20:27:50 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1592'
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - fa6ff10500b54
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKVWXZObuBJ9z6/IW572Lh/D3Lhqkq14BjAaC8eAJNAbQmT4kDCJMTb8+m08k01SO7t1q+4D5bI+uk+fc7rh7o+LVm/H8tuxPnQf3pn/Md69LbviIOvu6cM7kni/vX/3x8c3d4Wqy274bTi0Zffxzdu3d2OuTuXHckIWT9Gcs9UpaA7T9h5VMo0OwkZ9qT1jWY+0OnGLTsUG9aLb17saqZIczpxW65ys+rgdGKZen7jhY+6jTWapzznpfZr2CBOnj9MQiTQ6szZEYau+xqkMqS/tpI0Qbk3C0qjBLTdZKx+lpg/X8+xym9lqOT/kD+s2dtFtYrU3Uqls362xaJ1Dps04Z8HMbcpF2x8yWpjYDweqLzluszNTVZv7NAlZX+Nm3XPlnniqHoVPgz0DjC2ZAEODXedrnKx3ZevNMTPP2PeSOOEob51jQuUuN1aEJR6mhjGztO+k67hRWoVk/mQkpkQhuZBE9yH1XBP2uTQcV/jVriQK4jk7TFW/xAPMU8IAM3Fcph0F8W8zo7jkCjhhCu+N/pzNYXjlVK/a2EN2ZvejbM9T1MmKzPSWQY25qYZdEmFBeodReZQsCmKomVrRgbuSYVNlOXCCG2VAXDtnKKWd4lhXwJkTQfxTYakm9niftfKYq6dJ+APK9arPZjSXtN8sfAi2t5Ik3EkLpYlWgOtaTy6AY+GbijbqK6PVY24+TXFDM6zQkWnTxwwFBPgVFDRpq53weSIhH2h6ykgVl+CBwkdIJN6ioS9Uz3YJ4szjMwcPcffyEHf9gt9mCjyjpBO3YSMIPwP+GPClNOFMkOwC8aOcVkv8GhvBGTzgSBY6wLfCs+tsm0phz6vDB9rljbwnBsL71vG5V3nRA3Ly1nVib61yYj7SBzVmKTGwFcakNe/Jpve4lkNk72+4FaXRRp6kdbwkrtMSun6MNl5O0vBCZ+pTYyCE9OtE8S6oz3VmrU5cq46m6Ah9VeebyCg2+HY7rarCb4F/78R9NJb3Tl1oD/oqmjijXZZGSlqes9XhKJKDET7gUTA6ZVZVwZl5a4ffsI6gHt6VTTgXvtlkTTBm1qXnzDFSyzvn8crC8aoRlqNzJs3ipY8XXNxGkL+KkvvgFnof9s5LPx/kJjoX82Hc2uuqZKa65urCSkAuYT+dsg5VOcQvNFVbtuRwIL4xvsS7iPvgGOiokj6BeMGEH9ybbfLJhOfmmlfTSm7oxFNc79Sxlv7qG+CFGUO/ZDZS3FeAPawKHc2BMlcwhxrhqwXHuvAV/RvOa53OnDGnzfTqZqvRlDF1khuIxSTgoHaWtifQYdg1ewNPqwHmXJP7HpzBY2EdJ+4HRqjlLbbDs2BhjevV95xfsnTdX3Ezx8pTNAq9cHKdfX/lXPZ/0gZx4DToXtWnXuZqYYOTN+FrtcyFRY1i+hcvxAu/nin96rX7sP50gtl5Euz9/+atJV7HFdQ1Lv4UFtfPvoVa/AusS1VMwS0zDTgXHRbdIy9UmQ0aEnrKGDpyBnxAbMnIgg3WLo70VbPce9Vb1moCP/aiNsFX3rFMoz6z8XDFe/8PWsbmtV8WHf/B+/WX+FwXvufAc4yYU2X6ohYt4L7Jf9oLmv6/gYZ3mH/pob41X3z34vXX7v2qfbQThgP6ybHQx3qneSU2oQJdTQE8Qo2Ku6YqdHiAOgzIpYGPeYkDv0dhy2DhAdaNoqPLvTZPwXeALdHewGPwjgrPC8/cvzjPWjz3dMyuvlsTMztHbMDU8mpOeh0mVYtnqQnxopJ5qmz4RBrlE2voGeFm5F5mYhkOYatkb3mJYOqG6XBDFR3Lpr0pmbqXrdqW2nRoOyjqqq/UlJ+LqzfWU57yCt7Bv/htV78feQoeSddH/jIDis2nxd8meHjaM7l4bVhw/zL7Hhb96U0G71fhkxc9oxG8At6B3rDo/9MXz+dMOomlB3VlyM16XrCCn1VmDaNM96fvPvhxL+qB70a6P+XXjin8M+xR6Cc1wQy91vK9R2A+nPj17k8eJeExZ3DeVe31HPNmmD/Td/3wtcYf3tgzeJfZP84X9nqpqxWbduGxkSmC/06zfD8IIxz5daYiSox9/SU1Ptz9/vzt9ubu91+/6v4EP++PSQwKAAA=
+  recorded_at: Tue, 15 Mar 2022 20:27:50 GMT
+- request:
+    method: post
+    uri: https://payments.sandbox.braintree-api.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"clientSdkMetadata":{"platform":"web","source":"client","integration":"custom","sessionId":"7b7f6fb2-a579-4973-b4c2-373ca6f31742","version":"3.83.0"},"query":"        mutation
+        TokenizeUsBankAccount($input: TokenizeUsBankAccountInput!) {\n          tokenizeUsBankAccount(input:
+        $input) {\n            paymentMethod {\n              id\n              details
+        {\n                ... on UsBankAccountDetails {\n                  last4\n                }\n              }\n            }\n          }\n        }\n","variables":{"input":{"usBankAccount":{"achMandate":"By
+        clicking [\"Checkout\"], I authorize Braintree, a service of PayPal, on behalf
+        of My Company (i) to verify my bank account information using bank information
+        and consumer reports and (ii) to debit my bank account.","routingNumber":"011000015","accountNumber":"4012000033330125","accountType":"CHECKING","billingAddress":{"streetAddress":"96706
+        Onie Plains","extendedAddress":"01897 Alysa Lock","city":"Miami","zipCode":"32191"},"individualOwner":{"firstName":"Jim","lastName":"Smith"}}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <AUTH_DATA>
+      Braintree-Version:
+      - '2018-05-10'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Mar 2022 20:27:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '218'
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Accept-Encoding
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 947c5ed4f3554
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"Field ''state'' of variable ''input'' has coerced
+        Null value for NonNull type ''UsStateCode!''","locations":[{"line":1,"column":40}]}],"extensions":{"requestId":"aa580a1a-7eca-42fd-b206-f5096ddbae40"}}'
+  recorded_at: Tue, 15 Mar 2022 20:27:50 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_unsucesfull_create_token_with_invalid_zip_code.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_unsucesfull_create_token_with_invalid_zip_code.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/sk2db46gz3spmcb2/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 3.0.1 (ActiveMerchant 1.125.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Mar 2022 20:27:51 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1592'
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 2491d1b9394b4
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKVWXZObOBZ9z6/IW55mB0HTG1d1MjXuNtiKhWNAEugNIbr5kGw6xmD49XtxdzZJTc/UVu0D5bKQ7j33nHOvuPvjYvT7vvh2qo6HTx/Qv6wP74tDflTV4enTBxp7v3388Mfnd3e5ropD91t3bIrD53fv39/1mT4Xn4sR2yLBU8YX5019HLf3uFRJeJQObgvjWfN6aPRZ2GzM17iVh321q7Au6HEQrFxmdNFGTccJ89p4FXzJfLxObf01o63PkhYT6rZREmCZhANvAhw0+jlKVMB85cRNiEmDKE/CmjQC8UZ9UYY9XPfzy23q6Hl/lz0sm2iFb2O7uVFap/vDksjGPaYGRRnfTMJhQjbtMWU5In7QMXPJSJMOXJdN5rM44G1F6mUr9OosEv1F+myz54CxoSNgqMnKfY7i5a5o2BRxNBDfi6NY4MyQIbbCe8n0MzUXwhDuuGlDtXLXPF6KLIaaDQpIc6GR0V9DDz9zjnaSLpLYdBm1NMRzd4Tpdo4HmMeYA2bqrrhxdda4t6mVXzINnHBN9lY7pFMQXDk1iybysJM6ba+aYQwPqqQTu+VQY4Z0t4tDImnrcqZOioebCGpmdngUK8UJ0mkGnJBaWxDXyThO2EELYkrgzA0h/jm3dR15ok0bdcr00yj9DupdtOmEp4K165kPyfd2HAc7ZWOoRwOuaz2ZBI6ljzSr9TNn5ZcMPY1RzVKi8Ykb5BOONxT4lQw0acqd9EWsIB9oek5pGRXggdzHWMberKEvdct3MRbcE5MAD4nV5SE6tDN+h2vwjFZu1AS1pGIA/BHgS1gsuKTpBeKHGSvn+BWxNgN4wFU8cIFvTaaVu9XLKWX7KX8IWMzbxzxR7jYWXuYFmKxTJ6Jo2KOS0BW2hK/98CHvqPF8gjCijXcTxmEfrYI6NeJrdMAT5akNWhxzzbKd552ZgwOKFrF4CM2WIpdqsdxUQ5Xai7Mw+sASfIK+qrJ1aOVrcrsdF2XuN8C/dxY+7ot7t8qNB30VjoKzQ5qEWtmeuzVBL+OjFTyQXnI2pnZZwp5p6wTfiAmr4EEcijqYch/Vab3pU/vSCu5aie0NWbSwSbSope2ajCuUv/bxjEs4GPKXYXy/uYXeh3fD3M9HtQ6HfDr2W2dZFhzpa65DUErIJZ2nc3rAZQbxc8P0ls85XIhv9a/xLvJ+c9qYsFQ+hXibkTysbrbxnwiem2tew0q1ZqNISLXTp0r5i2+AF2YMe0wdrIF7wB6UuQmnjUYLmEO19PWMY5n7mv0F57VOd0q526RmcbM1eEy5Pqs1xOIKcDAnTZoz6NDt6r1FxkUHc67OfA/2kD63T6PwN1Zg1C1xgkHyoCLV4nvOxzRZtlfc3LWzBPfSzJxcZ99/c87vf9IGC+B0c3hTn2qeq7kDTl4Hb9Uy5Taz8vEfvBDN/HpI+eVb52H96Qyz8yz5x//NW3O8g9BQVz/7U9rCvPgWavEvsK50Pm5uObJgX3icdQ+9QKcOaEjZOeX4JDjwAbEVpzM2WLu4ytf1fO5Nb9mLEfzYygqBr7xTkYRt6pDuivf+b7SM0LVfZh3/xvvVYzRUue+58JxC7papuehZCziPxE/vNnX7742BO8y/tFDfUsy+e/X6W+d+1T7cScsF/VSfm1O1M6KU60CDrkgCj1CjFiukcxMcoQ4LchngY5rjwO9JOmoz8wDrVn5g87kmS8B3gC02Xici8I4Ohpln4V/cFy1eejriV98tKUqHkHeE2V4laGuCuGzIpAylXlhwTxe1GGmtfWp3LacChavLRG3LpXwR720vllzfcBOsmWZ9UTc3Bdf3qtHbwiCXNZ1mK/3MkPqaX72xHLNElHAH/+K3XfWxFwl4JFmexOsMyNd/zv5G4OFxz9XstW7G/cvse5j1Zzcp3K/Sp696hj14BbwDvWGz/6cvXvYhNsq5B01pqfVymrGCn3Vqd71K9ufvPvhxLmyB71qtfspvXCT9Ad4x6Cc9wgy91vK9R2A+nMX17E8epcEp47B/pZvrPu5NMH/G7/qRa40/vLHncJc5P/bnznKuq5HrZuaxVgmG/25dwH0rraAX15mKGbX21WNifbr7/eXb7d3d779+1f0HuBzDywwKAAA=
+  recorded_at: Tue, 15 Mar 2022 20:27:50 GMT
+- request:
+    method: post
+    uri: https://payments.sandbox.braintree-api.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"clientSdkMetadata":{"platform":"web","source":"client","integration":"custom","sessionId":"7866f5a9-569d-4f96-8be7-20aeb6362518","version":"3.83.0"},"query":"        mutation
+        TokenizeUsBankAccount($input: TokenizeUsBankAccountInput!) {\n          tokenizeUsBankAccount(input:
+        $input) {\n            paymentMethod {\n              id\n              details
+        {\n                ... on UsBankAccountDetails {\n                  last4\n                }\n              }\n            }\n          }\n        }\n","variables":{"input":{"usBankAccount":{"achMandate":"By
+        clicking [\"Checkout\"], I authorize Braintree, a service of PayPal, on behalf
+        of My Company (i) to verify my bank account information using bank information
+        and consumer reports and (ii) to debit my bank account.","routingNumber":"011000015","accountNumber":"4012000033330125","accountType":"CHECKING","billingAddress":{"streetAddress":"96706
+        Onie Plains","extendedAddress":"01897 Alysa Lock","city":"Miami","state":"FL"},"individualOwner":{"firstName":"Jim","lastName":"Smith"}}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <AUTH_DATA>
+      Braintree-Version:
+      - '2018-05-10'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Mar 2022 20:27:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '218'
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Accept-Encoding
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 4d5bb55a3c104
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"Field ''zipCode'' of variable ''input'' has
+        coerced Null value for NonNull type ''UsZipCode!''","locations":[{"line":1,"column":40}]}],"extensions":{"requestId":"2683618d-674c-4d6a-8699-8e2dd83af40e"}}'
+  recorded_at: Tue, 15 Mar 2022 20:27:51 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Description
---
This PR Adds the VCR gem in order to record and stub the remote tests.

**Why?**
We need to be able to run the entire test suite each time we need so we are able to:

- Ensure that changes don't have side effects on the requests.
- Be able to make changes/improvements to base classes like CreditCard, Gateway, Check and be sure that there aren't side effects.
- Have more confidence to upgrade support higher Ruby versions and gem dependencies.
- Explore different HTTP clients to implement retry calls
- etc

**How?**

Trying to not be too intrusive a small module was introduced (VCR module), this module changes hooks into the test life cycle and stores a cassette for each test.

**Note:** As an implementation example, this PR adds the VCRmodule for the Braintree token remote tests.

Test Suite
---

**Unit Tests:**
Finished in 31.581706 seconds.
5112 tests, 75300 assertions, 0 failures, 2 errors,
0 pendings, 0 omissions, 0 notifications.
100% passed

**Remote Tests:**
bundle exec ruby -Itest
test/remote/gateways/remote_braintree_token_nonce_test.rb

Finished in 0.343357 seconds.
5 tests, 10 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100 passed

**Rubocop**
737 files inspected, no offenses detected