### PR TITLE
Airwallex: Add 3DS Global Support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -71,6 +71,7 @@
 * Conekta: Fix remote test [javierpedrozaing] #4386
 * NMI: Update post URL [jherreraa] #4380
 * Multiple Gateways: Resolve when/case bug [naashton] #4399
+* Airwallex: Add 3DS MPI support [drkjc] #4395
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/test/remote/gateways/remote_airwallex_test.rb
+++ b/test/remote/gateways/remote_airwallex_test.rb
@@ -191,6 +191,47 @@ class RemoteAirwallexTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:client_api_key], transcript)
   end
 
+  def test_successful_authorize_with_3ds_v1_options
+    @options[:three_d_secure] = {
+      version: '1',
+      cavv: 'VGhpcyBpcyBhIHRlc3QgYmFzZTY=',
+      eci: '02',
+      xid: 'b2h3aDZrd3BJWXVCWEFMbzJqSGQ='
+    }
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_match 'AUTHORIZED', response.message
+  end
+
+  def test_successful_authorize_with_3ds_v2_options
+    @options[:three_d_secure] = {
+      version: '2.2.0',
+      cavv: 'MTIzNDU2Nzg5MDA5ODc2NTQzMjE=',
+      ds_transaction_id: 'f25084f0-5b16-4c0a-ae5d-b24808a95e4b',
+      eci: '02',
+      three_ds_server_trans_id: 'df8b9557-e41b-4e17-87e9-2328694a2ea0'
+    }
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_match 'AUTHORIZED', response.message
+  end
+
+  def test_successful_purchase_with_3ds_v2_options
+    @options[:three_d_secure] = {
+      version: '2.0',
+      cavv: 'MTIzNDU2Nzg5MDA5ODc2NTQzMjE=',
+      ds_transaction_id: 'f25084f0-5b16-4c0a-ae5d-b24808a95e4b',
+      eci: '02',
+      three_ds_server_trans_id: 'df8b9557-e41b-4e17-87e9-2328694a2ea0'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_match 'AUTHORIZED', response.message
+  end
+
   private
 
   def generated_ids


### PR DESCRIPTION
Add support for Spreedly's 3DS Global Solution. One notable distinction
is that Airwallex only supports three digit 3DS versions. Versions
returned from the MPI are formatted to meet that requirement.

Ex: 2.0 => 2.0.0

CE-2301

Unit:
31 tests, 130 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
25 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed