### PR TITLE
DLocal: fix Idempotency Header bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Ogone: Updated home gateway URL [gasb150] #4419
 * Credorax: Update url gateway and credit cards [javierpedrozaing] #4417
 * Kushki: Pass extra_taxes with USD [therufs] #4426
+* DLocal: fix bug with `X-Idempotency-Key` header [dsmcclain] #4431
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -242,7 +242,7 @@ module ActiveMerchant #:nodoc:
           'X-Version' => '2.1',
           'Authorization' => signature(post, timestamp)
         }
-        headers.merge('X-Idempotency-Key' => options[:idempotency_key]) if options[:idempotency_key]
+        headers['X-Idempotency-Key'] = options[:idempotency_key] if options[:idempotency_key]
         headers
       end
 

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -234,6 +234,15 @@ class DLocalTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_idempotency_header
+    options = @options.merge(idempotency_key: '12345')
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, _data, headers|
+      assert_equal '12345', headers['X-Idempotency-Key']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_three_ds_v1_object_construction
     post = {}
     @options[:three_d_secure] = @three_ds_secure


### PR DESCRIPTION
The `X-Idempotency-Key` header was not being sent in requests.

CE-2655

Rubocop:
739 files inspected, no offenses detected

Unit:
5185 tests, 75757 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
31 tests, 80 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.7742% passed

 The following test is failing for reasons unrelated to this change:
`test_successful_purchase_naranja`

As far as I can tell, this test began failing with [this commit](https://github.com/activemerchant/active_merchant/commit/cdfce9fe3a9962f93a0f2a2c7c83ac59042a3656). This test fails with the message "Merchant has no authorization to use this API". My hunch is that resolving this would require contacting dLocal to make adjustments to our Sandbox account.