### PR TITLE
Cardstream expand 3ds2 global support

### DIFF
--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -27,6 +27,18 @@ class CardStreamTest < Test::Unit::TestCase
       description: 'AM test purchase'
     }
 
+    @visacredit_three_ds_options = {
+      threeds_required: true,
+      three_ds_version: '2.1.0',
+      three_d_secure: {
+        enrolled: 'true',
+        authentication_response_status: 'Y',
+        eci: 0o5,
+        cavv: 'Y2FyZGluYWxjb21tZXJjZWF1dGg',
+        xid: '362DF058-6061-47F1-A504-CACCBDF422B7'
+      }
+    }
+
     @visacredit_descriptor_options = {
       billing_address: {
         address1: 'Flat 6, Primrose Rise',
@@ -309,6 +321,40 @@ class CardStreamTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       assert_match(/threeDSRequired=N/, data)
     end.respond_with(successful_purchase_response)
+  end
+
+  def test_3ds2_data
+    stub_comms do
+      @gateway.purchase(142, @visacreditcard, @visacredit_options.merge(@visacredit_three_ds_options))
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      assert_match(/threeDSRequired=Y/, data)
+      assert_match(/threeDSEnrolled=Y/, data)
+      assert_match(/threeDSAuthenticated=Y/, data)
+      assert_match(/threeDSECI=5/, data)
+      assert_match(/threeDSCAVV=Y2FyZGluYWxjb21tZXJjZWF1dGg/, data)
+      assert_match(/threeDSXID=362DF058-6061-47F1-A504-CACCBDF422B7/, data)
+    end
+  end
+
+  def test_3ds2_not_enrolled
+    stub_comms do
+      @visacredit_three_ds_options[:three_d_secure][:enrolled] = 'false'
+      @gateway.purchase(142, @visacreditcard, @visacredit_options.merge(@visacredit_three_ds_options))
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      assert_match(/threeDSRequired=Y/, data)
+      assert_match(/threeDSEnrolled=N/, data)
+    end
+  end
+
+  def test_3ds2_not_authenticated
+    stub_comms do
+      @visacredit_three_ds_options[:three_d_secure][:authentication_response_status] = 'N'
+      @gateway.purchase(142, @visacreditcard, @visacredit_options.merge(@visacredit_three_ds_options))
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      assert_match(/threeDSRequired=Y/, data)
+      assert_match(/threeDSEnrolled=Y/, data)
+      assert_match(/threeDSAuthenticated=N/, data)
+    end
   end
 
   def test_transcript_scrubbing


### PR DESCRIPTION
# Add 3ds2 global support to CardStream
Creating add_threeds_fields method wich
Adds three_d_secure, enrolled, authentication_
response_status, eci, cavv and xid fields
to authorization and purchase methods.

Unit tests:
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
30 tests, 156 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
951.90 tests/s, 4949.87 assertions/s

Remote tests:
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
34 tests, 206 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
79.4118% passed

Failed:
test_failed_purchase_non_existent_currency
