### PR TITLE
Plexo: Change field name to `metadata`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Rapyd: Support `store` and `unstore` [naashton] #4439
 * Orbital: Update API version to 9.0 [gasb150] #4440
 * Plexo:  Add `meta_data` fields and reorder amount object in response [ajawadmirza] #4441
+* Plexo:  Change field name from `meta_data` to `metadata` [ajawadmirza] #4443
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -37,7 +37,7 @@ module ActiveMerchant #:nodoc:
 
         add_payment_method(post, payment, options)
         add_items(post, options[:items])
-        add_meta_data(post, options[:meta_data])
+        add_metadata(post, options[:metadata])
         add_amount(money, post, options[:amount_details])
         add_browser_details(post, options[:browser_details])
         add_capture_type(post, options)
@@ -132,11 +132,11 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_meta_data(post, meta_data)
-        return unless meta_data
+      def add_metadata(post, metadata)
+        return unless metadata
 
-        meta_data.transform_keys! { |key| key.to_s.camelize.to_sym }
-        post[:Metadata] = meta_data
+        metadata.transform_keys! { |key| key.to_s.camelize.to_sym }
+        post[:Metadata] = metadata
       end
 
       def add_amount(money, post, amount_options)

--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -49,11 +49,11 @@ class RemotePlexoTest < Test::Unit::TestCase
     assert_equal 'You have been mocked.', response.message
   end
 
-  def test_successful_authorize_with_meta_data
+  def test_successful_authorize_with_metadata
     meta = {
       custom_one: 'my field 1'
     }
-    auth = @gateway.authorize(@amount, @credit_card, @options.merge({ meta_data: meta }))
+    auth = @gateway.authorize(@amount, @credit_card, @options.merge({ metadata: meta }))
     assert_success auth
 
     assert capture = @gateway.capture(@amount, auth.authorization)

--- a/test/unit/gateways/plexo_test.rb
+++ b/test/unit/gateways/plexo_test.rb
@@ -29,7 +29,7 @@ class PlexoTest < Test::Unit::TestCase
         finger_print: '12345',
         ip: '127.0.0.1'
       },
-      meta_data: {
+      metadata: {
         custom_one: 'test1',
         test_a: 'abc'
       }
@@ -94,9 +94,9 @@ class PlexoTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, @options)
     end.check_request do |_endpoint, data, _headers|
       request = JSON.parse(data)
-      @options[:meta_data].keys.each do |meta_key|
+      @options[:metadata].keys.each do |meta_key|
         camel_key = meta_key.to_s.camelize
-        assert_equal request['Metadata'][camel_key], @options[:meta_data][meta_key]
+        assert_equal request['Metadata'][camel_key], @options[:metadata][meta_key]
       end
     end.respond_with(successful_authorize_response)
 


### PR DESCRIPTION
Changed field name from `meta_data` to `metadata` as per the standards
of the gateway field.

CE-2567

Unit:
5208 tests, 75877 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
742 files inspected, no offenses detected

Remote:
16 tests, 47 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed