### PR TITLE
CheckoutV2: add gateway-specific list of mada BINs

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -13,6 +13,21 @@ module ActiveMerchant #:nodoc:
       self.currencies_without_fractions = %w(BIF DJF GNF ISK KMF XAF CLF XPF JPY PYG RWF KRW VUV VND XOF)
       self.currencies_with_three_decimal_places = %w(BHD LYD JOD KWD OMR TND)
 
+      # This set of BINs is a superset of the mada BINs defined in credit_card_methods.rb
+      # Why? Because many mada BINs are co-branded with Visa or Mastercard, and we want those BINs
+      # to run as visa/mastercard for other gateways. However, for this gateway we want to send
+      # mada-specific fields in transactions involving these BINs.
+      # This list of BINs retrieved July 2022 from https://www.checkout.com/docs/payments/payment-methods/cards/mada
+      MADA_BINS = %w(
+        403024 406136 406996 407197 407395 409201 410621 410685 412565 417633 419593 420132 421141 422817
+        422818 422819 428331 428671 428672 428673 431361 432328 434107 439954 440533 440647 440795 445564
+        446393 446404 446672 455036 455708 457865 457997 458456 462220 468540 468541 468542 468543 474491
+        483010 483011 483012 484783 486094 486095 486096 489318 489319 504300 506968 508160 513213 520058
+        521076 524130 524514 529415 529741 530060 530906 531095 531196 532013 535825 535989 536023 537767
+        543085 543357 549760 554180 558563 585265 588845 588848 588850 588982 588983 589005 589206 604906
+        605141 636120 968201 968202 968203 968204 968205 968206 968207 968208 968209 968211
+      )
+
       def initialize(options = {})
         requires!(options, :secret_key)
         super
@@ -115,7 +130,7 @@ module ActiveMerchant #:nodoc:
       def add_metadata(post, options, payment_method = nil)
         post[:metadata] = {} unless post[:metadata]
         post[:metadata].merge!(options[:metadata]) if options[:metadata]
-        post[:metadata][:udf1] = 'mada' if payment_method.try(:brand) == 'mada'
+        post[:metadata][:udf1] = 'mada' if mada_card?(payment_method)
       end
 
       def add_payment_method(post, payment_method, options)
@@ -249,6 +264,12 @@ module ActiveMerchant #:nodoc:
           avs_result: avs_result,
           cvv_result: cvv_result
         )
+      end
+
+      def mada_card?(payment_method)
+        return false unless payment_method&.is_a?(CreditCard)
+
+        payment_method.brand == 'mada' || MADA_BINS.include?(payment_method.number[0..5])
       end
 
       def headers


### PR DESCRIPTION
This will make it possible for us to identify mada cards in the metadata of our requests to Checkout (see comment within the gateway adapter).

No remote tests added because Checkout does not provide test cards for these BINs.

Rubocop
746 files inspected, no offenses detected

Unit
5265 tests, 76143 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote
Loaded suite test/remote/gateways/remote_checkout_v2_test
47 tests, 120 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed