### PR TITLE
Shift4: Capture field changes and hardcode header values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,6 +86,7 @@
 * Shift4: Scrub `securityCode` fix [naashton] #4524
 * Credorax: Update `OpCode` for credit transactions [dsmcclain] #4279
 * CheckoutV2: Add `credit` method [ajawadmirza] #4490
+* Shift4: Add card `present` field, use previous transaction authorization for capture, and hardcode header values [ajawadmirza] #4528
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -73,11 +73,14 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options = {})
         post = {}
+        options[:invoice] = get_invoice(authorization)
+
         add_datetime(post, options)
         add_invoice(post, money, options)
         add_clerk(post, options)
         add_transaction(post, options)
         add_card(post, get_card_token(authorization), options)
+        add_card_present(post, options)
 
         commit('capture', post, options)
       end
@@ -90,6 +93,7 @@ module ActiveMerchant #:nodoc:
         add_transaction(post, options)
         add_customer(post, options)
         add_card(post, get_card_token(authorization), options)
+        add_card_present(post, options)
 
         commit('refund', post, options)
       end
@@ -206,10 +210,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_purchase_card(post, options)
+        return unless options[:customer_reference] || options[:destination_postal_code] || options[:product_descriptors]
+
         post[:purchaseCard] = {}
-        post[:purchaseCard][:customerReference] = options[:customer_reference]
-        post[:purchaseCard][:destinationPostalCode] = options[:destination_postal_code]
-        post[:purchaseCard][:productDescriptors] = options[:product_descriptors]
+        post[:purchaseCard][:customerReference] = options[:customer_reference] if options[:customer_reference]
+        post[:purchaseCard][:destinationPostalCode] = options[:destination_postal_code] if options[:destination_postal_code]
+        post[:purchaseCard][:productDescriptors] = options[:product_descriptors] if options[:product_descriptors]
       end
 
       def add_card_on_file(post, options)
@@ -286,9 +292,9 @@ module ActiveMerchant #:nodoc:
         }
         headers['AccessToken'] = @access_token
         headers['Invoice'] = options[:invoice] if options[:invoice].present?
-        headers['InterfaceVersion'] = options[:interface_version] if options[:interface_version]
-        headers['InterfaceName'] = options[:interface_name] if options[:interface_name]
-        headers['CompanyName'] = options[:company_name] if options[:company_name]
+        headers['InterfaceVersion'] = '1'
+        headers['InterfaceName'] = 'Spreedly'
+        headers['CompanyName'] = 'Spreedly'
         headers
       end
 

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -14,10 +14,7 @@ class RemoteShift4Test < Test::Unit::TestCase
       tax: '2',
       customer_reference: 'D019D09309F2',
       destination_postal_code: '94719',
-      product_descriptors: %w(Hamburger Fries Soda Cookie),
-      company_name: 'Spreedly',
-      interface_name: 'ForwardPOS',
-      interface_version: '2.1'
+      product_descriptors: %w(Hamburger Fries Soda Cookie)
     }
   end
 
@@ -42,6 +39,7 @@ class RemoteShift4Test < Test::Unit::TestCase
     assert_success response
     assert_equal response.message, 'Transaction successful'
     assert response_result(response)['transaction']['invoice'].present?
+    assert_equal response_result(response)['transaction']['invoice'], response_result(authorize_res)['transaction']['invoice']
   end
 
   def test_successful_purchase
@@ -111,7 +109,7 @@ class RemoteShift4Test < Test::Unit::TestCase
   end
 
   def test_failed_capture
-    response = @gateway.capture(@amount, @declined_card, @options)
+    response = @gateway.capture(@amount, '', @options)
     assert_failure response
     assert_include response.message, 'Card  for Merchant Id 0008628968 not found'
   end

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -25,11 +25,6 @@ class Shift4Test < Test::Unit::TestCase
       destination_postal_code: '94719',
       product_descriptors: %w(Hamburger Fries Soda Cookie)
     }
-    @extra_headers = {
-      company_name: 'Spreedly',
-      interface_name: 'ForwardPOS',
-      interface_version: '2.1'
-    }
   end
 
   def test_successful_capture
@@ -119,6 +114,9 @@ class Shift4Test < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.refund(@amount, '1111g66gw3ryke06', @options.merge!(invoice: '4666309473'))
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['card']['present'], 'N'
     end.respond_with(successful_refund_response)
 
     assert response.success?
@@ -195,11 +193,11 @@ class Shift4Test < Test::Unit::TestCase
 
   def test_successful_header_fields
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @extra_headers)
+      @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_endpoint, _data, headers|
-      assert_equal headers['CompanyName'], @extra_headers[:company_name]
-      assert_equal headers['InterfaceVersion'], @extra_headers[:interface_version]
-      assert_equal headers['InterfaceName'], @extra_headers[:interface_name]
+      assert_equal headers['CompanyName'], 'Spreedly'
+      assert_equal headers['InterfaceVersion'], '1'
+      assert_equal headers['InterfaceName'], 'Spreedly'
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Capture changes to add card present field, use same invoice number as authorization, and hardcode header values.

SER-223
SER-226
SER-222

Remote:
16 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5273 tests, 76175 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected