### PR TITLE
Priority: Refactor gateway integration, add additional fields to request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,7 @@
 * Credorax: add `recipient_street_address`, `recipient_city`, `recipient_province_code`, and `recipient_country_code` fields [ajawadmirza] #4384
 * Airwallex: add support for stored credentials [drkjc] #4382
 * Rapyd: Add metadata and ewallet_id options [naashton] #4387
+* Priority: Add additional fields to request and refactor gateway integration [dsmcclain] #4383
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/priority.rb
+++ b/lib/active_merchant/billing/gateways/priority.rb
@@ -50,75 +50,75 @@ module ActiveMerchant #:nodoc:
 
       def purchase(amount, credit_card, options = {})
         params = {}
-        params['amount'] = localized_amount(amount.to_f, options[:currency])
         params['authOnly'] = false
+        params['isSettleFunds'] = true
 
-        add_replay_id(params, options)
-        add_credit_card(params, credit_card, 'purchase', options)
-        add_type_merchant_purchase(params, @options[:merchant_id], true, options)
-        commit('purchase', params: params, jwt: options)
+        add_merchant_id(params)
+        add_amount(params, amount, options)
+        add_auth_purchase_params(params, credit_card, options)
+
+        commit('purchase', params: params)
       end
 
       def authorize(amount, credit_card, options = {})
         params = {}
-        params['amount'] = localized_amount(amount.to_f, options[:currency])
         params['authOnly'] = true
+        params['isSettleFunds'] = false
 
-        add_replay_id(params, options)
-        add_credit_card(params, credit_card, 'purchase', options)
-        add_type_merchant_purchase(params, @options[:merchant_id], false, options)
-        commit('purchase', params: params, jwt: options)
+        add_merchant_id(params)
+        add_amount(params, amount, options)
+        add_auth_purchase_params(params, credit_card, options)
+
+        commit('purchase', params: params)
       end
 
       def refund(amount, authorization, options = {})
         params = {}
-        params['merchantId'] = @options[:merchant_id]
-        params['paymentToken'] = get_hash(authorization)['payment_token'] || options[:payment_token]
+        add_merchant_id(params)
+        params['paymentToken'] = payment_token(authorization) || options[:payment_token]
+
         # refund amounts must be negative
         params['amount'] = ('-' + localized_amount(amount.to_f, options[:currency])).to_f
 
-        commit('refund', params: params, jwt: options)
+        commit('refund', params: params)
       end
 
       def capture(amount, authorization, options = {})
         params = {}
-        params['invoice'] = options[:invoice]
-        params['amount'] = localized_amount(amount.to_f, options[:currency])
-        params['authCode'] = options[:auth_code]
-        params['merchantId'] = @options[:merchant_id]
-        params['paymentToken'] = get_hash(authorization)['payment_token']
-        params['shouldGetCreditCardLevel'] = true
-        params['source'] = options[:source]
-        params['tenderType'] = 'Card'
+        add_merchant_id(params)
+        add_amount(params, amount, options)
+        params['paymentToken'] = payment_token(authorization) || options[:payment_token]
+        params['tenderType'] = options[:tender_type].present? ? options[:tender_type] : 'Card'
 
-        commit('capture', params: params, jwt: options)
+        commit('capture', params: params)
       end
 
       def void(authorization, options = {})
         params = {}
 
-        commit('void', params: params, iid: get_hash(authorization)['id'], jwt: options)
+        commit('void', params: params, iid: payment_id(authorization))
       end
 
-      def verify(credit_card, options)
-        jwt = options[:jwt_token]
+      def verify(credit_card)
+        jwt = create_jwt.params['jwtToken']
+
         commit('verify', card_number: credit_card.number, jwt: jwt)
+      end
+
+      def get_payment_status(batch_id)
+        commit('get_payment_status', params: batch_id)
+      end
+
+      def close_batch(batch_id)
+        commit('close_batch', params: batch_id)
+      end
+
+      def create_jwt
+        commit('create_jwt', params: @options[:merchant_id])
       end
 
       def supports_scrubbing?
         true
-      end
-
-      def get_payment_status(batch_id, options)
-        commit('get_payment_status', params: batch_id, jwt: options)
-      end
-
-      def close_batch(batch_id, options)
-        commit('close_batch', params: batch_id, jwt: options)
-      end
-
-      def create_jwt(options)
-        commit('create_jwt', params: @options[:merchant_id], jwt: options)
       end
 
       def scrub(transcript)
@@ -126,6 +126,25 @@ module ActiveMerchant #:nodoc:
           gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
           gsub(%r((number\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
           gsub(%r((cvv\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]')
+      end
+
+      private
+
+      def add_amount(params, amount, options)
+        params['amount'] = localized_amount(amount.to_f, options[:currency])
+      end
+
+      def add_merchant_id(params)
+        params['merchantId'] = @options[:merchant_id]
+      end
+
+      def add_auth_purchase_params(params, credit_card, options)
+        add_replay_id(params, options)
+        add_credit_card(params, credit_card, 'purchase', options)
+        add_purchases_data(params, options)
+        add_shipping_data(params, options)
+        add_pos_data(params, options)
+        add_additional_data(params, options)
       end
 
       def add_replay_id(params, options)
@@ -143,24 +162,8 @@ module ActiveMerchant #:nodoc:
         card_details['last4'] = credit_card.last_digits
         card_details['cvv'] = credit_card.verification_value
         card_details['number'] = credit_card.number
-        card_details['code'] = options[:code]
-        card_details['taxRate'] = options[:tax_rate]
-        card_details['taxAmount'] = options[:tax_amount]
-        card_details['entryMode'] = options['entryMode'].blank? ? 'Keyed' : options['entryMode']
-        case action
-        when 'purchase'
-          card_details['avsStreet'] = options[:billing_address][:address1] if options[:billing_address]
-          card_details['avsZip'] =  options[:billing_address][:zip] if options[:billing_address]
-        when 'refund'
-          card_details['cardId'] = options[:card_id]
-          card_details['cardPresent'] = options[:card_present]
-          card_details['hasContract'] = options[:has_contract]
-          card_details['isCorp'] = options[:is_corp]
-          card_details['isDebit'] = options[:is_debit]
-          card_details['token'] = options[:token]
-        else
-          card_details
-        end
+        card_details['avsStreet'] = options[:billing_address][:address1] if options[:billing_address]
+        card_details['avsZip'] =  options[:billing_address][:zip] if options[:billing_address]
 
         params['cardAccount'] = card_details
       end
@@ -169,26 +172,86 @@ module ActiveMerchant #:nodoc:
         "#{format(credit_card.month, :two_digits)}/#{format(credit_card.year, :two_digits)}"
       end
 
-      def add_type_merchant_purchase(params, merchant, is_settle_funds, options)
-        params['cardPresent'] = options[:card_present].present? ? options[:card_present] : 'false'
-        params['cardPresentType'] = options[:card_present_type].present? ? options[:card_present_type] : 'CardNotPresent'
+      def add_additional_data(params, options)
         params['isAuth'] = options[:is_auth].present? ? options[:is_auth] : 'true'
-        params['isSettleFunds'] = is_settle_funds
-        params['isTicket'] = false
-        params['merchantId'] = merchant
-        params['mxAdvantageEnabled'] = false
         params['paymentType'] = options[:payment_type].present? ? options[:payment_type] : 'Sale'
-        params['purchases'] = add_purchases_data(params, options)
-        params['shouldGetCreditCardLevel'] = true
-        params['shouldVaultCard'] = options[:should_vault_card].present? ? options[:should_vault_card] : 'true'
-        params['source'] = options[:source]
-        params['sourceZip'] = options[:billing_address][:zip] if options[:billing_address]
-        params['taxExempt'] = options[:tax_exempt].present? ? options[:tax_exempt] : 'false'
         params['tenderType'] = options[:tender_type].present? ? options[:tender_type] : 'Card'
-        params['posData'] = options[:pos_data]
-        params['shipAmount'] = options[:ship_amount]
-        params['shipToCountry'] = options[:ship_to_country]
-        params['shipToZip'] = options[:ship_to_zip]
+        params['taxExempt'] = options[:tax_exempt].present? ? options[:tax_exempt] : 'false'
+        params['taxAmount'] = options[:tax_amount] if options[:tax_amount]
+        params['shouldGetCreditCardLevel'] = options[:should_get_credit_card_level] if options[:should_get_credit_card_level]
+        params['source'] = options[:source] if options[:source]
+        params['invoice'] = options[:invoice] if options[:invoice]
+      end
+
+      def add_pos_data(params, options)
+        pos_data = {}
+
+        pos_data['cardholderPresence'] = options.dig(:pos_data, :cardholder_presence) || 'Ecom'
+        pos_data['deviceAttendance'] = options.dig(:pos_data, :device_attendance) || 'HomePc'
+        pos_data['deviceInputCapability'] = options.dig(:pos_data, :device_input_capability) || 'Unknown'
+        pos_data['deviceLocation'] = options.dig(:pos_data, :device_location) || 'HomePc'
+        pos_data['panCaptureMethod'] = options.dig(:pos_data, :pan_capture_method) || 'Manual'
+        pos_data['partialApprovalSupport'] = options.dig(:pos_data, :partial_approval_support) || 'NotSupported'
+        pos_data['pinCaptureCapability'] = options.dig(:pos_data, :pin_capture_capability) || 'Incapable'
+
+        params['posData'] = pos_data
+      end
+
+      def add_purchases_data(params, options)
+        return unless options[:purchases]
+
+        params['purchases'] = []
+
+        options[:purchases].each do |purchase|
+          purchase_object = {}
+
+          purchase_object['name'] = purchase[:name] if purchase[:name]
+          purchase_object['description'] = purchase[:description] if purchase[:description]
+          purchase_object['code'] = purchase[:code] if purchase[:code]
+          purchase_object['unitOfMeasure'] = purchase[:unit_of_measure] if purchase[:unit_of_measure]
+          purchase_object['unitPrice'] = purchase[:unit_price] if purchase[:unit_price]
+          purchase_object['quantity'] = purchase[:quantity] if purchase[:quantity]
+          purchase_object['taxRate'] = purchase[:tax_rate] if purchase[:tax_rate]
+          purchase_object['taxAmount'] = purchase[:tax_amount] if purchase[:tax_amount]
+          purchase_object['discountRate'] = purchase[:discount_rate] if purchase[:discount_rate]
+          purchase_object['discountAmount'] = purchase[:discount_amount] if purchase[:discount_amount]
+          purchase_object['extendedAmount'] = purchase[:extended_amount] if purchase[:extended_amount]
+          purchase_object['lineItemId'] = purchase[:line_item_id] if purchase[:line_item_id]
+
+          params['purchases'].append(purchase_object)
+        end
+      end
+
+      def add_shipping_data(params, options)
+        params['shipAmount'] = options[:ship_amount] if options[:ship_amount]
+
+        shipping_country = shipping_country_from(options)
+        params['shipToCountry'] = shipping_country if shipping_country
+
+        shipping_zip = shipping_zip_from(options)
+        params['shipToZip'] = shipping_zip if shipping_zip
+      end
+
+      def shipping_country_from(options)
+        options[:ship_to_country] || options.dig(:shipping_address, :country) || options.dig(:billing_address, :country)
+      end
+
+      def shipping_zip_from(options)
+        options[:ship_to_zip] || options.dig(:shipping_addres, :zip) || options.dig(:billing_address, :zip)
+      end
+
+      def payment_token(authorization)
+        return unless authorization
+        return authorization unless authorization.include?('|')
+
+        authorization.split('|').last
+      end
+
+      def payment_id(authorization)
+        return unless authorization
+        return authorization unless authorization.include?('|')
+
+        authorization.split('|').first
       end
 
       def commit(action, params: '', iid: '', card_number: nil, jwt: '')
@@ -207,11 +270,12 @@ module ActiveMerchant #:nodoc:
               parse(ssl_post(url(action, params), post_data(params), request_headers))
             end
           rescue ResponseError => e
-            parse(e.response.body)
+            # currently Priority returns a 404 with no body on certain calls. In those cases we will substitute the response status from response.message
+            gateway_response = e.response.body.presence || e.response.message
+            parse(gateway_response)
           end
 
         success = success_from(response, action)
-        response = { 'code' => '204' } if response == ''
         Response.new(
           success,
           message_from(response),
@@ -220,16 +284,6 @@ module ActiveMerchant #:nodoc:
           error_code: success || response == '' ? nil : error_from(response),
           test: test?
         )
-      end
-
-      def handle_response(response)
-        if response.code != '204' && (200...300).cover?(response.code.to_i)
-          response.body
-        elsif response.code == '204' || response == ''
-          response.body = { 'code' => '204' }
-        else
-          raise ResponseError.new(response)
-        end
       end
 
       def url(action, params, ref_number: '', credit_card_number: nil)
@@ -263,10 +317,22 @@ module ActiveMerchant #:nodoc:
         test? ? self.test_url_batch : self.live_url_batch
       end
 
-      def parse(body)
-        return body if body['code'] == '204'
+      def handle_response(response)
+        case response.code.to_i
+        when 204
+          { status: 'Success' }.to_json
+        when 200...300
+          response.body
+        else
+          raise ResponseError.new(response)
+        end
+      end
 
-        JSON.parse(body)
+      def parse(body)
+        return {} if body.blank?
+
+        parsed_response = JSON.parse(body)
+        parsed_response.is_a?(String) ? { 'message' => parsed_response } : parsed_response
       rescue JSON::ParserError
         message = 'Invalid JSON response received from Priority Gateway. Please contact Priority Gateway if you continue to receive this message.'
         message += " (The raw response returned by the API was #{body.inspect})"
@@ -276,10 +342,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(response, action)
-        success = response['status'] == 'Approved' || response['status'] == 'Open' if response['status']
-        success = response['code'] == '204' if action == 'void'
-        success = !response['bank'].empty? if action == 'verify' && response['bank']
-        success
+        return !response['bank'].empty? if action == 'verify' && response['bank']
+
+        %w[Approved Open Success].include?(response['status'])
       end
 
       def message_from(response)
@@ -289,10 +354,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response)
-        {
-          'payment_token' => response['paymentToken'],
-          'id' => response['id']
-        }
+        [response['id'], response['paymentToken']].join('|')
       end
 
       def error_from(response)
@@ -301,56 +363,6 @@ module ActiveMerchant #:nodoc:
 
       def post_data(params)
         params.to_json
-      end
-
-      def add_pos_data(options)
-        pos_options = {}
-        pos_options['panCaptureMethod'] = options[:pan_capture_method]
-
-        pos_options
-      end
-
-      def add_purchases_data(params, options)
-        return unless options[:purchases]
-
-        params['purchases'] = []
-        options[:purchases].each do |purchase|
-          purchases = {}
-
-          purchases['dateCreated'] = purchase[:date_created] if purchase[:date_created]
-          purchases['iId'] = purchase[:i_id] if purchase[:i_id]
-          purchases['transactionIId'] = purchase[:transaction_i_id] if purchase[:transaction_i_id]
-          purchases['transactionId'] = purchase[:transaction_id] if purchase[:transaction_id]
-          purchases['name'] = purchase[:name] if purchase[:name]
-          purchases['description'] = purchase[:description] if purchase[:description]
-          purchases['code'] = purchase[:code] if purchase[:code]
-          purchases['unitOfMeasure'] = purchase[:unit_of_measure] if purchase[:unit_of_measure]
-          purchases['unitPrice'] = purchase[:unit_price] if purchase[:unit_price]
-          purchases['quantity'] = purchase[:quantity] if purchase[:quantity]
-          purchases['taxRate'] = purchase[:tax_rate] if purchase[:tax_rate]
-          purchases['taxAmount'] = purchase[:tax_amount] if purchase[:tax_amount]
-          purchases['discountRate'] = purchase[:discount_rate] if purchase[:discount_rate]
-          purchases['discountAmount'] = purchase[:discount_amt] if purchase[:discount_amt]
-          purchases['extendedAmount'] = purchase[:extended_amt] if purchase[:extended_amt]
-          purchases['lineItemId'] = purchase[:line_item_id] if purchase[:line_item_id]
-          params['purchases'].append(purchases)
-        end
-      end
-
-      def add_risk_data(options)
-        risk = {}
-        risk['cvvResponseCode'] = options[:cvv_response_code]
-        risk['cvvResponse'] = options[:cvv_response]
-        risk['cvvMatch'] = options[:cvv_match]
-        risk['avsResponse'] = options[:avs_response]
-        risk['avsAddressMatch'] = options[:avs_address_match]
-        risk['avsZipMatch'] = options[:avs_zip_match]
-
-        risk
-      end
-
-      def get_hash(string)
-        JSON.parse(string.gsub('=>', ':'))
       end
     end
   end

--- a/test/remote/gateways/remote_priority_test.rb
+++ b/test/remote/gateways/remote_priority_test.rb
@@ -2,323 +2,268 @@ require 'test_helper'
 
 class RemotePriorityTest < Test::Unit::TestCase
   def setup
-    # Consumer API Key: Generated in MX Merchant for specific test merchant
-    # Consumer API Secret:= Generated in MX Merchant for specific test merchant
-
-    # run command below to run tests in debug (byebug)
-    # byebug -Itest test/unit/gateways/card_stream_test.rb
-    #
-    # bundle exec rake test:remote TEST=test/remote/gateways/remote_priority_test.rb
-    # ruby -Itest test/unit/gateways/priority_test.rb -n test_successful_void
-
-    # Run specific remote test
-    # ruby -Itest test/remote/gateways/remote_priority_test.rb -n test_fail_refund_already_refunded_purchase_response
-
     @gateway = PriorityGateway.new(fixtures(:priority))
 
-    # purchase params success
-    @amount_purchase = 2
-    @credit_card = credit_card('4111111111111111', month: '01', year: '2029', first_name: 'Marcus', last_name: 'Rashford', verification_value: '999')
-    @invalid_credit_card = credit_card('123456', month: '01', year: '2029', first_name: 'Marcus', last_name: 'Rashford', verification_value: '999')
-    @faulty_credit_card = credit_card('12345', month: '01', year: '2029', first_name: 'Marcus', last_name: 'Rashford', verification_value: '999')
-    @replay_id = rand(100...1000)
+    @amount = 2
+    @credit_card = credit_card
+    @invalid_credit_card = credit_card('123456')
+    @replay_id = rand(100...99999999)
+    @options = { billing_address: address }
 
-    @option_spr = {
-      billing_address: address(),
-      invoice: '666',
-      card_present: 'false',
-      card_present_type: 'CardNotPresent',
-      is_auth: 'false',
-      payment_type: 'Sale',
-      bank_account: '',
-      should_vault_card: 'false',
-      tax_exempt: 'false',
-      tender_type: 'Card',
-      ship_amount: 0.01,
-      ship_to_country: 'USA',
-      ship_to_zip: '55667',
-      purchases: [
-        {
-          line_item_id: 79402,
-          name: 'Anita',
-          description: 'Dump',
-          quantity: 1,
-          unit_price: '1.23',
-          discount_amt: 0,
-          extended_amt: '1.23',
-          discount_rate: 0
-        },
-        {
-          line_item_id: 79403,
-          name: 'Old Peculier',
-          description: 'Beer',
-          quantity: 1,
-          unit_price: '2.34',
-          discount_amt: 0,
-          extended_amt: '2.34',
-          discount_rate: 0
-        }
-      ],
-      code: '101',
-      tax_rate: '05',
-      tax_amount: '0.50',
+    @additional_options = {
+      is_auth: false,
+      should_get_credit_card_level: true,
+      should_vault_card: false,
+      invoice: '123',
+      tax_exempt: true
+    }
+
+    @custom_pos_data = {
       pos_data: {
-        cardholder_presence: 'Ecom',
-        device_attendance: 'HomePc',
-        device_input_capability: 'Unknown',
-        device_location: 'HomePc',
+        cardholder_presence: 'NotPresent',
+        device_attendance: 'Unknown',
+        device_input_capability: 'KeyedOnly',
+        device_location: 'Unknown',
         pan_capture_method: 'Manual',
-        partial_approval_support: 'NotSupported',
-        pin_capture_capability: 'Incapable'
+        partial_approval_support: 'Supported',
+        pin_capture_capability: 'Twelve'
       }
     }
 
-    # purchase params fail inavalid card number
-    @credit_card_purchase_fail_invalid_number = credit_card('4111', month: '01', year: '2029', first_name: 'Marcus', last_name: 'Rashford', verification_value: '999')
+    @purchases_data = {
+      purchases: [
+        {
+          line_item_id: 79402,
+          name: 'Book',
+          description: 'The Elements of Style',
+          quantity: 1,
+          unit_price: 1.23,
+          discount_amount: 0,
+          extended_amount: '1.23',
+          discount_rate: 0,
+          tax_amount: 1
+        },
+        {
+          line_item_id: 79403,
+          name: 'Cat Poster',
+          description: 'A sleeping cat',
+          quantity: 1,
+          unit_price: '2.34',
+          discount_amount: 0,
+          extended_amount: '2.34',
+          discount_rate: 0
+        }
+      ]
+    }
+  end
 
-    # purchase params fail missing card number month
-    @credit_card_purchase_fail_missing_month = credit_card('4111111111111111', month: '', year: '2029', first_name: 'Marcus', last_name: 'Rashford', verification_value: '999')
+  def test_successful_authorize
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved or completed successfully', response.message
+  end
 
-    # purchase params fail missing card verification number
-    @credit_card_purchase_fail_missing_verification = credit_card('4111111111111111', month: '01', year: '2029', first_name: 'Marcus', last_name: 'Rashford', verification_value: '')
-
-    # authorize params success
-    @amount_authorize = 799
-    # authorize params success end
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @invalid_credit_card, @options)
+    assert_failure response
+    assert_equal 'Invalid card number', response.message
   end
 
   def test_successful_purchase
-    response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr)
+    response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
-    assert_equal 'Approved', response.params['status']
+    assert_equal 'Approved or completed successfully', response.message
   end
 
-  # Invalid card number
   def test_failed_purchase
-    response = @gateway.purchase(@amount_purchase, @credit_card_purchase_fail_invalid_number, @option_spr)
+    response = @gateway.purchase(@amount, @invalid_credit_card, @options)
     assert_failure response
-
     assert_equal 'Invalid card number', response.message
-    assert_equal 'Declined', response.params['status']
   end
 
-  # Missing card number month
   def test_failed_purchase_missing_card_month
-    response = @gateway.purchase(@amount_purchase, @credit_card_purchase_fail_missing_month, @option_spr)
-    assert_failure response
+    card_without_month = credit_card('4242424242424242', month: '')
+    response = @gateway.purchase(@amount, card_without_month, @options)
 
+    assert_failure response
     assert_equal 'ValidationError', response.error_code
-    assert_equal 'Validation error happened', response.params['message']
     assert_equal 'Missing expiration month and / or year', response.message
   end
 
-  # Missing card verification number
   def test_failed_purchase_missing_card_verification_number
-    response = @gateway.purchase(@amount_purchase, @credit_card_purchase_fail_missing_verification, @option_spr)
-    assert_failure response
+    card_without_cvv = credit_card('4242424242424242', verification_value: '')
+    response = @gateway.purchase(@amount, card_without_cvv, @options)
 
+    assert_failure response
     assert_equal 'CVV is required based on merchant fraud settings', response.message
-    assert_equal 'Declined', response.params['status']
   end
 
-  # Authorize tests
-  def test_successful_authorize
-    response = @gateway.authorize(@amount_purchase, @credit_card, @option_spr)
-    assert_success response
-    assert_equal 'Approved', response.params['status']
-  end
+  def test_successful_authorize_and_capture
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
 
-  # Invalid card number
-  def test_failed_authorize
-    response = @gateway.authorize(@amount_purchase, @credit_card_purchase_fail_invalid_number, @option_spr)
-    assert_failure response
-
-    assert_equal 'Invalid card number', response.message
-    assert_equal 'Declined', response.params['status']
-  end
-
-  # Missing card number month
-  def test_failed_authorize_missing_card_month
-    response = @gateway.authorize(@amount_purchase, @credit_card_purchase_fail_missing_month, @option_spr)
-    assert_failure response
-
-    assert_equal 'ValidationError', response.error_code
-    assert_equal 'Validation error happened', response.params['message']
-    assert_equal 'Missing expiration month and / or year', response.message
-  end
-
-  # Missing card verification number
-  def test_failed_authorize_missing_card_verification_number
-    response = @gateway.authorize(@amount_purchase, @credit_card_purchase_fail_missing_verification, @option_spr)
-    assert_failure response
-
-    assert_equal 'CVV is required based on merchant fraud settings', response.message
-    assert_equal 'Declined', response.params['status']
-  end
-
-  # Capture tests
-  def test_successful_capture
-    auth_obj = @gateway.authorize(@amount_authorize, @credit_card, @option_spr)
-    assert_success auth_obj
-    # add auth code to options
-    @option_spr.update(auth_code: auth_obj.params['authCode'])
-
-    capture = @gateway.capture(@amount_authorize, auth_obj.authorization.to_s, @option_spr)
+    capture = @gateway.capture(@amount, auth.authorization, @options)
     assert_success capture
     assert_equal 'Approved', capture.message
-    assert_equal 'Approved', capture.params['status']
   end
 
-  # Invalid authorization and null auth code
   def test_failed_capture
-    # add auth code to options
-    @option_spr.update(auth_code: '12345')
-    capture = @gateway.capture(@amount_authorize, { 'payment_token' => 'bogus' }.to_s, @option_spr)
+    capture = @gateway.capture(@amount, 'bogus_authorization', @options)
     assert_failure capture
-
     assert_equal 'Original Transaction Not Found', capture.message
-    assert_equal 'Declined', capture.params['status']
   end
 
-  # Void tests
-  # Batch status is by default is set to Open when Sale transaction is created
-  def test_successful_void_batch_open
-    response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr)
+  def test_successful_purchase_with_shipping_data
+    options_with_shipping = @options.merge({ ship_to_country: 'USA', ship_to_zip: 27703, ship_amount: 0.01 })
+    response = @gateway.purchase(@amount, @credit_card, options_with_shipping)
+
     assert_success response
+    assert_equal 'Approved or completed successfully', response.message
+  end
 
-    batch_check = @gateway.get_payment_status(response.params['batchId'], @option_spr)
-    assert_equal batch_check.params['status'], 'Open'
+  def test_successful_purchase_with_purchases_data
+    options_with_purchases = @options.merge(@purchases_data)
+    response = @gateway.purchase(@amount, @credit_card, options_with_purchases)
 
-    void = @gateway.void({ 'id' => response.params['id'] }.to_s, @option_spr)
+    assert_success response
+    assert_equal response.params['purchases'].first['name'], @purchases_data[:purchases].first[:name]
+    assert_equal response.params['purchases'].last['name'], @purchases_data[:purchases].last[:name]
+    assert_equal 'Approved or completed successfully', response.message
+  end
+
+  def test_successful_purchase_with_custom_pos_data
+    options_with_custom_pos_data = @options.merge(@custom_pos_data)
+    response = @gateway.purchase(@amount, @credit_card, options_with_custom_pos_data)
+
+    assert_success response
+    assert_equal 'Approved or completed successfully', response.message
+  end
+
+  def test_successful_purchase_with_additional_options
+    options = @options.merge(@additional_options)
+    response = @gateway.purchase(@amount, @credit_card, options)
+
+    assert_success response
+    assert_equal 'Approved or completed successfully', response.message
+  end
+
+  def test_successful_void_with_batch_open
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    # Batch status is by default is set to Open when Sale transaction is created
+    batch_check = @gateway.get_payment_status(purchase.params['batchId'])
+    assert_equal 'Open', batch_check.message
+
+    void = @gateway.void(purchase.authorization, @options)
     assert_success void
+    assert_equal 'Success', void.message
+  end
+
+  def test_successful_void_after_closing_batch
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    # Manually close open batch; resulting status should be 'Pending'
+    @gateway.close_batch(purchase.params['batchId'])
+    payment_status = @gateway.get_payment_status(purchase.params['batchId'])
+    assert_equal 'Pending', payment_status.message
+
+    void = @gateway.void(purchase.authorization, @options)
+    assert_success void
+    assert_equal 'Success', void.message
   end
 
   def test_failed_void
-    assert void = @gateway.void({ 'id' => 123456 }.to_s, @option_spr)
+    bogus_transaction_id = '123456'
+    assert void = @gateway.void(bogus_transaction_id, @options)
+
     assert_failure void
     assert_equal 'Unauthorized', void.error_code
     assert_equal 'Original Payment Not Found Or You Do Not Have Access.', void.message
   end
 
-  def test_success_get_payment_status
-    response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr)
+  def test_successful_refund_with_open_batch
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    batch_check = @gateway.get_payment_status(purchase.params['batchId'])
+    assert_equal 'Open', batch_check.message
+
+    refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'Approved or completed successfully', refund.message
+  end
+
+  def test_successful_refund_after_closing_batch
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    # Manually close open batch; resulting status should be 'Pending'
+    @gateway.close_batch(purchase.params['batchId'])
+    payment_status = @gateway.get_payment_status(purchase.params['batchId'])
+    assert_equal 'Pending', payment_status.message
+
+    refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'Approved or completed successfully', refund.message
+  end
+
+  def test_successful_get_payment_status
+    response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
 
-    # check is this transaction associated batch is "Closed".
-    batch_check = @gateway.get_payment_status(response.params['batchId'], @option_spr)
+    batch_check = @gateway.get_payment_status(response.params['batchId'])
 
     assert_success batch_check
-    assert_equal 'Open', batch_check.params['status']
+    assert_equal 'Open', batch_check.message
   end
 
   def test_failed_get_payment_status
-    # check is this transaction associated batch is "Closed".
-    batch_check = @gateway.get_payment_status(123456, @option_spr)
+    batch_check = @gateway.get_payment_status(123456)
 
     assert_failure batch_check
     assert_equal 'Invalid JSON response', batch_check.params['message'][0..20]
   end
 
-  # Must enter 6 to 10 numbers from start of card to test
   def test_successful_verify
-    # Generate jwt token from key and secret. Pass generated jwt to verify function. The verify function requires a jwt for header authorization.
-    jwt_response = @gateway.create_jwt(@option_spr)
-    response = @gateway.verify(@credit_card, { jwt_token: jwt_response.params['jwtToken'] })
+    response = @gateway.verify(credit_card('411111111111111'))
     assert_success response
     assert_match 'JPMORGAN CHASE BANK, N.A.', response.params['bank']['name']
   end
 
-  # Must enter 6 to 10 numbers from start of card to test
   def test_failed_verify
-    # Generate jwt token from key and secret. Pass generated jwt to verify function. The verify function requires a jwt for header authorization.
-    jwt_response = @gateway.create_jwt(@option_spr)
-    @gateway.verify(@invalid_credit_card, { jwt_token: jwt_response.params['jwtToken'] })
-  rescue StandardError => e
-    if e.to_s.include? 'No bank information found for bin number'
-      response = { 'error' => 'No bank information found for bin number' }
-      assert_match 'No bank information found for bin number', response['error']
-    else
-      assert_match 'No bank information found for bin number', 'error'
-    end
-  end
-
-  def test_failed_verify_must_be_6_to_10_digits
-    # Generate jwt token from key and secret. Pass generated jwt to verify function. The verify function requires a jwt for header authorization.
-    jwt_response = @gateway.create_jwt(@option_spr)
-    @gateway.verify(@faulty_credit_card, { jwt_token: jwt_response.params['jwtToken'] })
-  rescue StandardError => e
-    if e.to_s.include? 'Invalid bank bin number, must be 6-10 digits'
-      response = { 'error' => 'Invalid bank bin number, must be 6-10 digits' }
-      assert_match 'Invalid bank bin number, must be 6-10 digits', response['error']
-    else
-      assert_match 'Invalid bank bin number, must be 6-10 digits', 'error'
-    end
+    response = @gateway.verify(@invalid_credit_card)
+    assert_failure response
+    assert_match 'No bank information found for bin number', response.message
   end
 
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
-      @gateway.purchase(@amount_purchase, @credit_card, @option_spr)
+      @gateway.purchase(@amount, @credit_card, @options)
     end
     clean_transcript = @gateway.scrub(transcript)
     assert_scrubbed(@credit_card.number, clean_transcript)
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
   end
 
-  # Refund tests
-  # Test if we can perform a refund by following steps. This is the happy path.
-  #   1. Create Sale/Purchase
-  #   2. Test if linked batch is Open
-  #   3. Close linked batch with Sale/Purchase transaction
-  #   4. Perform Refund
-  def test_successful_refund_and_batch_closed
-    response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr)
-    assert_success response
-
-    batch_check = @gateway.get_payment_status(response.params['batchId'], @option_spr)
-    assert_equal batch_check.params['status'], 'Open'
-
-    @gateway.close_batch(response.params['batchId'], @option_spr)
-    refund_params = @option_spr.merge(response.params).deep_transform_keys { |key| key.to_s.underscore }.transform_keys(&:to_sym)
-
-    refund = @gateway.refund(response.params['amount'].to_f * 100, response.authorization.to_s, refund_params)
-    assert_success refund
-    assert refund.params['status'] == 'Approved'
-    assert_equal 'Approved or completed successfully', refund.message
-  end
-
-  def test_successful_batch_closed_and_void
-    response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr)
-    assert_success response
-    batch_check = @gateway.get_payment_status(response.params['batchId'], @option_spr)
-
-    @gateway.close_batch(response.params['batchId'], @option_spr) if batch_check.params['status'] == 'Open'
-
-    void = @gateway.void({ 'id' => response.params['id'] }.to_s, @option_spr)
-    assert void.params['code'] == '204'
-
-    payment_status = @gateway.get_payment_status(response.params['batchId'], @option_spr)
-    assert payment_status.params['status'] == 'Pending'
-  end
-
   def test_successful_purchase_with_duplicate_replay_id
-    response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr.merge(replay_id: @replay_id))
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(replay_id: @replay_id))
 
     assert_success response
     assert_equal @replay_id, response.params['replayId']
 
-    duplicate_response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr.merge(replay_id: response.params['replayId']))
+    duplicate_response = @gateway.purchase(@amount, @credit_card, @options.merge(replay_id: response.params['replayId']))
 
     assert_success duplicate_response
     assert_equal response.params['id'], duplicate_response.params['id']
   end
 
   def test_failed_purchase_with_duplicate_replay_id
-    response = @gateway.purchase(@amount_purchase, @credit_card_purchase_fail_invalid_number, @option_spr.merge(replay_id: @replay_id))
-
+    response = @gateway.purchase(@amount, @invalid_credit_card, @options.merge(replay_id: @replay_id))
     assert_failure response
 
-    duplicate_response = @gateway.purchase(@amount_purchase, @credit_card_purchase_fail_invalid_number, @option_spr.merge(replay_id: response.params['replayId']))
-
+    duplicate_response = @gateway.purchase(@amount, @invalid_credit_card, @options.merge(replay_id: response.params['replayId']))
     assert_failure duplicate_response
 
     assert_equal response.message, duplicate_response.message
@@ -328,44 +273,40 @@ class RemotePriorityTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_unique_replay_id
-    first_purchase_response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr.merge(replay_id: @replay_id))
+    first_purchase_response = @gateway.purchase(@amount, @credit_card, @options.merge(replay_id: @replay_id))
 
     assert_success first_purchase_response
     assert_equal @replay_id, first_purchase_response.params['replayId']
 
-    second_purchase_response = @gateway.purchase(@amount_purchase + 1, @credit_card, @option_spr.merge(replay_id: @replay_id + 1))
+    second_purchase_response = @gateway.purchase(@amount + 1, @credit_card, @options.merge(replay_id: @replay_id + 1))
 
     assert_success second_purchase_response
     assert_not_equal first_purchase_response.params['id'], second_purchase_response.params['id']
   end
 
   def test_failed_duplicate_refund
-    purchase_response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr)
+    purchase_response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase_response
 
-    refund_params = @option_spr.merge(purchase_response.params).deep_transform_keys { |key| key.to_s.underscore }.transform_keys(&:to_sym)
-
-    refund_response = @gateway.refund(purchase_response.params['amount'].to_f * 100, purchase_response.authorization.to_s, refund_params)
+    refund_response = @gateway.refund(@amount, purchase_response.authorization)
 
     assert_success refund_response
-    assert refund_response.params['status'] == 'Approved'
     assert_equal 'Approved or completed successfully', refund_response.message
 
-    duplicate_refund_response = @gateway.refund(purchase_response.params['amount'].to_f * 100, purchase_response.authorization.to_s, refund_params)
+    duplicate_refund_response = @gateway.refund(@amount, purchase_response.authorization)
 
     assert_failure duplicate_refund_response
-    assert duplicate_refund_response.params['status'] == 'Declined'
     assert_equal 'Payment already refunded', duplicate_refund_response.message
   end
 
   def test_failed_duplicate_void
-    response = @gateway.purchase(@amount_purchase, @credit_card, @option_spr)
-    assert_success response
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
 
-    void = @gateway.void({ 'id' => response.params['id'] }.to_s, @option_spr)
+    void = @gateway.void(purchase.authorization)
     assert_success void
 
-    duplicate_void = @gateway.void({ 'id' => response.params['id'] }.to_s, @option_spr)
+    duplicate_void = @gateway.void(purchase.authorization)
 
     assert_failure duplicate_void
     assert_equal 'Payment already voided.', duplicate_void.message

--- a/test/unit/gateways/priority_test.rb
+++ b/test/unit/gateways/priority_test.rb
@@ -3,194 +3,55 @@ class PriorityTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    # run command below to run tests in debug (byebug)
-    # byebug -Itest test/unit/gateways/priority_test.rb
-
     @gateway = PriorityGateway.new(key: 'sandbox_key', secret: 'secret', merchant_id: 'merchant_id')
-
-    # purchase params success
-    @amount_purchase = 4
-    @credit_card = credit_card('4111111111111111', month: '01', year: '2029', first_name: 'Marcus', last_name: 'Rashford', verification_value: '123')
+    @amount = 4
+    @credit_card = credit_card
+    @invalid_credit_card = credit_card('4111')
     @replay_id = rand(100...1000)
-
-    # Note the 'avsStreet' and 'avsZip' are the values obtained from credit card input on MX Merchant
-    @option_spr = {
-      billing_address: address(),
-      invoice: '666',
-      card_present: false,
-      card_present_type: 'CardNotPresent',
-      is_auth: false,
-      payment_type: 'Sale',
-      bank_account: '',
-      should_vault_card: false,
-      tax_exempt: false,
-      tender_type: 'Card',
-      ship_amount: 0.01,
-      ship_to_country: 'USA',
-      ship_to_zip: '55667',
-      purchases: [
-        {
-          line_item_id: 79402,
-          name: 'Anita',
-          description: 'Dump',
-          quantity: 1,
-          unit_price: '1.23',
-          discount_amount: 0,
-          extended_amount: '1.23',
-          discount_rate: 0
-        },
-        {
-          line_item_id: 79403,
-          name: 'Old Peculier',
-          description: 'Beer',
-          quantity: 1,
-          unit_price: '2.34',
-          discount_amount: 0,
-          extended_amount: '2.34',
-          discount_rate: 0
-        }
-      ],
-      code: '101',
-      tax_rate: '05',
-      tax_amount: '0.50',
-      pos_data: {
-        cardholder_presence: 'Ecom',
-        device_attendance: 'HomePc',
-        device_input_capability: 'Unknown',
-        device_location: 'HomePc',
-        pan_capture_method: 'Manual',
-        partial_approval_support: 'NotSupported',
-        pin_capture_capability: 'Incapable'
-      }
-    }
-
-    # purchase params fail
-    @invalid_credit_card = credit_card('4111', month: '01', year: '2029', first_name: 'Marcus', last_name: 'Rashford', verification_value: '123')
-    # purchase params fail end
-
-    # authorize params success
-    @amount_authorize = 799
-
-    setup_options_hashes
-  end
-
-  def setup_options_hashes
-    # Options  - A standard ActiveMerchant options hash:
-    @options = {
-      card_present: false,
-      client_ref: 'PTHER000IKZK',
-      created: '2021-07-01T19:01:57.69Z',
-      creator_name: 'Mike Saylor',
-      currency: 'USD',
-      customer_code: 'PTHER000IKZK',
-      invoice: 'R000IKZK',
-      is_duplicate: false,
-      merchant_id: @gateway.options[:merchant_id],
-      payment_token: 'P6NyKC5UfmZjgAlF3ZEd3YSaJG9qKT6E',
-      card_type: 'Visa',
-      entry_mode: 'Keyed',
-      last_4: '9898',
-      card_id: 'y15QvOteHZGBm7LH3GNIlTWbA1If',
-      token: 'P3hhDiddFRFTlsa8xmv7LHBGK9aI70UR',
-      has_contract: false,
-      is_debit: false,
-      is_corp: false,
-
-      pos_data: { pan_capture_method: 'Manual' },
-
-      risk: {
-        avs_address_match: false,
-        avs_response: 'No Response from AVS',
-        avs_zip_match: false,
-        cvv_match: true,
-        cvv_response: 'Match',
-        cvv_response_code: 'M'
-      },
-
-      purchases: [
-        {
-          code: 'MISC',
-          date_created: '0001-01-01T00:00:00',
-          description: 'Miscellaneous',
-          discount_amt: '0',
-          discount_rate: '0',
-          extended_amt: '9.51',
-          i_id: '11036546',
-          line_item_id: 0,
-          name: 'Miscellaneous',
-          quantity: '1',
-          tax_amount: '0.2',
-          tax_rate: '0.01',
-          transaction_i_id: 0,
-          transaction_id: '10000001610620',
-          unit_of_measure: 'EA',
-          unit_price: '1.51'
-        }
-      ],
-
-      reference: '118819000095',
-      replayId: nil,
-      require_signature: false,
-      review_indicator: nil,
-
-      settled_amt: '0',
-      settled_currency: 'USD',
-      settled_date: '2021-07-01T19:02:21.553',
-      ship_to_country: 'USA',
-      should_get_credit_card_level: true,
-      source: 'Tester1',
-      source_zip: '94102',
-      status: 'Settled',
-      tax: '0.12',
-      tax_exempt: false,
-      tender_type: 'Card',
-      type: 'Sale'
-    }
+    @approval_message = 'Approved or completed successfully. '
+    @options = { billing_address: address }
   end
 
   def test_successful_purchase
     response = stub_comms do
-      @gateway.purchase(@amount_purchase, @credit_card, @option_spr)
+      @gateway.purchase(@amount, @credit_card, @options)
     end.respond_with(successful_purchase_response)
 
     assert_success response
-    assert_equal 'Approved', response.params['status']
+    assert_equal @approval_message, response.message
     assert_equal 'Sale', response.params['type']
-
     assert response.test?
   end
 
-  def test_failed_purchase_invalid_creditcard
+  def test_failed_purchase_invalid_credit_card
     response = stub_comms do
-      @gateway.purchase(@amount_purchase, @invalid_credit_card, @option_spr)
+      @gateway.purchase(@amount, @invalid_credit_card, @options)
     end.respond_with(failed_purchase_response)
 
     assert_failure response
-    assert_equal 'Declined', response.params['status']
-
+    assert_equal 'Declined', response.error_code
     assert_equal 'Invalid card number', response.message
     assert response.test?
   end
 
   def test_successful_authorize
     response = stub_comms do
-      @gateway.authorize(333, @credit_card, @option_spr)
+      @gateway.authorize(333, @credit_card, @options)
     end.respond_with(successful_authorize_response)
+
     assert_success response
-    assert_equal 'Approved', response.params['status']
-    assert_equal 'Approved or completed successfully. ', response.message
+    assert_equal @approval_message, response.message
     assert_equal 'Authorization', response.params['type']
     assert response.test?
   end
 
-  def test_failed_authorize_invalid_creditcard
+  def test_failed_authorize_invalid_credit_card
     response = stub_comms do
-      @gateway.purchase(@amount_purchase, @invalid_credit_card, @option_spr)
+      @gateway.purchase(@amount, @invalid_credit_card, @options)
     end.respond_with(failed_authorize_response)
 
     assert_failure response
     assert_equal 'Declined', response.error_code
-
     assert_equal 'Invalid card number', response.message
     assert_equal 'Authorization', response.params['type']
     assert response.test?
@@ -198,74 +59,153 @@ class PriorityTest < Test::Unit::TestCase
 
   def test_successful_capture
     response = stub_comms do
-      @gateway.capture(@amount_authorize, { 'payment_token' => 'authobj' }.to_s, @option_spr)
+      @gateway.capture(@amount, '10000001625060|PaQLIYLRdWtcFKl5VaKTdUVxMutXJ5Ru', @options)
     end.respond_with(successful_capture_response)
+
     assert_success response
     assert_equal 'Approved', response.message
-    assert_equal 'PaQLIYLRdWtcFKl5VaKTdUVxMutXJ5Ru', response.authorization['payment_token']
+    assert_equal '10000001625061|PaQLIYLRdWtcFKl5VaKTdUVxMutXJ5Ru', response.authorization
   end
 
   def test_failed_capture
     response = stub_comms do
-      @gateway.capture(@amount_authorize, { 'payment_token' => 'bogus' }.to_s, jwt: {})
+      @gateway.capture(@amount, 'bogus_authorization', @options)
     end.respond_with(failed_capture_response)
+
     assert_failure response
-    assert_equal 'merchantId required', response.message
+    assert_equal 'Declined', response.error_code
+    assert_equal 'Original Transaction Not Found', response.message
     assert_equal nil, response.authorization
   end
 
   def test_failed_void
     @gateway.expects(:ssl_request).returns(failed_void_response)
 
-    response = @gateway.void({ 'id' => 123456 }.to_s)
+    response = @gateway.void('bogus authorization')
     assert_failure response
     assert_equal 'Unauthorized', response.error_code
     assert_equal 'Original Payment Not Found Or You Do Not Have Access.', response.message
   end
 
   def test_successful_refund
-    authorization = '{"payment_token"=>"PTp2WxLTXEP9Ml4DfDzTAbDWRaEFLKEM", "id"=>86044396}'
-
+    authorization = '86044396|PTp2WxLTXEP9Ml4DfDzTAbDWRaEFLKEM'
     response = stub_comms do
       @gateway.refund(544, authorization, @options)
     end.respond_with(successful_refund_response)
+
     assert_success response
-    assert_equal 'Approved', response.params['status']
-    assert_equal 'Approved or completed successfully. ', response.message
+    assert_equal @approval_message, response.message
     assert response.test?
   end
 
-  # Payment already refunded
-  def test_failed_refund_purchase_response
-    authorization = '{"payment_token"=>"PTp2WxLTXEP9Ml4DfDzTAbDWRaEFLKEM", "id"=>86044396}'
+  def test_failed_duplicate_refund
+    authorization = '86044396|PTp2WxLTXEP9Ml4DfDzTAbDWRaEFLKEM'
     response = stub_comms do
       @gateway.refund(544, authorization, @options)
-    end.respond_with(failed_refund_purchase_response)
+    end.respond_with(failed_duplicate_refund)
+
     assert_failure response
     assert_equal 'Declined', response.error_code
     assert_equal 'Payment already refunded', response.message
     assert response.test?
   end
 
-  def test_get_payment_status
-    # check is this transaction associated batch is "Closed".
-    @gateway.expects(:ssl_request).returns('')
+  def test_failed_get_payment_status
+    @gateway.expects(:ssl_get).returns('Not Found')
 
-    batch_check = @gateway.get_payment_status(123456, @option_spr)
+    batch_check = @gateway.get_payment_status(123456)
+
     assert_failure batch_check
-    assert_equal 'Invalid JSON response', batch_check.params['message'][0..20]
+    assert_includes batch_check.message, 'Invalid JSON response'
+    assert_includes batch_check.message, 'Not Found'
+  end
+
+  def test_purchase_passes_shipping_data
+    options_with_shipping = @options.merge({ ship_to_country: 'USA', ship_to_zip: 27703, ship_amount: 0.01 })
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_shipping)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/shipAmount\":0.01/, data)
+      assert_match(/shipToZip\":27703/, data)
+      assert_match(/shipToCountry\":\"USA/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_purchase_passes_purchases_data
+    purchases_data = {
+      purchases: [
+        {
+          line_item_id: 79402,
+          name: 'Book',
+          description: 'The Elements of Style',
+          quantity: 1,
+          unit_price: 1.23,
+          discount_amount: 0,
+          extended_amount: '1.23',
+          discount_rate: 0,
+          tax_amount: 1
+        }
+      ]
+    }
+    options_with_purchases = @options.merge(purchases_data)
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_purchases)
+    end.check_request do |_endpoint, data, _headers|
+      purchase_item = purchases_data[:purchases].first
+      purchase_object = JSON.parse(data)['purchases'].first
+
+      assert_equal(purchase_item[:name], purchase_object['name'])
+      assert_equal(purchase_item[:description], purchase_object['description'])
+      assert_equal(purchase_item[:unit_price], purchase_object['unitPrice'])
+      assert_equal(purchase_item[:quantity], purchase_object['quantity'])
+      assert_equal(purchase_item[:tax_amount], purchase_object['taxAmount'])
+      assert_equal(purchase_item[:discount_rate], purchase_object['discountRate'])
+      assert_equal(purchase_item[:discount_amount], purchase_object['discountAmount'])
+      assert_equal(purchase_item[:extended_amount], purchase_object['extendedAmount'])
+      assert_equal(purchase_item[:line_item_id], purchase_object['lineItemId'])
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_purchase_passes_pos_data
+    custom_pos_data = {
+      pos_data: {
+        cardholder_presence: 'NotPresent',
+        device_attendance: 'Unknown',
+        device_input_capability: 'KeyedOnly',
+        device_location: 'Unknown',
+        pan_capture_method: 'Manual',
+        partial_approval_support: 'Supported',
+        pin_capture_capability: 'Twelve'
+      }
+    }
+    options_with_custom_pos_data = @options.merge(custom_pos_data)
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_custom_pos_data)
+    end.check_request do |_endpoint, data, _headers|
+      pos_data_object = JSON.parse(data)['posData']
+      assert_equal(custom_pos_data[:pos_data][:cardholder_presence], pos_data_object['cardholderPresence'])
+      assert_equal(custom_pos_data[:pos_data][:device_attendance], pos_data_object['deviceAttendance'])
+      assert_equal(custom_pos_data[:pos_data][:device_input_capability], pos_data_object['deviceInputCapability'])
+      assert_equal(custom_pos_data[:pos_data][:device_location], pos_data_object['deviceLocation'])
+      assert_equal(custom_pos_data[:pos_data][:pan_capture_method], pos_data_object['panCaptureMethod'])
+      assert_equal(custom_pos_data[:pos_data][:partial_approval_support], pos_data_object['partialApprovalSupport'])
+      assert_equal(custom_pos_data[:pos_data][:pin_capture_capability], pos_data_object['pinCaptureCapability'])
+    end.respond_with(successful_purchase_response)
   end
 
   def test_successful_purchase_with_duplicate_replay_id
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @option_spr.merge(replay_id: @replay_id))
+      @gateway.purchase(@amount, @credit_card, @options.merge(replay_id: @replay_id))
     end.check_request do |_endpoint, data, _headers|
       assert_equal @replay_id, JSON.parse(data)['replayId']
     end.respond_with(successful_purchase_response_with_replay_id)
     assert_success response
 
     duplicate_response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @option_spr.merge(replay_id: response.params['replayId']))
+      @gateway.purchase(@amount, @credit_card, @options.merge(replay_id: response.params['replayId']))
     end.check_request do |_endpoint, data, _headers|
       assert_equal response.params['replayId'], JSON.parse(data)['replayId']
     end.respond_with(successful_purchase_response_with_replay_id)
@@ -276,12 +216,12 @@ class PriorityTest < Test::Unit::TestCase
 
   def test_failed_purchase_with_duplicate_replay_id
     response = stub_comms do
-      @gateway.purchase(@amount_purchase, @invalid_credit_card, @option_spr.merge(replay_id: @replay_id))
+      @gateway.purchase(@amount, @invalid_credit_card, @options.merge(replay_id: @replay_id))
     end.respond_with(failed_purchase_response_with_replay_id)
     assert_failure response
 
     duplicate_response = stub_comms do
-      @gateway.purchase(@amount_purchase, @invalid_credit_card, @option_spr.merge(replay_id: response.params['replayId']))
+      @gateway.purchase(@amount, @invalid_credit_card, @options.merge(replay_id: response.params['replayId']))
     end.respond_with(failed_purchase_response_with_replay_id)
     assert_failure duplicate_response
 
@@ -989,14 +929,7 @@ class PriorityTest < Test::Unit::TestCase
 
   def failed_capture_response
     %(
-      {
-        "errorCode": "ValidationError",
-        "message": "Validation error happened",
-        "details": [
-            "merchantId required"
-        ],
-        "responseCode": "eENKmhrToV9UYxsXAh7iGAQ"
-    }
+      {"created":"2022-04-06T16:54:08.9Z","paymentToken":"PHubmbgcqEPVUI2HmOAr2sF7Vl33MnuJ","id":86777943,"creatorName":"API Key","isDuplicate":false,"merchantId":12345678,"batch":"0028","batchId":10000000272426,"tenderType":"Card","currency":"USD","amount":"0.02","cardAccount":{"token":"PHubmbgcqEPVUI2HmOAr2sF7Vl33MnuJ","hasContract":false,"cardPresent":false},"posData":{"panCaptureMethod":"Manual"},"authOnly":false,"status":"Declined","risk":{},"requireSignature":false,"settledAmount":"0","settledCurrency":"USD","cardPresent":false,"authMessage":"Original Transaction Not Found","availableAuthAmount":"0","reference":"209616004816","type":"Sale","source":"API","shouldGetCreditCardLevel":false}
     )
   end
 
@@ -1082,7 +1015,7 @@ class PriorityTest < Test::Unit::TestCase
     )
   end
 
-  def failed_refund_purchase_response
+  def failed_duplicate_refund
     %(
       {
         "created": "2021-07-27T04:35:58.397Z",


### PR DESCRIPTION
CE-2491

This PR makes significant adjustments to the Priority gateway integration.

I will describe some of the changes below, but I also want to note two areas that warrant additional investigation:
1. the`verify` action and its dependency `create_jwt`. These methods are using the gateway's BIN lookup service, which is not a standard approach to verifying a card.
2. the `get_payment_status` and `close_batch` actions. It's not clear why these actions were implemented, as they are currently being used exclusively to manipulate transactions within the test cases. A merchant going through Spreedly would have no way to take advantage of these actions.

I will open some new tickets to investigate these two areas.

 The changes made in this PR include:
* The  `pos_data` object has been extracted to its own method and is now added line-by-line to the request
* The various `shipping_data` fields have their own method now.
* The `verify` method, as well as the auxiliary `get_payment_status`, `close_batch`, and `create_jwt` methods, have been simplified to conform to Active Merchant standards.
* The `authorization_from` method has been updated to conform to Active Merchant standards. Instead of returning a ruby hash it now returns a string of format `"<request_id>|<payment_token>"`
* Handling of gateway responses has been refactored
* Substantial changes were made to the test files. Instead of including every option in every test case, we are now including the minimum options required to test the behavior in question.
* There were multiple remote tests which rescued a runtime error, meaning that the transaction being tested would cause an uncaught error in production. The behavior under test has been corrected and tests that rescue errors have been reworked or removed.
* Test coverage has been added for fields whose presence were not previously tested.

In addition to the above changes, the following fields were removed from requests to the gateway, because they are either not mentioned in the gateway documentation, not necessary for the request, or else described as gateway response fields (meaning that they do not belong in the request):
* `authCode`
* `cardAccount.code`
* `cardAccount.taxRate`
* `cardAccount.entryMode`
* `cardAccount.cardId`
* `cardAccount.hasContract`
* `cardAccount.isCorp`
* `cardAccount.isDebit`
* `cardAccount.token`
* `cardPresent`
* `cardPresentType`
* `isTicket`
* `mxAdvantageEnabled`
* `sourceZip`
* `purchases.dateCreated`
* `purchases.iId`
* `purchases.transactionIId`
* `purchases.transactionId`

The following fields were removed from the gateway adapter because they were actually dead code, meaning they were never even added to requests in the first place (from the `add_risk_data` method):
* `cvvResponseCode`
* `cvvResponse`
* `cvvMatch`
* `avsResponse`
* `avsAddressMatch`
* `avsZipMatch`

The following fields were removed from requests to the gateway because they were not correctly implemented according to the gateway's documentation and they represent features that are currently not supported by Spreedly's integration with the gateway:
* `shouldVaultCard`

---

Rubocop:
739 files inspected, no offenses detected

Unit:
5147 tests, 75501 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_priority_test
27 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed