### PR TITLE
BlueSnap: parse refund-transaction-id correctly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -80,6 +80,7 @@
 * Securion Pay: Pass external 3DS data [jherreraa] #4404
 * Airwallex: Update Stored Credentials testing, remove support for `original_transaction_id` field [drkjc] 4407
 * Credorax: Convert country codes for  `recipient_country_code` field [ajawadmirza] #4408
+* BlueSnap: Correctly parse `refund-transaction-id` [dsmcclain] #4411
 
 == Version 1.125.0 (January 20, 2022)
 * Wompi: support gateway [therufs] #4173

--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -512,7 +512,9 @@ module ActiveMerchant
       end
 
       def authorization_from(action, parsed_response, payment_method_details)
-        action == :store ? vaulted_shopper_id(parsed_response, payment_method_details) : parsed_response['transaction-id']
+        return vaulted_shopper_id(parsed_response, payment_method_details) if action == :store
+
+        parsed_response['refund-transaction-id'] || parsed_response['transaction-id']
       end
 
       def vaulted_shopper_id(parsed_response, payment_method_details)

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -449,6 +449,7 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert refund = @gateway.refund(@amount, purchase.authorization, @refund_options)
     assert_success refund
     assert_equal 'Success', refund.message
+    assert_not_nil refund.authorization
   end
 
   def test_successful_refund_with_merchant_id

--- a/test/unit/gateways/blue_snap_test.rb
+++ b/test/unit/gateways/blue_snap_test.rb
@@ -416,9 +416,9 @@ class BlueSnapTest < Test::Unit::TestCase
         assert_match item.elements['meta-description'].text, options[:transaction_meta_data][index][:meta_description]
         assert_match item.elements['is-visible'].text, options[:transaction_meta_data][index][:meta_is_visible]
       end
-    end.respond_with(successful_refund_response)
+    end.respond_with(successful_refund_without_merchant_transaction_id_response)
     assert_success response
-    assert_equal '1012082907', response.authorization
+    assert_equal '1061398943', response.authorization
   end
 
   def test_successful_refund_with_merchant_id
@@ -429,6 +429,7 @@ class BlueSnapTest < Test::Unit::TestCase
       assert_includes endpoint, "/refund/merchant/#{merchant_transaction_id}"
     end.respond_with(successful_refund_response)
     assert_success response
+    assert_equal '1012082907', response.authorization
   end
 
   def test_failed_refund
@@ -1091,6 +1092,32 @@ class BlueSnapTest < Test::Unit::TestCase
       </messages>
     XML
     MockResponse.failed(body, 400)
+  end
+
+  def successful_refund_without_merchant_transaction_id_response
+    MockResponse.succeeded <<-XML
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <refund xmlns="http://ws.plimus.com">
+        <refund-transaction-id>1061398943</refund-transaction-id>
+        <amount>1.00</amount>
+        <tax-amount>0.05</tax-amount>
+        <transaction-meta-data>
+          <meta-data>
+            <meta-key>refundedItems</meta-key>
+            <meta-value>1552,8832</meta-value>
+            <meta-description>Refunded Items</meta-description>
+            <is-visible>false</is-visible>
+          </meta-data>
+          <meta-data>
+            <meta-key>Number2</meta-key>
+            <meta-value>KTD</meta-value>
+            <meta-description>Metadata 2</meta-description>
+            <is-visible>true</is-visible>
+          </meta-data>
+        </transaction-meta-data>
+        <reason>Refund for order #1992</reason>
+      </refund>
+    XML
   end
 
   def successful_void_response


### PR DESCRIPTION
Depending on which endpoint is being used, the gateway's response on a refund will include the transaction id in either the `transaction-id` or the `refund-transaction-id` field of the parsed response.

This change updates the `authorize_from` method to account for the presence of `refund-transaction-id` on select refund transactions.

Currently, there is one remote test that is failing on master: `test_successful_purchase_with_level3_data`. When I inspect the response for this test, I do not see any of [the response fields that BlueSnap's documentation lists for level3data](https://developers.bluesnap.com/v8976-JSON/docs/level3data). Instead I see ` "transaction-processed-with-l3d-supported-acquirer"=>"false"`. My best guess here is that this indicates a setting that needs to be changed on our sandbox account. I do not have the ability to do this through BlueSnap's developer portal, so I am just going to leave this test as failing because attempting to contact the gateway to get this changed is outside the scope of this current task.

CE-2522

Rubocop:
739 files inspected, no offenses detected

Unit:
5174 tests, 75678 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_blue_snap_test
50 tests, 169 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98% passed