### PR TITLE
Rapyd: Update `type` option to `pm_type`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,7 @@
 * Airwallex: add support for stored credentials [drkjc] #4382
 * Rapyd: Add metadata and ewallet_id options [naashton] #4387
 * Priority: Add additional fields to request and refactor gateway integration [dsmcclain] #4383
+* Rapyd: Update `type` option to `pm_type` [naashton] #4391
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -93,11 +93,15 @@ module ActiveMerchant #:nodoc:
       private
 
       def payment_is_ach?(options)
-        return true if options[:type].include?('_bank')
+        return unless options[:pm_type]
+
+        return true if options[:pm_type].include?('_bank')
       end
 
       def payment_is_card?(options)
-        return true if options[:type].include?('_card')
+        return unless options[:pm_type]
+
+        return true if options[:pm_type].include?('_card')
       end
 
       def add_address(post, creditcard, options)
@@ -133,7 +137,7 @@ module ActiveMerchant #:nodoc:
         post[:payment_method][:fields] = {}
         pm_fields = post[:payment_method][:fields]
 
-        post[:payment_method][:type] = options[:type]
+        post[:payment_method][:type] = options[:pm_type]
         pm_fields[:number] = payment.number
         pm_fields[:expiration_month] = payment.month.to_s
         pm_fields[:expiration_year] = payment.year.to_s
@@ -145,7 +149,7 @@ module ActiveMerchant #:nodoc:
         post[:payment_method] = {}
         post[:payment_method][:fields] = {}
 
-        post[:payment_method][:type] = options[:type]
+        post[:payment_method][:type] = options[:pm_type]
         post[:payment_method][:fields][:proof_of_authorization] = options[:proof_of_authorization]
         post[:payment_method][:fields][:first_name] = payment.first_name if payment.first_name
         post[:payment_method][:fields][:last_name] = payment.last_name if payment.last_name

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -9,11 +9,11 @@ class RemoteRapydTest < Test::Unit::TestCase
     @declined_card = credit_card('4111111111111105')
     @check = check
     @options = {
-      type: 'us_visa_card',
+      pm_type: 'us_visa_card',
       currency: 'USD'
     }
     @ach_options = {
-      type: 'us_ach_bank',
+      pm_type: 'us_ach_bank',
       currency: 'USD',
       proof_of_authorization: false,
       payment_purpose: 'Testing Purpose'
@@ -162,7 +162,7 @@ class RemoteRapydTest < Test::Unit::TestCase
 
   def test_successful_verify_with_peso
     options = {
-      type: 'mx_visa_card',
+      pm_type: 'mx_visa_card',
       currency: 'MXN'
     }
     response = @gateway.verify(@credit_card, options)
@@ -172,7 +172,7 @@ class RemoteRapydTest < Test::Unit::TestCase
 
   def test_successful_verify_with_yen
     options = {
-      type: 'jp_visa_card',
+      pm_type: 'jp_visa_card',
       currency: 'JPY'
     }
     response = @gateway.verify(@credit_card, options)

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -7,7 +7,7 @@ class RapydTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
-      type: 'in_amex_card',
+      pm_type: 'in_amex_card',
       currency: 'USD'
     }
 


### PR DESCRIPTION
Field name change to `pm_type` to be more specific

CE-2396

Unit: 16 tests, 47 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 21 tests, 57 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed