### PR TITLE
Shift4: Update `success` definition

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,7 @@
 * CyberSource: Updatie API version to 1.198 and fix 3DS test [cristian] #4456
 * Shift4: add `store` method, `present` field in card, and to pass amount in cents [ajawadmirza] #4475
 * Shift4: add `3ds2` implementation [ajawadmirza] #4476
+* Shift4: update `success_from` definition to consider response code [ajawadmirza] #4477
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -5,7 +5,7 @@ class RemoteShift4Test < Test::Unit::TestCase
     @gateway = Shift4Gateway.new(fixtures(:shift4))
 
     @amount = 500
-    @credit_card = credit_card('4000100011112224')
+    @credit_card = credit_card('4000100011112224', verification_value: '333')
     @declined_card = credit_card('400030001111220')
     @options = {}
     @extra_options = {

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -335,7 +335,7 @@ class Shift4Test < Test::Unit::TestCase
                               "Test"
                           ]
                       },
-                      "responseCode": "D",
+                      "responseCode": "A",
                       "saleFlag": "S"
                   },
                   "universalToken": {
@@ -586,7 +586,7 @@ class Shift4Test < Test::Unit::TestCase
                   "Test"
                 ]
               },
-              "responseCode": "D",
+              "responseCode": "A",
               "saleFlag": "S"
             },
             "universalToken": {
@@ -651,7 +651,7 @@ class Shift4Test < Test::Unit::TestCase
             "transaction": {
               "authSource": "E",
               "invoice": "0000000001",
-              "responseCode": "D",
+              "responseCode": "A",
               "saleFlag": "S"
             }
           }


### PR DESCRIPTION
Updated `success_from` method to look into response code along with errors in response to determine success.

SER-166

Unit:
5243 tests, 76069 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
16 tests, 35 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed