### PR TITLE
Litle: Add support for Level 2 and 3 enhanced data

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -39,6 +39,96 @@ module ActiveMerchant #:nodoc:
         check?(payment_method) ? commit(:echeckSales, request, money) : commit(:sale, request, money)
       end
 
+      def add_level_two_data(doc, payment_method, options = {})
+        level_2_data = options[:level_2_data]
+        if level_2_data
+          doc.enhancedData do
+            case payment_method.brand
+            when 'visa'
+              doc.salesTax(level_2_data[:sales_tax]) if level_2_data[:sales_tax]
+            when 'master'
+              doc.customerReference(level_2_data[:customer_code]) if level_2_data[:customer_code]
+              doc.salesTax(level_2_data[:total_tax_amount]) if level_2_data[:total_tax_amount]
+              doc.detailTax do
+                doc.taxIncludedInTotal(level_2_data[:tax_included_in_total]) if level_2_data[:tax_included_in_total]
+                doc.taxAmount(level_2_data[:tax_amount]) if level_2_data[:tax_amount]
+                doc.cardAcceptorTaxId(level_2_data[:card_acceptor_tax_id]) if level_2_data[:card_acceptor_tax_id]
+              end
+            end
+          end
+        end
+      end
+
+      def add_level_three_data(doc, payment_method, options = {})
+        level_3_data = options[:level_3_data]
+        if level_3_data
+          doc.enhancedData do
+            case payment_method.brand
+            when 'visa'
+              add_level_three_information_tags_visa(doc, payment_method, level_3_data)
+            when 'master'
+              add_level_three_information_tags_master(doc, payment_method, level_3_data)
+            end
+          end
+        end
+      end
+
+      def add_level_three_information_tags_visa(doc, payment_method, level_3_data)
+        doc.discountAmount(level_3_data[:discount_amount]) if level_3_data[:discount_amount]
+        doc.shippingAmount(level_3_data[:shipping_amount]) if level_3_data[:shipping_amount]
+        doc.dutyAmount(level_3_data[:duty_amount]) if level_3_data[:duty_amount]
+        doc.detailTax do
+          doc.taxIncludedInTotal(level_3_data[:tax_included_in_total]) if level_3_data[:tax_included_in_total]
+          doc.taxAmount(level_3_data[:tax_amount]) if level_3_data[:tax_amount]
+          doc.taxRate(level_3_data[:tax_rate]) if level_3_data[:tax_rate]
+          doc.taxTypeIdentifier(level_3_data[:tax_type_identifier]) if level_3_data[:tax_type_identifier]
+          doc.cardAcceptorTaxId(level_3_data[:card_acceptor_tax_id]) if level_3_data[:card_acceptor_tax_id]
+        end
+        add_line_item_information_for_level_three_visa(doc, payment_method, level_3_data)
+      end
+
+      def add_level_three_information_tags_master(doc, payment_method, level_3_data)
+        doc.customerReference :customerReference, level_3_data[:customer_code] if level_3_data[:customer_code]
+        doc.salesTax(level_3_data[:total_tax_amount]) if level_3_data[:total_tax_amount]
+        doc.detailTax do
+          doc.taxIncludedInTotal(level_3_data[:tax_included_in_total]) if level_3_data[:tax_included_in_total]
+          doc.taxAmount(level_3_data[:tax_amount]) if level_3_data[:tax_amount]
+          doc.cardAcceptorTaxId :cardAcceptorTaxId, level_3_data[:card_acceptor_tax_id] if level_3_data[:card_acceptor_tax_id]
+        end
+        doc.lineItemData do
+          level_3_data[:line_items].each do |line_item|
+            doc.itemDescription(line_item[:item_description]) if line_item[:item_description]
+            doc.productCode(line_item[:product_code]) if line_item[:product_code]
+            doc.quantity(line_item[:quantity]) if line_item[:quantity]
+            doc.unitOfMeasure(line_item[:unit_of_measure]) if line_item[:unit_of_measure]
+            doc.lineItemTotal(line_item[:line_item_total]) if line_item[:line_item_total]
+          end
+        end
+      end
+
+      def add_line_item_information_for_level_three_visa(doc, payment_method, level_3_data)
+        doc.lineItemData do
+          level_3_data[:line_items].each do |line_item|
+            doc.itemSequenceNumber(line_item[:item_sequence_number]) if line_item[:item_sequence_number]
+            doc.commodityCode(line_item[:commodity_code]) if line_item[:commodity_code]
+            doc.itemDescription(line_item[:item_description]) if line_item[:item_description]
+            doc.productCode(line_item[:product_code]) if line_item[:product_code]
+            doc.quantity(line_item[:quantity]) if line_item[:quantity]
+            doc.unitOfMeasure(line_item[:unit_of_measure]) if line_item[:unit_of_measure]
+            doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]
+            doc.itemDiscountAmount(line_item[:discount_per_line_item]) unless line_item[:discount_per_line_item] < 0
+            doc.unitCost(line_item[:unit_cost]) unless line_item[:unit_cost] < 0
+            doc.detailTax do
+              doc.taxIncludedInTotal(line_item[:tax_included_in_total]) if line_item[:tax_included_in_total]
+              doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]
+              doc.taxRate(line_item[:tax_rate]) if line_item[:tax_rate]
+              doc.taxTypeIdentifier(line_item[:tax_type_identifier]) if line_item[:tax_type_identifier]
+              doc.cardAcceptorTaxId(line_item[:card_acceptor_tax_id]) if line_item[:card_acceptor_tax_id]
+            end
+          end
+        end
+      end
+
       def authorize(money, payment_method, options = {})
         request = build_xml_request do |doc|
           add_authentication(doc)
@@ -225,6 +315,8 @@ module ActiveMerchant #:nodoc:
         add_payment_method(doc, payment_method, options)
         add_pos(doc, payment_method)
         add_descriptor(doc, options)
+        add_level_two_data(doc, payment_method, options)
+        add_level_three_data(doc, payment_method, options)
         add_merchant_data(doc, options)
         add_debt_repayment(doc, options)
         add_stored_credential_params(doc, options)

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -235,6 +235,108 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_level_two_data_visa
+    options = @options.merge(
+      level_2_data: {
+        sales_tax: 200
+      }
+    )
+    assert response = @gateway.purchase(10010, @credit_card1, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_level_two_data_master
+    credit_card = CreditCard.new(
+      first_name: 'John',
+      last_name: 'Smith',
+      month: '01',
+      year: '2024',
+      brand: 'master',
+      number: '5555555555554444',
+      verification_value: '349'
+    )
+
+    options = @options.merge(
+      level_2_data: {
+        total_tax_amount: 200,
+        customer_code: 'PO12345',
+        card_acceptor_tax_id: '011234567',
+        tax_included_in_total: 'true',
+        tax_amount: 50
+      }
+    )
+    assert response = @gateway.purchase(10010, credit_card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_level_three_data_visa
+    options = @options.merge(
+      level_3_data: {
+        discount_amount: 50,
+        shipping_amount: 50,
+        duty_amount: 20,
+        tax_included_in_total: true,
+        tax_amount: 100,
+        tax_rate: 0.05,
+        tax_type_identifier: '01',
+        card_acceptor_tax_id: '361531321',
+        line_items: [{
+          item_sequence_number: 1,
+          item_commodity_code: 300,
+          item_description: 'ramdom-object',
+          product_code: 'TB123',
+          quantity: 2,
+          unit_of_measure: 'EACH',
+          unit_cost: 25,
+          discount_per_line_item: 5,
+          line_item_total: 300,
+          tax_included_in_total: true,
+          tax_amount: 100,
+          tax_rate: 0.05,
+          tax_type_identifier: '01',
+          card_acceptor_tax_id: '361531321'
+        }]
+      }
+    )
+    assert response = @gateway.purchase(10010, @credit_card1, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_level_three_data_master
+    credit_card = CreditCard.new(
+      first_name: 'John',
+      last_name: 'Smith',
+      month: '01',
+      year: '2024',
+      brand: 'master',
+      number: '5555555555554444',
+      verification_value: '349'
+    )
+
+    options = @options.merge(
+      level_3_data: {
+        total_tax_amount: 200,
+        customer_code: 'PO12345',
+        card_acceptor_tax_id: '011234567',
+        tax_amount: 50,
+        line_items: [{
+          item_description: 'ramdom-object',
+          product_code: 'TB123',
+          quantity: 2,
+          unit_of_measure: 'EACH',
+          line_item_total: 300
+        }]
+      }
+    )
+
+    assert response = @gateway.purchase(10010, credit_card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_purchase_with_merchant_data
     options = @options.merge(
       affiliate: 'some-affiliate',


### PR DESCRIPTION
Litle: Add support for Level 2 and 3 enhanced data
------

Summary:
This PR includes the enhanced data to enable level 2 and 3 data support in this gateway

Test Execution:
-------
Finished in 37.183788 seconds.
54 tests, 221 assertions, 13 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
75.9259% passed

Failing tests are not related to this requirement

RuboCop:
736 files inspected, no offenses detected