### PR TITLE
Worldpay: Update  `required_status_message` and `message_from` methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -98,6 +98,7 @@
 * Rapyd: Pass Customer ID and fix `add_token` method [naashton] #4538
 * Shift4: If no timezone is sent on transactions, the code uses the hours and minutes as a timezone offset [ali-hassan] #4536
 * Priority: Add support for general credit and updating cvv and zip [priorityspreedly] #4517
+* Worldpay: Update actions for generated message in `required_status_message` method [rachelkirk] #4530
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -441,7 +441,6 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -469,7 +468,6 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert response = @gateway.authorize(@amount, @threeDS2_challenge_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", response.message
     assert response.test?
     refute response.authorization.blank?
     refute response.params['issuer_url'].blank?
@@ -557,7 +555,6 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?
@@ -580,7 +577,6 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       }
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
-    assert_equal "A transaction status of 'AUTHORISED' or 'CAPTURED' is required.", first_message.message
     assert first_message.test?
     refute first_message.authorization.blank?
     refute first_message.params['issuer_url'].blank?


### PR DESCRIPTION
CER-18

Updating the `required_status_message` method to only generate the AM response if using one of the actions called out in the method. The transaction types are all multi-response and use a combination of actions.

Remote Tests:
100 tests, 392 assertions, 4 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
95% passed
*4 failing tests are 3DS tests that hinge on that message being auto-generated. The message being auto-generated means that the transaction itself failed. When prying into the responses, for these tests `@success = false`. The 1 error is also happening on master, may be related to recent Worldpay updates.

Unit Tests:
104 tests, 613 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Local:
5274 tests, 76180 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed