### PR TITLE
Airwallex: Add support for `original_transaction_id`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,7 @@
 * Airwallex: add support for stored credentials [drkjc] #4382
 * Rapyd: Add metadata and ewallet_id options [naashton] #4387
 * Priority: Add additional fields to request and refactor gateway integration [dsmcclain] #4383
+* Airwallex: Add support for `original_transaction_id` field [drkjc] #4401
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -231,6 +231,7 @@ module ActiveMerchant #:nodoc:
         return unless stored_credential = options[:stored_credential]
 
         external_recurring_data = post[:external_recurring_data] = {}
+        original_transaction_id = add_original_transaction_id(options)
 
         case stored_credential.dig(:reason_type)
         when 'recurring', 'installment'
@@ -239,8 +240,14 @@ module ActiveMerchant #:nodoc:
           external_recurring_data[:merchant_trigger_reason] = 'unscheduled'
         end
 
-        external_recurring_data[:original_transaction_id] = stored_credential.dig(:network_transaction_id)
+        external_recurring_data[:original_transaction_id] = original_transaction_id || stored_credential.dig(:network_transaction_id)
         external_recurring_data[:triggered_by] = stored_credential.dig(:initiator) == 'cardholder' ? 'customer' : 'merchant'
+      end
+
+      def add_original_transaction_id(options)
+        return unless options[:auto_capture] == false || original_transaction_id = options[:original_transaction_id]
+
+        original_transaction_id
       end
 
       def authorization_only?(options = {})

--- a/test/unit/gateways/airwallex_test.rb
+++ b/test/unit/gateways/airwallex_test.rb
@@ -24,6 +24,9 @@ class AirwallexTest < Test::Unit::TestCase
       billing_address: address,
       return_url: 'https://example.com'
     }
+
+    @stored_credential_cit_options = { initial_transaction: true, initiator: 'cardholder', reason_type: 'recurring', network_transaction_id: nil }
+    @stored_credential_mit_options = { initial_transaction: false, initiator: 'merchant', reason_type: 'recurring', network_transaction_id: '123456789012345' }
   end
 
   def test_gateway_has_access_token
@@ -228,68 +231,138 @@ class AirwallexTest < Test::Unit::TestCase
   end
 
   def test_successful_cit_with_stored_credential
-    stored_credential_params = {
-      initial_transaction: true,
-      reason_type: 'recurring',
-      initiator: 'cardholder',
-      network_transaction_id: nil
-    }
-
     auth = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+      @gateway.authorize(@amount, @credit_card, @options.merge!({ stored_credential: @stored_credential_cit_options }))
     end.check_request do |endpoint, data, _headers|
-      # This conditional asserts after the initial setup call is made
-      assert_match(/"external_recurring_data\":{\"merchant_trigger_reason\":\"scheduled\",\"original_transaction_id\":null,\"triggered_by\":\"customer\"}/, data) if endpoint != 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+      # This conditional runs assertions after the initial setup call is made
+      unless endpoint == 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+        assert_match(/"external_recurring_data\"/, data)
+        assert_match(/"merchant_trigger_reason\":\"scheduled\"/, data)
+        assert_match(/"original_transaction_id\":null,/, data)
+        assert_match(/"triggered_by\":\"customer\"/, data)
+      end
     end.respond_with(successful_authorize_response)
     assert_success auth
   end
 
   def test_successful_mit_with_recurring_stored_credential
-    stored_credential_params = {
-      initial_transaction: false,
-      reason_type: 'recurring',
-      initiator: 'merchant',
-      network_transaction_id: 'MCC123ABC0101'
-    }
-
     auth = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+      @gateway.authorize(@amount, @credit_card, @options.merge!({ stored_credential: @stored_credential_cit_options }))
     end.check_request do |endpoint, data, _headers|
-      assert_match(/"external_recurring_data\":{\"merchant_trigger_reason\":\"scheduled\",\"original_transaction_id\":\"MCC123ABC0101\",\"triggered_by\":\"merchant\"}/, data) if endpoint != 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+      unless endpoint == 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+        assert_match(/"external_recurring_data\"/, data)
+        assert_match(/"merchant_trigger_reason\":\"scheduled\"/, data)
+        assert_match(/"original_transaction_id\":null,/, data)
+        assert_match(/"triggered_by\":\"customer\"/, data)
+      end
     end.respond_with(successful_authorize_response)
     assert_success auth
+
+    purchase = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge!({ stored_credential: @stored_credential_mit_options }))
+    end.check_request do |endpoint, data, _headers|
+      unless endpoint == 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+        assert_match(/"external_recurring_data\"/, data)
+        assert_match(/"merchant_trigger_reason\":\"scheduled\"/, data)
+        assert_match(/"original_transaction_id\":\"123456789012345\"/, data)
+        assert_match(/"triggered_by\":\"merchant\"/, data)
+      end
+    end.respond_with(successful_purchase_response)
+    assert_success purchase
   end
 
   def test_successful_mit_with_unscheduled_stored_credential
-    stored_credential_params = {
-      initial_transaction: false,
-      reason_type: 'unscheduled',
-      initiator: 'merchant',
-      network_transaction_id: 'MCC123ABC0101'
-    }
+    @stored_credential_cit_options[:reason_type] = 'unscheduled'
+    @stored_credential_mit_options[:reason_type] = 'unscheduled'
 
     auth = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+      @gateway.authorize(@amount, @credit_card, @options.merge!({ stored_credential: @stored_credential_cit_options }))
     end.check_request do |endpoint, data, _headers|
-      assert_match(/"external_recurring_data\":{\"merchant_trigger_reason\":\"unscheduled\",\"original_transaction_id\":\"MCC123ABC0101\",\"triggered_by\":\"merchant\"}/, data) if endpoint != 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+      unless endpoint == 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+        assert_match(/"external_recurring_data\"/, data)
+        assert_match(/"merchant_trigger_reason\":\"unscheduled\"/, data)
+        assert_match(/"original_transaction_id\":null,/, data)
+        assert_match(/"triggered_by\":\"customer\"/, data)
+      end
     end.respond_with(successful_authorize_response)
     assert_success auth
+
+    purchase = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge!({ stored_credential: @stored_credential_mit_options }))
+    end.check_request do |endpoint, data, _headers|
+      unless endpoint == 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+        assert_match(/"external_recurring_data\"/, data)
+        assert_match(/"merchant_trigger_reason\":\"unscheduled\"/, data)
+        assert_match(/"original_transaction_id\":\"123456789012345\"/, data)
+        assert_match(/"triggered_by\":\"merchant\"/, data)
+      end
+    end.respond_with(successful_purchase_response)
+    assert_success purchase
   end
 
   def test_successful_mit_with_installment_stored_credential
-    stored_credential_params = {
-      initial_transaction: false,
-      reason_type: 'installment',
-      initiator: 'merchant',
-      network_transaction_id: 'MCC123ABC0101'
-    }
+    @stored_credential_cit_options[:reason_type] = 'installment'
+    @stored_credential_mit_options[:reason_type] = 'installment'
 
     auth = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_params }))
+      @gateway.authorize(@amount, @credit_card, @options.merge!({ stored_credential: @stored_credential_cit_options }))
     end.check_request do |endpoint, data, _headers|
-      assert_match(/"external_recurring_data\":{\"merchant_trigger_reason\":\"scheduled\",\"original_transaction_id\":\"MCC123ABC0101\",\"triggered_by\":\"merchant\"}/, data) if endpoint != 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+      unless endpoint == 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+        assert_match(/"external_recurring_data\"/, data)
+        assert_match(/"merchant_trigger_reason\":\"scheduled\"/, data)
+        assert_match(/"original_transaction_id\":null,/, data)
+        assert_match(/"triggered_by\":\"customer\"/, data)
+      end
     end.respond_with(successful_authorize_response)
     assert_success auth
+
+    purchase = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge!({ stored_credential: @stored_credential_mit_options }))
+    end.check_request do |endpoint, data, _headers|
+      unless endpoint == 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+        assert_match(/"external_recurring_data\"/, data)
+        assert_match(/"merchant_trigger_reason\":\"scheduled\"/, data)
+        assert_match(/"original_transaction_id\":\"123456789012345\"/, data)
+        assert_match(/"triggered_by\":\"merchant\"/, data)
+      end
+    end.respond_with(successful_purchase_response)
+    assert_success purchase
+  end
+
+  def test_successful_mit_with_original_transaction_id
+    mastercard = credit_card('2223 0000 1018 1375', { brand: 'master' })
+    @options[:original_transaction_id] = 'MCC123ABC0101'
+
+    auth = stub_comms do
+      @gateway.authorize(@amount, mastercard, @options.merge!({ stored_credential: @stored_credential_cit_options }))
+    end.check_request do |endpoint, data, _headers|
+      unless endpoint == 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+        assert_match(/"external_recurring_data\"/, data)
+        assert_match(/"merchant_trigger_reason\":\"scheduled\"/, data)
+        assert_match(/"original_transaction_id\":null,/, data)
+        assert_match(/"triggered_by\":\"customer\"/, data)
+      end
+    end.respond_with(successful_authorize_response)
+    assert_success auth
+
+    purchase = stub_comms do
+      @gateway.purchase(@amount, mastercard, @options.merge!({ stored_credential: @stored_credential_mit_options }))
+    end.check_request do |endpoint, data, _headers|
+      unless endpoint == 'https://api-demo.airwallex.com/api/v1/pa/payment_intents/create'
+        assert_match(/"external_recurring_data\"/, data)
+        assert_match(/"merchant_trigger_reason\":\"scheduled\"/, data)
+        assert_match(/"original_transaction_id\":\"MCC123ABC0101\"/, data)
+        assert_match(/"triggered_by\":\"merchant\"/, data)
+      end
+    end.respond_with(successful_purchase_response)
+    assert_success purchase
+  end
+
+  def test_failed_mit_with_unapproved_ntid
+    @gateway.expects(:ssl_post).returns(failed_ntid_response)
+    assert_raise ArgumentError do
+      @gateway.authorize(@amount, @credit_card, @options.merge!({ stored_credential: @stored_credential_cit_options }))
+    end
   end
 
   def test_scrub
@@ -357,5 +430,9 @@ class AirwallexTest < Test::Unit::TestCase
 
   def failed_void_response
     %({"code":"not_found","message":"The requested endpoint does not exist [/api/v1/pa/payment_intents/12345/cancel]"})
+  end
+
+  def failed_ntid_response
+    %({"code":"validation_error","source":"external_recurring_data.original_transaction_id","message":"external_recurring_data.original_transaction_id should be 13-15 characters long"})
   end
 end


### PR DESCRIPTION
The `original_transaction_id` field allows users to manually  override the
`network_transaction_id`. This is useful when testing MITs using Stored
Credentials on Airwallex because they only allow specific values to be
passed which they do not return, and would normally be passed automatically in a
standard MIT Stored Credentials flow.

Test NTID values:
Mastercard - MCC123ABC0101
Visa - 123456789012345

This PR also cleans up remote and unit tests for Airwallex stored creds.
CE-2560

Unit:
30 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
24 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed