### PR TITLE
CardConnect:  Add support for 3ds V2

### DIFF
--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -87,7 +87,7 @@ module ActiveMerchant #:nodoc:
           add_currency(post, money, options)
           add_address(post, options)
           add_customer_data(post, options)
-          add_3DS(post, options)
+          add_three_ds(post, options)
           add_additional_data(post, options)
           post[:capture] = 'Y'
           commit('auth', post)
@@ -102,7 +102,7 @@ module ActiveMerchant #:nodoc:
         add_payment(post, payment)
         add_address(post, options)
         add_customer_data(post, options)
-        add_3DS(post, options)
+        add_three_ds(post, options)
         add_additional_data(post, options)
         commit('auth', post)
       end
@@ -241,10 +241,12 @@ module ActiveMerchant #:nodoc:
         post[:userfields] = options[:user_fields] if options[:user_fields]
       end
 
-      def add_3DS(post, options)
-        post[:secureflag] = options[:secure_flag] if options[:secure_flag]
-        post[:securevalue] = options[:secure_value] if options[:secure_value]
-        post[:securexid] = options[:secure_xid] if options[:secure_xid]
+      def add_three_ds(post, options)
+        return unless three_d_secure = options[:three_d_secure]
+
+        post[:secureflag]  = three_d_secure[:eci]
+        post[:securevalue] = three_d_secure[:cavv]
+        post[:securedstid] = three_d_secure[:ds_transaction_id]
       end
 
       def headers

--- a/test/remote/gateways/remote_card_connect_test.rb
+++ b/test/remote/gateways/remote_card_connect_test.rb
@@ -134,11 +134,13 @@ class RemoteCardConnectTest < Test::Unit::TestCase
     assert_equal 'Approval Queued for Capture', response.message
   end
 
-  def test_successful_purchase_3DS
+  def test_successful_purchase_three_ds
     three_ds_options = @options.merge(
-      secure_flag: 'se3453',
-      secure_value: '233frdf',
-      secure_xid: '334ef34'
+      three_d_secure: {
+        eci: 'se3453',
+        cavv: 'AJkBByEyYgAAAASwgmEodQAAAAA=',
+        ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw=='
+      }
     )
     response = @gateway.purchase(@amount, @credit_card, three_ds_options)
     assert_success response


### PR DESCRIPTION
Description
-------------------------

In order to support 3dsv2 properly this PR does an update
to the recommended files used for this transactions

Unit test
-------------------------
Finished in 0.938125 seconds.

27 tests, 109 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

28.78 tests/s, 116.19 assertions/s

Remote test
-------------------------
Finished in 29.117144 seconds.

25 tests, 58 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92% passed

0.86 tests/s, 1.99 assertions/s

Rubocop
-------------------------
739 files inspected, no offenses detected