### PR TITLE
Wompi: allow partial refund amount on void_sync

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -116,6 +116,7 @@
 * Rapyd: No force capture for ACH [naashton] #4562
 * Shift4: Applied checks on Shift4 Time/Timezone offset [ali-hassan] #45611
 * Alelo: Add gateway [heavyblade] #4555
+* Wompi: Allow partial refund amount on void_sync [jcreiff] #4535
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/wompi.rb
+++ b/lib/active_merchant/billing/gateways/wompi.rb
@@ -65,11 +65,12 @@ module ActiveMerchant #:nodoc:
         # commit('refund', post, '/refunds_sync')
 
         # All refunds will instead be voided. This is temporary.
-        void(authorization)
+        void(authorization, options, money)
       end
 
-      def void(authorization, options = {})
-        commit('void', {}, "/transactions/#{authorization}/void_sync")
+      def void(authorization, options = {}, money = nil)
+        post = money ? { amount_in_cents: amount(money).to_i } : {}
+        commit('void', post, "/transactions/#{authorization}/void_sync")
       end
 
       def supports_scrubbing?

--- a/test/remote/gateways/remote_wompi_test.rb
+++ b/test/remote/gateways/remote_wompi_test.rb
@@ -74,13 +74,13 @@ class RemoteWompiTest < Test::Unit::TestCase
     assert_success refund
   end
 
-  # def test_partial_refund
-  #   purchase = @gateway.purchase(@amount, @credit_card, @options)
-  #   assert_success purchase
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
 
-  #   assert refund = @gateway.refund(@amount - 1, purchase.authorization)
-  #   assert_success refund
-  # end
+    assert refund = @gateway.refund(@amount - 50000, purchase.authorization)
+    assert_success refund
+  end
 
   # def test_failed_refund
   #   response = @gateway.refund(@amount, '')

--- a/test/unit/gateways/wompi_test.rb
+++ b/test/unit/gateways/wompi_test.rb
@@ -8,7 +8,7 @@ class WompiTest < Test::Unit::TestCase
     @prod_gateway = WompiGateway.new(prod_public_key: 'pub_prod_1234', prod_private_key: 'priv_prod_5678')
     @ambidextrous_gateway = WompiGateway.new(prod_public_key: 'pub_prod_1234', prod_private_key: 'priv_prod_5678', test_public_key: 'pub_test_1234', test_private_key: 'priv_test_5678')
     @credit_card = credit_card
-    @amount = 100
+    @amount = 150000
 
     @options = {
       order_id: '1',
@@ -106,7 +106,20 @@ class WompiTest < Test::Unit::TestCase
       @gateway.refund(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, _headers|
       assert_match 'void_sync', endpoint
-      assert_match '{}', data
+      assert_match @amount.to_s, data
+    end.respond_with(successful_void_response)
+    assert_success response
+
+    assert_equal '113879-1635301067-17128', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_partial_refund_to_void
+    response = stub_comms(@gateway) do
+      @gateway.refund(@amount - 50000, @credit_card, @options)
+    end.check_request do |endpoint, data, _headers|
+      assert_match 'void_sync', endpoint
+      assert_match (@amount - 50000).to_s, data
     end.respond_with(successful_void_response)
     assert_success response
 
@@ -115,9 +128,12 @@ class WompiTest < Test::Unit::TestCase
   end
 
   def test_successful_void
-    @gateway.expects(:ssl_post).returns(successful_void_response)
-
-    response = @gateway.void(@amount, @options)
+    response = stub_comms(@gateway) do
+      @gateway.void(@amount, @options)
+    end.check_request do |endpoint, data, _headers|
+      assert_match 'void_sync', endpoint
+      assert_match '{}', data
+    end.respond_with(successful_void_response)
     assert_success response
 
     assert_equal '113879-1635301067-17128', response.authorization


### PR DESCRIPTION
Previous changes to this gateway redirected all refund requests to the
void endpoint. This meant that any partial refund attempts were processed
as full refunds, because the void method did not accept an amount.

Wompi has advised that it is now possible to send amount_in_cents to this
void_sync endpoint to allow for partial refunds.

CER-152

LOCAL
5276 tests, 76199 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
746 files inspected, no offenses detected

UNIT
12 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
13 tests, 34 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed