### PR TITLE
MerchantE: Fix condition to disallow null values

### DIFF
--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, creditcard_or_card_id, options = {})
         post = {}
         post[:client_reference_number] = options[:customer] if options.has_key?(:customer)
-        post[:moto_ecommerce_ind] = options[:moto_ecommerce_ind] if options.has_key?(:moto_ecommerce_ind)
+        post[:moto_ecommerce_ind] = options[:moto_ecommerce_ind] if options[:moto_ecommerce_ind]
         add_invoice(post, options)
         add_payment_source(post, creditcard_or_card_id, options)
         add_address(post, options)


### PR DESCRIPTION
Updated condition so that nil value is not passed for the `moto_ecommerce_ind` field to make all the integration tests pass.

SER-272

Unit:
5293 tests, 76279 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
746 files inspected, no offenses detected

Remote:
20 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed