### PR TITLE
Orbital: Add `tandem` support in orbital

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,7 @@
 * Airwallex: QA fixes for address and create_setup_intent handling [therufs] #4377
 * Airwallex: add `descriptor` field and update logic for sending `request_id` and `merchant_order_id` [dsmcclain] #4379
 * Visanet Peru: use timestamp instead of random for purchaseNumber [therufs] #4093
+* Orbital: add `verify_amount` field [ajawadmirza] #4376
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -211,7 +211,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options = {})
-        amount = allow_zero_auth?(credit_card) ? 0 : 100
+        amount = options[:verify_amount] ? options[:verify_amount].to_i : default_verify_amount(credit_card)
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(amount, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization) } unless amount == 0
@@ -263,6 +263,10 @@ module ActiveMerchant #:nodoc:
         order = build_void_request_xml(authorization, options)
 
         commit(order, :void, options[:retry_logic], options[:trace_number])
+      end
+
+      def default_verify_amount(credit_card)
+        allow_zero_auth?(credit_card) ? 0 : 100
       end
 
       def allow_zero_auth?(credit_card)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -689,6 +689,11 @@ orbital_gateway:
   password: PASSWORD
   merchant_id: MERCHANTID
 
+orbital_tandem_gateway:
+  login: LOGIN
+  password: PASSWORD
+  merchant_id: MERCHANTID
+
 # Working credentials, no need to replace
 pagarme:
     api_key: 'ak_test_e1QGU2gL98MDCHZxHLJ9sofPUFJ7tH'

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -1048,3 +1048,460 @@ class BrandSpecificOrbitalTests < RemoteOrbitalGatewayTest
     )
   end
 end
