### PR TITLE
Stripe Payment Intents: fix bug with billing address email

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -108,6 +108,7 @@
 * MerchantE: Add tests for `moto_ecommerce_ind` field [ajawadmirza] #4554
 * Plexo: Update `purchase` method, add flags for header fields, add new fields `billing_address`, `identification_type`, `identification_value`, and `cardholder_birthdate` [ajawadmirza] #4540
 * Rapyd: Remove `BR`, `MX`, and `US` from supported countries [ajawadmirza] #4558
+* Stripe Payment Intents: fix bug with billing address email [jcreiff] #4556
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -451,6 +451,8 @@ module ActiveMerchant #:nodoc:
       def add_billing_address(post, options = {})
         return unless billing = options[:billing_address] || options[:address]
 
+        email = billing[:email] || options[:email]
+
         post[:billing_details] = {}
         post[:billing_details][:address] = {}
         post[:billing_details][:address][:city] = billing[:city] if billing[:city]
@@ -459,7 +461,7 @@ module ActiveMerchant #:nodoc:
         post[:billing_details][:address][:line2] = billing[:address2] if billing[:address2]
         post[:billing_details][:address][:postal_code] = billing[:zip] if billing[:zip]
         post[:billing_details][:address][:state] = billing[:state] if billing[:state]
-        post[:billing_details][:email] = billing[:email] if billing[:email]
+        post[:billing_details][:email] = email if email
         post[:billing_details][:name] = billing[:name] if billing[:name]
         post[:billing_details][:phone] = billing[:phone] if billing[:phone]
       end

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -776,13 +776,14 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       currency: 'USD',
       customer: @customer,
       billing_address: address,
+      email: 'jim@widgets.inc',
       confirm: true
     }
-
     assert response = @gateway.create_intent(@amount, @visa_card, options)
     assert_success response
-    assert billing = response.params.dig('charges', 'data')[0].dig('billing_details', 'address')
-    assert_equal 'Ottawa', billing['city']
+    assert billing_details = response.params.dig('charges', 'data')[0].dig('billing_details')
+    assert_equal 'Ottawa', billing_details['address']['city']
+    assert_equal 'jim@widgets.inc', billing_details['email']
   end
 
   def test_create_payment_intent_with_name_if_billing_address_absent


### PR DESCRIPTION
This corrects an issue where email was being dropped from billing_details in the request.

The previous assumption was that email would be a field contained within the billing_address hash, but (in Spreedly's integration, at least), it's actually nested at the top-level of the options hash.

This change should not affect behavior of the add_billing_address method for any other integrations with Active Merchant that do supply an email attribute as part of the billing_address hash.

CER-41

LOCAL
5292 tests, 76267 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

746 files inspected, no offenses detected

UNIT
39 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
78 tests, 372 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed