### PR TITLE
Adyen: add network_transaction_id to store call

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -81,6 +81,7 @@
 * Rapyd: Change key name to `network_transaction_id` [ajawadmirza] #4514
 * CyberSource: Handle unsupported Network Token brands [heavyblade] #4500
 * Ingenico(Global Collect): Add support for `payment_product_id` [rachelkirk] #4521
+* Adyen: Add network transaction id to store call [jcreiff] #4522
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -117,7 +117,7 @@ module ActiveMerchant #:nodoc:
         add_extra_data(post, credit_card, options)
         add_stored_credentials(post, credit_card, options)
         add_address(post, options)
-
+        add_network_transaction_reference(post, options)
         options[:recurring_contract_type] ||= 'RECURRING'
         add_recurring_contract(post, options)
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -993,6 +993,14 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_tokenize_only_store_with_ntid
+    assert response = @gateway.store(@credit_card, @options.merge({ tokenize_only: true, network_transaction_id: '858435661128555' }))
+
+    assert_success response
+    assert !response.authorization.split('#')[2].nil?
+    assert_equal 'Success', response.message
+  end
+
   def test_successful_store_with_elo_card
     assert response = @gateway.store(@elo_credit_card, @options)
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -737,6 +737,14 @@ class AdyenTest < Test::Unit::TestCase
     assert_equal '#8835205392522157#', response.authorization
   end
 
+  def test_successful_tokenize_only_store_with_ntid
+    stub_comms do
+      @gateway.store(@credit_card, @options.merge({ tokenize_only: true, network_transaction_id: '858435661128555' }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal '858435661128555', JSON.parse(data)['additionalData']['networkTxReference']
+    end.respond_with(successful_store_response)
+  end
+
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card, @options)


### PR DESCRIPTION
This makes it possible to pass the `networkTxReference` field with `store`

CER-91

Unit:
95 tests, 482 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
124 tests, 443 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.5806% passed

One failing test is related to something that might be an outdated assumption (Adyen doesn’t allow recurring transactions with Cabal). The other two are 3DS2-related. All are failing on master.

Local:
5272 tests, 76166 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed