### PR TITLE
BraintreeBlue: Add venmo profile_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* BraintreeBlue: Add venmo profile_id [molbrown] #4512
 * Maestro: Adding missing BIN ranges [bradbroge] #4423
 * Simetrik: Fix integer and float types, update scrub method [rachelkirk] #4405
 * Credorax: Convert country codes for  `recipient_country_code` field [ajawadmirza] #4408

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -622,6 +622,7 @@ module ActiveMerchant #:nodoc:
         add_account_type(parameters, options) if options[:account_type]
         add_skip_options(parameters, options)
         add_merchant_account_id(parameters, options)
+        add_profile_id(parameters, options)
 
         add_payment_method(parameters, credit_card_or_vault_id, options)
         add_stored_credential_data(parameters, credit_card_or_vault_id, options)
@@ -662,6 +663,13 @@ module ActiveMerchant #:nodoc:
         return unless merchant_account_id = (options[:merchant_account_id] || @merchant_account_id)
 
         parameters[:merchant_account_id] = merchant_account_id
+      end
+
+      def add_profile_id(parameters, options)
+        return unless profile_id = options[:venmo_profile_id]
+
+        parameters[:options][:venmo] = {}
+        parameters[:options][:venmo][:profile_id] = profile_id
       end
 
       def add_transaction_source(parameters, options)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -117,6 +117,7 @@ braintree_blue_with_ach_enabled:
   public_key: Y
   private_key: Z
   merchant_account_id: A
+  venmo_profile_id: B
 
 braintree_blue_with_processing_rules:
   merchant_id: X

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -201,6 +201,15 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_success response
   end
 
+  # Follow instructions found at https://developer.paypal.com/braintree/articles/guides/payment-methods/venmo#multiple-profiles
+  # for sandbox control panel https://sandbox.braintreegateway.com/login to create a venmo profile.
+  # Insert your Profile Id into fixtures.
+  def test_successful_purchase_with_venmo_profile_id
+    options = @options.merge(venmo_profile_id: fixtures(:braintree_blue)[:venmo_profile_id], payment_method_nonce: 'fake-venmo-account-nonce' )
+    assert response = @gateway.purchase(@amount, 'fake-venmo-account-nonce', options)
+    assert_success response
+  end
+
   def test_successful_verify
     assert response = @gateway.verify(@credit_card, @options)
     assert_success response

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -210,6 +210,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.authorize(100, credit_card('41111111111111111111'), service_fee_amount: '2.31')
   end
 
+  def test_venmo_profile_id_can_be_specified
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:options][:venmo][:profile_id] == 'profile_id')
+    end.returns(braintree_result)
+
+    @gateway.authorize(100, credit_card('41111111111111111111'), venmo_profile_id: 'profile_id')
+  end
+
   def test_risk_data_can_be_specified
     risk_data = {
       customer_browser: 'User-Agent Header',


### PR DESCRIPTION
Support for specifying the Venmo business profile, passed when specified
in creating the payment nonce client-side.
https://developer.paypal.com/braintree/docs/guides/venmo/server-side/ruby#specifying-the-business-profile

ECS-2518

Unit:
91 tests, 201 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
98 tests, 530 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed