### PR TITLE
PayTrace: Support ACH implementations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -109,6 +109,7 @@
 * Plexo: Update `purchase` method, add flags for header fields, add new fields `billing_address`, `identification_type`, `identification_value`, and `cardholder_birthdate` [ajawadmirza] #4540
 * Rapyd: Remove `BR`, `MX`, and `US` from supported countries [ajawadmirza] #4558
 * Stripe Payment Intents: fix bug with billing address email [jcreiff] #4556
+* PayTrace: Support ACH implementation for new endpoints and request body [ajawadmirza] #4545
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/pay_trace.rb
+++ b/lib/active_merchant/billing/gateways/pay_trace.rb
@@ -33,7 +33,14 @@ module ActiveMerchant #:nodoc:
         store: 'customer/create',
         redact: 'customer/delete',
         level_3_visa: 'level_three/visa',
-        level_3_mastercard: 'level_three/mastercard'
+        level_3_mastercard: 'level_three/mastercard',
+        ach_sale: 'checks/sale/by_account',
+        ach_customer_sale: 'checks/sale/by_customer',
+        ach_authorize: 'checks/hold/by_account',
+        ach_customer_authorize: 'checks/hold/by_customer',
+        ach_refund: 'checks/refund/by_transaction',
+        ach_capture: 'checks/manage/fund',
+        ach_void: 'checks/manage/void'
       }
 
       def initialize(options = {})
@@ -52,7 +59,15 @@ module ActiveMerchant #:nodoc:
           end
         else
           post = build_purchase_request(money, payment_or_customer_id, options)
-          post[:customer_id] ? endpoint = ENDPOINTS[:customer_id_sale] : endpoint = ENDPOINTS[:keyed_sale]
+          endpoint = if payment_or_customer_id.kind_of?(Check)
+                       ENDPOINTS[:ach_sale]
+                     elsif options[:check_transaction]
+                       ENDPOINTS[:ach_customer_sale]
+                     elsif post[:customer_id]
+                       ENDPOINTS[:customer_id_sale]
+                     else
+                       ENDPOINTS[:keyed_sale]
+                     end
           response = commit(endpoint, post)
           check_token_response(response, endpoint, post, options)
         end
@@ -63,12 +78,16 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money, options)
         if customer_id?(payment_or_customer_id)
           post[:customer_id] = payment_or_customer_id
-          endpoint = ENDPOINTS[:customer_id_auth]
+          endpoint = if options[:check_transaction]
+                       ENDPOINTS[:ach_customer_authorize]
+                     else
+                       ENDPOINTS[:customer_id_auth]
+                     end
         else
           add_payment(post, payment_or_customer_id)
           add_address(post, payment_or_customer_id, options)
           add_customer_data(post, options)
-          endpoint = ENDPOINTS[:keyed_auth]
+          endpoint = payment_or_customer_id.kind_of?(Check) ? ENDPOINTS[:ach_authorize] : ENDPOINTS[:keyed_auth]
         end
         response = commit(endpoint, post)
         check_token_response(response, endpoint, post, options)
@@ -82,8 +101,13 @@ module ActiveMerchant #:nodoc:
           end
         else
           post = build_capture_request(money, authorization, options)
-          response = commit(ENDPOINTS[:capture], post)
-          check_token_response(response, ENDPOINTS[:capture], post, options)
+          endpoint = if options[:check_transaction]
+                       ENDPOINTS[:ach_capture]
+                     else
+                       ENDPOINTS[:capture]
+                     end
+          response = commit(endpoint, post)
+          check_token_response(response, endpoint, post, options)
         end
       end
 
@@ -91,17 +115,29 @@ module ActiveMerchant #:nodoc:
         # currently only support full and partial refunds of settled transactions via a transaction ID
         post = {}
         add_amount(post, money, options)
-        post[:transaction_id] = authorization
-        response = commit(ENDPOINTS[:transaction_refund], post)
-        check_token_response(response, ENDPOINTS[:transaction_refund], post, options)
+        if options[:check_transaction]
+          post[:check_transaction_id] = authorization
+          endpoint = ENDPOINTS[:ach_refund]
+        else
+          post[:transaction_id] = authorization
+          endpoint = ENDPOINTS[:transaction_refund]
+        end
+        response = commit(endpoint, post)
+        check_token_response(response, endpoint, post, options)
       end
 
       def void(authorization, options = {})
         post = {}
-        post[:transaction_id] = authorization
+        if options[:check_transaction]
+          post[:check_transaction_id] = authorization
+          endpoint = ENDPOINTS[:ach_void]
+        else
+          post[:transaction_id] = authorization
+          endpoint = ENDPOINTS[:transaction_void]
+        end
 
-        response = commit(ENDPOINTS[:transaction_void], post)
-        check_token_response(response, ENDPOINTS[:transaction_void], post, options)
+        response = commit(endpoint, post)
+        check_token_response(response, endpoint, post, options)
       end
 
       def verify(credit_card, options = {})
@@ -175,7 +211,11 @@ module ActiveMerchant #:nodoc:
 
       def build_capture_request(money, authorization, options)
         post = {}
-        post[:transaction_id] = authorization
+        if options[:check_transaction]
+          post[:check_transaction_id] = authorization
+        else
+          post[:transaction_id] = authorization
+        end
         add_amount(post, money, options)
 
         post
@@ -234,10 +274,16 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment(post, payment)
-        post[:credit_card] = {}
-        post[:credit_card][:number] = payment.number
-        post[:credit_card][:expiration_month] = payment.month
-        post[:credit_card][:expiration_year] = payment.year
+        if payment.kind_of?(Check)
+          post[:check] = {}
+          post[:check][:account_number] = payment.account_number
+          post[:check][:routing_number] = payment.routing_number
+        else
+          post[:credit_card] = {}
+          post[:credit_card][:number] = payment.number
+          post[:credit_card][:expiration_month] = payment.month
+          post[:credit_card][:expiration_year] = payment.year
+        end
       end
 
       def add_level_3_data(post, options)
@@ -380,7 +426,7 @@ module ActiveMerchant #:nodoc:
         if action == ENDPOINTS[:store]
           response['customer_id']
         else
-          response['transaction_id']
+          response['transaction_id'] || response['check_transaction_id']
         end
       end
 

--- a/test/remote/gateways/remote_pay_trace_test.rb
+++ b/test/remote/gateways/remote_pay_trace_test.rb
@@ -22,6 +22,7 @@ class RemotePayTraceTest < Test::Unit::TestCase
     @invalid_card = credit_card('54545454545454', month: '14', year: '1999')
     @discover = credit_card('6011000993026909')
     @amex = credit_card('371449635392376')
+    @echeck = check(account_number: '123456', routing_number: '325070760')
     @options = {
       billing_address: {
         address1: '8320 This Way Lane',
@@ -50,6 +51,22 @@ class RemotePayTraceTest < Test::Unit::TestCase
     response = @gateway.purchase(500, customer_id, @options)
     assert_success response
     assert_equal 'Your transaction was successfully approved.', response.message
+  end
+
+  def test_successful_purchase_with_ach
+    @echeck.account_number = rand.to_s[2..7]
+    response = @gateway.purchase(1000, @echeck, @options)
+    assert_success response
+    assert_equal response.message, 'Your check was successfully processed.'
+  end
+
+  def test_successful_purchase_by_customer_with_ach
+    @echeck.account_number = rand.to_s[2..7]
+    create = @gateway.store(@echeck, @options)
+    assert_success create
+    customer_id = create.params['customer_id']
+    response = @gateway.purchase(500, customer_id, @options.merge({ check_transaction: 'true' }))
+    assert_success response
   end
 
   def test_successful_purchase_with_more_options
@@ -192,6 +209,23 @@ class RemotePayTraceTest < Test::Unit::TestCase
     assert_equal 'Your transaction was successfully approved.', response.message
   end
 
+  def test_successful_authorize_with_ach
+    @echeck.account_number = rand.to_s[2..7]
+    response = @gateway.authorize(1000, @echeck, @options)
+    assert_success response
+    assert_equal response.message, 'Your check was successfully processed.'
+  end
+
+  def test_successful_authorize_by_customer_with_ach
+    @echeck.account_number = rand.to_s[2..7]
+    store = @gateway.store(@echeck, @options)
+    assert_success store
+    customer_id = store.params['customer_id']
+
+    response = @gateway.authorize(200, customer_id, @options.merge({ check_transaction: 'true' }))
+    assert_success response
+  end
+
   def test_successful_authorize_and_capture_with_level_3_data
     options = {
       visa_or_mastercard: 'mastercard',
@@ -234,6 +268,15 @@ class RemotePayTraceTest < Test::Unit::TestCase
     assert_success auth
 
     assert capture = @gateway.capture(200, auth.authorization, @options)
+    assert_success capture
+  end
+
+  def test_authorize_and_capture_with_ach
+    @echeck.account_number = rand.to_s[2..7]
+    auth = @gateway.authorize(500, @echeck, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(500, auth.authorization, @options.merge({ check_transaction: 'true' }))
     assert_success capture
   end
 
@@ -299,6 +342,15 @@ class RemotePayTraceTest < Test::Unit::TestCase
     assert void = @gateway.void(auth.authorization)
     assert_success void
     assert_equal 'Your transaction was successfully voided.', void.message
+  end
+
+  def test_successful_void_with_ach
+    @echeck.account_number = rand.to_s[2..7]
+    auth = @gateway.authorize(@amount, @echeck, @options)
+    assert_success auth
+
+    assert void = @gateway.void(auth.authorization, { check_transaction: 'true' })
+    assert_success void
   end
 
   def test_failed_void


### PR DESCRIPTION
Added ACH support for all operations along with remote and unit tests. Purchase, Authorize, Refund, Capture, Void and Vault are altered to send request to new endpoints and request params when using Check payment method.

SER-242

Unit:
5298 tests, 76326 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected