### PR TITLE
Adyen: modify handling of countryCode for ACH

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -99,6 +99,7 @@
 * Shift4: If no timezone is sent on transactions, the code uses the hours and minutes as a timezone offset [ali-hassan] #4536
 * Priority: Add support for general credit and updating cvv and zip [priorityspreedly] #4517
 * Worldpay: Update actions for generated message in `required_status_message` method [rachelkirk] #4530
+* Adyen: Modify handling of countryCode for ACH [jcreiff] #4543
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -396,7 +396,7 @@ module ActiveMerchant #:nodoc:
         bank = {
           bankAccountNumber: bank_account.account_number,
           ownerName: bank_account.name,
-          countryCode: options[:billing_address][:country]
+          countryCode: options[:billing_address].try(:[], :country)
         }
 
         action == 'refundWithData' ? bank[:iban] = bank_account.routing_number : bank[:bankLocationId] = bank_account.routing_number

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -464,6 +464,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal 'Bank Account or Bank Location Id not valid or missing', response.message
   end
 
+  def test_failed_authorize_with_bank_account_missing_country_code
+    response = @gateway.authorize(@amount, @bank_account, @options.except(:billing_address))
+    assert_failure response
+    assert_equal 'BankDetails missing', response.message
+  end
+
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response


### PR DESCRIPTION
This change allows ACH transactions to fail with an Adyen error message
instead of with a NoMethodError when no `:country` is present inside the
`:billing_address` hash

CER-151

LOCAL
5284 tests, 76224 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
746 files inspected, no offenses detected

UNIT
95 tests, 482 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
125 tests, 445 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.6% passed
- There are two 3DS tests failing, and another related to Cabal card type. These failures are not connected to this change and are also failing on master