### PR TITLE
Shift4: Add `expirationDate` to refund transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -91,6 +91,7 @@
 * Shift4: Add card `present` field, use previous transaction authorization for capture, and hardcode header values [ajawadmirza] #4528
 * Orbital: Remove `DPANInd` field for RC transactions [ajawadmirza] #4502
 * EBANX: Add Spreedly tag to payment body [flaaviaa] #4527
+* Shift4: Add `expiration_date` field for refund transactions [ajawadmirza] #4532
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -187,6 +187,7 @@ module ActiveMerchant #:nodoc:
           post[:card] = {} if post[:card].nil?
           post[:card][:token] = {}
           post[:card][:token][:value] = payment_method
+          post[:card][:expirationDate] = options[:expiration_date] if options[:expiration_date]
         end
       end
 

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -127,6 +127,13 @@ class RemoteShift4Test < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_refund_with_expiration_date
+    res = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success res
+    response = @gateway.refund(@amount, res.authorization, @options.merge({ expiration_date: '1235' }))
+    assert_success response
+  end
+
   def test_successful_void
     authorize_res = @gateway.authorize(@amount, @credit_card, @options)
     assert response = @gateway.void(authorize_res.authorization, @options)

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -113,10 +113,11 @@ class Shift4Test < Test::Unit::TestCase
 
   def test_successful_refund
     response = stub_comms do
-      @gateway.refund(@amount, '1111g66gw3ryke06', @options.merge!(invoice: '4666309473'))
+      @gateway.refund(@amount, '1111g66gw3ryke06', @options.merge!(invoice: '4666309473', expiration_date: '1235'))
     end.check_request do |_endpoint, data, _headers|
       request = JSON.parse(data)
       assert_equal request['card']['present'], 'N'
+      assert_equal request['card']['expirationDate'], '1235'
     end.respond_with(successful_refund_response)
 
     assert response.success?


### PR DESCRIPTION
Add `expirationDate` to refund via options along with unit test.

SER-222

Unit:
5275 tests, 76191 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
16 tests, 37 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed