### PR TITLE
Rapyd: Pass Fields to `refund` and `store`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@
 * Plexo:  Change field name from `meta_data` to `metadata` [ajawadmirza] #4443
 * Simetrik: Update `vat` to be in cents [simetrik-frank] #4425
 * Cybersource: Handle Amex cryptograms [heavyblade] #4445
+* Rapyd: Pass fields to `refund` and `store` [naashton] #4449
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -66,6 +66,8 @@ module ActiveMerchant #:nodoc:
         post[:payment] = add_reference(authorization)
         add_invoice(post, money, options)
         add_metadata(post, options)
+        add_ewallet(post, options)
+
         commit(:post, 'refunds', post)
       end
 
@@ -82,6 +84,9 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_payment(post, payment, options)
         add_customer_object(post, payment)
+        add_metadata(post, options)
+        add_ewallet(post, options)
+        add_payment_fields(post, options)
         commit(:post, 'customers', post)
       end
 


### PR DESCRIPTION
Add `ewallet` to `refund` and `metadata`, `ewallet`, and
`payment_fields` to `store` transactions.

CE-2606

Unit: 18 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 27 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed