### PR TITLE
Orbital: Fix warning

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -196,6 +196,7 @@ module ActiveMerchant #:nodoc:
         requires!(options, :login, :password) unless options[:ip_authentication]
         super
         @options[:merchant_id] = @options[:merchant_id].to_s
+        @use_secondary_url = false
       end
 
       # A – Authorization request


### PR DESCRIPTION
Fixed warning on orbital that requried initialization of instance variable `@use_secondary_url`

Unit:
5213 tests, 75897 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
743 files inspected, no offenses detected

Remote:
119 tests, 497 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed