### PR TITLE
Rapyd: Additional Fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * BlueSnap: Add support for stored credentials [ajawadmirza] #4414
 * Monei: Add support for `lang` field [drkjc] #4421
 * Wompi: Redirect `refund` to `void` [drkjc] #4424
+* Rapyd: 3DS Support [naashton] #4422
 * Adyen: Update API version [jherreraa] #4418
 * Ogone: Updated home gateway URL [gasb150] #4419
 * Credorax: Update url gateway and credit cards [javierpedrozaing] #4417
@@ -20,6 +21,7 @@
 * DLocal: fix bug with `X-Idempotency-Key` header [dsmcclain] #4431
 * DLocal: Mark support for additional countries [gasb150] #4427
 * Authorize.net: Enable zero auth for allowed cards [jherreraa] #4430
+* Rapyd: Additional Fields [naashton] #4434
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -26,6 +26,7 @@ module ActiveMerchant #:nodoc:
         add_address(post, payment, options)
         add_metadata(post, options)
         add_ewallet(post, options)
+        add_payment_fields(post, options)
         post[:capture] = true if payment_is_card?(options)
 
         if payment_is_ach?(options)
@@ -49,6 +50,7 @@ module ActiveMerchant #:nodoc:
         add_address(post, payment, options)
         add_metadata(post, options)
         add_ewallet(post, options)
+        add_payment_fields(post, options)
         post[:capture] = false
 
         commit(:post, 'payments', post)
@@ -179,6 +181,15 @@ module ActiveMerchant #:nodoc:
 
       def add_ewallet(post, options)
         post[:ewallet_id] = options[:ewallet_id] if options[:ewallet_id]
+      end
+
+      def add_payment_fields(post, options)
+        post[:payment] = {}
+
+        post[:payment][:complete_payment_url] = options[:complete_payment_url] if options[:complete_payment_url]
+        post[:payment][:error_payment_url] = options[:error_payment_url] if options[:error_payment_url]
+        post[:payment][:description] = options[:description] if options[:description]
+        post[:payment][:statement_descriptor] = options[:statement_descriptor] if options[:statement_descriptor]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -10,7 +10,11 @@ class RemoteRapydTest < Test::Unit::TestCase
     @check = check
     @options = {
       pm_type: 'us_visa_card',
-      currency: 'USD'
+      currency: 'USD',
+      complete_payment_url: 'www.google.com',
+      error_payment_url: 'www.google.com',
+      description: 'Describe this transaction',
+      statement_descriptor: 'Statement Descriptor'
     }
     @ach_options = {
       pm_type: 'us_ach_bank',


### PR DESCRIPTION
Add support for:
* `complete_payment_url`
* `error_payment_url`
* `description`
* `statement_descriptor`

These fields are subfields of the `payment` object

CE-2606

Unit: 18 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 23 tests, 65 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed