### PR TITLE
Ogone: Updated home gateway URL

### DIFF
--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -136,7 +136,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w[BE DE FR NL AT CH]
       # also supports Airplus and UATP
       self.supported_cardtypes = %i[visa master american_express diners_club discover jcb maestro]
-      self.homepage_url = 'http://www.ogone.com/'
+      self.homepage_url = 'https://www.ingenico.com/login/ogone/'
       self.display_name = 'Ogone'
       self.default_currency = 'EUR'
       self.money_format = :cents

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -41,6 +41,10 @@ class OgoneTest < Test::Unit::TestCase
     Base.mode = :test
   end
 
+  def test_should_have_homepage_url
+    assert_equal 'https://www.ingenico.com/login/ogone/', OgoneGateway.homepage_url
+  end
+
   def test_successful_purchase
     @gateway.expects(:add_pair).at_least(1)
     @gateway.expects(:add_pair).with(anything, 'ECI', '7')


### PR DESCRIPTION
Summary:
---------------------------------------
In order to add  update the home gateway URL for Ogone
this PR change the homepage_url to https://www.ingenico.com/login/ogone/

Local Tests:
---------------------------------------
49 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
---------------------------------------
Finished in 86.941743 seconds.
32 tests, 132 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.875% passed

RuboCop:
---------------------------------------
739 files inspected, no offenses detected