### PR TITLE
Paypal Express: Add checkout status to response object

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@
 * Rapyd: Correctly add `billing_address` [naashton] #4465
 * Credorax: Update processor response messages [jcreiff] #4466
 * Shift4: add `customer_reference`, `destination_postal_code`, `product_descriptors` fields and core refactoring [ajawadmirza] #4469
+* Paypal Express: Add checkout status to response object [mbreenlyles] #4467
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/paypal/paypal_express_response.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_express_response.rb
@@ -13,6 +13,10 @@ module ActiveMerchant #:nodoc:
         (@params['PaymentDetails']||{})
       end
 
+      def payment_status
+        (@params['CheckoutStatus']||{})
+      end
+
       def name
         payer = (info['PayerName']||{})
         [payer['FirstName'], payer['MiddleName'], payer['LastName']].compact.join(' ')

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -88,6 +88,7 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal 'FWRVKNRRZ3WUC', response.payer_id
     assert_equal 'buyer@jadedpallet.com', response.email
     assert_equal 'This is a test note', response.note
+    assert_equal 'PaymentActionNotInitiated', response.payment_status
 
     assert address = response.address
     assert_equal 'Fred Brooks', address['name']


### PR DESCRIPTION
This adds an accessor method to the Paypal Express Response object that allows easy retrieval of the transaction status.

[ECS-2405](https://spreedly.atlassian.net/browse/ECS-2405)

Remote Paypal Express:
3 tests, 8 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit Paypal Express:
66 tests, 196 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Local:
5216 tests, 75920 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed