### PR TITLE
Revert "Credorax: Update OpCode for Credit transactions"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -72,7 +72,6 @@
 * Worldpay: Update `required_status_message` and `message_from` methods for response. [rachelkirk] #4493
 * CheckoutV2: Add support for transactions through OAuth [ajawadmirza] #4483
 * Vanco: Update unit test to remove remote call to gateway [ajawadmirza] #4497
-* Credorax: Update `OpCode` for credit transactions [dsmcclain] #4279
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -441,7 +441,7 @@ module ActiveMerchant #:nodoc:
         capture: '3',
         authorize_void: '4',
         refund: '5',
-        credit: '35',
+        credit: '6',
         purchase_void: '7',
         refund_void: '8',
         capture_void: '9',
@@ -482,9 +482,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def request_action(action, reference_action)
-        return ACTIONS["#{reference_action}_#{action}".to_sym] if reference_action
-
-        ACTIONS[action]
+        if reference_action
+          ACTIONS["#{reference_action}_#{action}".to_sym]
+        else
+          ACTIONS[action]
+        end
       end
 
       def url

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -413,12 +413,12 @@ class RemoteCredoraxTest < Test::Unit::TestCase
   end
 
   def test_successful_credit
-    response = @gateway.credit(@amount, @credit_card, @options.merge(first_name: 'Test', last_name: 'McTest'))
+    response = @gateway.credit(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Succeeded', response.message
   end
 
-  def test_failed_credit_with_zero_amount
+  def test_failed_credit
     response = @gateway.credit(0, @declined_card, @options)
     assert_failure response
     assert_equal 'Invalid amount', response.message

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -233,23 +233,6 @@ class CredoraxTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_credit_sends_correct_action_code
-    stub_comms do
-      @gateway.credit(@amount, @credit_card)
-    end.check_request do |_endpoint, data, _headers|
-      assert_match(/O=35/, data)
-    end.respond_with(successful_credit_response)
-  end
-
-  def test_credit_sends_customer_name
-    stub_comms do
-      @gateway.credit(@amount, @credit_card, { first_name: 'Test', last_name: 'McTest' })
-    end.check_request do |_endpoint, data, _headers|
-      assert_match(/j5=Test/, data)
-      assert_match(/j13=McTest/, data)
-    end.respond_with(successful_credit_response)
-  end
-
   def test_failed_credit
     response = stub_comms do
       @gateway.credit(@amount, @credit_card)
@@ -1109,11 +1092,11 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def successful_credit_response
-    'M=SPREE978&O=35&T=03%2F09%2F2016+03%3A16%3A35&V=413&a1=868f8b942fae639d28e27e8933d575d4&a2=2&a4=100&z1=8a82944a53515706015359604c135301&z13=606944188289&z15=100&z2=0&z3=Transaction+has+been+executed+successfully.&z5=0&z6=00&K=51ba24f6ef3aa161f86e53c34c9616ac'
+    'M=SPREE978&O=6&T=03%2F09%2F2016+03%3A16%3A35&V=413&a1=868f8b942fae639d28e27e8933d575d4&a2=2&a4=100&z1=8a82944a53515706015359604c135301&z13=606944188289&z15=100&z2=0&z3=Transaction+has+been+executed+successfully.&z5=0&z6=00&K=51ba24f6ef3aa161f86e53c34c9616ac'
   end
 
   def failed_credit_response
-    'M=SPREE978&O=35&T=03%2F09%2F2016+03%3A16%3A59&V=413&a1=ff28246cfc811b1c686a52d08d075d9c&a2=2&a4=100&z1=8a829449535154bc01535960a962524f&z13=606944188290&z15=100&z2=05&z3=Transaction+has+been+declined.&z5=0&z6=57&K=cf34816d5c25dc007ef3525505c4c610'
+    'M=SPREE978&O=6&T=03%2F09%2F2016+03%3A16%3A59&V=413&a1=ff28246cfc811b1c686a52d08d075d9c&a2=2&a4=100&z1=8a829449535154bc01535960a962524f&z13=606944188290&z15=100&z2=05&z3=Transaction+has+been+declined.&z5=0&z6=57&K=cf34816d5c25dc007ef3525505c4c610'
   end
 
   def empty_purchase_response


### PR DESCRIPTION
This reverts commit 7d15705bd1d575a18baec459d0722a1010a28525.

Remote:
46 tests, 157 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
86.9565% passed

Unit:
78 tests, 374 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected