### PR TITLE
Rapyd: Change parameter key name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -78,6 +78,7 @@
 * MerchantE: Update `store` and add `verify` method [ajawadmirza] #4507
 * Shift4: Add default `numericId`, add `InterfaceVersion`, `InterfaceName`, and `CompanyName` header fields, change date time format and allow merchant time zone [ajawadmirza] #4509
 * BraintreeBlue: Add support for partial capture [aenand] #4515
+* Rapyd: Change key name to `network_transaction_id` [ajawadmirza] #4514
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -152,7 +152,7 @@ module ActiveMerchant #:nodoc:
       def add_stored_credential(post, options)
         return unless stored_credential = options[:stored_credential]
 
-        post[:payment_method][:fields][:network_reference_id] = stored_credential[:original_network_transaction_id] if stored_credential[:original_network_transaction_id]
+        post[:payment_method][:fields][:network_reference_id] = stored_credential[:network_transaction_id] if stored_credential[:network_transaction_id]
         post[:initiation_type] = stored_credential[:reason_type] if stored_credential[:reason_type]
       end
 

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -60,7 +60,7 @@ class RemoteRapydTest < Test::Unit::TestCase
     @options[:complete_payment_url] = 'https://www.rapyd.net/platform/collect/online/'
     @options[:error_payment_url] = 'https://www.rapyd.net/platform/collect/online/'
 
-    response = @gateway.purchase(15000, @credit_card, @options.merge({ stored_credential: { original_network_transaction_id: '123456', reason_type: 'recurring' } }))
+    response = @gateway.purchase(15000, @credit_card, @options.merge({ stored_credential: { network_transaction_id: '123456', reason_type: 'recurring' } }))
     assert_success response
     assert_equal 'SUCCESS', response.message
   end

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -82,13 +82,13 @@ class RapydTest < Test::Unit::TestCase
   def test_successful_purchase_with_stored_credential
     @options[:stored_credential] = {
       reason_type: 'recurring',
-      original_network_transaction_id: '12345'
+      network_transaction_id: '12345'
     }
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_equal request['payment_method']['fields']['network_reference_id'], @options[:stored_credential][:original_network_transaction_id]
+      assert_equal request['payment_method']['fields']['network_reference_id'], @options[:stored_credential][:network_transaction_id]
       assert_equal request['initiation_type'], @options[:stored_credential][:reason_type]
     end.respond_with(successful_purchase_response)
   end


### PR DESCRIPTION
Change stored credential key name from `original_network_transaction_id` to `network_transaction_id` as per the standard framework of stored credential.

SER-126

Unit:
5268 tests, 76153 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
28 tests, 52 assertions, 15 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
46.4286% passed