### PR TITLE
Plexo: update `verify` implementation.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@
 * Airwallex: Update `referrer_data` field [drkjc] #4455
 * Simetrik: Update `order_id` and `description` to be top level fields [simetrik-frank] #4451
 * Plexo: Update `ip`, `description`, and `email` fields request format and scrub method to not filter cardholder name and reference id [ajawadmirza] #4457
+* Plexo: Update `verify` implementation and add `verify_amount` field [ajawadmirza] #4462
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -126,7 +126,13 @@ class RemotePlexoTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = @gateway.verify(@credit_card, @options.merge(@cancel_options))
+    response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_equal 'You have been mocked.', response.message
+  end
+
+  def test_successful_verify_with_custom_amount
+    response = @gateway.verify(@credit_card, @options.merge({ verify_amount: '400' }))
     assert_success response
     assert_equal 'You have been mocked.', response.message
   end
@@ -134,9 +140,8 @@ class RemotePlexoTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_equal 'You have been mocked.', response.message
-    assert_equal '96', response.error_code
-    assert_equal 'denied', response.params['status']
+    assert_equal 'The selected payment state is not valid.', response.message
+    assert_equal 400, response.error_code
   end
 
   def test_invalid_login


### PR DESCRIPTION
Updated `verify` implementation to send request on plexo API endpoint along with test cases.

SER-106

Unit:
5213 tests, 75902 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
743 files inspected, no offenses detected

Remote:
18 tests, 100 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed