### PR TITLE
Airwallex: Add `skip_3ds` field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -93,6 +93,7 @@
 * EBANX: Add Spreedly tag to payment body [flaaviaa] #4527
 * Shift4: Add `expiration_date` field for refund transactions [ajawadmirza] #4532
 * Improve handling of AVS and CVV Results in Multiresponses [gasb150] #4516
+* Airwallex: Add `skip_3ds` field for create payment transactions [ajawadmirza] #4534
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -154,6 +154,7 @@ module ActiveMerchant #:nodoc:
         post[:merchant_order_id] = merchant_order_id(options)
         add_referrer_data(post)
         add_descriptor(post, options)
+        post['payment_method_options'] = { 'card' => { 'risk_control' => { 'three_ds_action' => 'SKIP_3DS' } } } if options[:skip_3ds]
 
         response = commit(:setup, post)
         raise ArgumentError.new(response.message) unless response.success?

--- a/test/remote/gateways/remote_airwallex_test.rb
+++ b/test/remote/gateways/remote_airwallex_test.rb
@@ -41,6 +41,12 @@ class RemoteAirwallexTest < Test::Unit::TestCase
     assert_match(merchant_order_id, response.params.dig('merchant_order_id'))
   end
 
+  def test_successful_purchase_with_skip_3ds
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ skip_3ds: 'true' }))
+    assert_success response
+    assert_equal 'AUTHORIZED', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@declined_amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/airwallex_test.rb
+++ b/test/unit/gateways/airwallex_test.rb
@@ -157,6 +157,22 @@ class AirwallexTest < Test::Unit::TestCase
     assert_equal 'AUTHORIZED', response.message
   end
 
+  def test_successful_skip_3ds_in_payment_intent
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge({ skip_3ds: true }))
+    end.check_request do |endpoint, data, _headers|
+      data = JSON.parse(data)
+      assert_match(data['payment_method_options']['card']['risk_control']['three_ds_action'], 'SKIP_3DS') if endpoint == setup_endpoint
+    end.respond_with(successful_purchase_response)
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge({ skip_3ds: 'true' }))
+    end.check_request do |endpoint, data, _headers|
+      data = JSON.parse(data)
+      assert_match(data['payment_method_options']['card']['risk_control']['three_ds_action'], 'SKIP_3DS') if endpoint == setup_endpoint
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
 


### PR DESCRIPTION
Added `skip_3ds` field support for airwallex along with unit and remote test cases.

SEr-229

Unit:
5276 tests, 76200 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
27 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed