### PR TITLE
Securion Pay: Enable 3DS global

### DIFF
--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -133,11 +133,46 @@ module ActiveMerchant #:nodoc:
         add_creditcard(post, payment, options)
         add_customer(post, payment, options)
         add_customer_data(post, options)
+        add_external_three_ds(post, options)
         if options[:email]
           post[:metadata] = {}
           post[:metadata][:email] = options[:email]
         end
         post
+      end
+
+      def add_external_three_ds(post, options)
+        return if options[:three_d_secure].blank?
+
+        post[:threeDSecure] = {
+          external: {
+            version: options[:three_d_secure][:version],
+            authenticationValue: options[:three_d_secure][:cavv],
+            acsTransactionId: options[:three_d_secure][:acs_transaction_id],
+            status: options[:three_d_secure][:authentication_response_status],
+            eci: options[:three_d_secure][:eci]
+          }.merge(xid_or_ds_trans_id(options[:three_d_secure]))
+        }
+      end
+
+      def xid_or_ds_trans_id(three_ds)
+        if three_ds[:version].to_f >= 2.0
+          { dsTransactionId: three_ds[:ds_transaction_id] }
+        else
+          { xid: three_ds[:xid] }
+        end
+      end
+
+      def validate_three_ds_params(three_ds)
+        errors = {}
+        supported_version = %w{1.0.2 2.1.0 2.2.0}.include?(three_ds[:version])
+        supported_auth_response = ['Y', 'N', 'U', 'R', 'E', 'A', nil].include?(three_ds[:status])
+
+        errors[:three_ds_version] = 'ThreeDs version not supported' unless supported_version
+        errors[:auth_response] = 'Authentication response value not supported' unless supported_auth_response
+        errors.compact!
+
+        errors.present? ? Response.new(false, 'ThreeDs data is invalid', errors) : nil
       end
 
       def add_amount(post, money, options, include_currency = false)
@@ -182,6 +217,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(url, parameters = nil, options = {}, method = nil)
+        if parameters.present? && parameters[:threeDSecure].present?
+          three_ds_errors = validate_three_ds_params(parameters[:threeDSecure][:external])
+          return three_ds_errors if three_ds_errors
+        end
+
         response = api_request(url, parameters, options, method)
         success = !response.key?('error')
 

--- a/test/remote/gateways/remote_securion_pay_test.rb
+++ b/test/remote/gateways/remote_securion_pay_test.rb
@@ -66,6 +66,18 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
     assert_match CHARGE_ID_REGEX, response.authorization
   end
 
+  def test_successful_purchase_with_three_ds_data
+    @options[:three_d_secure] = {
+      version: '1.0.2',
+      eci: '05',
+      cavv: '3q2+78r+ur7erb7vyv66vv////8=',
+      acs_transaction_id: '6546464645623455665165+qe-jmhabcdefg',
+      authentication_response_status: 'Y'
+    }
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
   def test_unsuccessful_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/securion_pay_test.rb
+++ b/test/unit/gateways/securion_pay_test.rb
@@ -18,6 +18,15 @@ class SecurionPayTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase'
     }
+
+    @three_ds_secure = {
+      version: '1.0.2',
+      cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
+      eci: '05',
+      xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
   end
 
   def test_successful_store
@@ -61,6 +70,89 @@ class SecurionPayTest < Test::Unit::TestCase
 
     assert_equal 'char_J10t4hOZCHGO2izfJPKLM9W5', response.authorization
     assert response.test?
+  end
+
+  def test_three_ds_v1_object_construction
+    post = {}
+    @options[:three_d_secure] = @three_ds_secure
+    @gateway.send(:add_external_three_ds, post, @options)
+    assert post[:threeDSecure]
+    ds_data = post[:threeDSecure][:external]
+    ds_options = @options[:three_d_secure]
+    assert_equal ds_options[:version], ds_data[:version]
+    assert_equal ds_options[:cavv], ds_data[:authenticationValue]
+    assert_equal ds_options[:eci], ds_data[:eci]
+    assert_equal ds_options[:xid], ds_data[:xid]
+    assert_equal nil, ds_data[:ds_transaction_id]
+    assert_equal ds_options[:authentication_response_status], ds_data[:status]
+  end
+
+  def test_three_ds_v2_object_construction
+    post = {}
+    @three_ds_secure[:ds_transaction_id] = 'ODUzNTYzOTcwODU5NzY3Qw=='
+    @three_ds_secure[:version] = '2.2.0'
+    @options[:three_d_secure] = @three_ds_secure
+
+    @gateway.send(:add_external_three_ds, post, @options)
+
+    assert post[:threeDSecure]
+    ds_data = post[:threeDSecure][:external]
+    ds_options = @options[:three_d_secure]
+
+    assert_equal ds_options[:version], ds_data[:version]
+    assert_equal ds_options[:cavv], ds_data[:authenticationValue]
+    assert_equal ds_options[:eci], ds_data[:eci]
+    assert_equal nil, ds_data[:xid]
+    assert_equal ds_options[:ds_transaction_id], ds_data[:dsTransactionId]
+    assert_equal ds_options[:authentication_response_status], ds_data[:status]
+  end
+
+  def test_three_ds_version_validation
+    post = {}
+    @options[:three_d_secure] = @three_ds_secure
+    @gateway.send(:add_external_three_ds, post, @options)
+    resp = @gateway.send(:validate_three_ds_params, @three_ds_secure)
+
+    assert_equal nil, resp
+    post[:threeDSecure][:external][:version] = '4.0'
+    resp = @gateway.send(:validate_three_ds_params, post[:threeDSecure])
+
+    assert_equal 'ThreeDs data is invalid', resp.message
+    assert_equal 'ThreeDs version not supported', resp.params['three_ds_version']
+  end
+
+  def test_three_ds_auth_response_validation
+    post = {}
+    @options[:three_d_secure] = @three_ds_secure
+    @gateway.send(:add_external_three_ds, post, @options)
+    post[:threeDSecure][:external][:status] = 'P'
+    resp = @gateway.send(:validate_three_ds_params, post[:threeDSecure][:external])
+    assert_equal 'ThreeDs data is invalid', resp.message
+    assert_equal 'Authentication response value not supported', resp.params['auth_response']
+  end
+
+  def test_purchase_with_three_ds
+    @options[:three_d_secure] = @three_ds_secure
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      three_ds_params = JSON.parse(data)['three_dsecure']
+      assert_equal '1.0', three_ds_params['three_dsecure_version']
+      assert_equal '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=', three_ds_params['cavv']
+      assert_equal '05', three_ds_params['eci']
+      assert_equal 'ODUzNTYzOTcwODU5NzY3Qw==', three_ds_params['xid']
+      assert_equal 'Y', three_ds_params['enrollment_response']
+      assert_equal 'Y', three_ds_params['authentication_response']
+    end
+  end
+
+  def test_unsuccessfully_purchase_with_wrong_three_ds_data
+    @three_ds_secure.delete(:version)
+    @options[:three_d_secure] = @three_ds_secure
+    resp = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_equal 'ThreeDs data is invalid', resp.message
+    assert_equal 'ThreeDs version not supported', resp.params['three_ds_version']
   end
 
   def test_successful_purchase_with_token


### PR DESCRIPTION
Summary:
------------------------------
This PR includes the fields and logic required to send 3ds purchases and auths in the gateway related in title.

Test Execution:
------------------------------
Unit test
Finished in 0.033598 seconds.
33 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote test
Finished in 30.68658 seconds.
27 tests, 91 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
81.4815% passed
Failures not related with the added code

RuboCop:
------------------------------
739 files inspected, no offenses detected