### PR TITLE
MerchantE: Test `moto_ecommerce_ind` field passing.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -105,6 +105,7 @@
 * Stripe: Add shipping address [jcreiff] #4539
 * PayuLatam: Add extra1, extra2, extra3 fields [jcreiff] #4550
 * Paysafe: Add fundingTransaction object [jcreiff] #4552
+* MerchantE: Add tests for `moto_ecommerce_ind` field [ajawadmirza] #4554
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
       def authorize(money, creditcard_or_card_id, options = {})
         post = {}
         post[:client_reference_number] = options[:customer] if options.has_key?(:customer)
-        post[:moto_ecommerce_ind] = options[:moto_ecommerce_ind] if options.has_key?(:moto_ecommerce_ind)
+        post[:moto_ecommerce_ind] = options[:moto_ecommerce_ind] if options[:moto_ecommerce_ind]
         add_invoice(post, options)
         add_payment_source(post, creditcard_or_card_id, options)
         add_address(post, options)

--- a/test/remote/gateways/remote_merchant_e_solutions_test.rb
+++ b/test/remote/gateways/remote_merchant_e_solutions_test.rb
@@ -37,6 +37,12 @@ class RemoteMerchantESolutionTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved', response.message
   end
 
+  def test_successful_purchase_with_moto_ecommerce_ind
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge({ moto_ecommerce_ind: '7' }))
+    assert_success response
+    assert_equal 'This transaction has been approved', response.message
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/merchant_e_solutions_test.rb
+++ b/test/unit/gateways/merchant_e_solutions_test.rb
@@ -30,6 +30,14 @@ class MerchantESolutionsTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_moto_ecommerce_ind
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, { moto_ecommerce_ind: '7' })
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/moto_ecommerce_ind=7/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_unsuccessful_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
Test `moto_ecommerce_ind` field for purchase transaction along with unit and remote tests.

SER-271

Remote:
20 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5293 tests, 76270 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected