### PR TITLE
Revert "Worldpay: update logic for AM generated response message"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -69,7 +69,6 @@
 * Add `mada` card type and associated BINs; add support for `mada` in CheckoutV2 gateway [dsmcclain] #4486
 * Authorize.net: Refactor custom verify amount handling [jherreraa] #4485
 * EBANX:  Change amount for Colombia [flaaviaa] #4481
-* Worldpay: Update `required_status_message` and `message_from` methods for response. [rachelkirk] #4493
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -856,7 +856,7 @@ module ActiveMerchant #:nodoc:
           raw[:is3DSOrder] = true
         end
         success = success_from(action, raw, success_criteria)
-        message = message_from(success, raw, success_criteria, action)
+        message = message_from(success, raw, success_criteria)
 
         Response.new(
           success,
@@ -904,10 +904,10 @@ module ActiveMerchant #:nodoc:
         success_criteria_success?(raw, success_criteria) || action_success?(action, raw)
       end
 
-      def message_from(success, raw, success_criteria, action)
+      def message_from(success, raw, success_criteria)
         return 'SUCCESS' if success
 
-        raw[:iso8583_return_code_description] || raw[:error] || required_status_message(raw, success_criteria, action) || raw[:issuer_response_description]
+        raw[:iso8583_return_code_description] || raw[:error] || required_status_message(raw, success_criteria)
       end
 
       # success_criteria can be:
@@ -933,11 +933,8 @@ module ActiveMerchant #:nodoc:
         raw[:iso8583_return_code_code] || raw[:error_code] || nil unless success == 'SUCCESS'
       end
 
-      def required_status_message(raw, success_criteria, action)
-        return if success_criteria.include?(raw[:last_event])
-        return unless %w[cancel refund inquiry credit fast_credit].include?(action)
-
-        "A transaction status of #{success_criteria.collect { |c| "'#{c}'" }.join(' or ')} is required."
+      def required_status_message(raw, success_criteria)
+        "A transaction status of #{success_criteria.collect { |c| "'#{c}'" }.join(' or ')} is required." if !success_criteria.include?(raw[:last_event])
       end
 
       def authorization_from(action, raw, options)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -440,7 +440,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    # assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
+    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -515,12 +515,6 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_success capture
   end
 
-  # Lines have been commented out in the following two tests as well as
-  # test_successful_authorize_with_3ds because of changes to
-  # the message_from method. These tests were falsely passing, as the AM generated
-  # response in itself indicates failure. The work needed to get these tests passing
-  # is unrelated to the current task, but the failures have been brought up to the
-  # appropriate team. Feel free to delete these comments when the issue is resolved.
   def test_successful_authorize_with_3ds_with_normalized_stored_credentials
     session_id = generate_unique_id
     stored_credential_params = {
@@ -541,7 +535,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    # assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
+    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -564,7 +558,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    # assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
+    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -428,16 +428,6 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal('Insufficient funds/over credit limit', response.params['issuer_response_description'])
   end
 
-  def test_failed_purchase_without_active_merchant_generated_response_message
-    response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options)
-    end.respond_with(failed_purchase_response_without_useful_error_from_gateway)
-
-    assert_failure response
-    assert_equal('61', response.params['issuer_response_code'])
-    assert_equal('Exceeds withdrawal amount limit', response.message)
-  end
-
   def test_successful_void
     response = stub_comms do
       @gateway.void(@options[:order_id], @options)
@@ -1827,35 +1817,6 @@ class WorldpayTest < Test::Unit::TestCase
               <riskScore value="1"/>
             </payment>
             <date dayOfMonth="05" month="03" year="2013" hour="23" minute="6" second="0"/>
-          </orderStatus>
-        </reply>
-      </paymentService>
-    RESPONSE
-  end
-
-  def failed_purchase_response_without_useful_error_from_gateway
-    <<~RESPONSE
-      <?xml version="1.0" encoding="UTF-8"?>
-      <paymentService version="1.4" merchantCode="ACMECORP">
-        <reply>
-          <orderStatus orderCode="2119303">
-            <payment>
-              <paymentMethod>ECMC_DEBIT-SSL</paymentMethod>
-              <amount value="2000" currencyCode="USD" exponent="2" debitCreditIndicator="credit"/>
-              <lastEvent>REFUSED</lastEvent>
-              <IssuerResponseCode code="61" description="Exceeds withdrawal amount limit"/>
-              <CVCResultCode description="A"/>
-              <AVSResultCode description="H"/>
-              <AAVAddressResultCode description="B"/>
-              <AAVPostcodeResultCode description="B"/>
-              <AAVCardholderNameResultCode description="B"/>
-              <AAVTelephoneResultCode description="B"/>
-              <AAVEmailResultCode description="B"/>
-              <cardHolderName>Snuffy Smith</cardHolderName>
-              <issuerCountryCode>US</issuerCountryCode>
-              <issuerName>PRETEND BANK</issuerName>
-              <riskScore value="95"/>
-            </payment>
           </orderStatus>
         </reply>
       </paymentService>


### PR DESCRIPTION
This reverts commit 60f2fc9b8bff37a412a84f59335daaeee69294f7.

This is being done because these changes are triggering 3DS test failures.

CER-18

Unit
103 tests, 608 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote
99 tests, 408 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
98.9899% passed
* This test has been erroring on master, unrelated to this change

Local
5263 tests, 76133 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed