### PR TITLE
Shift4: Not to send `postalCode` if value is nil

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -124,6 +124,7 @@
 * Shift4: Add `usage_indicator`, `indicator`, `scheduled_indicator`, and `transaction_id` fields [ajawadmirza] #4564
 * Shift4: Retrieve `access_token` once [naashton] #4572
 * Redsys: Update Base64 encryption handling for secret key [jcreiff] #4565
+* Shift4: refuse `postalCode` when its null [ajawadmirza] #4574
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -205,7 +205,7 @@ module ActiveMerchant #:nodoc:
 
         post[:customer] = {}
         post[:customer][:addressLine1] = address[:address1] if address[:address1]
-        post[:customer][:postalCode] = address[:zip]
+        post[:customer][:postalCode] = address[:zip] if address[:zip] && !address[:zip]&.to_s&.empty?
         post[:customer][:firstName] = card.first_name if card.is_a?(CreditCard) && card.first_name
         post[:customer][:lastName] = card.last_name if card.is_a?(CreditCard) && card.last_name
         post[:customer][:emailAddress] = options[:email] if options[:email]

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -92,6 +92,22 @@ class Shift4Test < Test::Unit::TestCase
       assert_equal request['customer']['firstName'], @credit_card.first_name
       assert_equal request['customer']['lastName'], @credit_card.last_name
     end.respond_with(successful_purchase_response)
+
+    customer[:billing_address][:zip] = nil
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(customer))
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_nil request['customer']['postalCode']
+    end.respond_with(successful_purchase_response)
+
+    customer[:billing_address][:zip] = ''
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(customer))
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_nil request['customer']['postalCode']
+    end.respond_with(successful_purchase_response)
   end
 
   def test_successful_purchase_with_stored_credential_framework


### PR DESCRIPTION
Update implementation to refuse `postalCode` when its value is nil or empty string. Also added a unit test to verify the implementation.

SER-305

Remote:
21 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
5333 tests, 76511 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
749 files inspected, no offenses detected