### PR TITLE
Rapyd: Pass Customer ID and fix `add_token` method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -95,6 +95,7 @@
 * Improve handling of AVS and CVV Results in Multiresponses [gasb150] #4516
 * Airwallex: Add `skip_3ds` field for create payment transactions [ajawadmirza] #4534
 * Shift4: Typo correction for `initial_transaction` [ajawadmirza] #4537
+* Rapyd: Pass Customer ID and fix `add_token` method [naashton] #4538
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -28,6 +28,7 @@ module ActiveMerchant #:nodoc:
         add_ewallet(post, options)
         add_payment_fields(post, options)
         add_payment_urls(post, options)
+        add_customer_id(post, options)
         post[:capture] = true if payment.is_a?(CreditCard)
 
         if payment.is_a?(Check)
@@ -53,6 +54,7 @@ module ActiveMerchant #:nodoc:
         add_ewallet(post, options)
         add_payment_fields(post, options)
         add_payment_urls(post, options)
+        add_customer_id(post, options)
         post[:capture] = false
 
         commit(:post, 'payments', post)
@@ -185,7 +187,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_token(post, payment, options)
-        post[:payment_method] = payment
+        return unless token = payment.split('|')[1]
+
+        post[:payment_method] = token
       end
 
       def add_3ds(post, payment, options)
@@ -224,6 +228,10 @@ module ActiveMerchant #:nodoc:
         post[:name] = "#{payment.first_name} #{payment.last_name}"
         post[:phone_number] = options[:billing_address][:phone].gsub(/\D/, '') if options[:billing_address]
         post[:email] = options[:email] if options[:email]
+      end
+
+      def add_customer_id(post, options)
+        post[:customer] = options[:customer_id] if options[:customer_id]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -9,7 +9,7 @@ class RemoteRapydTest < Test::Unit::TestCase
     @declined_card = credit_card('4111111111111105')
     @check = check
     @options = {
-      pm_type: 'us_visa_card',
+      pm_type: 'us_debit_visa_card',
       currency: 'USD',
       complete_payment_url: 'www.google.com',
       error_payment_url: 'www.google.com',
@@ -202,6 +202,17 @@ class RemoteRapydTest < Test::Unit::TestCase
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
     assert_equal 'Do Not Honor', response.message
+  end
+
+  def test_successful_store_and_purchase
+    store = @gateway.store(@credit_card, @options)
+    assert_success store
+    assert store.params.dig('data', 'id')
+    assert store.params.dig('data', 'default_payment_method')
+
+    # 3DS authorization is required on storing a payment method for future transactions
+    # purchase = @gateway.purchase(100, store.authorization, @options.merge(customer_id: customer_id))
+    # assert_sucess purchase
   end
 
   def test_successful_store_and_unstore


### PR DESCRIPTION
For `authorize` and `purchase` transactions we can optionally pass the
`customer` object which is similarly used in the transaction endpoint.
The value is prepended `cus_` and is required if the payment method is
omitted

`add_token` was incorrectly sending the whole `authorization` which is a
combination of a transaction or customer id and a payment token (based
on the `authorization_from` method

Remote test for `test_successful_store_and_purchase` includes a
commented out test purchase (commented out) because the payment method
must go through a 3DS authorization flow before it can be utilized in
payment transactions (sandbox only)
[Create Customer Object](https://docs.rapyd.net/build-with-rapyd/reference/customer-object#create-customer)

SER-228

Unit: 20 tests, 91 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 29 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed