### PR TITLE
Shift4: Retrieve `access_token` once

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -122,6 +122,7 @@
 * Orbital: Add South African Rand to supported currencies [molbrown] #4569
 * Orbital: Fix CardSecValInd [molbrown] #4563
 * Shift4: Add `usage_indicator`, `indicator`, `scheduled_indicator`, and `transaction_id` fields [ajawadmirza] #4564
+* Shift4: Retrieve `access_token` once [naashton] #4572
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -40,8 +40,8 @@ module ActiveMerchant #:nodoc:
         requires!(options, :client_guid, :auth_token)
         @client_guid = options[:client_guid]
         @auth_token = options[:auth_token]
+        @access_token = options[:access_token]
         super
-        @access_token = setup_access_token
       end
 
       def purchase(money, payment_method, options = {})
@@ -136,14 +136,6 @@ module ActiveMerchant #:nodoc:
           gsub(%r(("securityCode\\?":{\\?"[\w]+\\?":[\d]+,\\?"value\\?":\\?")[\d]*)i, '\1[FILTERED]')
       end
 
-      private
-
-      def add_credentials(post, options)
-        post[:credential] = {}
-        post[:credential][:clientGuid] = @client_guid
-        post[:credential][:authToken] = @auth_token
-      end
-
       def setup_access_token
         post = {}
         add_credentials(post, options)
@@ -151,6 +143,14 @@ module ActiveMerchant #:nodoc:
 
         response = commit('accesstoken', post, request_headers(options))
         response.params['result'].first['credential']['accessToken']
+      end
+
+      private
+
+      def add_credentials(post, options)
+        post[:credential] = {}
+        post[:credential][:clientGuid] = @client_guid
+        post[:credential][:authToken] = @auth_token
       end
 
       def add_clerk(post, options)

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 class RemoteShift4Test < Test::Unit::TestCase
   def setup
     @gateway = Shift4Gateway.new(fixtures(:shift4))
+    access_token = @gateway.setup_access_token
+
+    @gateway = Shift4Gateway.new(fixtures(:shift4).merge(access_token: access_token))
 
     @amount = 500
     @credit_card = credit_card('4000100011112224', verification_value: '333', first_name: 'John', last_name: 'Smith')


### PR DESCRIPTION
Remove the `setup_access_token` method call from the constructor and make the method public so that users may retrieve the `access_token` one time and pass the value to other instances of the gateway class

Due to reasons at Shift4, calls to retrieve the `access_token` must be made once because the `auth_token` value has a one-time use. Any subsequent requests to exchange the `auth_token` for an `access_token` will lead to an invalid `access_token`

Because of the way we instantiate the gateway subclasses, in order to run this access token request on setup, we need to call `super` to initialize the `options` instance variable

SER-221

Unit: 21 tests, 121 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote: 21 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed