### PR TITLE
Braintree Blue: Partial capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,6 +77,7 @@
 * Rapyd: Add support for stored credential [ajawadmirza] #4487
 * MerchantE: Update `store` and add `verify` method [ajawadmirza] #4507
 * Shift4: Add default `numericId`, add `InterfaceVersion`, `InterfaceName`, and `CompanyName` header fields, change date time format and allow merchant time zone [ajawadmirza] #4509
+* BraintreeBlue: Add support for partial capture [aenand] #4515
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -88,9 +88,16 @@ module ActiveMerchant #:nodoc:
       end
 
       def capture(money, authorization, options = {})
-        commit do
-          result = @braintree_gateway.transaction.submit_for_settlement(authorization, localized_amount(money, options[:currency] || default_currency).to_s)
-          response_from_result(result)
+        if options[:partial_capture] == true
+          commit do
+            result = @braintree_gateway.transaction.submit_for_partial_settlement(authorization, localized_amount(money, options[:currency] || default_currency).to_s)
+            response_from_result(result)
+          end
+        else
+          commit do
+            result = @braintree_gateway.transaction.submit_for_settlement(authorization, localized_amount(money, options[:currency] || default_currency).to_s)
+            response_from_result(result)
+          end
         end
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -210,6 +210,18 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_partial_capture
+    options = @options.merge(venmo_profile_id: fixtures(:braintree_blue)[:venmo_profile_id], payment_method_nonce: 'fake-venmo-account-nonce')
+    assert auth = @gateway.authorize(@amount, 'fake-venmo-account-nonce', options)
+    assert_success auth
+    assert_equal '1000 Approved', auth.message
+    assert auth.authorization
+    assert capture_one = @gateway.capture(50, auth.authorization, { partial_capture: true })
+    assert_success capture_one
+    assert capture_two = @gateway.capture(50, auth.authorization, { partial_capture: true })
+    assert_success capture_two
+  end
+
   def test_successful_verify
     assert response = @gateway.verify(@credit_card, @options)
     assert_success response

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -94,6 +94,16 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal true, response.test
   end
 
+  def test_partial_capture_transaction
+    Braintree::TransactionGateway.any_instance.expects(:submit_for_partial_settlement).
+      returns(braintree_result(id: 'capture_transaction_id'))
+
+    response = @gateway.capture(100, 'transaction_id', { partial_capture: true })
+
+    assert_equal 'capture_transaction_id', response.authorization
+    assert_equal true, response.test
+  end
+
   def test_refund_transaction
     Braintree::TransactionGateway.any_instance.expects(:refund).
       returns(braintree_result(id: 'refund_transaction_id'))


### PR DESCRIPTION
Braintree blue can support partial captures for certain
types of transactions. This commit adds logic to handle partial capture
logic if the `partial_capture` field is passed down.

Test Summary
Local:
5269 tests, 76156 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
746 files inspected, no offenses detected
Unit:
92 tests, 204 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
98 tests, 530 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed