### PR TITLE
OpenPay: Update url endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -124,6 +124,7 @@
 * Shift4: Add `usage_indicator`, `indicator`, `scheduled_indicator`, and `transaction_id` fields [ajawadmirza] #4564
 * Shift4: Retrieve `access_token` once [naashton] #4572
 * Redsys: Update Base64 encryption handling for secret key [jcreiff] #4565
+* Openpay: Update url endpoints [ajawadmirza] #4573
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -1,8 +1,8 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class OpenpayGateway < Gateway
-      self.live_url = 'https://api.openpay.mx/v1/'
-      self.test_url = 'https://sandbox-api.openpay.mx/v1/'
+      self.live_url = 'https://api.openpay.co/v1/'
+      self.test_url = 'https://sandbox-api.openpay.co/v1/'
 
       self.supported_countries = %w(CO MX)
       self.supported_cardtypes = %i[visa master american_express carnet]

--- a/test/remote/gateways/remote_openpay_test.rb
+++ b/test/remote/gateways/remote_openpay_test.rb
@@ -31,7 +31,7 @@ class RemoteOpenpayTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'The card was declined', response.message
+    assert_equal 'The card was declined by the bank', response.message
   end
 
   def test_successful_refund
@@ -69,7 +69,7 @@ class RemoteOpenpayTest < Test::Unit::TestCase
   def test_unsuccessful_authorize
     assert response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'The card was declined', response.message
+    assert_equal 'The card was declined by the bank', response.message
   end
 
   def test_successful_capture

--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -20,6 +20,14 @@ class OpenpayTest < Test::Unit::TestCase
     }
   end
 
+  def test_endpoint_for_the_gateway
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, endpoint, _data, _headers|
+      assert endpoint.include?('.co')
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_request).returns(successful_purchase_response)
 


### PR DESCRIPTION
Updated endpoint from `.mx` to `.co` along with slight change in error message for the declined transactions as returned by the gateway. Added unit test to verify that the correct url is being hit for the gateway.

SER-304

Unit:
5334 tests, 76512 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
749 files inspected, no offenses detected

Remote:
24 tests, 80 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95.8333% passed