### PR TITLE
Add machine cookie to subsequent calls during 3DS challenge

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@
 * CyberSource: Handle unsupported Network Token brands [heavyblade] #4500
 * Ingenico(Global Collect): Add support for `payment_product_id` [rachelkirk] #4521
 * Adyen: Add network transaction id to store call [jcreiff] #4522
+* Worldpay: Add machine cookie to subsequent calls during 3DS challenge [mbreenlyles] #4513
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373


### PR DESCRIPTION
This change ensures that the machine cookie is extracted from the response correctly and returned in the initial 3DS setup request will be included in the headers on all the subsequent requests in the Worldpay challenge flow.

There are 3 calls total for a purchase using Worldpay's 3ds:
1. The preauth/setup request: sent to WP as an `authorize`, this one won't need a cookie as it's the first request. We'll receive a response that requests 3DS authentication, and contains a cookie. Then there is a redirect to the issuer's challenge form. 
2. The "3ds order": another redirect will happen after the user submits the form, and we get the authentication results from issuer. Then we'll send Worldpay the "3ds order" containing the authentication results in the `paResponse` field. This one must have the cookie in its header. The response will contain another cookie.
3. The capture call: If the "3ds order" call gets a response of `AUTHORISED`, then we'll complete the purchase with a capture call, and because this capture follows a response that contained another cookie from the 3ds flow, we should send that cookie in the header of the capture call as well. 

**Cookie saved in instance variable** 
Both the "3ds order" and capture calls that happen after a user completes a challenge on their purchase are made "by Core", but within the AM backend. In the "3ds order" call, following the redirect the cookie had been saved in the params from the setup response, and is already sent back successfully in the options hash. For purchases, the capture call had not been sending the cookie back, but the capture takes place right after the "3ds order" response, and it will have access to the instance variable cookie that is saved from that response. There will be a follow-up Core PR that adds testing and sends the cookie through the options hash, but this AM change will still ensure the cookie gets added to headers on the capture call by using the @cookie instance var which will contain the cookie saved from the `3ds order` response.

`authorize` (preauth, no cookie) --> *challenge submit, redirect* --> `3ds order` (pass auth results to wp, cookie already saved) --> `capture` (cookie has now been added)

**Cookie is saved as all characters before the first semi-colon**
Per Worldpay's docs, the cookie we must send back should not be the full string given in the Set-Cookie header, it should be all text preceding the first semi-colon.
From their docs:

> For example, if we send a cookie as:
> 
> Set-Cookie: machine=0aa20016;Secure;path=/
> 
> You must include the following HTTP header in your second order message: Cookie: machine=0aa20016

Local:
5264 tests, 76138 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
103 tests, 608 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
1 tests, 4 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed