### PR TITLE
GlobalCollect: Enable Google Pay and Apple Pay payment methods

### DIFF
--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -76,7 +76,10 @@ module ActiveMerchant #:nodoc:
         transcript.
           gsub(%r((Authorization: )[^\\]*)i, '\1[FILTERED]').
           gsub(%r(("cardNumber\\+":\\+")\d+), '\1[FILTERED]').
-          gsub(%r(("cvv\\+":\\+")\d+), '\1[FILTERED]')
+          gsub(%r(("cvv\\+":\\+")\d+), '\1[FILTERED]').
+          gsub(%r(("dpan\\+":\\+")\d+), '\1[FILTERED]').
+          gsub(%r(("pan\\+":\\+")\d+), '\1[FILTERED]').
+          gsub(%r(("cryptogram\\+":\\+"|("cavv\\+" : \\+"))[^\\]*), '\1[FILTERED]')
       end
 
       private
@@ -89,7 +92,9 @@ module ActiveMerchant #:nodoc:
         'jcb' => '125',
         'diners_club' => '132',
         'cabal' => '135',
-        'naranja' => '136'
+        'naranja' => '136',
+        'apple_pay': '302',
+        'google_pay': '320'
       }
 
       def add_order(post, money, options, capture: false)
@@ -250,20 +255,57 @@ module ActiveMerchant #:nodoc:
         month = format(payment.month, :two_digits)
         expirydate = "#{month}#{year}"
         pre_authorization = options[:pre_authorization] ? 'PRE_AUTHORIZATION' : 'FINAL_AUTHORIZATION'
-        post['cardPaymentMethodSpecificInput'] = {
+        specifics_inputs = {
           'paymentProductId' => BRAND_MAP[payment.brand],
           'skipAuthentication' => 'true', # refers to 3DSecure
           'skipFraudService' => 'true',
           'authorizationMode' => pre_authorization
         }
-        post['cardPaymentMethodSpecificInput']['requiresApproval'] = options[:requires_approval] unless options[:requires_approval].nil?
+        specifics_inputs['requiresApproval'] = options[:requires_approval] unless options[:requires_approval].nil?
+        if payment.is_a?(NetworkTokenizationCreditCard)
+          add_mobile_credit_card(post, payment, options, specifics_inputs, expirydate)
+        elsif payment.is_a?(CreditCard)
+          options[:google_pay_pan_only] ? add_mobile_credit_card(post, payment, options, specifics_inputs, expirydate) : add_credit_card(post, payment, specifics_inputs, expirydate)
+        end
+      end
 
-        post['cardPaymentMethodSpecificInput']['card'] = {
-          'cvv' => payment.verification_value,
-          'cardNumber' => payment.number,
-          'expiryDate' => expirydate,
-          'cardholderName' => payment.name
-        }
+      def add_credit_card(post, payment, specifics_inputs, expirydate)
+        post['cardPaymentMethodSpecificInput'] = specifics_inputs.merge({
+          'card' => {
+            'cvv' => payment.verification_value,
+            'cardNumber' => payment.number,
+            'expiryDate' => expirydate,
+            'cardholderName' => payment.name
+          }
+        })
+      end
+
+      def add_mobile_credit_card(post, payment, options, specifics_inputs, expirydate)
+        specifics_inputs['paymentProductId'] = options[:google_pay_pan_only] ? BRAND_MAP[:google_pay] : BRAND_MAP[payment.source]
+        post['mobilePaymentMethodSpecificInput'] = specifics_inputs
+        add_decrypted_payment_data(post, payment, options, expirydate)
+      end
+
+      def add_decrypted_payment_data(post, payment, options, expirydate)
+        if payment.is_a?(NetworkTokenizationCreditCard) && payment.payment_cryptogram
+          data = {
+            'cardholderName' => payment.name,
+            'cryptogram' => payment.payment_cryptogram,
+            'eci' => payment.eci,
+            'expiryDate' => expirydate,
+            'dpan' => payment.number
+          }
+          data['paymentMethod'] = 'TOKENIZED_CARD' if payment.source == :google_pay
+        # else case when google payment is an ONLY_PAN, doesn't have cryptogram or eci.
+        elsif options[:google_pay_pan_only]
+          data = {
+            'cardholderName' => payment.name,
+            'expiryDate' => expirydate,
+            'pan' => payment.number,
+            'paymentMethod' => 'CARD'
+          }
+        end
+        post['mobilePaymentMethodSpecificInput']['decryptedPaymentData'] = data if data
       end
 
       def add_customer_data(post, options, payment = nil)
@@ -431,7 +473,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def date
-        @date ||= Time.now.strftime('%a, %d %b %Y %H:%M:%S %Z') # Must be same in digest and HTTP header
+        @date ||= Time.now.gmtime.strftime('%a, %d %b %Y %H:%M:%S %Z') # Must be same in digest and HTTP header
       end
 
       def content_type
@@ -440,6 +482,8 @@ module ActiveMerchant #:nodoc:
 
       def success_from(action, response)
         return false if response['errorId'] || response['error_message']
+
+        return %w(CAPTURED CAPTURE_REQUESTED).include?(response.dig('payment', 'status')) if response.dig('payment', 'paymentOutput', 'paymentMethod') == 'mobile'
 
         case action
         when :authorize

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -12,6 +12,27 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     @cabal_card = credit_card('6271701225979642', brand: 'cabal')
     @declined_card = credit_card('5424180279791732')
     @preprod_card = credit_card('4111111111111111')
+    @apple_pay = network_tokenization_credit_card('4567350000427977',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: Time.new.year + 2,
+      first_name: 'John',
+      last_name: 'Smith',
+      eci: '05',
+      source: :apple_pay)
+
+    @google_pay = network_tokenization_credit_card('4567350000427977',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: Time.new.year + 2,
+      source: :google_pay,
+      transaction_id: '123456789',
+      eci: '05')
+
+    @google_pay_pan_only = credit_card('4567350000427977',
+      month: '01',
+      year: Time.new.year + 2)
+
     @accepted_amount = 4005
     @rejected_amount = 2997
     @options = {
@@ -56,6 +77,39 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Succeeded', response.message
     assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
+  end
+
+  def test_successful_purchase_with_apple_pay
+    options = @preprod_options.merge(requires_approval: false, currency: 'USD')
+    response = @gateway_preprod.purchase(4500, @apple_pay, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
+  end
+
+  def test_successful_purchase_with_google_pay
+    options = @preprod_options.merge(requires_approval: false)
+    response = @gateway_preprod.purchase(4500, @google_pay, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
+  end
+
+  def test_successful_purchase_with_google_pay_pan_only
+    options = @preprod_options.merge(requires_approval: false, customer: 'GP1234ID', google_pay_pan_only: true)
+    response = @gateway_preprod.purchase(4500, @google_pay_pan_only, options)
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
+  end
+
+  def test_unsuccessful_purchase_with_google_pay_pan_only
+    options = @preprod_options.merge(requires_approval: false, google_pay_pan_only: true, customer: '')
+    response = @gateway_preprod.purchase(4500, @google_pay_pan_only, options)
+
+    assert_failure response
+    assert_equal 'order.customer.merchantCustomerId is missing for UCOF', response.message
   end
 
   def test_successful_purchase_with_fraud_fields
@@ -399,6 +453,26 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
 
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@gateway.options[:secret_api_key], transcript)
+  end
+
+  def test_scrub_google_payment
+    options = @preprod_options.merge(requires_approval: false)
+    transcript = capture_transcript(@gateway) do
+      @gateway_preprod.purchase(@amount, @google_pay, options)
+    end
+    transcript = @gateway.scrub(transcript)
+    assert_scrubbed(@google_pay.payment_cryptogram, transcript)
+    assert_scrubbed(@google_pay.number, transcript)
+  end
+
+  def test_scrub_apple_payment
+    options = @preprod_options.merge(requires_approval: false)
+    transcript = capture_transcript(@gateway) do
+      @gateway_preprod.purchase(@amount, @apple_pay, options)
+    end
+    transcript = @gateway.scrub(transcript)
+    assert_scrubbed(@apple_pay.payment_cryptogram, transcript)
+    assert_scrubbed(@apple_pay.number, transcript)
   end
 
   def test_successful_preprod_auth_and_capture

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -9,6 +9,27 @@ class GlobalCollectTest < Test::Unit::TestCase
                                         secret_api_key: '109H/288H*50Y18W4/0G8571F245KA=')
 
     @credit_card = credit_card('4567350000427977')
+    @apple_pay_network_token = network_tokenization_credit_card('4444333322221111',
+      month: 10,
+      year: 24,
+      first_name: 'John',
+      last_name: 'Smith',
+      eci: '05',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      source: :apple_pay)
+
+    @google_pay_network_token = network_tokenization_credit_card('4444333322221111',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: Time.new.year + 2,
+      source: :google_pay,
+      transaction_id: '123456789',
+      eci: '05')
+
+    @google_pay_pan_only = credit_card('4444333322221111',
+      month: '01',
+      year: Time.new.year + 2)
+
     @declined_card = credit_card('5424180279791732')
     @accepted_amount = 4005
     @rejected_amount = 2997
@@ -69,6 +90,129 @@ class GlobalCollectTest < Test::Unit::TestCase
       @gateway.purchase(@accepted_amount, @credit_card, @options.merge(requires_approval: true))
     end.check_request do |endpoint, data, headers|
     end.respond_with(successful_authorize_response, successful_capture_response)
+  end
+
+  def test_purchase_request_with_google_pay
+    stub_comms do
+      @gateway.purchase(@accepted_amount, @google_pay_network_token)
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      assert_equal '320', JSON.parse(data)['mobilePaymentMethodSpecificInput']['paymentProductId']
+    end
+  end
+
+  def test_purchase_request_with_google_pay_pan_only
+    stub_comms do
+      @gateway.purchase(@accepted_amount, @google_pay_pan_only, @options.merge(customer: 'GP1234ID', google_pay_pan_only: true))
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      assert_equal '320', JSON.parse(data)['mobilePaymentMethodSpecificInput']['paymentProductId']
+    end
+  end
+
+  def test_add_payment_for_credit_card
+    post = {}
+    options = {}
+    payment = @credit_card
+    @gateway.send('add_payment', post, payment, options)
+    assert_includes post.keys, 'cardPaymentMethodSpecificInput'
+    assert_equal post['cardPaymentMethodSpecificInput']['paymentProductId'], '1'
+    assert_equal post['cardPaymentMethodSpecificInput']['authorizationMode'], 'FINAL_AUTHORIZATION'
+    assert_includes post['cardPaymentMethodSpecificInput'].keys, 'card'
+    assert_equal post['cardPaymentMethodSpecificInput']['card']['cvv'], '123'
+    assert_equal post['cardPaymentMethodSpecificInput']['card']['cardNumber'], '4567350000427977'
+  end
+
+  def test_add_payment_for_google_pay
+    post = {}
+    options = {}
+    payment = @google_pay_network_token
+    @gateway.send('add_payment', post, payment, options)
+    assert_includes post.keys.first, 'mobilePaymentMethodSpecificInput'
+    assert_equal post['mobilePaymentMethodSpecificInput']['paymentProductId'], '320'
+    assert_equal post['mobilePaymentMethodSpecificInput']['authorizationMode'], 'FINAL_AUTHORIZATION'
+    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['dpan'], '4444333322221111'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['cryptogram'], 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['eci'], '05'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], '0124'
+    assert_equal 'TOKENIZED_CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
+  end
+
+  def test_add_payment_for_google_pay_pan_only
+    post = {}
+    options = { google_pay_pan_only: true }
+    payment = @google_pay_pan_only
+    @gateway.send('add_payment', post, payment, options)
+    assert_includes post.keys.first, 'mobilePaymentMethodSpecificInput'
+    assert_equal post['mobilePaymentMethodSpecificInput']['paymentProductId'], '320'
+    assert_equal post['mobilePaymentMethodSpecificInput']['authorizationMode'], 'FINAL_AUTHORIZATION'
+    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['pan'], '4444333322221111'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], '0124'
+    assert_equal 'CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
+  end
+
+  def test_add_payment_for_apple_pay
+    post = {}
+    options = {}
+    payment = @apple_pay_network_token
+    @gateway.send('add_payment', post, payment, options)
+    assert_includes post.keys, 'mobilePaymentMethodSpecificInput'
+    assert_equal post['mobilePaymentMethodSpecificInput']['paymentProductId'], '302'
+    assert_equal post['mobilePaymentMethodSpecificInput']['authorizationMode'], 'FINAL_AUTHORIZATION'
+    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['dpan'], '4444333322221111'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['cryptogram'], 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['eci'], '05'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], '1024'
+  end
+
+  def test_add_decrypted_data_google_pay_pan_only
+    post = { 'mobilePaymentMethodSpecificInput' => {} }
+    payment = @google_pay_pan_only
+    options = { google_pay_pan_only: true }
+    expirydate = '0124'
+
+    @gateway.send('add_decrypted_payment_data', post, payment, options, expirydate)
+    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['pan'], '4444333322221111'
+    assert_equal 'CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
+  end
+
+  def test_add_decrypted_data_for_google_pay
+    post = { 'mobilePaymentMethodSpecificInput' => {} }
+    payment = @google_pay_network_token
+    options = {}
+    expirydate = '0124'
+
+    @gateway.send('add_decrypted_payment_data', post, payment, options, expirydate)
+    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['cryptogram'], 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['eci'], '05'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['dpan'], '4444333322221111'
+    assert_equal 'TOKENIZED_CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
+    assert_equal '0124', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate']
+  end
+
+  def test_add_decrypted_data_for_apple_pay
+    post = { 'mobilePaymentMethodSpecificInput' => {} }
+    payment = @google_pay_network_token
+    options = {}
+    expirydate = '0124'
+
+    @gateway.send('add_decrypted_payment_data', post, payment, options, expirydate)
+    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['cryptogram'], 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['eci'], '05'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['dpan'], '4444333322221111'
+    assert_equal '0124', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate']
+  end
+
+  def test_purchase_request_with_apple_pay
+    stub_comms do
+      @gateway.purchase(@accepted_amount, @apple_pay_network_token)
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      assert_equal '302', JSON.parse(data)['mobilePaymentMethodSpecificInput']['paymentProductId']
+    end
   end
 
   # When requires_approval is false, a `purchase` makes one call (`auth`).


### PR DESCRIPTION
Summary:
---------------------------------------
In order to add  Apple Pay and Google Pay support to GlobalCollect
this commit enables the option to add those payment methods for
use in the add_payment method.

Local Tests:
---------------------------------------
41 tests, 215 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
--------------------------------------
37 tests, 93 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.2973% passed

RuboCop:
---------------------------------------
728 files inspected, no offenses detected