+
+class TandemOrbitalTests < Test::Unit::TestCase
+  # Additional test cases to verify tandem integration
+  def setup
+    Base.mode = :test
+    @tandem_gateway = ActiveMerchant::Billing::OrbitalGateway.new(fixtures(:orbital_tandem_gateway))
+
+    @amount = 100
+    @google_pay_amount = 10000
+    @credit_card = credit_card('4556761029983886')
+    @declined_card = credit_card('4011361100000012')
+    @google_pay_card = network_tokenization_credit_card(
+      '4777777777777778',
+      payment_cryptogram: 'BwAQCFVQdwEAABNZI1B3EGLyGC8=',
+      verification_value: '987',
+      source: :google_pay,
+      brand: 'visa',
+      eci: '5'
+    )
+
+    @options = {
+      order_id: generate_unique_id,
+      address: address,
+      merchant_id: 'merchant1234'
+    }
+
+    @level_2_options = {
+      tax_indicator: '1',
+      tax: '75',
+      purchase_order: '123abc',
+      zip: address[:zip]
+    }
+
+    @level_3_options = {
+      freight_amount: 1,
+      duty_amount: 1,
+      ship_from_zip: 27604,
+      dest_country: 'USA',
+      discount_amount: 1,
+      vat_tax: 1,
+      vat_rate: 25
+    }
+
+    @line_items = [
+      {
+        desc: 'another item',
+        prod_cd: generate_unique_id[0, 11],
+        qty: 1,
+        u_o_m: 'LBR',
+        tax_amt: 250,
+        tax_rate: 10000,
+        comm_cd: '00584',
+        unit_cost: 2500,
+        gross_net: 'Y',
+        tax_type: 'sale',
+        debit_ind: 'C'
+      },
+      {
+        desc: 'something else',
+        prod_cd: generate_unique_id[0, 11],
+        qty: 1,
+        u_o_m: 'LBR',
+        tax_amt: 125,
+        tax_rate: 5000,
+        comm_cd: '00584',
+        unit_cost: 1000,
+        gross_net: 'Y',
+        tax_type: 'sale',
+        debit_ind: 'C'
+      }
+    ]
+  end
+
+  def test_successful_purchase
+    assert response = @tandem_gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_soft_descriptor
+    options = @options.merge(
+      soft_descriptors: {
+        merchant_name: 'Merch',
+        product_description: 'Description',
+        merchant_email: 'email@example'
+      }
+    )
+    assert response = @tandem_gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_level_2_data
+    response = @tandem_gateway.purchase(@amount, @credit_card, @options.merge(level_2_data: @level_2_options))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_level_3_data
+    response = @tandem_gateway.purchase(@amount, @credit_card, @options.merge(level_2_data: @level_2_options, level_3_data: @level_3_options, line_items: @line_items))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_visa_network_tokenization_credit_card_with_eci
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      verification_value: '111',
+      brand: 'visa',
+      eci: '5'
+    )
+
+    assert response = @tandem_gateway.purchase(3000, network_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_master_card_network_tokenization_credit_card
+    network_card = network_tokenization_credit_card('4788250000028291',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      verification_value: '111',
+      brand: 'master')
+    assert response = @tandem_gateway.purchase(3000, network_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_american_express_network_tokenization_credit_card
+    network_card = network_tokenization_credit_card('4788250000028291',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      verification_value: '111',
+      brand: 'american_express')
+    assert response = @tandem_gateway.purchase(3000, network_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_discover_network_tokenization_credit_card
+    network_card = network_tokenization_credit_card('4788250000028291',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      verification_value: '111',
+      brand: 'discover')
+    assert response = @tandem_gateway.purchase(3000, network_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  # verify stored credential flows in tandem support
+
+  def test_successful_purchase_with_mit_stored_credentials
+    mit_stored_credentials = {
+      mit_msg_type: 'MUSE',
+      mit_stored_credential_ind: 'Y',
+      mit_submitted_transaction_id: '111222333444555'
+    }
+
+    response = @tandem_gateway.purchase(@amount, @credit_card, @options.merge(mit_stored_credentials))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_cit_stored_credentials
+    cit_options = {
+      mit_msg_type: 'CUSE',
+      mit_stored_credential_ind: 'Y'
+    }
+
+    response = @tandem_gateway.purchase(@amount, @credit_card, @options.merge(cit_options))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_purchase_using_stored_credential_recurring_cit
+    initial_options = stored_credential_options(:cardholder, :recurring, :initial)
+    assert purchase = @tandem_gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+    assert network_transaction_id = purchase.params['mit_received_transaction_id']
+
+    used_options = stored_credential_options(:recurring, :cardholder, id: network_transaction_id)
+    assert purchase = @tandem_gateway.purchase(@amount, @credit_card, used_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+  end
+
+  def test_purchase_using_stored_credential_recurring_mit
+    initial_options = stored_credential_options(:merchant, :recurring, :initial)
+    assert purchase = @tandem_gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+    assert network_transaction_id = purchase.params['mit_received_transaction_id']
+
+    used_options = stored_credential_options(:recurring, :merchant, id: network_transaction_id)
+    assert purchase = @tandem_gateway.purchase(@amount, @credit_card, used_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+  end
+
+  def test_successful_purchase_with_overridden_normalized_stored_credentials
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: false,
+        initiator: 'merchant',
+        reason_type: 'unscheduled',
+        network_transaction_id: '111222333444555'
+      },
+      mit_msg_type: 'MRSB'
+    }
+
+    response = @tandem_gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  # verify google pay transactions on tandem account
+
+  def test_successful_purchase_with_google_pay
+    response = @tandem_gateway.purchase(@google_pay_amount, @google_pay_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_purchase
+    assert response = @tandem_gateway.purchase(101, @declined_card, @options)
+    assert_failure response
+    assert_match 'AUTH DECLINED', response.message
+  end
+
+  def test_authorize_and_capture
+    amount = @amount
+    assert auth = @tandem_gateway.authorize(amount, @credit_card, @options.merge(order_id: '2'))
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert auth.authorization
+    assert capture = @tandem_gateway.capture(amount, auth.authorization, order_id: '2')
+    assert_success capture
+  end
+
+  def test_successful_authorize_and_capture_with_level_2_data
+    auth = @tandem_gateway.authorize(@amount, @credit_card, @options.merge(level_2_data: @level_2_options))
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    capture = @tandem_gateway.capture(@amount, auth.authorization, @options.merge(level_2_data: @level_2_options))
+    assert_success capture
+  end
+
+  def test_successful_authorize_and_capture_with_line_items
+    auth = @tandem_gateway.authorize(@amount, @credit_card, @options.merge(level_2_data: @level_2_options, level_3_data: @level_3_options, line_items: @line_items))
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    capture = @tandem_gateway.capture(@amount, auth.authorization, @options.merge(level_2_data: @level_2_options, level_3_data: @level_3_options, line_items: @line_items))
+    assert_success capture
+  end
+
+  def test_successful_authorize_and_capture_with_google_pay
+    auth = @tandem_gateway.authorize(@amount, @google_pay_card, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    capture = @tandem_gateway.capture(@amount, auth.authorization, @options)
+    assert_success capture
+  end
+
+  def test_authorize_and_void
+    assert auth = @tandem_gateway.authorize(@amount, @credit_card, @options.merge(order_id: '2'))
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert auth.authorization
+    assert void = @tandem_gateway.void(auth.authorization, order_id: '2')
+    assert_success void
+  end
+
+  def test_authorize_and_void_using_google_pay
+    assert auth = @tandem_gateway.authorize(@amount, @google_pay_card, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    assert auth.authorization
+    assert void = @tandem_gateway.void(auth.authorization)
+    assert_success void
+  end
+
+  def test_successful_refund
+    amount = @amount
+    assert response = @tandem_gateway.purchase(amount, @credit_card, @options)
+    assert_success response
+    assert response.authorization
+    assert refund = @tandem_gateway.refund(amount, response.authorization, @options)
+    assert_success refund
+  end
+
+  def test_failed_refund
+    assert refund = @tandem_gateway.refund(@amount, '123;123', @options)
+    assert_failure refund
+    assert_equal '881', refund.params['proc_status']
+  end
+
+  def test_successful_refund_with_google_pay
+    auth = @tandem_gateway.authorize(@amount, @google_pay_card, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    capture = @tandem_gateway.capture(@amount, auth.authorization, @options)
+    assert_success capture
+
+    assert capture.authorization
+    assert refund = @tandem_gateway.refund(@amount, capture.authorization, @options)
+    assert_success refund
+  end
+
+  def test_successful_refund_with_level_2_data
+    amount = @amount
+    assert response = @tandem_gateway.purchase(amount, @credit_card, @options.merge(level_2_data: @level_2_options))
+    assert_success response
+    assert response.authorization
+    assert refund = @tandem_gateway.refund(amount, response.authorization, @options.merge(level_2_data: @level_2_options))
+    assert_success refund
+  end
+
+  def test_successful_credit
+    payment_method = credit_card('5454545454545454')
+    assert response = @tandem_gateway.credit(@amount, payment_method, @options)
+    assert_success response
+  end
+
+  def test_failed_capture
+    assert response = @tandem_gateway.capture(@amount, '')
+    assert_failure response
+    assert_equal 'Bad data error', response.message
+  end
+
+  def test_credit_purchase_with_address_responds_with_name
+    transcript = capture_transcript(@tandem_gateway) do
+      @tandem_gateway.authorize(@amount, @credit_card, @options.merge(order_id: '2'))
+    end
+
+    assert_match(/<AVSname>Longbob Longsen/, transcript)
+    assert_match(/<RespCode>00/, transcript)
+    assert_match(/<StatusMsg>Approved/, transcript)
+  end
+
+  def test_credit_purchase_with_no_address_responds_with_no_name
+    transcript = capture_transcript(@tandem_gateway) do
+      @tandem_gateway.authorize(@amount, @credit_card, @options.merge(order_id: '2', address: nil, billing_address: nil))
+    end
+
+    assert_match(/<RespCode>00/, transcript)
+    assert_match(/<StatusMsg>Approved/, transcript)
+  end
+
+  def test_void_transactions
+    [3000, 105500, 2900].each do |amount|
+      assert auth_response = @tandem_gateway.authorize(amount, @credit_card, @options)
+      assert void_response = @tandem_gateway.void(auth_response.authorization, @options.merge(transaction_index: 1))
+      assert_kind_of Response, void_response
+    end
+  end
+
+  def test_successful_verify
+    response = @tandem_gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_different_cards
+    @credit_card.brand = 'master'
+    response = @tandem_gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_verify_with_discover_brand
+    @credit_card.brand = 'discover'
+    response = @tandem_gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_verify_with_invalid_discover_card
+    @declined_card.brand = 'discover'
+    response = @tandem_gateway.verify(@declined_card, @options.merge({ verify_amount: '101' }))
+    assert_failure response
+    assert_match 'AUTH DECLINED', response.message
+  end
+
+  def test_failed_verify
+    response = @tandem_gateway.verify(@declined_card, @options.merge({ verify_amount: '101' }))
+    assert_failure response
+    assert_match 'AUTH DECLINED', response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@tandem_gateway) do
+      @tandem_gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @tandem_gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@tandem_gateway.options[:password], transcript)
+    assert_scrubbed(@tandem_gateway.options[:login], transcript)
+    assert_scrubbed(@tandem_gateway.options[:merchant_id], transcript)
+  end
+
+  def test_transcript_scrubbing_profile
+    transcript = capture_transcript(@tandem_gateway) do
+      @tandem_gateway.add_customer_profile(@credit_card, @options)
+    end
+    transcript = @tandem_gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@tandem_gateway.options[:password], transcript)
+    assert_scrubbed(@tandem_gateway.options[:login], transcript)
+    assert_scrubbed(@tandem_gateway.options[:merchant_id], transcript)
+  end
+
+  def test_transcript_scrubbing_network_card
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      verification_value: '111',
+      brand: 'visa',
+      eci: '5'
+    )
+    transcript = capture_transcript(@tandem_gateway) do
+      @tandem_gateway.purchase(@tandem_gateway, network_card, @options)
+    end
+    transcript = @tandem_gateway.scrub(transcript)
+
+    assert_scrubbed(network_card.payment_cryptogram, transcript)
+  end
+
+  private
+
+  def stored_credential_options(*args, id: nil)
+    @options.merge(order_id: generate_unique_id,
+                   stored_credential: stored_credential(*args, id: id))
+  end
+end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -1496,6 +1496,15 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_custom_amount_on_verify
+    response = stub_comms do
+      @gateway.verify(credit_card, @options.merge({ verify_amount: '101' }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r{<Amount>101<\/Amount>}, data if data.include?('MessageType')
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
   def test_valid_amount_with_jcb_card
     @credit_card.brand = 'jcb'
     stub_comms do


### PR DESCRIPTION
Added support for tandem implementation in orbital and test case
coverage.

CE-2432

Unit:
5145 tests, 75477 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Rubocop:
739 files inspected, no offenses detected
Remote:
118 tests, 492 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed