### PR TITLE
PayU Latam: Add `extra1`, `extra2`, `extra3` fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,6 +103,7 @@
 * CardConnect: update api end-point urls [heavyblade] #4541
 * Vantiv(Litle): Add support for `fraudFilterOverride` field [rachelkirk] #4544
 * Stripe: Add shipping address [jcreiff] #4539
+* PayuLatam: Add extra1, extra2, extra3 fields [jcreiff] #4550
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -313,6 +313,9 @@ module ActiveMerchant #:nodoc:
       def add_extra_parameters(post, options)
         extra_parameters = {}
         extra_parameters[:INSTALLMENTS_NUMBER] = options[:installments_number] || 1
+        extra_parameters[:EXTRA1] = options[:extra_1] if options[:extra_1]
+        extra_parameters[:EXTRA2] = options[:extra_2] if options[:extra_2]
+        extra_parameters[:EXTRA3] = options[:extra_3] if options[:extra_3]
         post[:transaction][:extraParameters] = extra_parameters
       end
 

--- a/test/remote/gateways/remote_payu_latam_test.rb
+++ b/test/remote/gateways/remote_payu_latam_test.rb
@@ -346,7 +346,7 @@ class RemotePayuLatamTest < Test::Unit::TestCase
   def test_failed_capture
     response = @gateway.capture(@amount, '')
     assert_failure response
-    assert_match(/must not be null/, response.message)
+    assert_match(/may not be null/, response.message)
   end
 
   def test_successful_refund
@@ -414,14 +414,14 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     verify = @gateway.verify(@credit_card, @options.merge(verify_amount: 0))
 
     assert_failure verify
-    assert_equal 'The amount must be greater than zero', verify.message
+    assert_equal 'INVALID_TRANSACTION | [The given payment value [0] is inferior than minimum configured value [0.01]]', verify.message
   end
 
   def test_failed_verify_with_specified_language
     verify = @gateway.verify(@credit_card, @options.merge(verify_amount: 0, language: 'es'))
 
     assert_failure verify
-    assert_equal 'El valor de la transacción debe ser mayor a cero', verify.message
+    assert_equal 'INVALID_TRANSACTION | [El valor recibido [0] es inferior al valor mínimo configurado [0,01]]', verify.message
   end
 
   def test_transcript_scrubbing
@@ -439,5 +439,11 @@ class RemotePayuLatamTest < Test::Unit::TestCase
     store = @gateway.store(@credit_card, @options)
     assert_success store
     assert_equal 'SUCCESS', store.message
+  end
+
+  def test_successful_purchase_with_extra_fields
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ extra_1: '123456', extra_2: 'abcdef', extra_3: 'testing' }))
+    assert_success response
+    assert_equal 'APPROVED', response.message
   end
 end

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -469,6 +469,16 @@ class PayuLatamTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_extra_parameters_fields
+    stub_comms(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({ extra_1: '123456', extra_2: 'abcdef', extra_3: 'testing' }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\"EXTRA1\":\"123456\"/, data)
+      assert_match(/\"EXTRA2\":\"abcdef\"/, data)
+      assert_match(/\"EXTRA3\":\"testing\"/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
This adds three optional fields to the `extra_parameters` block.

I have also modified the test expectations for three failing remote tests.
The behavior is the same, but the gateway error message seems to have slightly changed.

CER-150

LOCAL
5291 tests, 76262 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
746 files inspected, no offenses detected

UNIT
38 tests, 151 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
39 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed