### PR TITLE
Add Ascension Island and Tristan da Cunha

### DIFF
--- a/lib/active_merchant/country.rb
+++ b/lib/active_merchant/country.rb
@@ -67,6 +67,7 @@ module ActiveMerchant #:nodoc:
     COUNTRIES = [
       { alpha2: 'AF', name: 'Afghanistan', alpha3: 'AFG', numeric: '004' },
       { alpha2: 'AL', name: 'Albania', alpha3: 'ALB', numeric: '008' },
+      { alpha2: 'AC', name: 'Ascension Island', alpha3: 'ASC' },
       { alpha2: 'DZ', name: 'Algeria', alpha3: 'DZA', numeric: '012' },
       { alpha2: 'AS', name: 'American Samoa', alpha3: 'ASM', numeric: '016' },
       { alpha2: 'AD', name: 'Andorra', alpha3: 'AND', numeric: '020' },
@@ -292,6 +293,7 @@ module ActiveMerchant #:nodoc:
       { alpha2: 'TK', name: 'Tokelau', alpha3: 'TKL', numeric: '772' },
       { alpha2: 'TO', name: 'Tonga', alpha3: 'TON', numeric: '776' },
       { alpha2: 'TT', name: 'Trinidad and Tobago', alpha3: 'TTO', numeric: '780' },
+      { alpha2: 'TA', name: 'Tristan da Cunha', alpha3: 'TAA' },
       { alpha2: 'TN', name: 'Tunisia', alpha3: 'TUN', numeric: '788' },
       { alpha2: 'TR', name: 'Turkey', alpha3: 'TUR', numeric: '792' },
       { alpha2: 'TM', name: 'Turkmenistan', alpha3: 'TKM', numeric: '795' },


### PR DESCRIPTION
Similar to https://github.com/Shopify/active_utils/pull/123

Adding Ascension Island and Tristan da Cunha to the countries list under the ISO3166-1 special case of keeping them separate from Saint Helena. Pulled alpha3 from https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3, and alpha2 from https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2.

No numeric codes for AC and TA are listed at this time, example source https://en.wikipedia.org/wiki/ISO_3166-1_numeric, so left those blank for now.