### PR TITLE
Paypal Express: Correct naming mistake for accessor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@
 * Shift4: Update `cardOnFile` transaction requests [ajawadmirza] #4471
 * Plexo: Update `success_from` definition [ajawadmirza] #4468
 * Rapyd: Un-nest the payment urls [naashton] #4472
+* Paypal Express: Correct naming mistake for accessor [mbreenlyles] #4473
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/paypal/paypal_express_response.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_express_response.rb
@@ -13,7 +13,7 @@ module ActiveMerchant #:nodoc:
         (@params['PaymentDetails']||{})
       end
 
-      def payment_status
+      def checkout_status
         (@params['CheckoutStatus']||{})
       end
 

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -88,7 +88,7 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal 'FWRVKNRRZ3WUC', response.payer_id
     assert_equal 'buyer@jadedpallet.com', response.email
     assert_equal 'This is a test note', response.note
-    assert_equal 'PaymentActionNotInitiated', response.payment_status
+    assert_equal 'PaymentActionNotInitiated', response.checkout_status
 
     assert address = response.address
     assert_equal 'Fred Brooks', address['name']


### PR DESCRIPTION
Updates response method name.

Local:
5231 tests, 75997 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
66 tests, 196 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
3 tests, 8 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed