### PR TITLE
Airwallex: Send `referrer_data` on `create_payment_intent` requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,7 +37,7 @@
 * Rapyd: Pass fields to `refund` and `store` [naashton] #4449
 * VPOS: Allow reuse of encryption key [therufs] #4450
 * Orbital: Add `payment_action_ind` field and refund through credit card to support tandem implementation [ajawadmirza] #4420
-* Airwallex: Remove confusing comments [drkjc] #4452
+* Airwallex: Send `referrer_data` on setup transactions [drkjc] #4453
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -146,6 +146,7 @@ module ActiveMerchant #:nodoc:
         add_order(post, options)
         post[:request_id] = "#{request_id(options)}_setup"
         post[:merchant_order_id] = "#{merchant_order_id(options)}_setup"
+        post[:referrer_type] = 'spreedly'
         add_descriptor(post, options)
 
         response = commit(:setup, post)

--- a/test/unit/gateways/airwallex_test.rb
+++ b/test/unit/gateways/airwallex_test.rb
@@ -289,6 +289,15 @@ class AirwallexTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_purchase_passes_referrer_data
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      # only look for referrer data on the create_payment_intent request
+      assert_match(/\"referrer_type\":\"spreedly\"/, data) if data.include?('_setup')
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_purchase_passes_descriptor
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(description: 'a simple test'))


### PR DESCRIPTION
The `referrer_data` field is used internally by Airwallex to monitor traffic

CE-2678

Unit:
34 tests, 179 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed