### PR TITLE
Plexo: Fix `success_from` definition

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,7 @@
 * Credorax: Update processor response messages [jcreiff] #4466
 * Shift4: add `customer_reference`, `destination_postal_code`, `product_descriptors` fields and core refactoring [ajawadmirza] #4469
 * Paypal Express: Add checkout status to response object [mbreenlyles] #4467
+* Plexo: Update `success_from` definition [ajawadmirza] #4468
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -13,6 +13,7 @@ module ActiveMerchant #:nodoc:
 
       APPENDED_URLS = %w(captures refunds cancellations verify)
       AMOUNT_IN_RESPONSE = %w(authonly /verify)
+      APPROVED_STATUS = %w(approved authorized)
 
       def initialize(options = {})
         requires!(options, :client_id, :api_key)
@@ -261,7 +262,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(response)
-        response['status'] == 'approved'
+        APPROVED_STATUS.include?(response['status'])
       end
 
       def message_from(response)


### PR DESCRIPTION
Gateway response has changed to include `authorize` inplace of `approved` in status of some transactions that is causing bug in the `success_from` method.

SER-157

Unit:
5228 tests, 75971 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
17 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed