### PR TITLE
VisaNet Peru: purchase_number bug fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * CyberSource: Add bank account payment method support [heavyblade] #4428
 * Rapyd: Zero Dollar Auth [naashton] #4435
 * Rapyd: Scrub ACH [naashton] #4436
+* VisaNet Peru: Update `purchase_number` [rachelkirk] #4437
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -143,7 +143,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def generate_purchase_number_stamp
-        (Time.now.to_f.round(2) * 100).to_i.to_s
+        Time.now.to_f.to_s.delete('.')[1..10] + rand(99).to_s
       end
 
       def commit(action, params, options = {})


### PR DESCRIPTION
CE-2624

This updates the existing time stamp logic and filters it to be an even more specific slice of time, and appends two randomly generated numbers  to the end of the string. The existing unit test (def test_nonconsecutive_purchase_numbers
 on line 42) seemed sufficient and is passing. 16  of 18 remote tests are failing and have been for at least 6 months.

Unit:
16 tests, 96 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
18 tests, 27 assertions, 16 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
11.1111% passed

Local:
5184 tests, 75754 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed