### PR TITLE
Orbital: Fix CardSecValInd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -120,6 +120,7 @@
 * Shift4: Timezone Offset [naashton] #4566
 * MerchantE: `recurring_pmt_num` and `recurring_pmt_count` fields [ali-hassan] #4553
 * Orbital: Add South African Rand to supported currencies [molbrown] #4569
+* Orbital: Fix CardSecValInd [molbrown] #4563
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -594,7 +594,7 @@ module ActiveMerchant #:nodoc:
         #   Null-fill this attribute OR
         #   Do not submit the attribute at all.
         # - http://download.chasepaymentech.com/docs/orbital/orbital_gateway_xml_specification.pdf
-        xml.tag! :CardSecValInd, '1' if %w(visa master discover).include?(credit_card.brand) && bin == '000001'
+        xml.tag! :CardSecValInd, '1' if %w(visa discover diners_club).include?(credit_card.brand) && bin == '000001'
         xml.tag! :CardSecVal, credit_card.verification_value
       end
 


### PR DESCRIPTION
The card sec val ind is only valid on BIN 1 merchant Visa and Discover transactions

This issue is not reflected in the sandbox, but was exposed in Developer
Center testing during certification. The intended application of this
field is also documented in the code comment.

ECS-2144

Unit:
141 tests, 803 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
119 tests, 497 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed