### PR TITLE
CheckoutV2: Update logic to send payment id via options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,6 +86,7 @@
 * Shift4: Scrub `securityCode` fix [naashton] #4524
 * Credorax: Update `OpCode` for credit transactions [dsmcclain] #4279
 * CheckoutV2: Add `credit` method [ajawadmirza] #4490
+* CheckoutV2: Send payment id via `incremental_authorization` field [ajawadmirza] #4518
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         post[:capture] = false
         build_auth_or_purchase(post, amount, payment_method, options)
 
-        options[:incremental_authorization].to_s.casecmp('true').zero? ? commit(:incremental_authorize, post, payment_method) : commit(:authorize, post)
+        options[:incremental_authorization] ? commit(:incremental_authorize, post, options[:incremental_authorization]) : commit(:authorize, post)
       end
 
       def capture(amount, authorization, options = {})

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -336,6 +336,16 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_authorize_with_incremental_authoriation
+    response = @gateway_oauth.authorize(@amount, @credit_card, @options.merge({ authorization_type: 'Estimated' }))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+
+    response = @gateway_oauth.authorize(@amount, @credit_card, @options.merge({ incremental_authorization: response.authorization }))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_authorize_with_estimated_type_via_oauth
     response = @gateway_oauth.authorize(@amount, @credit_card, @options.merge({ authorization_type: 'Estimated' }))
     assert_success response

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -83,12 +83,11 @@ class CheckoutV2Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_successful_incremental_authorization
-    id = 'abcd123'
+  def test_successful_passing_incremental_authorization
     response = stub_comms do
-      @gateway.authorize(@amount, id, { incremental_authorization: 'true' })
+      @gateway.authorize(@amount, @credit_card, { incremental_authorization: 'abcd1234' })
     end.check_request do |endpoint, _data, _headers|
-      assert_equal endpoint, "https://api.sandbox.checkout.com/payments/#{id}/authorizations"
+      assert_include endpoint, 'abcd1234'
     end.respond_with(successful_incremental_authorize_response)
 
     assert_success response


### PR DESCRIPTION
Updated checkoutv2 to take payment id from options parameters instead of getting it as a payment method.

SER-201

Remote:
72 tests, 186 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5269 tests, 76156 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected