### PR TITLE
Redsys: update Base64 encryption handling for secret key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -123,6 +123,7 @@
 * Orbital: Fix CardSecValInd [molbrown] #4563
 * Shift4: Add `usage_indicator`, `indicator`, `scheduled_indicator`, and `transaction_id` fields [ajawadmirza] #4564
 * Shift4: Retrieve `access_token` once [naashton] #4572
+* Redsys: Update Base64 encryption handling for secret key [jcreiff] #4565
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -685,7 +685,7 @@ module ActiveMerchant #:nodoc:
         cipher = OpenSSL::Cipher.new('DES3')
         cipher.encrypt
 
-        cipher.key = Base64.strict_decode64(key)
+        cipher.key = Base64.urlsafe_decode64(key)
         # The OpenSSL default of an all-zeroes ("\\0") IV is used.
         cipher.padding = 0
 

--- a/test/remote/gateways/remote_redsys_test.rb
+++ b/test/remote/gateways/remote_redsys_test.rb
@@ -250,6 +250,17 @@ class RemoteRedsysTest < Test::Unit::TestCase
     assert_equal clean_transcript.include?('[BLANK]'), true
   end
 
+  def test_encrypt_handles_url_safe_character_in_secret_key_without_error
+    gateway = RedsysGateway.new({
+      login: '091952713',
+      secret_key: 'yG78qf-PkHyRzRiZGSTCJdO2TvjWgFa8',
+      terminal: '1',
+      signature_algorithm: 'sha256'
+    })
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert response
+  end
+
   private
 
   def generate_order_id


### PR DESCRIPTION
Some Redsys customers receive a secret key with url safe characters. This has caused problems with the `encrypt` method, because Base64.strict_decode64 throws an error when it encounters one of these characters. Using urlsafe_decode64 instead should prevent this error from occurring in the future.

CER-75
Local
5307 tests, 76382 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
746 files inspected, no offenses detected

Unit
33 tests, 104 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote
22 tests, 62 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 77.2727% passed
(The 5 failures also occur on master)