### PR TITLE
Shift4: Add customer object to transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -109,6 +109,7 @@
 * Plexo: Update `purchase` method, add flags for header fields, add new fields `billing_address`, `identification_type`, `identification_value`, and `cardholder_birthdate` [ajawadmirza] #4540
 * Rapyd: Remove `BR`, `MX`, and `US` from supported countries [ajawadmirza] #4558
 * Stripe Payment Intents: fix bug with billing address email [jcreiff] #4556
+* Shift4: Add customer to `purchase` & `store` and remove transaction from `store` [ajawadmirza] #4557
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -54,19 +54,22 @@ module ActiveMerchant #:nodoc:
         add_transaction(post, options)
         add_card(post, payment_method, options)
         add_card_present(post, options)
+        add_customer(post, payment_method, options)
 
         commit('sale', post, options)
       end
 
       def authorize(money, payment_method, options = {})
         post = {}
+
+        payment_method = get_card_token(payment_method) if payment_method.is_a?(String)
         add_datetime(post, options)
         add_invoice(post, money, options)
         add_clerk(post, options)
         add_transaction(post, options)
         add_card(post, payment_method, options)
         add_card_present(post, options)
-        add_customer(post, options)
+        add_customer(post, payment_method, options)
 
         commit('authorization', post, options)
       end
@@ -91,7 +94,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_clerk(post, options)
         add_transaction(post, options)
-        add_customer(post, options)
+        add_customer(post, authorization, options)
         add_card(post, get_card_token(authorization), options)
         add_card_present(post, options)
 
@@ -114,8 +117,8 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_datetime(post, options)
         add_clerk(post, options)
-        add_transaction(post, options)
         add_card(post, credit_card, options)
+        add_customer(post, credit_card, options)
 
         commit('add', post, options)
       end
@@ -197,17 +200,16 @@ module ActiveMerchant #:nodoc:
         post[:card][:present] = options[:card_present] || 'N'
       end
 
-      def add_customer(post, options)
-        if address = options[:billing_address]
-          post[:customer] = {}
-          post[:customer][:addressLine1] = address[:address1] if address[:address1]
-          post[:customer][:postalCode] = address[:zip]
-          name = address[:name].split(' ') if address[:name]
-          if name&.is_a?(Array)
-            post[:customer][:firstName] = name[0]
-            post[:customer][:lastName] = name[1]
-          end
-        end
+      def add_customer(post, card, options)
+        address = options[:billing_address] || {}
+
+        post[:customer] = {}
+        post[:customer][:addressLine1] = address[:address1] if address[:address1]
+        post[:customer][:postalCode] = address[:zip]
+        post[:customer][:firstName] = card.first_name if card.is_a?(CreditCard) && card.first_name
+        post[:customer][:lastName] = card.last_name if card.is_a?(CreditCard) && card.last_name
+        post[:customer][:emailAddress] = options[:email] if options[:email]
+        post[:customer][:ipAddress] = options[:ip] if options[:ip]
       end
 
       def add_purchase_card(post, options)


### PR DESCRIPTION
Added customer object to purchase and store & removed transaction object from store opertaion for shift4 gateway implementation.

SER-277
SER-275
SER-279

Unit:
5294 tests, 76283 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
19 tests, 45 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed