### PR TITLE
Rubocop GHA

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -42,3 +42,5 @@ jobs:
 
       - name: Test
         run: bundle exec rake test
+      - name: Linter
+        run: bundle exec rubocop


### PR DESCRIPTION
This commit adds Rubocop as a github action
to ensure all PRs have the linter run