### PR TITLE
Worldpay: extract issuer response code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Credorax: Convert country codes for  `recipient_country_code` field [ajawadmirza] #4408
 * BlueSnap: Correctly parse `refund-transaction-id` [dsmcclain] #4411
 * Worldpay: Add level II and level III data [javierpedrozaing] #4393
+* Worldpay: extract `issuer_response_code` and `issuer_response_description` from gateway response [dsmcclain] #4412
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -804,7 +804,16 @@ module ActiveMerchant #:nodoc:
         resp_params = { action: action }
 
         parse_elements(doc.root, resp_params)
+        extract_issuer_response(doc.root, resp_params)
+
         resp_params
+      end
+
+      def extract_issuer_response(doc, response)
+        return unless issuer_response = doc.at_xpath('//paymentService//reply//orderStatus//payment//IssuerResponseCode')
+
+        response[:issuer_response_code] = issuer_response['code']
+        response[:issuer_response_description] = issuer_response['description']
       end
 
       def parse_elements(node, response)


### PR DESCRIPTION
The data is embedded in XML attributes and was therefore not included in the parsed response.

There is no remote test to describe this behavior because Worldpay's Sandbox does not return `IssuerResponseCode`. An example of the XML response we should expect has been included in the unit tests.

CE-2546

Rubocop:
739 files inspected, no offenses detected

Unit:
5175 tests, 75682 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
Loaded suite test/remote/gateways/remote_worldpay_test
94 tests, 392 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed