### PR TITLE
Plexo: Update param key to `refund_type` and tests for `finger_print`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -124,6 +124,7 @@
 * Shift4: Add `usage_indicator`, `indicator`, `scheduled_indicator`, and `transaction_id` fields [ajawadmirza] #4564
 * Shift4: Retrieve `access_token` once [naashton] #4572
 * Redsys: Update Base64 encryption handling for secret key [jcreiff] #4565
+* Plexo: Update param key to `refund_type` [ajawadmirza] #4575
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options = {})
         post = {}
         post[:ReferenceId] = options[:reference_id] || generate_unique_id
-        post[:Type] = options[:type] || 'refund'
+        post[:Type] = options[:refund_type] || 'refund'
         post[:Description] = options[:description]
         post[:Reason] = options[:reason]
         post[:Amount] = amount(money)

--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -38,6 +38,11 @@ class RemotePlexoTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_finger_print
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ finger_print: 'USABJHABSFASNJKN123532' }))
+    assert_success response
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
@@ -94,7 +99,7 @@ class RemotePlexoTest < Test::Unit::TestCase
   end
 
   def test_partial_refund
-    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    purchase = @gateway.purchase(@amount, @credit_card, @options.merge({ refund_type: 'partial-refund' }))
     assert_success purchase
 
     assert refund = @gateway.refund(@amount - 1, purchase.authorization, @cancel_options.merge({ type: 'partial-refund' }))

--- a/test/unit/gateways/plexo_test.rb
+++ b/test/unit/gateways/plexo_test.rb
@@ -110,6 +110,15 @@ class PlexoTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_authorize_with_finger_print
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ finger_print: 'USABJHABSFASNJKN123532' }))
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['BrowserDetails']['DeviceFingerprint'], 'USABJHABSFASNJKN123532'
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_successful_reordering_of_amount_in_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
@@ -201,7 +210,7 @@ class PlexoTest < Test::Unit::TestCase
   def test_successful_refund
     refund_options = {
       reference_id: 'reference123',
-      type: 'partial-refund',
+      refund_type: 'partial-refund',
       description: 'my description',
       reason: 'reason abc'
     }
@@ -210,7 +219,7 @@ class PlexoTest < Test::Unit::TestCase
     end.check_request do |endpoint, data, _headers|
       request = JSON.parse(data)
       assert_equal request['ReferenceId'], refund_options[:reference_id]
-      assert_equal request['Type'], refund_options[:type]
+      assert_equal request['Type'], refund_options[:refund_type]
       assert_equal request['Description'], refund_options[:description]
       assert_equal request['Reason'], refund_options[:reason]
       assert_includes endpoint, '123456abcdef'


### PR DESCRIPTION

Updated field param name to `refund_type` and tested partial refund remote test.Also added tests for finger_print

SER-306
SER-307

Remote:
18 tests, 39 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
5334 tests, 76512 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
749 files inspected, no offenses detected