### PR TITLE
Add Cartes Bancaires bin ranges

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -72,6 +72,7 @@
 * NMI: Update post URL [jherreraa] #4380
 * Multiple Gateways: Resolve when/case bug [naashton] #4399
 * Airwallex: Add 3DS MPI support [drkjc] #4395
+* Add Cartes Bancaires card bin ranges [leahriffell] #4398
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -34,6 +34,7 @@ module ActiveMerchant #:nodoc:
             CARNET_BINS.any? { |bin| num.slice(0, bin.size) == bin }
           )
         },
+        'cartes_bancaires' => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), CARTES_BANCAIRES_RANGES) },
         'olimpica' => ->(num) { num =~ /^636853\d{10}$/ },
         'creditel' => ->(num) { num =~ /^601933\d{10}$/ },
         'confiable' => ->(num) { num =~ /^560718\d{10}$/ },
@@ -72,6 +73,17 @@ module ActiveMerchant #:nodoc:
           60462203 60462204 588772
         ]
       )
+
+      CARTES_BANCAIRES_RANGES = [
+        (507589..507590),
+        (507593..507595),
+        [507597],
+        [560408],
+        [581752],
+        (585402..585405),
+        (585501..585505),
+        (585577..585582)
+      ]
 
       # https://www.mastercard.us/content/dam/mccom/global/documents/mastercard-rules.pdf, page 73
       MASTERCARD_RANGES = [

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -378,6 +378,13 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     end
   end
 
+  def test_should_detect_cartes_bancaires_cards
+    assert_equal 'cartes_bancaires', CreditCard.brand?('5855010000000000')
+    assert_equal 'cartes_bancaires', CreditCard.brand?('5075935000000000')
+    assert_equal 'cartes_bancaires', CreditCard.brand?('5075901100000000')
+    assert_equal 'cartes_bancaires', CreditCard.brand?('5075890130000000')
+  end
+
   def test_electron_cards
     # return the card number so assert failures are easy to isolate
     electron_test = Proc.new do |card_number|


### PR DESCRIPTION
Add bin ranges so that the French card brand Cartes Bancaires can be identified.
Confirmed that all Cartes Bancaires cards are fixed at 16 characters in length.
_______

**Test Summary:**

Unit:
5156 tests, 75540 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
291.85 tests/s, 4275.79 assertions/s

Local
5160 tests, 75568 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
739 files inspected, no offenses detected
