### PR TITLE
Stripe: Add shipping address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -102,6 +102,7 @@
 * Adyen: Modify handling of countryCode for ACH [jcreiff] #4543
 * CardConnect: update api end-point urls [heavyblade] #4541
 * Vantiv(Litle): Add support for `fraudFilterOverride` field [rachelkirk] #4544
+* Stripe: Add shipping address [jcreiff] #4539
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -389,6 +389,7 @@ module ActiveMerchant #:nodoc:
         end
 
         add_metadata(post, options)
+        add_shipping_address(post, payment, options)
         add_application_fee(post, options)
         add_exchange_rate(post, options)
         add_destination(post, options)
@@ -553,6 +554,23 @@ module ActiveMerchant #:nodoc:
       def add_emv_metadata(post, creditcard)
         post[:metadata] ||= {}
         post[:metadata][:card_read_method] = creditcard.read_method if creditcard.respond_to?(:read_method)
+      end
+
+      def add_shipping_address(post, payment, options = {})
+        return unless shipping = options[:shipping_address]
+        return unless shipping_name = shipping[:name]
+
+        post[:shipping] = {}
+
+        post[:shipping][:name] = shipping_name
+        post[:shipping][:address] = {}
+        post[:shipping][:address][:line1] = shipping[:address1]
+        post[:shipping][:address][:line2] = shipping[:address2] if shipping[:address2]
+        post[:shipping][:address][:city] = shipping[:city] if shipping[:city]
+        post[:shipping][:address][:country] = shipping[:country] if shipping[:country]
+        post[:shipping][:address][:state] = shipping[:state] if shipping[:state]
+        post[:shipping][:address][:postal_code] = shipping[:zip] if shipping[:zip]
+        post[:shipping][:phone] = shipping[:phone_number] if shipping[:phone_number]
       end
 
       def add_source_owner(post, creditcard, options)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -234,6 +234,19 @@ module ActiveMerchant
       }.update(options)
     end
 
+    def shipping_address(options = {})
+      {
+        name:     'Jon Smith',
+        address1: '123 Your Street',
+        address2: 'Apt 2',
+        city:     'Toronto',
+        state:    'ON',
+        zip:      'K2C3N7',
+        country:  'CA',
+        phone_number: '(123)456-7890'
+      }.update(options)
+    end
+
     def statement_address(options = {})
       {
         address1: '456 My Street',

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -15,6 +15,7 @@ class StripeTest < Test::Unit::TestCase
     @options = {
       billing_address: address(),
       statement_address: statement_address(),
+      shipping_address: shipping_address(),
       description: 'Test Purchase'
     }
 
@@ -1146,6 +1147,31 @@ class StripeTest < Test::Unit::TestCase
     assert_equal @options[:statement_address][:address2], post[:statement_address][:line2]
     assert_equal @options[:statement_address][:country], post[:statement_address][:country]
     assert_equal @options[:statement_address][:city], post[:statement_address][:city]
+  end
+
+  def test_add_shipping_address
+    post = {}
+
+    @gateway.send(:add_shipping_address, post, @credit_card, @options)
+
+    assert_equal @options[:shipping_address][:zip], post[:shipping][:address][:postal_code]
+    assert_equal @options[:shipping_address][:state], post[:shipping][:address][:state]
+    assert_equal @options[:shipping_address][:address1], post[:shipping][:address][:line1]
+    assert_equal @options[:shipping_address][:address2], post[:shipping][:address][:line2]
+    assert_equal @options[:shipping_address][:country], post[:shipping][:address][:country]
+    assert_equal @options[:shipping_address][:city], post[:shipping][:address][:city]
+    assert_equal @options[:shipping_address][:name], post[:shipping][:name]
+    assert_equal @options[:shipping_address][:phone_number], post[:shipping][:phone]
+  end
+
+  def test_shipping_address_not_added_if_no_name_present
+    post = {}
+
+    options = @options.dup
+    options[:shipping_address] = options[:shipping_address].except(:name)
+    @gateway.send(:add_shipping_address, post, @credit_card, options)
+
+    assert_empty post
   end
 
   def test_add_statement_address_returns_nil_if_required_fields_missing


### PR DESCRIPTION
Update the `add_charge_details` method to include an `add_shipping_address`
method, similar to the Stripe Payment Intents integration.

CER-35
LOCAL
5288 tests, 76234 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

746 files inspected, no offenses detected

UNIT
146 tests, 765 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE

77 tests, 359 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed