### PR TITLE
Rapyd: Scrub ACH

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * Simetrik: Update `audience` field [simetrik-frank] #4433
 * CyberSource: Add bank account payment method support [heavyblade] #4428
 * Rapyd: Zero Dollar Auth [naashton] #4435
+* Rapyd: Scrub ACH [naashton] #4436
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -86,6 +86,8 @@ module ActiveMerchant #:nodoc:
         transcript.
           gsub(%r((Access_key: )\w+), '\1[FILTERED]').
           gsub(%r(("number\\?":\\?")\d+), '\1[FILTERED]').
+          gsub(%r(("account_number\\?":\\?")\d+), '\1[FILTERED]').
+          gsub(%r(("routing_number\\?":\\?")\d+), '\1[FILTERED]').
           gsub(%r(("cvv\\?":\\?")\d+), '\1[FILTERED]')
       end
 

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -216,6 +216,18 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:access_key], transcript)
   end
 
+  def test_transcript_scrubbing_with_ach
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @check, @ach_options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@check.account_number, transcript)
+    assert_scrubbed(@check.routing_number, transcript)
+    assert_scrubbed(@gateway.options[:secret_key], transcript)
+    assert_scrubbed(@gateway.options[:access_key], transcript)
+  end
+
   def test_successful_authorize_with_3ds_v1_options
     options = @options.merge(three_d_secure: @three_d_secure)
     options[:pm_type] = 'gb_visa_card'


### PR DESCRIPTION
Scrub the `account_number` and `routing_number` from the transcript

CE-2622

Unit: 17 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 24 tests, 69 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed