### PR TITLE
Add bp_plus card type and custom validations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -111,6 +111,7 @@
 * Stripe Payment Intents: fix bug with billing address email [jcreiff] #4556
 * Shift4: Add customer to `purchase` & `store` and remove transaction from `store` [ajawadmirza] #4557
 * MerchantE: only add `moto_commerce_ind` to request if it is present [ajawadmirza] #4560
+* Add BpPlus card type along with custom validation logic [dsmcclain] #4559
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -33,6 +33,7 @@ module ActiveMerchant #:nodoc:
     # * Creditel
     # * Confiable
     # * Mada
+    # * BpPlus
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -118,6 +119,7 @@ module ActiveMerchant #:nodoc:
       # * +'creditel'+
       # * +'confiable'+
       # * +'mada'+
+      # * +'bp_plus'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
       self.supported_countries = %w[AD AE AR AT AU BE BG BH BR CH CL CN CO CY CZ DE DK EE EG ES FI FR GB GR HK HR HU IE IS IT JO JP KW LI LT LU LV MC MT MX MY NL NO NZ OM PE PL PT QA RO SA SE SG SI SK SM TR US]
       self.default_currency = 'USD'
       self.money_format = :cents
-      self.supported_cardtypes = %i[visa master american_express diners_club maestro discover jcb mada]
+      self.supported_cardtypes = %i[visa master american_express diners_club maestro discover jcb mada bp_plus]
       self.currencies_without_fractions = %w(BIF DJF GNF ISK KMF XAF CLF XPF JPY PYG RWF KRW VUV VND XOF)
       self.currencies_with_three_decimal_places = %w(BHD LYD JOD KWD OMR TND)
 

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -204,6 +204,31 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'confiable', CreditCard.brand?('5607180000000000')
   end
 
+  def test_should_detect_bp_plus_card
+    assert_equal 'bp_plus', CreditCard.brand?('70501 501021600 378')
+    assert_equal 'bp_plus', CreditCard.brand?('70502 111111111 111')
+    assert_equal 'bp_plus', CreditCard.brand?('7050 15605297 00114')
+    assert_equal 'bp_plus', CreditCard.brand?('7050 15546992 00062')
+  end
+
+  def test_should_validate_bp_plus_card
+    assert_true CreditCard.valid_number?('70501 501021600 378')
+    assert_true CreditCard.valid_number?('7050 15605297 00114')
+    assert_true CreditCard.valid_number?('7050 15546992 00062')
+    assert_true CreditCard.valid_number?('7050 16150146 00110')
+    assert_true CreditCard.valid_number?('7050 16364764 00070')
+
+    # numbers with invalid formats
+    assert_false CreditCard.valid_number?('7050_15546992_00062')
+    assert_false CreditCard.valid_number?('70501 55469920 0062')
+    assert_false CreditCard.valid_number?('70 501554699 200062')
+
+    # numbers that are luhn-invalid
+    assert_false CreditCard.valid_number?('70502 111111111 111')
+    assert_false CreditCard.valid_number?('7050 16364764 00071')
+    assert_false CreditCard.valid_number?('7050 16364764 00072')
+  end
+
   def test_confiable_number_not_validated
     10.times do
       number = rand(5607180000000001..5607189999999999).to_s


### PR DESCRIPTION
BP Plus cards come in two formats, both 17 digits long, and _both containing two spaces:_

* 7050N NNNNNNNNN NNN
* 705N NNNNNNNN NNNNN

The first format (7050N) should pass a luhn check once the spaces are removed.

The second format (705N) contains a luhn check digit as the final digit. This PR adds an implementation of the luhn algorithm that accounts for this check digit (details on the algorithm can be found [here](https://en.wikipedia.org/wiki/Luhn_algorithm)).

The PR also includes a regex to identify the bp_plus card type, and modifications to the `valid_card_number_characters?` method to accommodate the spaces in the numbers.

SER-267

Unit Tests:
5295 tests, 76287 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected