### PR TITLE
Stripe PI: add options for setup intent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,6 +86,7 @@
 * Shift4: Scrub `securityCode` fix [naashton] #4524
 * Credorax: Update `OpCode` for credit transactions [dsmcclain] #4279
 * CheckoutV2: Add `credit` method [ajawadmirza] #4490
+* Stripe Payment Intents: Add `options` for retrieve_setup_intent [aenand] #4529
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -132,7 +132,7 @@ module ActiveMerchant #:nodoc:
         commit(:post, 'setup_intents', post, options)
       end
 
-      def retrieve_setup_intent(setup_intent_id)
+      def retrieve_setup_intent(setup_intent_id, options = {})
         # Retrieving a setup_intent passing 'expand[]=latest_attempt' allows the caller to
         # check for a network_transaction_id and ds_transaction_id
         # eg (latest_attempt -> payment_method_details -> card -> network_transaction_id)
@@ -140,7 +140,7 @@ module ActiveMerchant #:nodoc:
         # Being able to retrieve these fields enables payment flows that rely on MIT exemptions, e.g: off_session
         commit(:post, "setup_intents/#{setup_intent_id}", {
           'expand[]': 'latest_attempt'
-        }, {})
+        }, options)
       end
 
       def authorize(money, payment_method, options = {})


### PR DESCRIPTION
ECS-2548

The Stripe PI gateway setup intent flow does
not include an optional options hash during
the retrieve_setup_intent method. This
prohibits someone using Stripe connect
from completing this flow.

Test Summary
Local:
5273 tests, 76175 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
746 files inspected, no offenses detected
Unit:
39 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
78 tests, 371 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed