### PR TITLE
Cybersource: Fixing Amex cryptogram bug

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -769,7 +769,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'ccAuthService', { 'run' => 'true' } do
             xml.tag!('cavv', Base64.encode64(cryptogram[0...20]))
             xml.tag!('commerceIndicator', ECI_BRAND_MAPPING[brand])
-            xml.tag!('xid', Base64.encode64(cryptogram[20...40]))
+            xml.tag!('xid', Base64.encode64(cryptogram[20...40])) if cryptogram.bytes.count > 20
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
           end
         end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -622,6 +622,45 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(capture)
   end
 
+  def test_network_tokenization_with_amex_cc_and_basic_cryptogram
+    credit_card = network_tokenization_credit_card('378282246310005',
+      brand: 'american_express',
+      eci: '05',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+
+    assert auth = @gateway.authorize(@amount, credit_card, @options)
+    assert_successful_response(auth)
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_successful_response(capture)
+  end
+
+  def test_network_tokenization_with_amex_cc_longer_cryptogram
+    # Generate a random 40 bytes binary amex cryptogram => Base64.encode64(Random.bytes(40))
+    long_cryptogram = "NZwc40C4eTDWHVDXPekFaKkNYGk26w+GYDZmU50cATbjqOpNxR/eYA==\n"
+
+    credit_card = network_tokenization_credit_card('378282246310005',
+      brand: 'american_express',
+      eci: '05',
+      payment_cryptogram: long_cryptogram)
+
+    assert auth = @gateway.authorize(@amount, credit_card, @options)
+    assert_successful_response(auth)
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_successful_response(capture)
+  end
+
+  def test_purchase_with_network_tokenization_with_amex_cc
+    credit_card = network_tokenization_credit_card('378282246310005',
+      brand: 'american_express',
+      eci: '05',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+
+    assert auth = @gateway.purchase(@amount, credit_card, @options)
+    assert_successful_response(auth)
+  end
+
   def test_successful_authorize_with_mdd_fields
     (1..20).each { |e| @options["mdd_field_#{e}".to_sym] = "value #{e}" }
 


### PR DESCRIPTION
## Summary:
Add changes to the 'add_auth_network_tokenization' method so it is able to handle 20bytes and 40bytes American Express Network Tokens.

**Note:** The 3 failing remote tests correspond to authentication failures because of the lack of a latam-related account.

## Test Execution:

*Remote*
Finished in 98.402916 seconds.
115 tests, 590 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.3913% passed

*Unit*
Finished in 29.730562 seconds.
5207 tests, 75869 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

*RuboCop*
742 files inspected, no offenses detected