### PR TITLE
Cybersource: add support for `secCode` field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -128,6 +128,7 @@
 * Shift4: refuse `postalCode` when its null [ajawadmirza] #4574
 * Plexo: Update param key to `refund_type` [ajawadmirza] #4575
 * Shift4: Update request params for `verify`, `capture`, and `refund` [ajawadmirza] #4577
+* CyberSource: Add support for `sec_code` [rachelkirk] #4581
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -459,7 +459,7 @@ module ActiveMerchant #:nodoc:
         add_address(xml, payment_method, options[:billing_address], options)
         add_purchase_data(xml, options[:setup_fee] || 0, true, options)
         if card_brand(payment_method) == 'check'
-          add_check(xml, payment_method)
+          add_check(xml, payment_method, options)
           add_check_payment_method(xml)
           options[:payment_method] = :check
         else
@@ -680,11 +680,12 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_check(xml, check)
+      def add_check(xml, check, options)
         xml.tag! 'check' do
           xml.tag! 'accountNumber', check.account_number
           xml.tag! 'accountType', check.account_type[0]
           xml.tag! 'bankTransitNumber', check.routing_number
+          xml.tag! 'secCode', options[:sec_code] if options[:sec_code]
         end
       end
 
@@ -916,7 +917,7 @@ module ActiveMerchant #:nodoc:
           add_address(xml, payment_method_or_reference, options[:billing_address], options)
           add_purchase_data(xml, money, true, options)
           add_installments(xml, options)
-          add_check(xml, payment_method_or_reference)
+          add_check(xml, payment_method_or_reference, options)
         else
           add_address(xml, payment_method_or_reference, options[:billing_address], options)
           add_address(xml, payment_method_or_reference, options[:shipping_address], options, true)

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -233,6 +233,13 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
   end
 
+  def test_successful_bank_account_purchase_with_sec_code
+    options = @options.merge(sec_code: 'WEB')
+    bank_account = check({ account_number: '4100', routing_number: '011000015' })
+    assert response = @gateway.purchase(@amount, bank_account, options)
+    assert_successful_response(response)
+  end
+
   def test_unsuccessful_authorization
     assert response = @gateway.authorize(@amount, @declined_card, @options)
     assert response.test?

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -270,6 +270,14 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_authorization_response)
   end
 
+  def test_bank_account_purchase_includes_sec_code
+    stub_comms do
+      @gateway.purchase(@amount, @check, order_id: '1', sec_code: 'WEB')
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<check>.*<secCode>WEB</secCode>.*</check>)m, data)
+    end.respond_with(successful_authorization_response)
+  end
+
   def test_successful_check_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 


### PR DESCRIPTION
CER-198

`secCode` allows users to pass in  a three letter code that describes how a payment was authorized by the consumer or business receiving an ACH transaction. SEC stands for 'Standard Entry Class'. SEC codes are defined and maintained by NACHA, the governing body for the ACH network.

Unit Tests:
119 tests, 574 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests:
116 tests, 594 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.4138% passed
*Note - 3 failing tests have been several months, appears to be connected to lack of a LATAM account. Also failing on master

Local:
5334 tests, 76513 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed