### PR TITLE
Rapyd: Update Supported Countries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -107,6 +107,7 @@
 * Paysafe: Add fundingTransaction object [jcreiff] #4552
 * MerchantE: Add tests for `moto_ecommerce_ind` field [ajawadmirza] #4554
 * Plexo: Update `purchase` method, add flags for header fields, add new fields `billing_address`, `identification_type`, `identification_value`, and `cardholder_birthdate` [ajawadmirza] #4540
+* Rapyd: Remove `BR`, `MX`, and `US` from supported countries [ajawadmirza] #4558
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://sandboxapi.rapyd.net/v1/'
       self.live_url = 'https://api.rapyd.net/v1/'
 
-      self.supported_countries = %w(US BR CA CL CO DO SV MX PE PT VI AU HK IN ID JP MY NZ PH SG KR TW TH VN AD AT BE BA BG HR CY CZ DK EE FI FR GE DE GI GR GL HU IS IE IL IT LV LI LT LU MK MT MD MC ME NL GB NO PL RO RU SM SK SI ZA ES SE CH TR VA)
+      self.supported_countries = %w(CA CL CO DO SV PE PT VI AU HK IN ID JP MY NZ PH SG KR TW TH VN AD AT BE BA BG HR CY CZ DK EE FI FR GE DE GI GR GL HU IS IE IL IT LV LI LT LU MK MT MD MC ME NL GB NO PL RO RU SM SK SI ZA ES SE CH TR VA)
       self.default_currency = 'USD'
       self.supported_cardtypes = %i[visa master american_express discover]
 


### PR DESCRIPTION
Removed brazil, mexico, and US from rapyd supported countries.

SER-278

Unit:
5293 tests, 76279 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
29 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed