### PR TITLE
Rapyd: Correctly add `billing_address`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@
 * Vanco: Update `purchase` to complete a purchase transaction with an existing session id [BritneyS] #4461
 * Authorize.net: Allow custom verify_amount and validate it [jherreraa] #4464
 * Shift4: Add gateway adapter [ali-hassan] #4415
+* Rapyd: Correctly add `billing_address` [naashton] #4465
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -116,7 +116,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, creditcard, options)
-        return unless address = options[:address]
+        return unless address = options[:billing_address]
 
         post[:address] = {}
         # name and line_1 are required at the gateway
@@ -127,7 +127,7 @@ module ActiveMerchant #:nodoc:
         post[:address][:state] = address[:state] if address[:state]
         post[:address][:country] = address[:country] if address[:country]
         post[:address][:zip] = address[:zip] if address[:zip]
-        post[:address][:phone_number] = address[:phone] if address[:phone]
+        post[:address][:phone_number] = address[:phone].gsub(/\D/, '') if address[:phone]
       end
 
       def add_invoice(post, money, options)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -53,14 +53,9 @@ class RemoteRapydTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_address
-    options = {
-      address: {
-        name: 'Henry Winkler',
-        address1: '123 Happy Days Lane'
-      }
-    }
+    billing_address = address(name: 'Henry Winkler', address1: '123 Happy Days Lane')
 
-    response = @gateway.purchase(@amount, @credit_card, @options.merge(options))
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: billing_address))
     assert_success response
     assert_equal 'SUCCESS', response.message
   end
@@ -165,7 +160,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = @gateway.verify(@credit_card, @options)
+    response = @gateway.verify(@credit_card, @options.except(:billing_address))
     assert_success response
     assert_equal 'SUCCESS', response.message
   end

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -38,9 +38,12 @@ class RapydTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: address(name: 'Joe John-ston')))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_equal JSON.parse(data)['address']['name'], 'Joe John-ston'
+    end.respond_with(successful_purchase_response)
 
-    response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'payment_716ce0efc63aa8d91579e873d29d9d5e', response.authorization.split('|')[0]
   end


### PR DESCRIPTION
Update the `add_address` method to populate from the `billing_address`
subhash of the `options` hash.

Also modify the `phone` to remove non-int characters

SER-137

Unit: 18 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 27 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed