### PR TITLE
Shift4 - Custom `new_exception_response` to expose `invoice` used in …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -130,6 +130,7 @@
 * Shift4: Update request params for `verify`, `capture`, and `refund` [ajawadmirza] #4577
 * CyberSource: Add support for `sec_code` [rachelkirk] #4581
 * BraintreeBlue: Correctly vault payment method token for PayPal Checkout with Vault [almalee24] #4579
+* Shift4: Custom `new_exception_response` to expose `invoice` used in the request [ali-hassan] #4586
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -260,7 +260,8 @@ module ActiveMerchant #:nodoc:
           response,
           authorization: authorization_from(action, response),
           test: test?,
-          error_code: error_code_from(action, response)
+          error_code: error_code_from(action, response),
+          invoice: exception_response(action, response, parameters, option)
         )
       end
 
@@ -287,6 +288,12 @@ module ActiveMerchant #:nodoc:
         return unless success_from(action, response)
 
         STANDARD_ERROR_CODE_MAPPING[response['primaryCode']]
+      end
+
+      def exception_response(action, response, parameters, options)
+        return if success_from(action, response)
+
+        options[:invoice] || parameters[:transaction] && parameters[:transaction][:invoice]
       end
 
       def authorization_from(action, response)

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -4,7 +4,7 @@ module ActiveMerchant #:nodoc:
     end
 
     class Response
-      attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result, :error_code, :emv_authorization, :network_transaction_id
+      attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result, :error_code, :invoice, :emv_authorization, :network_transaction_id
 
       def success?
         @success
@@ -28,6 +28,7 @@ module ActiveMerchant #:nodoc:
         @authorization = options[:authorization]
         @fraud_review = options[:fraud_review]
         @error_code = options[:error_code]
+        @invoice = options[:invoice]
         @emv_authorization = options[:emv_authorization]
         @network_transaction_id = options[:network_transaction_id]
 
@@ -99,7 +100,7 @@ module ActiveMerchant #:nodoc:
         result.try(:cvv_result) || responses.last.try(:cvv_result)
       end
 
-      %w(params message test authorization error_code emv_authorization test? fraud_review?).each do |m|
+      %w(params message test authorization error_code invoice emv_authorization test? fraud_review?).each do |m|
         class_eval %(
           def #{m}
             (@responses.empty? ? nil : primary_response.#{m})

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -176,6 +176,13 @@ class RemoteShift4Test < Test::Unit::TestCase
     assert_include response.message, 'Card  for Merchant Id 0008628968 not found'
   end
 
+  def test_invoice_on_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert response.invoice.present?
+    assert_include response.message, 'Card  for Merchant Id 0008628968 not found'
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -245,6 +245,15 @@ class Shift4Test < Test::Unit::TestCase
     assert_nil response.authorization
   end
 
+  def test_invoice_on_failed_purchase
+    @gateway.expects(:ssl_request).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, 'abc', @options)
+    assert_failure response
+    assert response.invoice.present?
+    assert_nil response.authorization
+  end
+
   def test_failed_authorize
     @gateway.expects(:ssl_request).returns(failed_authorize_response)
 


### PR DESCRIPTION
…the request

Shift4 - Custom `new_exception_response` to expose `invoice` used in the request

[Ticket](https://spreedly.atlassian.net/browse/SER-321) Unit:
5342 tests, 76556 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
131.04 tests/s, 1877.92 assertions/s

Remote:
23 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

RuboCop:
Inspecting 749 files