### PR TITLE
Braintree Blue: Correctly vault payment method token for PayPal Check…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -129,6 +129,7 @@
 * Plexo: Update param key to `refund_type` [ajawadmirza] #4575
 * Shift4: Update request params for `verify`, `capture`, and `refund` [ajawadmirza] #4577
 * CyberSource: Add support for `sec_code` [rachelkirk] #4581
+* BraintreeBlue: Correctly vault payment method token for PayPal Checkout with Vault [almalee24] #4579
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -228,6 +228,23 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.authorize(100, credit_card('41111111111111111111'), venmo_profile_id: 'profile_id')
   end
 
+  def test_customer_has_default_payment_method
+    options = {
+      payment_method_nonce: 'fake-paypal-future-nonce',
+      store: true,
+      device_data: 'device_data',
+      paypal: {
+        paypal_flow_type: 'checkout_with_vault'
+      }
+    }
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).returns(braintree_result(paypal: { implicitly_vaulted_payment_method_token: 'abc123' }))
+
+    Braintree::CustomerGateway.any_instance.expects(:update).with(nil, { default_payment_method_token: 'abc123' }).returns(nil)
+
+    @gateway.authorize(100, 'fake-paypal-future-nonce', options)
+  end
+
   def test_risk_data_can_be_specified
     risk_data = {
       customer_browser: 'User-Agent Header',


### PR DESCRIPTION
…out with Vault

If the payment_method_nonce comes from PayPal and was created with 'Checkout with Vault' and additional step is need to vault the payment method to the customer. After a successful Transaction.sale the customer has to be updated with default_payment_method_token to be the implicitly_vaulted_payment_method_token found in the result.transaction.paypal_details.

Unit: 93 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote: 99 tests, 538 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed