### PR TITLE
BlueSnap: Add stored credential

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Worldpay: extract `issuer_response_code` and `issuer_response_description` from gateway response [dsmcclain] #4412
 * Vantiv: Support `duplicate` field read from saleResponse.duplicate attr [mashton] #4413
 * Ogone: Add support for 3dsv2 [gasb150] #4410
+* BlueSnap: Add support for stored credentials [ajawadmirza] #4414
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/test/remote/gateways/remote_blue_snap_test.rb
+++ b/test/remote/gateways/remote_blue_snap_test.rb
@@ -249,6 +249,40 @@ class RemoteBlueSnapTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_for_stored_credentials_with_cit
+    cit_stored_credentials = {
+      initiator: 'cardholder'
+    }
+    response = @gateway.purchase(@amount, @three_ds_visa_card, @options_3ds2.merge({ stored_credential: cit_stored_credentials }))
+    assert_success response
+    assert_equal 'Success', response.message
+
+    cit_stored_credentials = {
+      initiator: 'cardholder',
+      network_transaction_id: response.params['original-network-transaction-id']
+    }
+    response = @gateway.purchase(@amount, @three_ds_visa_card, @options_3ds2.merge({ stored_credential: cit_stored_credentials }))
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
+  def test_successful_purchase_for_stored_credentials_with_mit
+    mit_stored_credentials = {
+      initiator: 'merchant'
+    }
+    response = @gateway.purchase(@amount, @three_ds_visa_card, @options_3ds2.merge({ stored_credential: mit_stored_credentials }))
+    assert_success response
+    assert_equal 'Success', response.message
+
+    mit_stored_credentials = {
+      initiator: 'merchant',
+      network_transaction_id: response.params['original-network-transaction-id']
+    }
+    response = @gateway.purchase(@amount, @three_ds_visa_card, @options_3ds2.merge({ stored_credential: mit_stored_credentials }))
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_successful_purchase_with_currency
     response = @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'CAD'))
     assert_success response


### PR DESCRIPTION
Added `stored_credential` support by adding `transaction-initiator` and
`original-network-transaction-id` in the request parameters for blue
snap gateway implementation.

CE-2536

Rubocop:
739 files inspected, no offenses detected

Unit:
5180 tests, 75721 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
52 tests, 177 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.0769% passed