### PR TITLE
CyberSource: handling not supported Network Token brands

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -802,6 +802,8 @@ module ActiveMerchant #:nodoc:
             xml.tag!('xid', Base64.encode64(cryptogram[20...40])) if cryptogram.bytes.count > 20
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
           end
+        else
+          raise ArgumentError.new("Payment method #{brand} is not supported, check https://developer.cybersource.com/docs/cybs/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html")
         end
       end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -1388,6 +1388,29 @@ class CyberSourceTest < Test::Unit::TestCase
     end
   end
 
+  def test_raises_error_on_network_token_with_an_underlying_discover_card
+    error = assert_raises ArgumentError do
+      credit_card = network_tokenization_credit_card('4111111111111111',
+        brand: 'discover',
+        payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+
+      @gateway.authorize(100, credit_card, @options)
+    end
+    assert_equal 'Payment method discover is not supported, check https://developer.cybersource.com/docs/cybs/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html', error.message
+  end
+
+  def test_raises_error_on_network_token_with_an_underlying_apms
+    error = assert_raises ArgumentError do
+      credit_card = network_tokenization_credit_card('4111111111111111',
+        brand: 'sodexo',
+        payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+
+      @gateway.authorize(100, credit_card, @options)
+    end
+
+    assert_equal 'Payment method sodexo is not supported, check https://developer.cybersource.com/docs/cybs/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html', error.message
+  end
+
   private
 
   def options_with_normalized_3ds(


### PR DESCRIPTION
Summary:
---
This PR adds a check on Cybersource adapter to deal with not supported brands on Network Tokens.

Test Execution:
---
Remote
Finished in 91.83718 seconds.
115 tests, 590 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.3913% passed

Unit
5266 tests, 76138 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
---
746 files inspected, no offenses detected