### PR TITLE
Ingenico: add support for `paymentProductId`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -80,6 +80,7 @@
 * BraintreeBlue: Add support for partial capture [aenand] #4515
 * Rapyd: Change key name to `network_transaction_id` [ajawadmirza] #4514
 * CyberSource: Handle unsupported Network Token brands [heavyblade] #4500
+* Ingenico(Global Collect): Add support for `payment_product_id` [rachelkirk] #4521
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -255,8 +255,9 @@ module ActiveMerchant #:nodoc:
         month = format(payment.month, :two_digits)
         expirydate = "#{month}#{year}"
         pre_authorization = options[:pre_authorization] ? 'PRE_AUTHORIZATION' : 'FINAL_AUTHORIZATION'
+        product_id = options[:payment_product_id] || BRAND_MAP[payment.brand]
         specifics_inputs = {
-          'paymentProductId' => BRAND_MAP[payment.brand],
+          'paymentProductId' => product_id,
           'skipAuthentication' => 'true', # refers to 3DSecure
           'skipFraudService' => 'true',
           'authorizationMode' => pre_authorization

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -327,6 +327,14 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_payment_product_id
+    options = @preprod_options.merge(requires_approval: false, currency: 'ARS')
+    response = @gateway_preprod.purchase(1000, @cabal_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 135, response.params['payment']['paymentOutput']['cardPaymentMethodSpecificOutput']['paymentProductId']
+  end
+
   def test_successful_purchase_with_truncated_address
     response = @gateway.purchase(@amount, @credit_card, @long_address)
     assert_success response

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -371,7 +371,8 @@ class GlobalCollectTest < Test::Unit::TestCase
         {
           'website' => 'www.example.com',
           'giftMessage' => 'Happy Day!'
-        }
+        },
+        payment_product_id: '123ABC'
       }
     )
 
@@ -381,6 +382,7 @@ class GlobalCollectTest < Test::Unit::TestCase
       assert_match %r("fraudFields":{"website":"www.example.com","giftMessage":"Happy Day!","customerIpAddress":"127.0.0.1"}), data
       assert_match %r("merchantReference":"123"), data
       assert_match %r("customer":{"personalInformation":{"name":{"firstName":"Longbob","surname":"Longsen"}},"merchantCustomerId":"123987","contactDetails":{"emailAddress":"example@example.com","phoneNumber":"\(555\)555-5555"},"billingAddress":{"street":"456 My Street","additionalInfo":"Apt 1","zip":"K1C2N6","city":"Ottawa","state":"ON","countryCode":"CA"}}}), data
+      assert_match %r("paymentProductId":"123ABC"), data
     end.respond_with(successful_authorize_response)
 
     assert_success response


### PR DESCRIPTION
CER-59

Adds `payment_product_id` as an option that can be passed as an override to the
existing `BRAND MAP`.

Unit:
43 tests, 219 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
40 tests, 104 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.5% passed
The failing test is also failing on master

Local:
5271 tests, 76163 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed