### PR TITLE
Airwallex: update `return_url`

### DIFF
--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -36,17 +36,15 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(money, card, options = {})
-        requires!(options, :return_url)
-
         payment_intent_id = create_payment_intent(money, options)
         post = {
           'request_id' => request_id(options),
-          'merchant_order_id' => merchant_order_id(options),
-          'return_url' => options[:return_url]
+          'merchant_order_id' => merchant_order_id(options)
         }
         add_card(post, card, options)
         add_descriptor(post, options)
         add_stored_credential(post, options)
+        add_return_url(post, options)
         post['payment_method_options'] = { 'card' => { 'auto_capture' => false } } if authorization_only?(options)
 
         add_three_ds(post, options)
@@ -119,6 +117,10 @@ module ActiveMerchant #:nodoc:
 
       def merchant_order_id(options)
         options[:merchant_order_id] || options[:order_id] || generate_uuid
+      end
+
+      def add_return_url(post, options)
+        post[:return_url] = options[:return_url] if options[:return_url]
       end
 
       def generate_uuid


### PR DESCRIPTION
`return_url` is no longer a required field on Airwallex authorizations. This PR changes it to an optional field.
CE-225

Unit:
33 tests, 181 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
26 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed