### PR TITLE
Rapyd: Add `metadata` and `ewallet_id` options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,6 +65,7 @@
 * Orbital: add `verify_amount` field [ajawadmirza] #4376
 * Credorax: add `recipient_street_address`, `recipient_city`, `recipient_province_code`, and `recipient_country_code` fields [ajawadmirza] #4384
 * Airwallex: add support for stored credentials [drkjc] #4382
+* Rapyd: Add metadata and ewallet_id options [naashton] #4387
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -23,6 +23,8 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_payment(post, payment, options)
         add_address(post, payment, options)
+        add_metadata(post, options)
+        add_ewallet(post, options)
         post[:capture] = true if payment_is_card?(options)
 
         if payment_is_ach?(options)
@@ -43,6 +45,8 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_payment(post, payment, options)
         add_address(post, payment, options)
+        add_metadata(post, options)
+        add_ewallet(post, options)
         post[:capture] = false
         commit(:post, 'payments', post)
       end
@@ -56,6 +60,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:payment] = authorization
         add_invoice(post, money, options)
+        add_metadata(post, options)
         commit(:post, 'refunds', post)
       end
 
@@ -147,6 +152,14 @@ module ActiveMerchant #:nodoc:
         post[:payment_method][:fields][:routing_number] = payment.routing_number
         post[:payment_method][:fields][:account_number] = payment.account_number
         post[:payment_method][:fields][:payment_purpose] = options[:payment_purpose] if options[:payment_purpose]
+      end
+
+      def add_metadata(post, options)
+        post[:metadata] = options[:metadata] if options[:metadata]
+      end
+
+      def add_ewallet(post, options)
+        post[:ewallet_id] = options[:ewallet_id] if options[:ewallet_id]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -18,6 +18,22 @@ class RemoteRapydTest < Test::Unit::TestCase
       proof_of_authorization: false,
       payment_purpose: 'Testing Purpose'
     }
+    @metadata = {
+      'array_of_objects': [
+        { 'name': 'John Doe' },
+        { 'type': 'customer' }
+      ],
+      'array_of_strings': %w[
+        color
+        size
+      ],
+      'number': 1234567890,
+      'object': {
+        'string': 'person'
+      },
+      'string': 'preferred',
+      'Boolean': true
+    }
   end
 
   def test_successful_purchase
@@ -44,6 +60,13 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'SUCCESS', response.message
     assert_equal 'CLO', response.params['data']['status']
+  end
+
+  def test_successful_purchase_with_options
+    options = @options.merge(metadata: @metadata, ewallet_id: 'ewallet_1a867a32b47158b30a8c17d42f12f3f1')
+    response = @gateway.purchase(100000, @credit_card, options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
   end
 
   def test_failed_purchase
@@ -86,6 +109,15 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert_success purchase
 
     assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal 'SUCCESS', refund.message
+  end
+
+  def test_successful_refund_with_options
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @options.merge(metadata: @metadata))
     assert_success refund
     assert_equal 'SUCCESS', refund.message
   end

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -10,6 +10,25 @@ class RapydTest < Test::Unit::TestCase
       type: 'in_amex_card',
       currency: 'USD'
     }
+
+    @metadata = {
+      'array_of_objects': [
+        { 'name': 'John Doe' },
+        { 'type': 'customer' }
+      ],
+      'array_of_strings': %w[
+        color
+        size
+      ],
+      'number': 1234567890,
+      'object': {
+        'string': 'person'
+      },
+      'string': 'preferred',
+      'Boolean': true
+    }
+
+    @ewallet_id = 'ewallet_1a867a32b47158b30a8c17d42f12f3f1'
   end
 
   def test_successful_purchase
@@ -26,6 +45,14 @@ class RapydTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'ACT', response.params['data']['status']
+  end
+
+  def test_successful_purchase_with_options
+    @gateway.expects(:ssl_request).returns(successful_purchase_with_options_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(metadata: @metadata))
+    assert_success response
+    assert_equal @metadata, response.params['data']['metadata'].deep_transform_keys(&:to_sym)
   end
 
   def test_failed_purchase
@@ -187,6 +214,12 @@ class RapydTest < Test::Unit::TestCase
   def successful_purchase_response
     %(
       {"status":{"error_code":"","status":"SUCCESS","message":"","response_code":"","operation_id":"99571e34-f236-4f86-9040-5e0f256d6f64"},"data":{"id":"payment_716ce0efc63aa8d91579e873d29d9d5e","amount":1,"original_amount":1,"is_partial":false,"currency_code":"USD","country_code":"in","status":"CLO","description":"","merchant_reference_id":"","customer_token":"cus_f991c9a9f0cc7abdad64f9f7aea13f31","payment_method":"card_652d9fef3ec0089689fcaf0154340c64","payment_method_data":{"id":"card_652d9fef3ec0089689fcaf0154340c64","type":"in_amex_card","category":"card","metadata":null,"image":"","webhook_url":"","supporting_documentation":"","next_action":"not_applicable","name":"Ryan Reynolds","last4":"1111","acs_check":"unchecked","cvv_check":"unchecked","bin_details":{"type":null,"brand":null,"country":null,"bin_number":"411111"},"expiration_year":"35","expiration_month":"12","fingerprint_token":"ocfp_eb9edd24a3f3f59651aee0bd3d16201e"},"expiration":1648237659,"captured":true,"refunded":false,"refunded_amount":0,"receipt_email":"","redirect_url":"","complete_payment_url":"","error_payment_url":"","receipt_number":"","flow_type":"","address":null,"statement_descriptor":"N/A","transaction_id":"","created_at":1647632859,"metadata":{},"failure_code":"","failure_message":"","paid":true,"paid_at":1647632859,"dispute":null,"refunds":null,"order":null,"outcome":null,"visual_codes":{},"textual_codes":{},"instructions":{},"ewallet_id":"ewallet_1936682fdca7a188c49eb9f9817ade77","ewallets":[{"ewallet_id":"ewallet_1936682fdca7a188c49eb9f9817ade77","amount":1,"percent":100,"refunded_amount":0}],"payment_method_options":{},"payment_method_type":"in_amex_card","payment_method_type_category":"card","fx_rate":1,"merchant_requested_currency":null,"merchant_requested_amount":null,"fixed_side":"","payment_fees":null,"invoice":"","escrow":null,"group_payment":"","cancel_reason":null,"initiation_type":"customer_present","mid":"","next_action":"not_applicable","error_code":"","remitter_information":{}}}
+    )
+  end
+
+  def successful_purchase_with_options_response
+    %(
+      {"status":{"error_code":"", "status":"SUCCESS", "message":"", "response_code":"", "operation_id":"2852540b-ffa4-4547-9260-26f101f649ad"}, "data":{"id":"payment_6b00756cfefb0fdf6fb295fa507594d3", "amount":1000, "original_amount":1000, "is_partial":false, "currency_code":"USD", "country_code":"US", "status":"CLO", "description":"", "merchant_reference_id":"", "customer_token":"cus_9cb7908aec8a75a95846f1b3759ad1ef", "payment_method":"card_a838c23ef7be1ece86aa27a330167737", "payment_method_data":{"id":"card_a838c23ef7be1ece86aa27a330167737", "type":"us_visa_card", "category":"card", "metadata":null, "image":"", "webhook_url":"", "supporting_documentation":"", "next_action":"not_applicable", "name":"Ryan Reynolds", "last4":"1111", "acs_check":"unchecked", "cvv_check":"unchecked", "bin_details":{"type":null, "brand":null, "country":null, "bin_number":"411111"}, "expiration_year":"35", "expiration_month":"12", "fingerprint_token":"ocfp_eb9edd24a3f3f59651aee0bd3d16201e"}, "expiration":1649955834, "captured":true, "refunded":false, "refunded_amount":0, "receipt_email":"", "redirect_url":"", "complete_payment_url":"", "error_payment_url":"", "receipt_number":"", "flow_type":"", "address":null, "statement_descriptor":"N/A", "transaction_id":"", "created_at":1649351034, "metadata":{"number":1234567890, "object":{"string":"person"}, "string":"preferred", "Boolean":true, "array_of_objects":[{"name":"John Doe"}, {"type":"customer"}], "array_of_strings":["color", "size"]}, "failure_code":"", "failure_message":"", "paid":true, "paid_at":1649351034, "dispute":null, "refunds":null, "order":null, "outcome":null, "visual_codes":{}, "textual_codes":{}, "instructions":[], "ewallet_id":"ewallet_1936682fdca7a188c49eb9f9817ade77", "ewallets":[{"ewallet_id":"ewallet_1936682fdca7a188c49eb9f9817ade77", "amount":1000, "percent":100, "refunded_amount":0}], "payment_method_options":{}, "payment_method_type":"us_visa_card", "payment_method_type_category":"card", "fx_rate":1, "merchant_requested_currency":null, "merchant_requested_amount":null, "fixed_side":"", "payment_fees":null, "invoice":"", "escrow":null, "group_payment":"", "cancel_reason":null, "initiation_type":"customer_present", "mid":"", "next_action":"not_applicable", "error_code":"", "remitter_information":{}}}
     )
   end
 


### PR DESCRIPTION
Add support to pass `metadata` on `purchase`, `authorize`, and `refund`
transactions and `ewallet_id` on `purchase` and `authorize`
transactions.

`metadata` can contain any collection of data so long as it is a json
object.

CE-2396

Unit: 16 tests, 47 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 21 tests, 57 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed