### PR TITLE
StripePI: Fix Invalid Token.

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -332,7 +332,7 @@ module ActiveMerchant #:nodoc:
             cryptogram: payment.payment_cryptogram
           }
         }
-        token_response = api_request(:post, 'tokens', post, {})
+        token_response = api_request(:post, 'tokens', post, options)
         success = token_response['error'].nil?
         if success && token_response['id']
           Response.new(success, nil, token: token_response)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -61,6 +61,13 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     )
 
     @destination_account = fixtures(:stripe_destination)[:stripe_user_id]
+
+    @options = {
+      currency: 'USD',
+      description: 'ActiveMerchant Test Purchase',
+      email: 'wow@example.com',
+      stripe_account: fixtures(:stripe_destination)[:stripe_user_id]
+    }
   end
 
   def test_authorization_and_void
@@ -160,6 +167,16 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_match('apple_pay', purchase.responses.first.params.dig('token', 'card', 'tokenization_method'))
     assert purchase.success?
     assert_match('apple_pay', purchase.params.dig('charges', 'data')[0]['payment_method_details']['card']['wallet']['type'])
+  end
+
+  def test_succesful_purchase_with_connect_for_apple_pay
+    assert response = @gateway.purchase(@amount, @apple_pay, @options)
+    assert_success response
+  end
+
+  def test_succesful_application_with_connect_for_google_pay
+    assert response = @gateway.purchase(@amount, @google_pay, @options)
+    assert_success response
   end
 
   def test_purchases_with_same_idempotency_key


### PR DESCRIPTION
In order to solve the error when attempting to make a purchase using an
Apple Pay payment, this error was using connect for authentication,
because was not include the options that contain the account information.
This PR includes the options to the tokenization and the request to tokenize
and create intent has the same authentication values.

Local Tests:
---------------------------------------
39 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
---------------------------------------
76 tests, 341 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
---------------------------------------
736 files inspected, no offenses detected