### PR TITLE
CheckoutV2: Scrub Cryptogram Fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,7 @@
 * Shift4: update `success_from` definition to consider response code [ajawadmirza] #4477
 * Rapyd: Customer Object [naashton] #4478
 * Shift4: Verify Endopint Fix [naashton] #4479
+* CheckoutV2: Scrub cryptogram and credit card number [ajawadmirza] #4488
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -74,7 +74,9 @@ module ActiveMerchant #:nodoc:
         transcript.
           gsub(/(Authorization: )[^\\]*/i, '\1[FILTERED]').
           gsub(/("number\\":\\")\d+/, '\1[FILTERED]').
-          gsub(/("cvv\\":\\")\d+/, '\1[FILTERED]')
+          gsub(/("cvv\\":\\")\d+/, '\1[FILTERED]').
+          gsub(/("cryptogram\\":\\")\w+/, '\1[FILTERED]').
+          gsub(/(source\\":\{.*\\"token\\":\\")\d+/, '\1[FILTERED]')
       end
 
       private

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -104,6 +104,16 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:secret_key], transcript)
   end
 
+  def test_network_transaction_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(100, @apple_pay_network_token, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+    assert_scrubbed(@apple_pay_network_token.payment_cryptogram, transcript)
+    assert_scrubbed(@apple_pay_network_token.number, transcript)
+    assert_scrubbed(@gateway.options[:secret_key], transcript)
+  end
+
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -581,6 +581,10 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_equal post_scrubbed, @gateway.scrub(pre_scrubbed)
   end
 
+  def test_network_transaction_scrubbing
+    assert_equal network_transaction_post_scrubbed, @gateway.scrub(network_transaction_pre_scrubbed)
+  end
+
   def test_invalid_json
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
@@ -618,6 +622,20 @@ class CheckoutV2Test < Test::Unit::TestCase
     %q(
       <- "POST /payments HTTP/1.1\r\nContent-Type: application/json;charset=UTF-8\r\nAuthorization: sk_test_ab12301d-e432-4ea7-97d1-569809518aaf\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.checkout.com\r\nContent-Length: 346\r\n\r\n"
       <- "{\"capture\":false,\"amount\":\"200\",\"reference\":\"1\",\"currency\":\"USD\",\"source\":{\"type\":\"card\",\"name\":\"Longbob Longsen\",\"number\":\"4242424242424242\",\"cvv\":\"100\",\"expiry_year\":\"2025\"
+    )
+  end
+
+  def network_transaction_pre_scrubbed
+    %q(
+      <- "POST /payments HTTP/1.1\r\nContent-Type: application/json;charset=UTF-8\r\nAuthorization: sk_test_ab12301d-e432-4ea7-97d1-569809518aaf\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.checkout.com\r\nContent-Length: 346\r\n\r\n"
+      <- "{\"amount\":\"100\",\"reference\":\"1\",\"currency\":\"USD\",\"metadata\":{\"udf5\":\"ActiveMerchant\"},\"source\":{\"type\":\"network_token\",\"token\":\"4242424242424242\",\"token_type\":\"applepay\",\"cryptogram\":\"AgAAAAAAAIR8CQrXcIhbQAAAAAA\",\"eci\":\"05\",\"expiry_year\":\"2025\",\"expiry_month\":\"10\",\"billing_address\":{\"address_line1\":\"456 My Street\",\"address_line2\":\"Apt 1\",\"city\":\"Ottawa\",\"state\":\"ON\",\"country\":\"CA\",\"zip\":\"K1C2N6\"}},\"customer\":{\"email\":\"longbob.longsen@example.com\"}}"
+    )
+  end
+
+  def network_transaction_post_scrubbed
+    %q(
+      <- "POST /payments HTTP/1.1\r\nContent-Type: application/json;charset=UTF-8\r\nAuthorization: [FILTERED]\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.checkout.com\r\nContent-Length: 346\r\n\r\n"
+      <- "{\"amount\":\"100\",\"reference\":\"1\",\"currency\":\"USD\",\"metadata\":{\"udf5\":\"ActiveMerchant\"},\"source\":{\"type\":\"network_token\",\"token\":\"[FILTERED]\",\"token_type\":\"applepay\",\"cryptogram\":\"[FILTERED]\",\"eci\":\"05\",\"expiry_year\":\"2025\",\"expiry_month\":\"10\",\"billing_address\":{\"address_line1\":\"456 My Street\",\"address_line2\":\"Apt 1\",\"city\":\"Ottawa\",\"state\":\"ON\",\"country\":\"CA\",\"zip\":\"K1C2N6\"}},\"customer\":{\"email\":\"longbob.longsen@example.com\"}}"
     )
   end
 


### PR DESCRIPTION
Scrubed `payment_cryptogram` and card number for Google Pay and Apply Pay support along with tests.

SER-37

Remote:
44 tests, 113 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5245 tests, 76077 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected