### PR TITLE
Orbital: Remove `DPANInd` for RC transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,6 +86,7 @@
 * Shift4: Scrub `securityCode` fix [naashton] #4524
 * Credorax: Update `OpCode` for credit transactions [dsmcclain] #4279
 * CheckoutV2: Add `credit` method [ajawadmirza] #4490
+* Orbital: Remove `DPANInd` field for RC transactions [ajawadmirza] #4502
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -749,10 +749,10 @@ module ActiveMerchant #:nodoc:
         xml.tag!(:AuthenticationECIInd, eci) if eci
       end
 
-      def add_dpanind(xml, credit_card)
+      def add_dpanind(xml, credit_card, industry_type = nil)
         return unless credit_card.is_a?(NetworkTokenizationCreditCard)
 
-        xml.tag! :DPANInd, 'Y'
+        xml.tag! :DPANInd, 'Y' unless industry_type == 'RC'
       end
 
       def add_digital_token_cryptogram(xml, credit_card)
@@ -970,7 +970,7 @@ module ActiveMerchant #:nodoc:
 
             add_soft_descriptors(xml, parameters[:soft_descriptors])
             add_payment_action_ind(xml, parameters[:payment_action_ind])
-            add_dpanind(xml, payment_source)
+            add_dpanind(xml, payment_source, parameters[:industry_type])
             add_aevv(xml, payment_source, three_d_secure)
             add_digital_token_cryptogram(xml, payment_source)
 


### PR DESCRIPTION
Update condition not to pass `DPANInd` when using RC Transactions.

SER-168

Unit:
5264 tests, 76138 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
119 tests, 497 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed