### PR TITLE
Add mada card type; add support in CheckoutV2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,7 @@
 * CheckoutV2: Scrub cryptogram and credit card number [ajawadmirza] #4488
 * CheckoutV2: Add `3ds.status` field to send status of 3DS flow of all 3DS transactions [BritneyS] #4492
 * CheckoutV2: Add `challenge_indicator`, `exemption`, `authorization_type`, `processing_channel_id`, and `capture_type` fields [ajawadmirza] #4482
+* Add `mada` card type and associated BINs; add support for `mada` in CheckoutV2 gateway [dsmcclain] #4486
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -32,6 +32,7 @@ module ActiveMerchant #:nodoc:
     # * Olimpica
     # * Creditel
     # * Confiable
+    # * Mada
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -116,6 +117,7 @@ module ActiveMerchant #:nodoc:
       # * +'olimpica'+
       # * +'creditel'+
       # * +'confiable'+
+      # * +'mada'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -39,7 +39,8 @@ module ActiveMerchant #:nodoc:
         'creditel' => ->(num) { num =~ /^601933\d{10}$/ },
         'confiable' => ->(num) { num =~ /^560718\d{10}$/ },
         'synchrony' => ->(num) { num =~ /^700600\d{10}$/ },
-        'routex' => ->(num) { num =~ /^(700676|700678)\d{13}$/ }
+        'routex' => ->(num) { num =~ /^(700676|700678)\d{13}$/ },
+        'mada' => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), MADA_RANGES) }
       }
 
       # http://www.barclaycard.co.uk/business/files/bin_rules.pdf
@@ -209,6 +210,12 @@ module ActiveMerchant #:nodoc:
         60420100..60440099,
         58965700..58965799,
         60352200..60352299
+      ]
+
+      MADA_RANGES = [
+        504300..504300, 506968..506968, 508160..508160, 585265..585265, 588848..588848,
+        588850..588850, 588982..588983, 589005..589005, 589206..589206, 604906..604906,
+        605141..605141, 636120..636120, 968201..968209, 968211..968211
       ]
 
       NARANJA_RANGES = [

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w[AD AE AR AT AU BE BG BH BR CH CL CN CO CY CZ DE DK EE EG ES FI FR GB GR HK HR HU IE IS IT JO JP KW LI LT LU LV MC MT MX MY NL NO NZ OM PE PL PT QA RO SA SE SG SI SK SM TR US]
       self.default_currency = 'USD'
       self.money_format = :cents
-      self.supported_cardtypes = %i[visa master american_express diners_club maestro discover jcb]
+      self.supported_cardtypes = %i[visa master american_express diners_club maestro discover jcb mada]
       self.currencies_without_fractions = %w(BIF DJF GNF ISK KMF XAF CLF XPF JPY PYG RWF KRW VUV VND XOF)
       self.currencies_with_three_decimal_places = %w(BHD LYD JOD KWD OMR TND)
 
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
         add_stored_credential_options(post, options)
         add_transaction_data(post, options)
         add_3ds(post, options)
-        add_metadata(post, options)
+        add_metadata(post, options, payment_method)
         add_processing_channel(post, options)
         add_marketplace_data(post, options)
       end
@@ -112,9 +112,10 @@ module ActiveMerchant #:nodoc:
         post[:authorization_type] = options[:authorization_type] if options[:authorization_type]
       end
 
-      def add_metadata(post, options)
+      def add_metadata(post, options, payment_method = nil)
         post[:metadata] = {} unless post[:metadata]
         post[:metadata].merge!(options[:metadata]) if options[:metadata]
+        post[:metadata][:udf1] = 'mada' if payment_method.try(:brand) == 'mada'
       end
 
       def add_payment_method(post, payment_method, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -9,6 +9,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @expired_card = credit_card('4242424242424242', verification_value: '100', month: '6', year: '2010')
     @declined_card = credit_card('42424242424242424', verification_value: '234', month: '6', year: '2025')
     @threeds_card = credit_card('4485040371536584', verification_value: '100', month: '12', year: '2020')
+    @mada_card = credit_card('5043000000000000', brand: 'mada')
 
     @vts_network_token = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
@@ -161,6 +162,13 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_success response
     assert_equal 'Succeeded', response.message
   end
+
+  # # currently, checkout does not provide any valid test card numbers for testing mada cards
+  # def test_successful_purchase_with_mada_card
+  #   response = @gateway.purchase(@amount, @mada_card, @options)
+  #   assert_success response
+  #   assert_equal 'Succeeded', response.message
+  # end
 
   def test_successful_purchase_with_additional_options
     response = @gateway.purchase(@amount, @credit_card, @additional_options)

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -184,6 +184,14 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'alia', CreditCard.brand?('5058740000000000')
   end
 
+  def test_should_detect_mada_card
+    assert_equal 'mada', CreditCard.brand?('5043000000000000')
+    assert_equal 'mada', CreditCard.brand?('5852650000000000')
+    assert_equal 'mada', CreditCard.brand?('5888500000000000')
+    assert_equal 'mada', CreditCard.brand?('6361200000000000')
+    assert_equal 'mada', CreditCard.brand?('9682040000000000')
+  end
+
   def test_alia_number_not_validated
     10.times do
       number = rand(5058740000000001..5058749999999999).to_s

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -272,6 +272,17 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_passing_metadata_with_mada_card_type
+    @credit_card.brand = 'mada'
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      request_data = JSON.parse(data)
+      assert_equal(request_data['metadata']['udf1'], 'mada')
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_failed_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)


### PR DESCRIPTION
This PR takes the BINs from [this list](https://www.checkout.com/docs/payments/payment-methods/cards/mada#Mada_BINs) and adds any that do not already pass validation.

CheckoutV2 also requests the metadata field `udf1` be sent on Mada transactions, so this will be added on BINs where we can definitively determine the `mada` card type.

No remote tests are added using these BINs, because Checkout does not provide any test numbers in these BIN ranges, and Checkout's sandbox rejects any payments not using test numbers.

A support ticket has been opened at the gateway to request valid test data for Mada cards.

SER-35

Unit:
5246 tests, 76083 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
Loaded suite test/remote/gateways/remote_checkout_v2_test
46 tests, 117 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed