### PR TITLE
BraintreeBlue: Added Transaction Id and Customer Name

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -393,6 +393,7 @@ module ActiveMerchant #:nodoc:
       def response_params(result)
         params = {}
         params[:customer_vault_id] = result.transaction.customer_details.id if result.success?
+        params[:transaction_id] = result.transaction.id if result.success?
         params[:braintree_transaction] = transaction_hash(result)
         params
       end
@@ -614,6 +615,8 @@ module ActiveMerchant #:nodoc:
             hold_in_escrow: options[:hold_in_escrow]
           }
         }
+
+        parameters[:customer][:first_name], parameters[:customer][:last_name] = split_names(options[:billing_address][:name]) if options[:billing_address] && options[:billing_address][:name]
 
         parameters[:custom_fields] = options[:custom_fields]
         parameters[:device_data] = options[:device_data] if options[:device_data]

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -71,6 +71,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     response = @gateway.authorize(100, credit_card('41111111111111111111'))
 
     assert_equal 'transaction_id', response.authorization
+    assert_equal 'transaction_id', response.params['transaction_id']
     assert_equal true, response.test
   end
 
@@ -81,6 +82,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
     response = @gateway.purchase(100, credit_card('41111111111111111111'))
 
     assert_equal 'transaction_id', response.authorization
+    assert_equal 'transaction_id', response.params['transaction_id']
     assert_equal true, response.test
   end
 
@@ -668,6 +670,13 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card('41111111111111111111'), billing_address: { country_code_numeric: 840 })
   end
 
+  def test_address_name_handling
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      params[:customer][:first_name] == 'John' && params[:customer][:last_name] == 'Smith'
+    end.returns(braintree_result)
+    @gateway.purchase(100, 'present', billing_address: { country: 'US', name: 'John Smith' })
+  end
+
   def test_address_zip_handling
     Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
       (params[:billing][:postal_code] == '12345')
@@ -957,6 +966,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
+    assert_equal 'transaction_id', response.params['transaction_id']
   end
 
   def test_android_pay_card
@@ -990,6 +1000,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
+    assert_equal 'transaction_id', response.params['transaction_id']
   end
 
   def test_google_pay_card
@@ -1023,6 +1034,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
+    assert_equal 'transaction_id', response.params['transaction_id']
   end
 
   def test_supports_network_tokenization


### PR DESCRIPTION
- Added transaction id to the response parameters when transaction result is success
- Added first_name and last_name to the customer address hash if billing_address has the data

Unit:
5209 tests, 75883 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
742 files inspected, no offenses detected