### PR TITLE
DLocal: Add support for aditional countires

### DIFF
--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://sandbox.dlocal.com'
       self.live_url = 'https://api.dlocal.com'
 
-      self.supported_countries = %w[AR BD BO BR CL CM CN CO CR DO EC EG GH IN ID KE MY MX MA NG PA PY PE PH SN ZA TR UY VN]
+      self.supported_countries = %w[AR BD BO BR CL CM CN CO CR DO EC EG GH GT IN ID JP KE MY MX MA NG PA PY PE PH SN SV TH TR TZ UG UY VN ZA]
       self.default_currency = 'USD'
       self.supported_cardtypes = %i[visa master american_express discover jcb diners_club maestro naranja cabal elo alia carnet]
 

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -22,6 +22,10 @@ class DLocalTest < Test::Unit::TestCase
     }
   end
 
+  def test_supported_countries
+    assert_equal %w[AR BD BO BR CL CM CN CO CR DO EC EG GH GT IN ID JP KE MY MX MA NG PA PY PE PH SN SV TH TR TZ UG UY VN ZA], DLocalGateway.supported_countries
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 


### PR DESCRIPTION
Summary:
---------------------------------------
In order to add support to an updated list of countries
this PR add to the supported_countires the next ones:
El Salvador (SV), Guatemala (GT), Japan (JP), Tanzania (TZ),
Thailand (TH) and Uganda (UG)

Local Tests:
---------------------------------------
33 tests, 144 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
---------------------------------------
Finished in 18.186212 seconds.
31 tests, 80 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.7742% passed

RuboCop:
---------------------------------------
739 files inspected, no offenses detected