### PR TITLE
Shift4: Decline referral transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -130,6 +130,7 @@
 * Shift4: Update request params for `verify`, `capture`, and `refund` [ajawadmirza] #4577
 * CyberSource: Add support for `sec_code` [rachelkirk] #4581
 * BraintreeBlue: Correctly vault payment method token for PayPal Checkout with Vault [almalee24] #4579
+* Shift4: Decline referral transactions and parse message for internal server errors [ajawadmirza] #4583
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -13,7 +13,7 @@ module ActiveMerchant #:nodoc:
 
       RECURRING_TYPE_TRANSACTIONS = %w(recurring installment)
       TRANSACTIONS_WITHOUT_RESPONSE_CODE = %w(accesstoken add)
-      SUCCESS_TRANSACTION_STATUS = %w(A R)
+      SUCCESS_TRANSACTION_STATUS = %w(A)
       DISALLOWED_ENTRY_MODE_ACTIONS = %w(capture refund)
       URL_POSTFIX_MAPPING = {
         'accesstoken' => 'credentials',
@@ -266,7 +266,7 @@ module ActiveMerchant #:nodoc:
 
       def handle_response(response)
         case response.code.to_i
-        when 200...300, 400, 401
+        when 200...300, 400, 401, 500
           response.body
         else
           raise ResponseError.new(response)
@@ -322,7 +322,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def error(response)
-        response['result'].first['error']
+        server_error = { 'longText' => response['error'] } if response['error']
+        server_error || response['result'].first['error']
       end
 
       def current_date_time(options = {})


### PR DESCRIPTION
Update AM to decline referral transactions (having responseCode of R) for shift4 along with test case.
Also updated response handling to parse error message from gateway for the 500 (internal server errors) along with remote test.

SER-323
SER-324

Remote:
23 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
5338 tests, 76541 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
749 files inspected, no offenses detected