### PR TITLE
Plexo: Add Cardholder fields

### DIFF
--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -207,6 +207,10 @@ module ActiveMerchant #:nodoc:
         cardholder[:FirstName] = payment.first_name if payment.first_name
         cardholder[:LastName] = payment.last_name if payment.last_name
         cardholder[:Email] = options[:email]
+        cardholder[:Birthdate] = options[:cardholder_birthdate] if options[:cardholder_birthdate]
+        cardholder[:Identification] = {}
+        cardholder[:Identification][:Type] = options[:identification_type] if options[:identification_type]
+        cardholder[:Identification][:Value] = options[:identification_value] if options[:identification_value]
         card[:Cardholder] = cardholder
       end
 

--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -21,7 +21,9 @@ class RemotePlexoTest < Test::Unit::TestCase
       ],
       amount_details: {
         tip_amount: '5'
-      }
+      },
+      identification_type: '1',
+      identification_value: '123456'
     }
 
     @cancel_options = {

--- a/test/unit/gateways/plexo_test.rb
+++ b/test/unit/gateways/plexo_test.rb
@@ -27,7 +27,9 @@ class PlexoTest < Test::Unit::TestCase
       metadata: {
         custom_one: 'test1',
         test_a: 'abc'
-      }
+      },
+      identification_type: '1',
+      identification_value: '123456'
     }
 
     @cancel_options = {
@@ -62,6 +64,8 @@ class PlexoTest < Test::Unit::TestCase
       assert_equal @credit_card.verification_value, request['paymentMethod']['Card']['Cvc']
       assert_equal @credit_card.first_name, request['paymentMethod']['Card']['Cardholder']['FirstName']
       assert_equal @options[:email], request['paymentMethod']['Card']['Cardholder']['Email']
+      assert_equal @options[:identification_type], request['paymentMethod']['Card']['Cardholder']['Identification']['Type']
+      assert_equal @options[:identification_value], request['paymentMethod']['Card']['Cardholder']['Identification']['Value']
     end.respond_with(successful_authorize_response)
 
     assert_success response
@@ -114,7 +118,8 @@ class PlexoTest < Test::Unit::TestCase
     other_fields = {
       installments: '1',
       statement_descriptor: 'Plexo * Test',
-      customer_id: 'customer1'
+      customer_id: 'customer1',
+      cardholder_birthdate: '1999-08-18T19:49:37.023Z'
     }
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(other_fields))
@@ -123,6 +128,7 @@ class PlexoTest < Test::Unit::TestCase
       assert_equal request['Installments'], other_fields[:installments]
       assert_equal request['CustomerId'], other_fields[:customer_id]
       assert_equal request['StatementDescriptor'], other_fields[:statement_descriptor]
+      assert_equal request['paymentMethod']['Card']['Cardholder']['Birthdate'], other_fields[:cardholder_birthdate]
     end.respond_with(successful_authorize_response)
 
     assert_success response


### PR DESCRIPTION
Added `identification_type`, `identification_value`, and `cardholder_birthdate` fields for plexo implementation along with tests.

SER-237

Unit:
5287 tests, 76246 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected