### PR TITLE
Vantiv: Read saleResponse duplicate attribute

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * BlueSnap: Correctly parse `refund-transaction-id` [dsmcclain] #4411
 * Worldpay: Add level II and level III data [javierpedrozaing] #4393
 * Worldpay: extract `issuer_response_code` and `issuer_response_description` from gateway response [dsmcclain] #4412
+* Vantiv: Support `duplicate` field read from saleResponse.duplicate attr [mashton] #4413
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -532,8 +532,10 @@ module ActiveMerchant #:nodoc:
 
       def parse(kind, xml)
         parsed = {}
-
         doc = Nokogiri::XML(xml).remove_namespaces!
+
+        parsed['duplicate'] = doc.at_xpath('//saleResponse').try(:[], 'duplicate') == 'true' if kind == :sale
+
         doc.xpath("//litleOnlineResponse/#{kind}Response/*").each do |node|
           if node.elements.empty?
             parsed[node.name.to_sym] = node.text

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -112,6 +112,22 @@ class LitleTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_sale_response_duplicate_attribute
+    dup_response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(duplicate_purchase_response)
+
+    assert_success dup_response
+    assert_true dup_response.params['duplicate']
+
+    non_dup_response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success non_dup_response
+    assert_false non_dup_response.params['duplicate']
+  end
+
   def test_failed_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
@@ -712,6 +728,25 @@ class LitleTest < Test::Unit::TestCase
     %(
       <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
         <saleResponse id='1' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>100000000000000006</litleTxnId>
+          <orderId>1</orderId>
+          <response>000</response>
+          <responseTime>2014-03-31T11:34:39</responseTime>
+          <message>Approved</message>
+          <authCode>11111 </authCode>
+          <fraudResult>
+            <avsResult>01</avsResult>
+            <cardValidationResult>M</cardValidationResult>
+          </fraudResult>
+        </saleResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def duplicate_purchase_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <saleResponse id='1' duplicate='true' reportGroup='Default Report Group' customerId=''>
           <litleTxnId>100000000000000006</litleTxnId>
           <orderId>1</orderId>
           <response>000</response>


### PR DESCRIPTION
The LitleGateway parse method reads elements and their text values, but does not read any of the elements attributes. Here we read one very specific attribute (probably not worth generalizing just yet). Here we're interested in a Litle saleResponse that may or may not have the attribute `duplicate='true'`. All Litle saleResponses will include duplicate: true/false.

Note on testing: Remote test for this feature is missing. It looks like the `testvantivcnp` api does not return the duplicate attribute the same way the production api does. Additionally, something seems to have changed in the `testvantivcnp` api such that existing remote tests fail. PR coming soon with fixes for existing tests.

CE-2506

Local:
5175 tests, 75684 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
See note.

Linting:
739 files inspected, no offenses detected