### PR TITLE
Shift4: Remove 3ds support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -72,6 +72,7 @@
 * Worldpay: Update `required_status_message` and `message_from` methods for response. [rachelkirk] #4493
 * CheckoutV2: Add support for transactions through OAuth [ajawadmirza] #4483
 * Vanco: Update unit test to remove remote call to gateway [ajawadmirza] #4497
+* Shift4: remove support for 3ds2 [ajawadmirza] #4503
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -54,7 +54,6 @@ module ActiveMerchant #:nodoc:
         add_transaction(post, options)
         add_card(post, payment_method, options)
         add_card_present(post, options)
-        add_three_d_secure(post, payment_method, options)
 
         commit('sale', post, options)
       end
@@ -67,7 +66,6 @@ module ActiveMerchant #:nodoc:
         add_transaction(post, options)
         add_card(post, payment_method, options)
         add_card_present(post, options)
-        add_three_d_secure(post, payment_method, options)
         add_customer(post, options)
 
         commit('authorization', post, options)
@@ -146,23 +144,6 @@ module ActiveMerchant #:nodoc:
 
         response = commit('accesstoken', post, request_headers(options))
         response.params['result'].first['credential']['accessToken']
-      end
-
-      def add_three_d_secure(post, payment_method, options)
-        return unless three_d_secure = options[:three_d_secure]
-
-        post[:threeDSecure] = {}
-        post[:threeDSecure][:cryptogram] = payment_method.payment_cryptogram if payment_method.is_a?(NetworkTokenizationCreditCard)
-        post[:threeDSecure][:ecommIndicator] = three_d_secure[:eci] || payment_method.eci if three_d_secure[:eci] || (payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.eci)
-        post[:threeDSecure][:securityLevelIndicator] = options[:security_level_indicator] || '241'
-        post[:threeDSecure][:xid] = three_d_secure[:xid] if three_d_secure[:xid]
-        post[:threeDSecure][:programProtocol] = three_d_secure[:version][0, 1] if three_d_secure[:version]
-        post[:threeDSecure][:authenticationSource] = options[:authentication_source] if options[:authentication_source]
-        post[:threeDSecure][:cavvResult] = options[:cavv_result] if options[:cavv_result]
-        post[:threeDSecure][:authenticationValue] = three_d_secure[:cavv] if three_d_secure[:cavv]
-        post[:threeDSecure][:tavvResult] = options[:tavv_result] if options[:tavv_result]
-        post[:threeDSecure][:directoryServerTranId] = three_d_secure[:ds_transaction_id] if three_d_secure[:ds_transaction_id]
-        post[:threeDSecure][:walletID] = options[:wallet_id] if options[:wallet_id]
       end
 
       def add_clerk(post, options)

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -52,18 +52,6 @@ class RemoteShift4Test < Test::Unit::TestCase
     assert_success response
   end
 
-  def test_successful_purchase_with_3ds2
-    three_d_fields = {
-      version: '2.1.0',
-      cavv: '7451894935398554493186199357',
-      xid: '7170741190961626698806524700',
-      ds_transaction_id: '720428161140523826506349191480340441',
-      eci: '5'
-    }
-    response = @gateway.purchase(@amount, @credit_card, @options.merge({ three_d_secure: three_d_fields }))
-    assert_success response
-  end
-
   def test_successful_purchase_with_stored_credential
     stored_credential_options = {
       inital_transaction: true,


### PR DESCRIPTION
Removing fields for 3ds2 fields because its no longer supported by gateway.

SER-159

Unit:
5264 tests, 76138 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
16 tests, 35 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed