### PR TITLE
Credorax: convert country codes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -79,6 +79,7 @@
 * Airwallex: Add support for `original_transaction_id` field [drkjc] #4401
 * Securion Pay: Pass external 3DS data [jherreraa] #4404
 * Airwallex: Update Stored Credentials testing, remove support for `original_transaction_id` field [drkjc] 4407
+* Credorax: Convert country codes for  `recipient_country_code` field [ajawadmirza] #4408
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -213,6 +213,7 @@ module ActiveMerchant #:nodoc:
         add_submerchant_id(post, options)
         add_transaction_type(post, options)
         add_processor(post, options)
+        add_customer_name(post, options)
 
         commit(:credit, post)
       end
@@ -324,10 +325,11 @@ module ActiveMerchant #:nodoc:
       def add_recipient(post, options)
         return unless options[:recipient_street_address] || options[:recipient_city] || options[:recipient_province_code] || options[:recipient_country_code]
 
+        recipient_country_code = options[:recipient_country_code]&.length == 3 ? options[:recipient_country_code] : Country.find(options[:recipient_country_code]).code(:alpha3).value if options[:recipient_country_code]
         post[:j6] = options[:recipient_street_address] if options[:recipient_street_address]
         post[:j7] = options[:recipient_city] if options[:recipient_city]
         post[:j8] = options[:recipient_province_code] if options[:recipient_province_code]
-        post[:j9] = options[:recipient_country_code] if options[:recipient_country_code]
+        post[:j9] = recipient_country_code
       end
 
       def add_customer_name(post, options)

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -157,7 +157,7 @@ class CredoraxTest < Test::Unit::TestCase
       recipient_street_address: 'street',
       recipient_city: 'chicago',
       recipient_province_code: '312',
-      recipient_country_code: 'USA'
+      recipient_country_code: 'US'
     }
     refund = stub_comms do
       @gateway.refund(@amount, '123', refund_options)


### PR DESCRIPTION
Convert 2 character country code to 3 characters country code as
required by the gateway for j9 parameter.

[CE-2573](https://spreedly.atlassian.net/browse/CE-2573)

Rubocop:
739 files inspected, no offenses detected

Unit:
5173 tests, 75673 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
46 tests, 157 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
86.9565% passed