### PR TITLE
Shift4: Stored credential parameter name change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -94,6 +94,7 @@
 * Shift4: Add `expiration_date` field for refund transactions [ajawadmirza] #4532
 * Improve handling of AVS and CVV Results in Multiresponses [gasb150] #4516
 * Airwallex: Add `skip_3ds` field for create payment transactions [ajawadmirza] #4534
+* Shift4: Typo correction for `initial_transaction` [ajawadmirza] #4537
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -223,7 +223,7 @@ module ActiveMerchant #:nodoc:
         return unless stored_credential = options[:stored_credential]
 
         post[:cardOnFile] = {}
-        post[:cardOnFile][:usageIndicator] = stored_credential[:inital_transaction] ? '01' : '02'
+        post[:cardOnFile][:usageIndicator] = stored_credential[:initial_transaction] ? '01' : '02'
         post[:cardOnFile][:indicator] = options[:card_on_file_indicator] || '01'
         post[:cardOnFile][:scheduledIndicator] = RECURRING_TYPE_TRANSACTIONS.include?(stored_credential[:reason_type]) ? '01' : '02' if stored_credential[:reason_type]
         post[:cardOnFile][:transactionId] = stored_credential[:network_transaction_id] if stored_credential[:network_transaction_id]

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -55,7 +55,7 @@ class RemoteShift4Test < Test::Unit::TestCase
 
   def test_successful_purchase_with_stored_credential
     stored_credential_options = {
-      inital_transaction: true,
+      initial_transaction: true,
       reason_type: 'recurring'
     }
     first_response = @gateway.purchase(@amount, @credit_card, @options.merge(@extra_options.merge({ stored_credential: stored_credential_options })))
@@ -63,7 +63,7 @@ class RemoteShift4Test < Test::Unit::TestCase
 
     ntxid = first_response.params['result'].first['transaction']['cardOnFile']['transactionId']
     stored_credential_options = {
-      inital_transaction: false,
+      initial_transaction: false,
       reason_type: 'recurring',
       network_transaction_id: ntxid
     }


### PR DESCRIPTION
Corrected parameter typo for stored credential to `initial_transaction` in the shift4 implementation along with testing.

SER-193

Unit:
5284 tests, 76224 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
17 tests, 39 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed