### PR TITLE
CheckoutV2: Add support for `OAuth`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -69,6 +69,8 @@
 * Add `mada` card type and associated BINs; add support for `mada` in CheckoutV2 gateway [dsmcclain] #4486
 * Authorize.net: Refactor custom verify amount handling [jherreraa] #4485
 * EBANX:  Change amount for Colombia [flaaviaa] #4481
+* Worldpay: Update `required_status_message` and `message_from` methods for response. [rachelkirk] #4493
+* CheckoutV2: Add support for transactions through OAuth [ajawadmirza] #4483
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -189,7 +189,9 @@ checkout:
   password: Password1!
 
 checkout_v2:
-  secret_key: secret_key
+  secret_key: SECRET_KEY_FOR_BASIC_TRANSACTIONS
+  client_id: CLIENT_ID_FOR_OAUTH_TRANSACTIONS
+  client_secret: CLIENT_SECRET_FOR_OAUTH_TRANSACTIONS
 
 citrus_pay:
   userid: CPF00001

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 class RemoteCheckoutV2Test < Test::Unit::TestCase
   def setup
-    @gateway = CheckoutV2Gateway.new(fixtures(:checkout_v2))
+    gateway_fixtures = fixtures(:checkout_v2)
+    @gateway = CheckoutV2Gateway.new(secret_key: gateway_fixtures[:secret_key])
+    @gateway_oauth = CheckoutV2Gateway.new({ client_id: gateway_fixtures[:client_id], client_secret: gateway_fixtures[:client_secret] })
 
     @amount = 200
     @credit_card = credit_card('4242424242424242', verification_value: '100', month: '6', year: '2025')
@@ -62,7 +64,8 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
       order_id: '1',
       billing_address: address,
       description: 'Purchase',
-      email: 'longbob.longsen@example.com'
+      email: 'longbob.longsen@example.com',
+      processing_channel_id: 'pc_lxgl7aqahkzubkundd2l546hdm'
     }
     @additional_options = @options.merge(
       card_on_file: true,
@@ -109,6 +112,18 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:secret_key], transcript)
   end
 
+  def test_transcript_scrubbing_via_oauth
+    declined_card = credit_card('4000300011112220', verification_value: '309')
+    transcript = capture_transcript(@gateway_oauth) do
+      @gateway_oauth.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway_oauth.scrub(transcript)
+    assert_scrubbed(declined_card.number, transcript)
+    assert_scrubbed(declined_card.verification_value, transcript)
+    assert_scrubbed(@gateway_oauth.options[:client_id], transcript)
+    assert_scrubbed(@gateway_oauth.options[:client_secret], transcript)
+  end
+
   def test_network_transaction_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(100, @apple_pay_network_token, @options)
@@ -125,8 +140,21 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_via_oauth
+    response = @gateway_oauth.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_vts_network_token
     response = @gateway.purchase(100, @vts_network_token, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_not_nil response.params['source']['payment_account_reference']
+  end
+
+  def test_successful_purchase_with_vts_network_token_via_oauth
+    response = @gateway_oauth.purchase(100, @vts_network_token, @options)
     assert_success response
     assert_equal 'Succeeded', response.message
     assert_not_nil response.params['source']['payment_account_reference']
@@ -145,6 +173,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_google_pay_visa_cryptogram_3ds_network_token_via_oauth
+    response = @gateway_oauth.purchase(100, @google_pay_visa_cryptogram_3ds_network_token, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_google_pay_master_cryptogram_3ds_network_token
     response = @gateway.purchase(100, @google_pay_master_cryptogram_3ds_network_token, @options)
     assert_success response
@@ -159,6 +193,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
 
   def test_successful_purchase_with_apple_pay_network_token
     response = @gateway.purchase(100, @apple_pay_network_token, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_apple_pay_network_token_via_oauth
+    response = @gateway_oauth.purchase(100, @apple_pay_network_token, @options)
     assert_success response
     assert_equal 'Succeeded', response.message
   end
@@ -201,9 +241,39 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_stored_credentials_via_oauth
+    initial_options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring'
+      }
+    )
+    initial_response = @gateway_oauth.purchase(@amount, @credit_card, initial_options)
+    assert_success initial_response
+    assert_equal 'Succeeded', initial_response.message
+    assert_not_nil initial_response.params['id']
+    network_transaction_id = initial_response.params['id']
+
+    stored_options = @options.merge(
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'installment',
+        network_transaction_id: network_transaction_id
+      }
+    )
+    response = @gateway_oauth.purchase(@amount, @credit_card, stored_options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_moto_flag
     response = @gateway.authorize(@amount, @credit_card, @options.merge(transaction_indicator: 3))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
 
+  def test_successful_purchase_with_moto_flag_via_oauth
+    response = @gateway_oauth.authorize(@amount, @credit_card, @options.merge(transaction_indicator: 3))
     assert_success response
     assert_equal 'Succeeded', response.message
   end
@@ -221,6 +291,14 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
     assert_equal 'S', response.avs_result['code']
     assert_equal 'U.S.-issuing bank does not support AVS.', response.avs_result['message']
+  end
+
+  def test_successful_purchase_includes_avs_result_via_oauth
+    response = @gateway_oauth.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'G', response.avs_result['code']
+    assert_equal 'Non-U.S. issuing bank does not support AVS.', response.avs_result['message']
   end
 
   def test_successful_authorize_includes_avs_result
@@ -245,8 +323,21 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Y', response.cvv_result['code']
   end
 
+  def test_successful_authorize_includes_cvv_result_via_oauth
+    response = @gateway_oauth.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'Y', response.cvv_result['code']
+  end
+
   def test_successful_authorize_with_estimated_type
     response = @gateway.authorize(@amount, @credit_card, @options.merge({ authorization_type: 'Estimated' }))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_authorize_with_estimated_type_via_oauth
+    response = @gateway_oauth.authorize(@amount, @credit_card, @options.merge({ authorization_type: 'Estimated' }))
     assert_success response
     assert_equal 'Succeeded', response.message
   end
@@ -264,6 +355,13 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_descriptors_via_oauth
+    options = @options.merge(descriptor_name: 'shop', descriptor_city: 'london')
+    response = @gateway_oauth.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_metadata
     options = @options.merge(
       metadata: {
@@ -272,6 +370,18 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
       }
     )
     response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_metadata_via_oauth
+    options = @options.merge(
+      metadata: {
+        coupon_code: 'NY2018',
+        partner_id: '123989'
+      }
+    )
+    response = @gateway_oauth.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal 'Succeeded', response.message
   end
@@ -300,6 +410,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Declined - Do Not Honour', response.message
   end
 
+  def test_failed_purchase_via_oauth
+    response = @gateway_oauth.purchase(100, @declined_card, @options)
+    assert_failure response
+    assert_equal 'request_invalid: card_number_invalid', response.message
+  end
+
   def test_avs_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, billing_address: address.update(address1: 'Test_A'))
     assert_failure response
@@ -320,11 +436,27 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorize_and_capture_via_oauth
+    auth = @gateway_oauth.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway_oauth.capture(nil, auth.authorization)
+    assert_success capture
+  end
+
   def test_successful_authorize_and_partial_capture
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
     assert capture = @gateway.capture((@amount / 2).to_i, auth.authorization, { capture_type: 'NonFinal' })
+    assert_success capture
+  end
+
+  def test_successful_authorize_and_partial_capture_via_oauth
+    auth = @gateway_oauth.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway_oauth.capture((@amount / 2).to_i, auth.authorization, { capture_type: 'NonFinal' })
     assert_success capture
   end
 
@@ -344,11 +476,27 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_authorize_and_capture_with_3ds_via_oauth
+    auth = @gateway_oauth.authorize(@amount, @credit_card, @additional_options_3ds)
+    assert_success auth
+
+    assert capture = @gateway_oauth.capture(nil, auth.authorization)
+    assert_success capture
+  end
+
   def test_successful_authorize_and_capture_with_3ds2
     auth = @gateway.authorize(@amount, @credit_card, @additional_options_3ds2)
     assert_success auth
 
     assert capture = @gateway.capture(nil, auth.authorization)
+    assert_success capture
+  end
+
+  def test_successful_authorize_and_capture_with_3ds2_via_oauth
+    auth = @gateway_oauth.authorize(@amount, @credit_card, @additional_options_3ds2)
+    assert_success auth
+
+    assert capture = @gateway_oauth.capture(nil, auth.authorization)
     assert_success capture
   end
 
@@ -381,6 +529,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Invalid Card Number', response.message
   end
 
+  def test_failed_authorize_via_oauth
+    response = @gateway_oauth.authorize(12314, @declined_card, @options)
+    assert_failure response
+    assert_equal 'request_invalid: card_number_invalid', response.message
+  end
+
   def test_partial_capture
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
@@ -394,6 +548,11 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failed_capture_via_oauth
+    response = @gateway_oauth.capture(nil, '')
+    assert_failure response
+  end
+
   def test_successful_refund
     purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
@@ -401,6 +560,16 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     sleep 1
 
     assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+  end
+
+  def test_successful_refund_via_oauth
+    purchase = @gateway_oauth.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    sleep 1
+
+    assert refund = @gateway_oauth.refund(@amount, purchase.authorization)
     assert_success refund
   end
 
@@ -436,11 +605,24 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failed_refund_via_oauth
+    response = @gateway_oauth.refund(nil, '')
+    assert_failure response
+  end
+
   def test_successful_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
 
     assert void = @gateway.void(auth.authorization)
+    assert_success void
+  end
+
+  def test_successful_void_via_oauth
+    auth = @gateway_oauth.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert void = @gateway_oauth.void(auth.authorization)
     assert_success void
   end
 
@@ -464,11 +646,24 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failed_void_via_oauth
+    response = @gateway_oauth.void('')
+    assert_failure response
+  end
+
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     # this should only be a Response and not a MultiResponse
     # as we are passing in a 0 amount and there should be
     # no void call
+    assert_instance_of(Response, response)
+    refute_instance_of(MultiResponse, response)
+    assert_success response
+    assert_match %r{Succeeded}, response.message
+  end
+
+  def test_successful_verify_via_oauth
+    response = @gateway_oauth.verify(@credit_card, @options)
     assert_instance_of(Response, response)
     refute_instance_of(MultiResponse, response)
     assert_success response


### PR DESCRIPTION
Added support for OAuth and bearer access support along with backward compatibility with Basic Auth. All API calls will remain same for OAuth transactions, only the Bearer token support is added along with tests to demonstrate the behaviour.

SER-40

Unit:
5244 tests, 76075 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
43 tests, 110 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed