### PR TITLE
Ogone: Add support for 3dsv2

### DIFF
--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -264,7 +264,6 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_source(post, payment_source, options)
         add_d3d(post, options) if options[:d3d]
-
         if payment_source.is_a?(String)
           add_alias(post, payment_source, options[:alias_operation])
           add_eci(post, options[:eci] || '9')
@@ -285,8 +284,6 @@ module ActiveMerchant #:nodoc:
           THREE_D_SECURE_DISPLAY_WAYS[options[:win_3ds]] :
           THREE_D_SECURE_DISPLAY_WAYS[:main_window]
         add_pair post, 'WIN3DS', win_3ds
-
-        add_pair post, 'HTTP_ACCEPT',     options[:http_accept] || '*/*'
         add_pair post, 'HTTP_USER_AGENT', options[:http_user_agent] if options[:http_user_agent]
         add_pair post, 'ACCEPTURL',       options[:accept_url]      if options[:accept_url]
         add_pair post, 'DECLINEURL',      options[:decline_url]     if options[:decline_url]
@@ -296,6 +293,36 @@ module ActiveMerchant #:nodoc:
         add_pair post, 'PARAMPLUS',       options[:paramplus]       if options[:paramplus]
         add_pair post, 'COMPLUS',         options[:complus]         if options[:complus]
         add_pair post, 'LANGUAGE',        options[:language]        if options[:language]
+        if  options[:three_ds_2]
+          browser_info = options[:three_ds_2][:browser_info]
+          ecom_postal = options[:billing_address]
+          if browser_info
+            add_pair post, 'BROWSERACCEPTHEADER', browser_info[:accept_header]
+            add_pair post, 'BROWSERCOLORDEPTH', browser_info[:depth]
+
+            # for 3ds v2.1 to v2.2 add BROWSERJAVASCRIPTENABLED: This boolean indicates whether your customers have enabled JavaScript in their browsers when making a purchase.
+            # he following BROWSER<tag> parameters will remain mandatory
+            post['BROWSERJAVASCRIPTENABLED'] = browser_info[:javascript].to_s unless browser_info[:javascript].nil?
+            post['BROWSERJAVAENABLED'] = browser_info[:java] unless browser_info[:java].nil?
+            add_pair post, 'BROWSERLANGUAGE', browser_info[:language]
+            add_pair post, 'BROWSERSCREENHEIGHT', browser_info[:height]
+            add_pair post, 'BROWSERSCREENWIDTH', browser_info[:width]
+            add_pair post, 'BROWSERTIMEZONE', browser_info[:timezone]
+            add_pair post, 'BROWSERUSERAGENT', browser_info[:user_agent]
+          end
+          # recommended
+          if ecom_postal
+            add_pair post, 'ECOM_BILLTO_POSTAL_CITY', ecom_postal[:city]
+            add_pair post, 'ECOM_BILLTO_POSTAL_COUNTRYCODE', ecom_postal[:country]
+            add_pair post, 'ECOM_BILLTO_POSTAL_STREET_LINE1', ecom_postal[:address1]
+            add_pair post, 'ECOM_BILLTO_POSTAL_STREET_LINE2', ecom_postal[:address2]
+            add_pair post, 'ECOM_BILLTO_POSTAL_POSTALCODE', ecom_postal[:zip]
+          end
+          # optional
+          add_pair post, 'Mpi.threeDSRequestorChallengeIndicator', options[:three_ds_reqchallengeind]
+        else
+          add_pair post, 'HTTP_ACCEPT', options[:http_accept] || '*/*'
+        end
       end
 
       def add_eci(post, eci)
@@ -414,7 +441,7 @@ module ActiveMerchant #:nodoc:
           return
         end
 
-        add_pair parameters, 'SHASign', calculate_signature(parameters, @options[:signature_encryptor], @options[:signature])
+        add_pair parameters, 'SHASIGN', calculate_signature(parameters, @options[:signature_encryptor], @options[:signature])
       end
 
       def calculate_signature(signed_parameters, algorithm, secret)
@@ -432,7 +459,7 @@ module ActiveMerchant #:nodoc:
             raise "Unknown signature algorithm #{algorithm}"
           end
 
-        filtered_params = signed_parameters.select { |_k, v| !v.blank? }
+        filtered_params = signed_parameters.select { |_k, v| !v.nil? }
         sha_encryptor.hexdigest(
           filtered_params.sort_by { |k, _v| k.upcase }.map { |k, v| "#{k.upcase}=#{v}#{secret}" }.join('')
         ).upcase

--- a/test/remote/gateways/remote_ogone_test.rb
+++ b/test/remote/gateways/remote_ogone_test.rb
@@ -10,12 +10,30 @@ class RemoteOgoneTest < Test::Unit::TestCase
     @mastercard      = credit_card('5399999999999999', brand: 'mastercard')
     @declined_card   = credit_card('1111111111111111')
     @credit_card_d3d = credit_card('4000000000000002', verification_value: '111')
+    @credit_card_d3d_2_challenge = credit_card('4874970686672022', verification_value: '123')
+    @credit_card_d3d_2_friction_less = credit_card('4186455175836497', verification_value: '123')
     @options = {
       order_id: generate_unique_id[0...30],
       billing_address: address,
       description: 'Store Purchase',
       currency: fixtures(:ogone)[:currency] || 'EUR',
       origin: 'STORE'
+    }
+    @options_browser_info = {
+      three_ds_2: {
+        browser_info:  {
+          "width": 390,
+          "height": 400,
+          "depth": 24,
+          "timezone": 300,
+          "user_agent": 'Spreedly Agent',
+          "java": false,
+          "javascript": true,
+          "language": 'en-US',
+          "browser_size": '05',
+          "accept_header": 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
+        }
+      }
     }
   end
 
@@ -74,6 +92,55 @@ class RemoteOgoneTest < Test::Unit::TestCase
     assert_equal '46', response.params['STATUS']
     assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
     assert response.params['HTML_ANSWER']
+    assert_match 'mpi-v1', Base64.decode64(response.params['HTML_ANSWER'])
+  end
+
+  def test_successful_purchase_with_3d_secure_v2
+    assert response = @gateway.purchase(@amount, @credit_card_d3d_2_challenge, @options_browser_info.merge(d3d: true))
+    assert_success response
+    assert_equal '46', response.params['STATUS']
+    assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
+    assert response.params['HTML_ANSWER']
+    assert_match 'mpi-v2', Base64.decode64(response.params['HTML_ANSWER'])
+  end
+
+  def test_successful_purchase_with_3d_secure_v2_friction_less
+    assert response = @gateway.purchase(@amount, @credit_card_d3d_2_friction_less, @options_browser_info.merge(d3d: true))
+    assert_success response
+    assert_includes response.params, 'PAYID'
+    assert_equal '0', response.params['NCERROR']
+    assert_equal '9', response.params['STATUS']
+    assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
+  end
+
+  def test_successful_purchase_with_3d_secure_v2_recomended_parameters
+    options = @options.merge(@options_browser_info)
+    assert response = @gateway.authorize(@amount, @credit_card_d3d_2_challenge, options.merge(d3d: true))
+    assert_success response
+    assert_equal '46', response.params['STATUS']
+    assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
+    assert response.params['HTML_ANSWER']
+    assert_match 'mpi-v2', Base64.decode64(response.params['HTML_ANSWER'])
+  end
+
+  def test_successful_purchase_with_3d_secure_v2_optional_parameters
+    options = @options.merge(@options_browser_info).merge(mpi: { threeDSRequestorChallengeIndicator: '04' })
+    assert response = @gateway.authorize(@amount, @credit_card_d3d_2_challenge, options.merge(d3d: true))
+    assert_success response
+    assert_equal '46', response.params['STATUS']
+    assert_equal OgoneGateway::SUCCESS_MESSAGE, response.message
+    assert response.params['HTML_ANSWER']
+    assert_match 'mpi-v2', Base64.decode64(response.params['HTML_ANSWER'])
+  end
+
+  def test_unsuccessful_purchase_with_3d_secure_v2
+    @credit_card_d3d_2_challenge.number = '4419177274955460'
+    assert response = @gateway.purchase(@amount, @credit_card_d3d_2_challenge, @options_browser_info.merge(d3d: true))
+    assert_failure response
+    assert_includes response.params, 'PAYID'
+    assert_equal response.params['NCERROR'], '40001134'
+    assert_equal response.params['STATUS'], '2'
+    assert_equal response.params['NCERRORPLUS'], 'Authentication failed. Please retry or cancel.'
   end
 
   def test_successful_with_non_numeric_order_id
@@ -117,7 +184,7 @@ class RemoteOgoneTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'No brand', response.message
+    assert_equal 'No brand or invalid card number', response.message
   end
 
   def test_successful_authorize_with_mastercard
@@ -147,7 +214,7 @@ class RemoteOgoneTest < Test::Unit::TestCase
   def test_unsuccessful_capture
     assert response = @gateway.capture(@amount, '')
     assert_failure response
-    assert_equal 'No card no, no exp date, no brand', response.message
+    assert_equal 'No card no, no exp date, no brand or invalid card number', response.message
   end
 
   def test_successful_void
@@ -215,7 +282,7 @@ class RemoteOgoneTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_equal 'No brand', response.message
+    assert_equal 'No brand or invalid card number', response.message
   end
 
   def test_reference_transactions


### PR DESCRIPTION
Summary:
---------------------------------------
In order to  support 3dsv2 this PR add the 
mandatories, recommended and optionals 
fields required for those transactions

Local Tests:
---------------------------------------
Finished in 0.124174 seconds.
48 tests, 206 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
---------------------------------------
Finished in 103.344988 seconds.
32 tests, 132 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.875% passed

RuboCop:
---------------------------------------
739 files inspected, no offenses detected