### PR TITLE
Airwallex: change timestamps to uuids and remove `_setup` suffix from merchant_order_id

### DIFF
--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -114,15 +114,15 @@ module ActiveMerchant #:nodoc:
       private
 
       def request_id(options)
-        options[:request_id] || generate_timestamp
+        options[:request_id] || generate_uuid
       end
 
       def merchant_order_id(options)
-        options[:merchant_order_id] || options[:order_id] || generate_timestamp
+        options[:merchant_order_id] || options[:order_id] || generate_uuid
       end
 
-      def generate_timestamp
-        (Time.now.to_f.round(2) * 100).to_i.to_s
+      def generate_uuid
+        SecureRandom.uuid
       end
 
       def setup_access_token
@@ -149,7 +149,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_order(post, options)
         post[:request_id] = "#{request_id(options)}_setup"
-        post[:merchant_order_id] = "#{merchant_order_id(options)}_setup"
+        post[:merchant_order_id] = merchant_order_id(options)
         add_referrer_data(post)
         add_descriptor(post, options)
 

--- a/test/remote/gateways/remote_airwallex_test.rb
+++ b/test/remote/gateways/remote_airwallex_test.rb
@@ -33,8 +33,8 @@ class RemoteAirwallexTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_specified_ids
-    request_id = "request_#{(Time.now.to_f.round(2) * 100).to_i}"
-    merchant_order_id = "order_#{(Time.now.to_f.round(2) * 100).to_i}"
+    request_id = SecureRandom.uuid
+    merchant_order_id = SecureRandom.uuid
     response = @gateway.purchase(@amount, @credit_card, @options.merge(request_id: request_id, merchant_order_id: merchant_order_id))
     assert_success response
     assert_match(request_id, response.params.dig('request_id'))
@@ -84,10 +84,10 @@ class RemoteAirwallexTest < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    purchase = @gateway.purchase(@amount, @credit_card, @options.merge(generated_ids))
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
 
-    assert refund = @gateway.refund(@amount, purchase.authorization, @options.merge(generated_ids))
+    assert refund = @gateway.refund(@amount, purchase.authorization, @options)
     assert_success refund
     assert_equal 'RECEIVED', refund.message
   end
@@ -107,7 +107,7 @@ class RemoteAirwallexTest < Test::Unit::TestCase
   end
 
   def test_successful_void
-    auth = @gateway.authorize(@amount, @credit_card, @options.merge(generated_ids))
+    auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
     assert void = @gateway.void(auth.authorization, @options)
@@ -240,11 +240,6 @@ class RemoteAirwallexTest < Test::Unit::TestCase
   end
 
   private
-
-  def generated_ids
-    timestamp = (Time.now.to_f.round(2) * 100).to_i.to_s
-    { request_id: timestamp.to_s, merchant_order_id: "mid_#{timestamp}" }
-  end
 
   def add_cit_network_transaction_id_to_stored_credential(auth)
     @stored_credential_mit_options[:network_transaction_id] = auth.params['latest_payment_attempt']['provider_transaction_id']

--- a/test/unit/gateways/airwallex_test.rb
+++ b/test/unit/gateways/airwallex_test.rb
@@ -251,7 +251,7 @@ class AirwallexTest < Test::Unit::TestCase
   end
 
   def test_purchase_passes_appropriate_request_id_per_call
-    request_id = "request_#{(Time.now.to_f.round(2) * 100).to_i}"
+    request_id = SecureRandom.uuid
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(request_id: request_id))
     end.check_request do |_endpoint, data, _headers|
@@ -265,18 +265,12 @@ class AirwallexTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_purchase_passes_appropriate_merchant_order_id_per_call
-    merchant_order_id = "order_#{(Time.now.to_f.round(2) * 100).to_i}"
+  def test_purchase_passes_appropriate_merchant_order_id
+    merchant_order_id = SecureRandom.uuid
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(merchant_order_id: merchant_order_id))
     end.check_request do |_endpoint, data, _headers|
-      if data.include?('payment_method')
-        # check for this on the purchase call
-        assert_match(/\"merchant_order_id\":\"#{merchant_order_id}\"/, data)
-      else
-        # check for this on the create_payment_intent calls
-        assert_match(/\"merchant_order_id\":\"#{merchant_order_id}_setup\"/, data)
-      end
+      assert_match(/\"merchant_order_id\":\"#{merchant_order_id}\"/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Airwallex has requested that we default to a uuid instead of a timestamp for these fields.

They have also requested that we remove the `_setup` suffix from the `merchant_order_id` field, as that field does not need to be unique per transaction and will be used by customers during reconciliation.

The `_setup` suffix remains for the `request_id` field, because that field must be unique for every request, so the suffix is useful for differentiating two separate but associated requests (e.g. a `create_payment_intent` followed by a subsequent `sale`).

SER-65

Unit:
5243 tests, 76069 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
Loaded suite test/remote/gateways/remote_airwallex_test
26 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed