### PR TITLE
Monei: add cardholderName field

### DIFF
--- a/lib/active_merchant/billing/gateways/monei.rb
+++ b/lib/active_merchant/billing/gateways/monei.rb
@@ -201,6 +201,7 @@ module ActiveMerchant #:nodoc:
           request[:paymentMethod][:card][:expMonth] = format(payment_method.month, :two_digits)
           request[:paymentMethod][:card][:expYear] = format(payment_method.year, :two_digits)
           request[:paymentMethod][:card][:cvc] = payment_method.verification_value.to_s
+          request[:paymentMethod][:card][:cardholderName] = payment_method.name
         end
       end
 

--- a/test/unit/gateways/monei_test.rb
+++ b/test/unit/gateways/monei_test.rb
@@ -149,6 +149,14 @@ class MoneiTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_sending_cardholder_name
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal @credit_card.name, JSON.parse(data)['paymentMethod']['card']['cardholderName']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_scrub
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end


### PR DESCRIPTION
Monei's sandbox does not care if this field gets passed or not, but its omission will cause failures in production.

This field can be found[ here in Monei's docs ](https://docs.monei.com/api/#operation/payments_create
)if you expand the `paymentMethod` object and the child `card` object.

CE-2562

Rubocop:
739 files inspected, no offenses detected

Unit:
5174 tests, 75676 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
25 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed