### PR TITLE
Multiple Gateways: Resolve `when/case` bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -70,6 +70,7 @@
 * Rapyd: Update `type` option to `pm_type` [naashton] #4391
 * Conekta: Fix remote test [javierpedrozaing] #4386
 * NMI: Update post URL [jherreraa] #4380
+* Multiple Gateways: Resolve when/case bug [naashton] #4399
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -483,7 +483,7 @@ module ActiveMerchant #:nodoc:
         return unless reason_type = options.dig(:stored_credential, :reason_type)
 
         case reason_type
-        when 'recurring' || 'installment'
+        when 'recurring', 'installment'
           'Y'
         when 'unscheduled'
           'N'

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -169,7 +169,7 @@ module ActiveMerchant #:nodoc:
         end
 
         case options[:stored_credential][:reason_type]
-        when 'recurring' || 'installment'
+        when 'recurring', 'installment'
           post[:payment_type] = 'Recurring'
         when 'unscheduled'
           return

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -299,7 +299,7 @@ module ActiveMerchant #:nodoc:
         end
 
         case options[:stored_credential][:reason_type]
-        when 'recurring' || 'installment'
+        when 'recurring', 'installment'
           post[:storedCredential][:type] = 'RECURRING'
         when 'unscheduled'
           if options[:stored_credential][:initiator] == 'merchant'

--- a/test/remote/gateways/remote_blue_pay_test.rb
+++ b/test/remote/gateways/remote_blue_pay_test.rb
@@ -37,7 +37,7 @@ class BluePayTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, check, @options.merge(email: 'foo@example.com'))
     assert_success response
     assert response.test?
-    assert_equal 'App ACH Sale', response.message
+    assert_equal 'ACH Accepted', response.message
     assert response.authorization
   end
 
@@ -184,18 +184,18 @@ class BluePayTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, check, @options.merge(email: 'foo@example.com'))
     assert_success response
     assert response.test?
-    assert_equal 'App ACH Sale', response.message
+    assert_equal 'ACH Accepted', response.message
     assert response.authorization
 
     assert refund = @gateway.refund(@amount, response.authorization, @options.merge(doc_type: 'PPD'))
     assert_success refund
-    assert_equal 'App ACH Void', refund.message
+    assert_equal 'ACH VOIDED', refund.message
   end
 
   def test_successful_credit_with_check
     assert credit = @gateway.credit(@amount, check, @options.merge(doc_type: 'PPD'))
     assert_success credit
-    assert_equal 'App ACH Credit', credit.message
+    assert_equal 'ACH Accepted', credit.message
   end
 
   def test_transcript_scrubbing

--- a/test/remote/gateways/remote_paysafe_test.rb
+++ b/test/remote/gateways/remote_paysafe_test.rb
@@ -373,7 +373,7 @@ class RemotePaysafeTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = PaysafeGateway.new(username: '', password: '', account_id: '')
+    gateway = PaysafeGateway.new(username: 'badbunny', password: 'carrotsrock', account_id: 'rejectstew')
 
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -225,7 +225,7 @@ class BluePayTest < Test::Unit::TestCase
   end
 
   def test_passing_stored_credentials_data_for_mit_transaction
-    options = @options.merge({ stored_credential: { initiator: 'merchant', reason_type: 'recurring' } })
+    options = @options.merge({ stored_credential: { initiator: 'merchant', reason_type: 'installment' } })
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -282,7 +282,7 @@ class CheckoutV2Test < Test::Unit::TestCase
       initial_options = {
         stored_credential: {
           initial_transaction: true,
-          reason_type: 'recurring'
+          reason_type: 'installment'
         }
       }
       @gateway.purchase(@amount, @credit_card, initial_options)

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -101,7 +101,7 @@ class PaysafeTest < Test::Unit::TestCase
     stored_credential_options = {
       stored_credential: {
         initial_transaction: true,
-        reason_type: 'recurring',
+        reason_type: 'installment',
         initiator: 'merchant'
       }
     }


### PR DESCRIPTION
CE-2541

There is a bug in the `case` statements where we are attempting to
resolve it conditionally with an `||`, but `case` takes a single value
or list of values

Tests for BluePay were failing, due to a different `response.message`

The `test_invalid_credentials` test for PaySafe was not failing with the expected response

Unit:

BluePay: 30 tests, 142 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Paysafe: 16 tests, 77 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

40 tests, 236 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:

CheckoutV2: 43 tests, 110 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

BluePay: 19 tests, 90 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Paysafe: 31 tests, 94 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed