### PR TITLE
Shift4: Timezone Offset

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -117,6 +117,7 @@
 * Shift4: Applied checks on Shift4 Time/Timezone offset [ali-hassan] #45611
 * Alelo: Add gateway [heavyblade] #4555
 * Wompi: Allow partial refund amount on void_sync [jcreiff] #4535
+* Shift4: Timezone Offset [naashton] #4566
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -313,12 +313,10 @@ module ActiveMerchant #:nodoc:
 
       def current_date_time(options = {})
         time_zone = options[:merchant_time_zone] || 'Pacific Time (US & Canada)'
-        time_zone_diff = Time.now.in_time_zone(time_zone)
-        if options[:merchant_time_zone].present?
-          time_zone_diff.strftime('%Y-%m-%dT%H:%M:%S.%3N+%H:%M')
-        else
-          time_zone_diff.strftime('%Y-%m-%dT%H:%M:%S.%3N+00:00')
-        end
+        time = Time.now.in_time_zone(time_zone)
+        offset = Time.now.in_time_zone(time_zone).formatted_offset
+
+        time.strftime('%Y-%m-%dT%H:%M:%S.%3N') + offset
       end
     end
   end

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -78,6 +78,7 @@ class RemoteShift4Test < Test::Unit::TestCase
       initial_transaction: true,
       reason_type: 'recurring'
     }
+    @options[:merchant_time_zone] = 'EST'
     first_response = @gateway.purchase(@amount, @credit_card, @options.merge(@extra_options.merge({ stored_credential: stored_credential_options })))
     assert_success first_response
 

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -230,6 +230,14 @@ class Shift4Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_time_zone_offset
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge!(merchant_time_zone: 'EST'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal DateTime.parse(JSON.parse(data)['dateTime']).formatted_offset, Time.now.in_time_zone(@options[:merchant_time_zone]).formatted_offset
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_support_scrub
     assert @gateway.supports_scrubbing?
   end


### PR DESCRIPTION
Shift4 requires a timestamp be sent with the timezone offset (offset from GMT).

Correct format: `yyyy-mm-ddThh:mm:ss.nnn+hh:mm`

This PR corrects the offset for the timestamp to be either `-hh:mm` or `+hh:mm` depending on the offset relative to GMT (i.e., `-05:00` for 'EST').

SER-273

Unit: 19 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote: 21 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed