### PR TITLE
Airwallex: Update Stored Credential testing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,6 +77,7 @@
 * Add Cartes Bancaires card bin ranges [leahriffell] #4398
 * Airwallex: Add support for `original_transaction_id` field [drkjc] #4401
 * Securion Pay: Pass external 3DS data [jherreraa] #4404
+* Airwallex: Update Stored Credentials testing, remove support for `original_transaction_id` field [drkjc] 4407
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173


### PR DESCRIPTION
Airwallex requires specific NTID values in order to test the full Stored
Credential flow from CIT auth to MIT purchase. These values are now
automatically populated based on card `brand`. This PR also removes the
`original_transaction_id` GSF.

CE-2593

Unit:
33 tests, 176 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed