### PR TITLE
Paysafe: Add fundingTransaction object

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -104,6 +104,7 @@
 * Vantiv(Litle): Add support for `fraudFilterOverride` field [rachelkirk] #4544
 * Stripe: Add shipping address [jcreiff] #4539
 * PayuLatam: Add extra1, extra2, extra3 fields [jcreiff] #4550
+* Paysafe: Add fundingTransaction object [jcreiff] #4552
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -115,6 +115,17 @@ class PaysafeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_funding_transaction
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({ funding_transaction: 'SDW_WALLET_TRANSFER' }))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(%r("fundingTransaction":{"type":"SDW_WALLET_TRANSFER"}), data)
+      assert_match(%r("profile":{.+"merchantCustomerId"), data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_request).returns(failed_purchase_response)
 


### PR DESCRIPTION
Beginning in September 2022, Paysafe will require mandatory changes to the handling of Account Funding Transactions via the Visa network

https://developer.paysafe.com/en/cards/api/#/fundingTransaction

CER-96

LOCAL
5288 tests, 76248 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
746 files inspected, no offenses detected

UNIT
17 tests, 82 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
33 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed