### PR TITLE
Rapyd: Add `stored_credential` support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -73,6 +73,7 @@
 * CheckoutV2: Add support for transactions through OAuth [ajawadmirza] #4483
 * Vanco: Update unit test to remove remote call to gateway [ajawadmirza] #4497
 * Shift4: remove support for 3ds2 [ajawadmirza] #4503
+* Rapyd: Add support for stored credential [ajawadmirza] #4487
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -149,6 +149,13 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def add_stored_credential(post, options)
+        return unless stored_credential = options[:stored_credential]
+
+        post[:payment_method][:fields][:network_reference_id] = stored_credential[:original_network_transaction_id] if stored_credential[:original_network_transaction_id]
+        post[:initiation_type] = stored_credential[:reason_type] if stored_credential[:reason_type]
+      end
+
       def add_creditcard(post, payment, options)
         post[:payment_method] = {}
         post[:payment_method][:fields] = {}
@@ -158,8 +165,10 @@ module ActiveMerchant #:nodoc:
         pm_fields[:number] = payment.number
         pm_fields[:expiration_month] = payment.month.to_s
         pm_fields[:expiration_year] = payment.year.to_s
-        pm_fields[:cvv] = payment.verification_value.to_s
         pm_fields[:name] = "#{payment.first_name} #{payment.last_name}"
+        pm_fields[:cvv] = payment.verification_value.to_s
+
+        add_stored_credential(post, options)
       end
 
       def add_ach(post, payment, options)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -54,6 +54,17 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_subsequent_purchase_with_stored_credential
+    @options[:currency] = 'EUR'
+    @options[:pm_type] = 'gi_visa_card'
+    @options[:complete_payment_url] = 'https://www.rapyd.net/platform/collect/online/'
+    @options[:error_payment_url] = 'https://www.rapyd.net/platform/collect/online/'
+
+    response = @gateway.purchase(15000, @credit_card, @options.merge({ stored_credential: { original_network_transaction_id: '123456', reason_type: 'recurring' } }))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_successful_purchase_with_address
     billing_address = address(name: 'Henry Winkler', address1: '123 Happy Days Lane')
 


### PR DESCRIPTION
Added `network_reference_id` to pass in from stored credential framework.

SER-126

Unit:
5245 tests, 76079 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
28 tests, 81 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed