### PR TITLE
Braintree Blue: Return client token in AM response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * DLocal: Mark support for additional countries [gasb150] #4427
 * Authorize.net: Enable zero auth for allowed cards [jherreraa] #4430
 * Rapyd: Additional Fields [naashton] #4434
+* Braintree: Return generated client token [BritneyS] #4416
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -75,6 +75,12 @@ module ActiveMerchant #:nodoc:
         @braintree_gateway = Braintree::Gateway.new(@configuration)
       end
 
+      def setup_purchase
+        commit do
+          Response.new(true, 'Client token created', { client_token: @braintree_gateway.client_token.generate })
+        end
+      end
+
       def authorize(money, credit_card_or_vault_id, options = {})
         return Response.new(false, DIRECT_BANK_ERROR) if credit_card_or_vault_id.is_a? Check
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -83,6 +83,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal('510510', response.params['braintree_transaction']['credit_card_details']['bin'])
   end
 
+  def test_successful_setup_purchase
+    assert response = @gateway.setup_purchase
+    assert_success response
+    assert_equal 'Client token created', response.message
+    assert_not_nil response.params['client_token']
+  end
+
   def test_successful_authorize_with_order_id
     assert response = @gateway.authorize(@amount, @credit_card, order_id: '123')
     assert_success response


### PR DESCRIPTION
For ECS-2435

Test Summary
Local: 5176 tests, 75655 assertions, 0 failures, 18 errors, 0 pendings, 0 omissions, 0 notifications
99.6522% passed
Unit: 90 tests, 200 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote: 96 tests, 524 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed