### PR TITLE
Updated error messaging for Adyen/StripePI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * VPOS: Allow reuse of encryption key [therufs] #4450
 * Orbital: Add `payment_action_ind` field and refund through credit card to support tandem implementation [ajawadmirza] #4420
 * Airwallex: Send `referrer_data` on setup transactions [drkjc] #4453
+* Adyen and StripPI: Updated error messaging [mbreenlyles] #4454
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -616,7 +616,7 @@ module ActiveMerchant #:nodoc:
 
       def success_from(action, response, options)
         if %w[RedirectShopper ChallengeShopper].include?(response.dig('resultCode')) && !options[:execute_threed] && !options[:threed_dynamic]
-          response['refusalReason'] = 'Received unexpected 3DS authentication response. Use the execute_threed and/or threed_dynamic options to initiate a proper 3DS flow.'
+          response['refusalReason'] = 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.'
           return false
         end
         case action.to_s

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -501,7 +501,7 @@ module ActiveMerchant #:nodoc:
       def success_from(response, options)
         if response['status'] == 'requires_action' && !options[:execute_threed]
           response['error'] = {}
-          response['error']['message'] = 'Received unexpected 3DS authentication response. Use the execute_threed option to initiate a proper 3DS flow.'
+          response['error']['message'] = 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.'
           return false
         end
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -363,7 +363,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_purchase_fails_on_unexpected_3ds_initiation
     response = @gateway.purchase(8484, @three_ds_enrolled_card, @options)
     assert_failure response
-    assert_match 'Received unexpected 3DS authentication response', response.message
+    assert_match 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.', response.message
   end
 
   def test_successful_purchase_with_auth_data_via_threeds1_standalone

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -715,7 +715,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
 
     assert response = @gateway.purchase(100, @three_ds_credit_card, options)
     assert_failure response
-    assert_match 'Received unexpected 3DS authentication response', response.message
+    assert_match 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.', response.message
   end
 
   def test_create_payment_intent_with_shipping_address

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -165,7 +165,7 @@ class AdyenTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorize_with_3ds_response)
     response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options)
     assert_failure response
-    assert_match 'Received unexpected 3DS authentication response', response.message
+    assert_match 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.', response.message
   end
 
   def test_successful_authorize_with_recurring_contract_type


### PR DESCRIPTION
This changes the error message returned when the 'attempt_3dsecure' flag is left off a gateway request in need of authentication at the gateway to be clearer to someone using Spreedly's API.

[ECS-2393](https://spreedly.atlassian.net/browse/ECS-2393)

rake test:local - 5213 tests, 75896 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Stripe PI Unit: 39 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Stripe PI Remote: 77 tests, 357 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Adyen Unit: 94 tests, 479 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Adyen Remote (same 3 failures appear on Master): 123 tests, 439 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.561% passed

Adyen remote failures also appear on the Master branch:
X test_failed_store_with_cabal_card (fails at failure response assertion, maybe they support recurring transactions with this card now?)
X test_successful_authorize_with_3ds2_browser_client_data (fails  assert_equal response.params['resultCode'], 'IdentifyShopper' ---- with <nil> expected but was <"IdentifyShopper"> )
X test_successful_purchase_with_3ds2_exemption_requested_and_execute_threed_true (fails at assert_equal response.params['resultCode'], 'IdentifyShopper' ---- with <nil> expected but was <"IdentifyShopper"> )