### PR TITLE
Accept both formats of Canadian routing numbers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * iVeri: Remove schema validation on Live requests [curiousepic] #4606
 * Beanstream: Adding Third Party 3DS fields [heavyblade] #4602
 * Borgun: Add support for 3DS preauth [ajawadmirza] #4603
+* Accept both formats of Canadian routing numbers [molbrown] #4568
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -60,20 +60,52 @@ module ActiveMerchant #:nodoc:
         false
       end
 
+      def valid_routing_number?
+        digits = routing_number.to_s.split('').map(&:to_i).select { |d| (0..9).cover?(d) }
+        case digits.size
+        when 9
+          return checksum(digits) == 0 || CAN_INSTITUTION_NUMBERS.include?(routing_number[1..3])
+        when 8
+          return CAN_INSTITUTION_NUMBERS.include?(routing_number[5..7])
+        end
+
+        false
+      end
+
       # Routing numbers may be validated by calculating a checksum and dividing it by 10. The
       # formula is:
       #   (3(d1 + d4 + d7) + 7(d2 + d5 + d8) + 1(d3 + d6 + d9))mod 10 = 0
       # See http://en.wikipedia.org/wiki/Routing_transit_number#Internal_checksums
-      def valid_routing_number?
-        digits = routing_number.to_s.split('').map(&:to_i).select { |d| (0..9).cover?(d) }
-        if digits.size == 9
-          checksum = ((3 * (digits[0] + digits[3] + digits[6])) +
-            (7 * (digits[1] + digits[4] + digits[7])) +
-            (digits[2] + digits[5] + digits[8])) % 10
+      def checksum(digits)
+        ((3 * (digits[0] + digits[3] + digits[6])) +
+        (7 * (digits[1] + digits[4] + digits[7])) +
+        (digits[2] + digits[5] + digits[8])) % 10
+      end
 
-          return checksum == 0 || CAN_INSTITUTION_NUMBERS.include?(routing_number[1..3])
+      # Always return MICR-formatted routing number for Canadian routing numbers, US routing numbers unchanged
+      def micr_format_routing_number
+        digits = routing_number.to_s.split('').map(&:to_i).select { |d| (0..9).cover?(d) }
+        case digits.size
+        when 9
+          if checksum(digits) == 0
+            return routing_number
+          else
+            return routing_number[4..8] + routing_number[1..3]
+          end
+        when 8
+          return routing_number
         end
-        false
+      end
+
+      # Always return electronic-formatted routing number for Canadian routing numbers, US routing numbers unchanged
+      def electronic_format_routing_number
+        digits = routing_number.to_s.split('').map(&:to_i).select { |d| (0..9).cover?(d) }
+        case digits.size
+        when 9
+          return routing_number
+        when 8
+          return '0' + routing_number[5..7] + routing_number[0..4]
+        end
       end
     end
   end

--- a/test/unit/check_test.rb
+++ b/test/unit/check_test.rb
@@ -4,11 +4,34 @@ class CheckTest < Test::Unit::TestCase
   VALID_ABA     = '111000025'
   INVALID_ABA   = '999999999'
   MALFORMED_ABA = 'I like fish'
-  VALID_CBA = '000194611'
+  VALID_ELECTRONIC_CBA = '000194611'
+  VALID_MICR_CBA = '94611001'
   INVALID_NINE_DIGIT_CBA = '012345678'
   INVALID_SEVEN_DIGIT_ROUTING_NUMBER = '0123456'
 
   ACCOUNT_NUMBER = '123456789012'
+
+  CHECK_US = Check.new(
+    name: 'Fred Bloggs',
+    routing_number: VALID_ABA,
+    account_number: ACCOUNT_NUMBER,
+    account_holder_type: 'personal',
+    account_type: 'checking'
+  )
+  CHECK_CAN_E_FORMAT = Check.new(
+    name: 'Tim Horton',
+    routing_number: VALID_ELECTRONIC_CBA,
+    account_number: ACCOUNT_NUMBER,
+    account_holder_type: 'personal',
+    account_type: 'checking'
+  )
+  CHECK_CAN_MICR_FORMAT = Check.new(
+    name: 'Tim Horton',
+    routing_number: VALID_MICR_CBA,
+    account_number: ACCOUNT_NUMBER,
+    account_holder_type: 'personal',
+    account_type: 'checking'
+  )
 
   def test_validation
     assert_not_valid Check.new
@@ -29,13 +52,7 @@ class CheckTest < Test::Unit::TestCase
   end
 
   def test_valid
-    assert_valid Check.new(
-      name: 'Fred Bloggs',
-      routing_number: VALID_ABA,
-      account_number: ACCOUNT_NUMBER,
-      account_holder_type: 'personal',
-      account_type: 'checking'
-    )
+    assert_valid CHECK_US
   end
 
   def test_credit_card?
@@ -82,14 +99,12 @@ class CheckTest < Test::Unit::TestCase
     assert !c.validate[:account_type]
   end
 
-  def test_valid_canada_routing_number
-    assert_valid Check.new(
-      name: 'Tim Horton',
-      routing_number: VALID_CBA,
-      account_number: ACCOUNT_NUMBER,
-      account_holder_type: 'personal',
-      account_type: 'checking'
-    )
+  def test_valid_canada_routing_number_electronic_format
+    assert_valid CHECK_CAN_E_FORMAT
+  end
+
+  def test_valid_canada_routing_number_micr_format
+    assert_valid CHECK_CAN_MICR_FORMAT
   end
 
   def test_invalid_canada_routing_number
@@ -114,5 +129,15 @@ class CheckTest < Test::Unit::TestCase
     )
 
     assert_equal ['is invalid'], errors[:routing_number]
+  end
+
+  def test_format_routing_number
+    assert CHECK_CAN_E_FORMAT.micr_format_routing_number == '94611001'
+    assert CHECK_CAN_MICR_FORMAT.micr_format_routing_number == '94611001'
+    assert CHECK_US.micr_format_routing_number == '111000025'
+
+    assert CHECK_CAN_E_FORMAT.electronic_format_routing_number == '000194611'
+    assert CHECK_CAN_MICR_FORMAT.electronic_format_routing_number == '000194611'
+    assert CHECK_US.electronic_format_routing_number == '111000025'
   end
 end

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -33,7 +33,7 @@ class CardStreamTest < Test::Unit::TestCase
       three_d_secure: {
         enrolled: 'true',
         authentication_response_status: 'Y',
-        eci: 05,
+        eci: '05',
         cavv: 'Y2FyZGluYWxjb21tZXJjZWF1dGg',
         xid: '362DF058-6061-47F1-A504-CACCBDF422B7'
       }
@@ -330,7 +330,7 @@ class CardStreamTest < Test::Unit::TestCase
       assert_match(/threeDSRequired=Y/, data)
       assert_match(/threeDSEnrolled=Y/, data)
       assert_match(/threeDSAuthenticated=Y/, data)
-      assert_match(/threeDSECI=5/, data)
+      assert_match(/threeDSECI=05/, data)
       assert_match(/threeDSCAVV=Y2FyZGluYWxjb21tZXJjZWF1dGg/, data)
       assert_match(/threeDSXID=362DF058-6061-47F1-A504-CACCBDF422B7/, data)
     end


### PR DESCRIPTION
Canadian routing numbers are typically handled either in print/MICR format or electronic format (see https://en.wikipedia.org/wiki/Routing_number_(Canada)#Format).

Adds ability to send valid MICR formatted Canadian routing numbers, which may still be expected by some gateways.

Unit tests:
5308 tests, 76382 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
746 files inspected, no offenses detected

ECS-2144