### PR TITLE
EBANX: add Spreedly tag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -90,6 +90,7 @@
 * CheckoutV2: Send payment id via `incremental_authorization` field [ajawadmirza] #4518
 * Shift4: Add card `present` field, use previous transaction authorization for capture, and hardcode header values [ajawadmirza] #4528
 * Orbital: Remove `DPANInd` field for RC transactions [ajawadmirza] #4502
+* EBANX: Add Spreedly tag to payment body [flaaviaa] #4527
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -11,6 +11,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.ebanx.com/'
       self.display_name = 'EBANX'
 
+      TAGS = ['Spreedly']
+
       CARD_BRAND = {
         visa: 'visa',
         master: 'master_card',
@@ -216,6 +218,7 @@ module ActiveMerchant #:nodoc:
         post[:metadata] = {} if post[:metadata].nil?
         post[:metadata][:merchant_payment_code] = options[:order_id] if options[:order_id]
         post[:processing_type] = options[:processing_type] if options[:processing_type]
+        post[:payment][:tags] = TAGS
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -22,7 +22,8 @@ class RemoteEbanxTest < Test::Unit::TestCase
       metadata: {
         metadata_1: 'test',
         metadata_2: 'test2'
-      }
+      },
+      tags: EbanxGateway::TAGS
     }
   end
 


### PR DESCRIPTION
Short Summary:
EBANX: it should add Spreedly tag to payment body, so we can identify its payments internally at EBANX.

Full Description:
It should add Spreedly tag to payment body, so we can identify its payments internally at EBANX. It will be for us to have more control of the transactions.

Successful Test Summary
Remote:
26 tests, 70 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.1538% passed

Unit:
5069 tests, 75101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
728 files inspected, no offenses detected