### PR TITLE
Credorax: Add `recipient` fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,7 @@
 * Airwallex: QA fixes for address and create_setup_intent handling [therufs] #4377
 * Airwallex: add `descriptor` field and update logic for sending `request_id` and `merchant_order_id` [dsmcclain] #4379
 * Visanet Peru: use timestamp instead of random for purchaseNumber [therufs] #4093
+* Credorax: add `recipient_street_address`, `recipient_city`, `recipient_province_code`, and `recipient_country_code` fields [ajawadmirza] #4384
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -193,6 +193,7 @@ module ActiveMerchant #:nodoc:
         add_submerchant_id(post, options)
         add_processor(post, options)
         add_email(post, options)
+        add_recipient(post, options)
 
         if options[:referral_cft]
           add_customer_name(post, options)
@@ -318,6 +319,15 @@ module ActiveMerchant #:nodoc:
 
       def add_email(post, options)
         post[:c3] = options[:email] || 'unspecified@example.com'
+      end
+
+      def add_recipient(post, options)
+        return unless options[:recipient_street_address] || options[:recipient_city] || options[:recipient_province_code] || options[:recipient_country_code]
+
+        post[:j6] = options[:recipient_street_address] if options[:recipient_street_address]
+        post[:j7] = options[:recipient_city] if options[:recipient_city]
+        post[:j8] = options[:recipient_province_code] if options[:recipient_province_code]
+        post[:j9] = options[:recipient_country_code] if options[:recipient_country_code]
       end
 
       def add_customer_name(post, options)

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -338,6 +338,22 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal 'Succeeded', refund.message
   end
 
+  def test_successful_refund_with_recipient_fields
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    refund_options = {
+      recipient_street_address: 'street',
+      recipient_city: 'chicago',
+      recipient_province_code: '312',
+      recipient_country_code: 'USA'
+    }
+
+    refund = @gateway.refund(@amount, response.authorization, refund_options)
+    assert_success refund
+    assert_equal 'Succeeded', refund.message
+  end
+
   def test_successful_refund_and_void
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -152,6 +152,25 @@ class CredoraxTest < Test::Unit::TestCase
     assert_equal 'Succeeded', refund.message
   end
 
+  def test_successful_refund_with_recipient_fields
+    refund_options = {
+      recipient_street_address: 'street',
+      recipient_city: 'chicago',
+      recipient_province_code: '312',
+      recipient_country_code: 'USA'
+    }
+    refund = stub_comms do
+      @gateway.refund(@amount, '123', refund_options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/j6=street/, data)
+      assert_match(/j7=chicago/, data)
+      assert_match(/j8=312/, data)
+      assert_match(/j9=USA/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
   def test_failed_refund
     response = stub_comms do
       @gateway.refund(nil, '')


### PR DESCRIPTION
Added `recipient_street_address`, `recipient_city`, `recipient_province_code`, and `recipient_country_code` fields to pass recipient information for refund operation.

CE-2500

Unit:
5148 tests, 75508 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
739 files inspected, no offenses detected

Remote:
46 tests, 157 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
86.9565% passed