### PR TITLE
TransFirstTransactionExpress: Add prefix to transCode xml tag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * MerchantE: Add support for recurring transactions [naashton] #4594
 * CyberSource: Add support for `discount_management_indicator`, `purchase_tax_amount`, `installment_total_amount`, and `installment_annual_interest_rate` fields. [rachelkirk] #4595
 * Shift4: Remove `customer` from refund and `clerk` from store requests [ajawadmirza] #4596
+* TransFirst Transaction Express: Update xml prefixing to be compatible with Nokogiri 1.13.4 [dsmcclain] #4582
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -482,7 +482,7 @@ module ActiveMerchant #:nodoc:
 
         doc = Nokogiri::XML::Document.parse(request)
         merc_nodeset = doc.xpath('//v1:merc', 'v1' => V1_NAMESPACE)
-        merc_nodeset.after "<tranCode>#{TRANSACTION_CODES[action]}</tranCode>"
+        merc_nodeset.after "<v1:tranCode>#{TRANSACTION_CODES[action]}</v1:tranCode>"
         doc.root.to_xml
       end
 

--- a/test/unit/gateways/trans_first_transaction_express_test.rb
+++ b/test/unit/gateways/trans_first_transaction_express_test.rb
@@ -257,6 +257,15 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     assert_equal nil, response.message
   end
 
+  def test_transaction_code_xml_tag_added_with_correct_prefix
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      doc = Nokogiri::XML(data)
+      assert_not_empty doc.xpath('//v1:tranCode', 'v1' => 'http://postilion/realtime/merchantframework/xsd/v1/')
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_transcript_scrubbing
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end


### PR DESCRIPTION
This change makes the gateway compatible with Nokogiri versions 1.2x and greater.

While the PR does not include an change to the Nokogiri version within Active Merchant, it should be tested locally against Nokogiri version 1.13.4 to ensure that downstream apps using Rails 6 can enforce this version of Nokogiri without causing problems for this gateway.

_NOTE: NO REMOTE TESTS HAVE BEEN RUN ON THIS BRANCH_ because attempts to connect to the gateway's sandbox are timing out. It is not clear if this is an account-specific issue or if the gateway sandbox no longer exists. Attempts to consult the gateway itself have revealed that TransactionExpress may be nearing its end-of-life.

ECS-2536

Unit:
5354 tests, 76627 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
750 files inspected, no offenses detected