### PR TITLE
Stripe PI: add request_three_d_secure to setup_intent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@
 * DecidirPlus: Add `establishment_name`, `aggregate_data`, `sub_payments`, `card_holder_identification_type`, `card_holder_identification_number`, `card_door_number`, and `card_holder_birthday` fields [ajawadmirza] #4361
 * DecidirPlus: Update `error_code_from` to get error reason id [ajawadmirza] #4364
 * Dlocal: Add three_ds mpi support [cristian] #4345
+* Stripe PI: Add `request_three_d_secure` field for `create_setup_intent` [aenand] #4365
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -124,6 +124,7 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_return_url(post, options)
         add_fulfillment_date(post, options)
+        request_three_d_secure(post, options)
         post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
         post[:usage] = options[:usage] if %w(on_session off_session).include?(options[:usage])
         post[:description] = options[:description] if options[:description]


### PR DESCRIPTION
Merchants that want to trigger 3DS flows manually
use the `request_three_d_secure` field when creating an intent
to do that. This was already added to `create_intent`, this
commit adds it to the `create_setup_intent` as well.

Stripe docs: https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method_options-card-request_three_d_secure

ECS-2391

Test Summary
Local:
5123 tests, 75395 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit:
39 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
75 tests, 353 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed