### PR TITLE
Rapyd: Un-nest the payment urls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@
 * Shift4: Scrub security code [naashton] #4470
 * Shift4: Update `cardOnFile` transaction requests [ajawadmirza] #4471
 * Plexo: Update `success_from` definition [ajawadmirza] #4468
+* Rapyd: Un-nest the payment urls [naashton] #4472
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -27,6 +27,7 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_ewallet(post, options)
         add_payment_fields(post, options)
+        add_payment_urls(post, options)
         post[:capture] = true if payment.is_a?(CreditCard)
 
         if payment.is_a?(Check)
@@ -51,6 +52,7 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_ewallet(post, options)
         add_payment_fields(post, options)
+        add_payment_urls(post, options)
         post[:capture] = false
 
         commit(:post, 'payments', post)
@@ -87,6 +89,7 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_ewallet(post, options)
         add_payment_fields(post, options)
+        add_payment_urls(post, options)
         commit(:post, 'customers', post)
       end
 
@@ -198,10 +201,13 @@ module ActiveMerchant #:nodoc:
       def add_payment_fields(post, options)
         post[:payment] = {}
 
-        post[:payment][:complete_payment_url] = options[:complete_payment_url] if options[:complete_payment_url]
-        post[:payment][:error_payment_url] = options[:error_payment_url] if options[:error_payment_url]
         post[:payment][:description] = options[:description] if options[:description]
         post[:payment][:statement_descriptor] = options[:statement_descriptor] if options[:statement_descriptor]
+      end
+
+      def add_payment_urls(post, options)
+        post[:complete_payment_url] = options[:complete_payment_url] if options[:complete_payment_url]
+        post[:error_payment_url] = options[:error_payment_url] if options[:error_payment_url]
       end
 
       def add_customer_object(post, payment)


### PR DESCRIPTION
`complete_payment_url` and `error_payment_url` were incorrectly nested
in the `payment` hash.

[Rapyd Payment Object](https://docs.rapyd.net/build-with-rapyd/reference/payment-object)

SER-154

Unit: 18 tests, 80 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 27 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed