### PR TITLE
Airwallex: Fix `referrer_data` on Setup transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,7 @@
 * Airwallex: Send `referrer_data` on setup transactions [drkjc] #4453
 * Adyen and StripPI: Updated error messaging [mbreenlyles] #4454
 * Authorize.net: Enable zero auth for allowed cards [jherreraa] #4430
+* Airwallex: Update `referrer_data` field [drkjc] #4455
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -140,13 +140,17 @@ module ActiveMerchant #:nodoc:
         base_url + ENDPOINTS[action].to_s % { id: id }
       end
 
+      def add_referrer_data(post)
+        post[:referrer_data] = { type: 'spreedly' }
+      end
+
       def create_payment_intent(money, options = {})
         post = {}
         add_invoice(post, money, options)
         add_order(post, options)
         post[:request_id] = "#{request_id(options)}_setup"
         post[:merchant_order_id] = "#{merchant_order_id(options)}_setup"
-        post[:referrer_type] = 'spreedly'
+        add_referrer_data(post)
         add_descriptor(post, options)
 
         response = commit(:setup, post)

--- a/test/unit/gateways/airwallex_test.rb
+++ b/test/unit/gateways/airwallex_test.rb
@@ -294,7 +294,7 @@ class AirwallexTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_endpoint, data, _headers|
       # only look for referrer data on the create_payment_intent request
-      assert_match(/\"referrer_type\":\"spreedly\"/, data) if data.include?('_setup')
+      assert_match(/\"referrer_data\":{\"type\":\"spreedly\"}/, data) if data.include?('_setup')
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
This commit changes `referrer_type` to `referrer_data`
CE-2678

Unit:
34 tests, 179 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed