### PR TITLE
Dlocal add three_ds support

### DIFF
--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -272,7 +272,7 @@ module ActiveMerchant #:nodoc:
           three_dsecure_version: three_d_secure[:version],
           cavv: three_d_secure[:cavv],
           eci: three_d_secure[:eci],
-          enrollment_response: three_d_secure[:enrolled],
+          enrollment_response: formatted_enrollment(three_d_secure[:enrolled]),
           authentication_response: three_d_secure[:authentication_response_status]
         }.merge(xid_or_ds_trans_id(three_d_secure))
       end
@@ -280,8 +280,8 @@ module ActiveMerchant #:nodoc:
       def validate_three_ds_params(three_ds)
         errors = {}
         supported_version = %w{1.0 2.0 2.1.0 2.2.0}.include?(three_ds[:three_dsecure_version])
-        supported_enrollment = %w{Y N U}.include?(three_ds[:enrollment_response])
-        supported_auth_response = %w{Y A N U}.include?(three_ds[:authentication_response])
+        supported_enrollment = ['Y', 'N', 'U', nil].include?(three_ds[:enrollment_response])
+        supported_auth_response = ['Y', 'N', 'U', nil].include?(three_ds[:authentication_response])
 
         errors[:three_ds_version] = 'ThreeDs version not supported' unless supported_version
         errors[:enrollment] = 'Enrollment value not supported' unless supported_enrollment
@@ -289,6 +289,14 @@ module ActiveMerchant #:nodoc:
         errors.compact!
 
         errors.present? ? Response.new(false, 'ThreeDs data is invalid', errors) : nil
+      end
+
+      def formatted_enrollment(val)
+        case val
+        when 'Y', 'N', 'U' then val
+        when true, 'true' then 'Y'
+        when false, 'false' then 'N'
+        end
       end
     end
   end

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -275,7 +275,7 @@ class RemoteDLocalTest < Test::Unit::TestCase
       cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
       eci: '05',
       xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
-      enrolled: 'Y',
+      enrolled: 'true',
       authentication_response_status: 'Y'
     }
     auth = @gateway.authorize(@amount, @credit_card, @options)

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -17,7 +17,7 @@ class DLocalTest < Test::Unit::TestCase
       cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
       eci: '05',
       xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
-      enrolled: 'Y',
+      enrolled: 'true',
       authentication_response_status: 'Y'
     }
   end
@@ -249,7 +249,7 @@ class DLocalTest < Test::Unit::TestCase
     assert_equal ds_options[:eci], ds_data[:eci]
     assert_equal ds_options[:xid], ds_data[:xid]
     assert_equal nil, ds_data[:ds_transaction_id]
-    assert_equal ds_options[:enrolled], ds_data[:enrollment_response]
+    assert_equal 'Y', ds_data[:enrollment_response]
     assert_equal ds_options[:authentication_response_status], ds_data[:authentication_response]
   end
 
@@ -270,7 +270,7 @@ class DLocalTest < Test::Unit::TestCase
     assert_equal ds_options[:eci], ds_data[:eci]
     assert_equal nil, ds_data[:xid]
     assert_equal ds_options[:ds_transaction_id], ds_data[:ds_transaction_id]
-    assert_equal ds_options[:enrolled], ds_data[:enrollment_response]
+    assert_equal 'Y', ds_data[:enrollment_response]
     assert_equal ds_options[:authentication_response_status], ds_data[:authentication_response]
   end
 
@@ -332,6 +332,18 @@ class DLocalTest < Test::Unit::TestCase
 
     assert_equal 'ThreeDs data is invalid', resp.message
     assert_equal 'ThreeDs version not supported', resp.params['three_ds_version']
+  end
+
+  def test_formatted_enrollment
+    assert_equal 'Y', @gateway.send('formatted_enrollment', 'Y')
+    assert_equal 'Y', @gateway.send('formatted_enrollment', 'true')
+    assert_equal 'Y', @gateway.send('formatted_enrollment', true)
+
+    assert_equal 'N', @gateway.send('formatted_enrollment', 'N')
+    assert_equal 'N', @gateway.send('formatted_enrollment', 'false')
+    assert_equal 'N', @gateway.send('formatted_enrollment', false)
+
+    assert_equal 'U', @gateway.send('formatted_enrollment', 'U')
   end
 
   private


### PR DESCRIPTION
Summary:
------------------------------
This PR adds support for third party three ds authentication
data on the DLocal gateway.

Test Execution:
------------------------------
Remote
Finished in 19.797433 seconds.
31 tests, 79 assertions, 2 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
93.5484% passed

Unit
Finished in 30.997677 seconds.
5076 tests, 75140 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100% passed

RuboCop:
------------------------------
728 files inspected, no offenses detected