### PR TITLE
Vantiv(Litle): Add support for `fraudFilterOverride`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -101,6 +101,7 @@
 * Worldpay: Update actions for generated message in `required_status_message` method [rachelkirk] #4530
 * Adyen: Modify handling of countryCode for ACH [jcreiff] #4543
 * CardConnect: update api end-point urls [heavyblade] #4541
+* Vantiv(Litle): Add support for `fraudFilterOverride` field [rachelkirk] #4544
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -320,6 +320,7 @@ module ActiveMerchant #:nodoc:
         add_merchant_data(doc, options)
         add_debt_repayment(doc, options)
         add_stored_credential_params(doc, options)
+        add_fraud_filter_override(doc, options)
       end
 
       def add_credit_params(doc, money, payment_method, options)
@@ -363,6 +364,10 @@ module ActiveMerchant #:nodoc:
 
       def add_debt_repayment(doc, options)
         doc.debtRepayment(true) if options[:debt_repayment] == true
+      end
+
+      def add_fraud_filter_override(doc, options)
+        doc.fraudFilterOverride(options[:fraud_filter_override]) if options[:fraud_filter_override]
       end
 
       def add_payment_method(doc, payment_method, options)

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -206,6 +206,17 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_fraud_filter_override_flag
+    assert response = @gateway.purchase(10010, @credit_card1, @options.merge(fraud_filter_override: true))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_failed_purchase_when_fraud_filter_override_flag_not_sent_as_boolean
+    assert response = @gateway.purchase(10010, @credit_card1, @options.merge(fraud_filter_override: 'hey'))
+    assert_failure response
+  end
+
   def test_successful_purchase_with_3ds_fields
     options = @options.merge({
       order_source: '3dsAuthenticated',

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -237,6 +237,14 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_fraud_filter_override
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, { fraud_filter_override: true })
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<fraudFilterOverride>true</fraudFilterOverride>), data)
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_passing_payment_cryptogram
     stub_comms do
       @gateway.purchase(@amount, @decrypted_apple_pay)


### PR DESCRIPTION
CER-51

This PR adds the `fraudFilterOverride` flag, a boolean which when set to true will override all fraud filters for the submitted transaction.

Unit Tests:
56 tests, 240 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
56 tests, 226 assertions, 13 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
76.7857% passed
* I ran the remote tests several times and 13 (sometimes 14) tests are failing and have been for over a year. I think this gateway is due for an overhaul but the failures aren’t related to the changes and are also failing on master.

Local Tests:
5288 tests, 76246 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed