### PR TITLE
CyberSource add bank account payment method support

### DIFF
--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -60,7 +60,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_equal 'Successful transaction', response.message
     assert_success response
-    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;", response.authorization
+    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;;credit_card", response.authorization
     assert response.test?
   end
 
@@ -88,7 +88,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @elo_credit_card, @options)
     assert_equal 'Successful transaction', response.message
     assert_success response
-    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;", response.authorization
+    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;;credit_card", response.authorization
     assert response.test?
   end
 
@@ -276,7 +276,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @check, @options)
     assert_equal 'Successful transaction', response.message
     assert_success response
-    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;", response.authorization
+    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;;check", response.authorization
     assert response.test?
   end
 
@@ -286,7 +286,7 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(pinless_debit_card: true))
     assert_equal 'Successful transaction', response.message
     assert_success response
-    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;", response.authorization
+    assert_equal "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};purchase;100;USD;;credit_card", response.authorization
     assert response.test?
   end
 
@@ -620,7 +620,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
     assert_failure(response = @gateway.authorize(@amount, @credit_card, @options))
     assert response.fraud_review?
-    assert_equal(response.authorization, "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};authorize;100;USD;")
+    assert_equal(response.authorization, "#{@options[:order_id]};#{response.params['requestID']};#{response.params['requestToken']};authorize;100;USD;;")
   end
 
   def test_successful_credit_to_subscription_request


### PR DESCRIPTION
Summary:
---
This PR adds some test cases to ensure the current ACH implementation for CyberSource and modifies the credit method so it is able to support 'follow on' credits on transactions created with ACH debits.

**Note:** The 3 failing remote tests correspond to authentication failures because of the lack of a latam-related account.

Test Execution:
---
Remote
Finished in 89.497321 seconds.
110 tests, 555 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.2727% passed

Unit
Finished in 23.96186 seconds.
5183 tests, 75749 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
------------------------------
739 files inspected, no offenses detected