### PR TITLE
Simetrik: Fixes VAT not as cents

### DIFF
--- a/lib/active_merchant/billing/gateways/simetrik.rb
+++ b/lib/active_merchant/billing/gateways/simetrik.rb
@@ -69,7 +69,7 @@ module ActiveMerchant #:nodoc:
             acquire_extra_options: options[:acquire_extra_options] || {}
           }
         }
-        post[:forward_payload][:amount][:vat] = options[:vat].to_f if options[:vat]
+        post[:forward_payload][:amount][:vat] = amount(options[:vat]).to_f if options[:vat]
 
         add_forward_route(post, options)
         commit('capture', post, { token_acquirer: options[:token_acquirer] })
@@ -247,7 +247,7 @@ module ActiveMerchant #:nodoc:
         amount_obj = {}
         amount_obj[:total_amount] = amount(money).to_f
         amount_obj[:currency] = (options[:currency] || currency(money))
-        amount_obj[:vat] = options[:vat].to_f if options[:vat]
+        amount_obj[:vat] = amount(options[:vat]).to_f if options[:vat]
 
         post[:amount] = amount_obj
       end

--- a/test/unit/gateways/simetrik_test.rb
+++ b/test/unit/gateways/simetrik_test.rb
@@ -56,7 +56,7 @@ class SimetrikTest < Test::Unit::TestCase
         installments: 1
       },
       currency: 'USD',
-      vat: 19,
+      vat: 190,
       three_ds_fields: {
         version: '2.1.0',
         eci: '02',
@@ -92,7 +92,7 @@ class SimetrikTest < Test::Unit::TestCase
           "amount": {
             "total_amount": 10.0,
             "currency": 'USD',
-            "vat": 19
+            "vat": 1.9
           }
         },
         "payment_method": {
@@ -232,7 +232,7 @@ class SimetrikTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(failed_capture_response_body)
 
     response = @gateway.capture(@amount, 'SI-226', {
-      vat: 19,
+      vat: 190,
       currency: 'USD',
       token_acquirer: @token_acquirer,
       trace_id: @trace_id


### PR DESCRIPTION
VAT quantity was not in cents, resulting in an inconsistent user experience. Ej: An amount of 1000 would be $10 but a VAT of 19 would be $19.

This PR fixes this issue treating VAT as a number in cents.

Unit tests: 
12 tests, 83 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote tests:
12 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
