### PR TITLE
Airwallex: Remove comments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Rapyd: Pass fields to `refund` and `store` [naashton] #4449
 * VPOS: Allow reuse of encryption key [therufs] #4450
 * Orbital: Add `payment_action_ind` field and refund through credit card to support tandem implementation [ajawadmirza] #4420
+* Airwallex: Remove confusing comments [drkjc] #4452
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -313,10 +313,6 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, post, id = nil)
         url = build_request_url(action, id)
-        # MIT txn w/ no NTID should fail and the gateway should say so
-        # Logic to prevent sending anything on test transactions
-        # if Airwallex changes the value it won't matter
-        # Passing nothing still doesn't test the happy path
 
         post_headers = { 'Authorization' => "Bearer #{@access_token}", 'Content-Type' => 'application/json' }
         response = parse(ssl_post(url, post_data(post), post_headers))


### PR DESCRIPTION
Accidentally left comments in a previous commit. This PR removes them.
CE-2665

Unit:
33 tests, 176 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed