### PR TITLE
ActiveMerchant: Fix MultiResponse Class

### DIFF
--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -85,7 +85,21 @@ module ActiveMerchant #:nodoc:
         (primary_response ? primary_response.success? : true)
       end
 
-      %w(params message test authorization avs_result cvv_result error_code emv_authorization test? fraud_review?).each do |m|
+      def avs_result
+        return @primary_response.try(:avs_result) if @use_first_response
+
+        result = responses.reverse.find { |r| r.avs_result['code'].present? }
+        result.try(:avs_result) || responses.last.try(:avs_result)
+      end
+
+      def cvv_result
+        return @primary_response.try(:cvv_result) if @use_first_response
+
+        result = responses.reverse.find { |r| r.cvv_result['code'].present? }
+        result.try(:cvv_result) || responses.last.try(:cvv_result)
+      end
+
+      %w(params message test authorization error_code emv_authorization test? fraud_review?).each do |m|
         class_eval %(
           def #{m}
             (@responses.empty? ? nil : primary_response.#{m})


### PR DESCRIPTION
Summary:
---------------------------------------

To be able to pull if there exist the  avs_result and cvv_result properties
in the MultiResponse object, this PR fixes the MultiResponse class by
modifying the logic behind the avs_result and cvv_result method, taking the
last response that has avs_result and cvv_result :code different of nil,
currently, if a transaction returns those values, but the next one returns nil,
the multiresponse methods pulled the AVS and CVV result from the last response transaction.

Local Tests:
---------------------------------------
17 tests, 71 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
---------------------------------------
746 files inspected, no offenses detected