### PR TITLE
MercadoPago: Add transaction inquire request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* dLocal: Add transaction query API(s) request [almalee24] #4584
+* MercadoPago: Add transaction inquire request [molbrown] #4588
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -58,6 +58,13 @@ module ActiveMerchant #:nodoc:
         authorize(0, credit_card, options.merge(verify: 'true'))
       end
 
+      def inquire(authorization, options = {})
+        post = {}
+        post[:payment_id] = authorization
+        action = authorization ? 'status' : 'orders'
+        commit(action, post, options)
+      end
+
       def supports_scrubbing?
         true
       end
@@ -67,11 +74,6 @@ module ActiveMerchant #:nodoc:
           gsub(%r((X-Trans-Key: )\w+), '\1[FILTERED]').
           gsub(%r((\"number\\\":\\\")\d+), '\1[FILTERED]').
           gsub(%r((\"cvv\\\":\\\")\d+), '\1[FILTERED]')
-      end
-
-      def inquire(parameters, options)
-        action = parameters[:payment_id] ? 'status' : 'orders'
-        commit(action, parameters, options)
       end
 
       private
@@ -241,7 +243,7 @@ module ActiveMerchant #:nodoc:
         when 'status'
           "payments/#{parameters[:payment_id]}/status"
         when 'orders'
-          "orders/#{parameters[:order_id]}"
+          "orders/#{options[:order_id]}"
         end
       end
 

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -61,6 +61,10 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def inquire(authorization, options = {})
+        commit('inquire', inquire_path(authorization, options), {})
+      end
+
       def supports_scrubbing?
         true
       end
@@ -261,6 +265,10 @@ module ActiveMerchant #:nodoc:
       def commit(action, path, parameters)
         if %w[capture void].include?(action)
           response = parse(ssl_request(:put, url(path), post_data(parameters), headers))
+        elsif action == 'inquire'
+          response = parse(ssl_get(url(path), headers))
+
+          response = response[0]['results'][0] if response.is_a?(Array)
         else
           response = parse(ssl_post(url(path), post_data(parameters), headers(parameters)))
         end
@@ -293,6 +301,15 @@ module ActiveMerchant #:nodoc:
 
       def post_data(parameters = {})
         parameters.clone.tap { |p| p.delete(:device_id) }.to_json
+      end
+
+      def inquire_path(authorization, options)
+        if authorization
+          authorization, = authorization.split('|')
+          "payments/#{authorization}"
+        else
+          "payments/search?external_reference=#{options[:order_id] || options[:external_reference]}"
+        end
       end
 
       def error_code_from(action, response)

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -73,14 +73,14 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_success response
     assert_match 'The payment was paid', response.message
 
-    gateway_transaction_id = response.params['id']
-    response = @gateway.inquire({ payment_id: gateway_transaction_id }, @options)
+    authorization = response.params['id']
+    response = @gateway.inquire(authorization, @options)
     assert_success response
     assert_match 'PAID', response.params['status']
     assert_match 'The payment was paid.', response.params['status_detail']
   end
 
-  def test_successful_iquire_with_order_id
+  def test_successful_inquire_with_order_id
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_match 'The payment was paid', response.message
@@ -88,7 +88,7 @@ class RemoteDLocalTest < Test::Unit::TestCase
     purchase_payment_id = response.params['id']
     order_id = response.params['order_id']
 
-    response = @gateway.inquire({ order_id: order_id }, @options)
+    response = @gateway.inquire(nil, { order_id: order_id })
     check_payment_id = response.params['payment_id']
     assert_success response
     assert_match purchase_payment_id, check_payment_id

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -320,6 +320,26 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     assert_match %r{cc_rejected_other_reason}, response.message
   end
 
+  def test_successful_inquire_with_id
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+    assert_equal 'pending_capture', auth.message
+
+    assert inquire = @gateway.inquire(auth.authorization)
+    assert_success inquire
+    assert_equal auth.message, inquire.message
+  end
+
+  def test_successful_inquire_with_external_reference
+    auth = @gateway.authorize(@amount, @credit_card, @options.merge(order_id: 'abcd1234'))
+    assert_success auth
+    assert auth.params['external_reference'] = 'abcd1234'
+
+    assert inquire = @gateway.inquire(nil, { external_reference: 'abcd1234' })
+    assert_success inquire
+    assert_equal auth.authorization, inquire.authorization
+  end
+
   def test_invalid_login
     gateway = MercadoPagoGateway.new(access_token: '')
 

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -125,7 +125,7 @@ class DLocalTest < Test::Unit::TestCase
 
   def test_successful_inquire_with_payment_id
     stub_comms(@gateway, :ssl_request) do
-      @gateway.inquire({ payment_id: 'D-15104-f9e16b85-5fc8-40f0-a4d8-4e73a892594f' }, {})
+      @gateway.inquire('D-15104-f9e16b85-5fc8-40f0-a4d8-4e73a892594f', {})
     end.check_request do |_method, endpoint, data, _headers|
       refute_match(/"https:\/\/sandbox.dlocal.com\/payments\/D-15104-f9e16b85-5fc8-40f0-a4d8-4e73a892594f\/status\/"/, endpoint)
       refute_match(nil, data)
@@ -134,7 +134,7 @@ class DLocalTest < Test::Unit::TestCase
 
   def test_successful_inquire_with_order_id
     stub_comms(@gateway, :ssl_request) do
-      @gateway.inquire({ order_id: '62595c5db10fdf7b5d5bb3a16d130992' }, {})
+      @gateway.inquire(nil, { order_id: '62595c5db10fdf7b5d5bb3a16d130992' })
     end.check_request do |_method, endpoint, data, _headers|
       refute_match(/"https:\/\/sandbox.dlocal.com\/orders\/62595c5db10fdf7b5d5bb3a16d130992\/"/, endpoint)
       refute_match(nil, data)

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -283,6 +283,29 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_inquire_with_id
+    @gateway.expects(:ssl_get).returns(successful_authorize_response)
+
+    response = @gateway.inquire('authorization|amount')
+    assert_success response
+
+    assert_equal '4261941|', response.authorization
+    assert_equal 'pending_capture', response.message
+    assert response.test?
+  end
+
+  def test_successful_inquire_with_external_reference
+    @gateway.expects(:ssl_get).returns(successful_search_payments_response)
+
+    response = @gateway.inquire(nil, { external_reference: '1234' })
+    assert_success response
+
+    assert_equal '1234', response.params['external_reference']
+    assert_equal '1|', response.authorization
+    assert_equal 'accredited', response.message
+    assert response.test?
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
@@ -705,6 +728,12 @@ class MercadoPagoTest < Test::Unit::TestCase
   def successful_purchase_with_metadata_response
     %(
       {"id":4141491,"date_created":"2017-07-06T09:49:35.000-04:00","date_approved":"2017-07-06T09:49:35.000-04:00","date_last_updated":"2017-07-06T09:49:35.000-04:00","date_of_expiration":null,"money_release_date":"2017-07-18T09:49:35.000-04:00","operation_type":"regular_payment","issuer_id":"166","payment_method_id":"visa","payment_type_id":"credit_card","status":"approved","status_detail":"accredited","currency_id":"MXN","description":"Store Purchase","live_mode":false,"sponsor_id":null,"authorization_code":null,"related_exchange_rate":null,"collector_id":261735089,"payer":{"type":"guest","id":null,"email":"user@example.com","identification":{"type":null,"number":null},"phone":{"area_code":null,"number":null,"extension":""},"first_name":"First User","last_name":"User","entity_type":null},"metadata":{"key_1":"value_1","key_2":"value_2","key_3":{"nested_key_1":"value_3"}},"additional_info":{"payer":{"address":{"zip_code":"K1C2N6","street_name":"My Street","street_number":"456"}}},"order":{"type":"mercadopago","id":"2326513804447055222"},"external_reference":null,"transaction_amount":5,"transaction_amount_refunded":0,"coupon_amount":0,"differential_pricing_id":null,"deduction_schema":null,"transaction_details":{"net_received_amount":0.14,"total_paid_amount":5,"overpaid_amount":0,"external_resource_url":null,"installment_amount":5,"financial_institution":null,"payment_method_reference_id":null,"payable_deferral_period":null,"acquirer_reference":null},"fee_details":[{"type":"mercadopago_fee","amount":4.86,"fee_payer":"collector"}],"captured":true,"binary_mode":false,"call_for_authorize_id":null,"statement_descriptor":"WWW.MERCADOPAGO.COM","installments":1,"card":{"id":null,"first_six_digits":"450995","last_four_digits":"3704","expiration_month":9,"expiration_year":2018,"date_created":"2017-07-06T09:49:35.000-04:00","date_last_updated":"2017-07-06T09:49:35.000-04:00","cardholder":{"name":"Longbob Longsen","identification":{"number":null,"type":null}}},"notification_url":null,"refunds":[],"processing_mode":null,"merchant_account_id":null,"acquirer":null,"merchant_number":null}
+    )
+  end
+
+  def successful_search_payments_response
+    %(
+      [{"paging":{"total":17493,"limit":30,"offset":0},"results":[{"id":1,"date_created":"2017-08-31T11:26:38.000Z","date_approved":"2017-08-31T11:26:38.000Z","date_last_updated":"2017-08-31T11:26:38.000Z","money_release_date":"2017-09-14T11:26:38.000Z","payment_method_id":"account_money","payment_type_id":"credit_card","status":"approved","status_detail":"accredited","currency_id":"BRL","description":"PagoPizza","collector_id":2,"payer":{"id":123,"email":"afriend@gmail.com","identification":{"type":"DNI","number":12345678},"type":"customer"},"metadata":{},"additional_info":{},"external_reference":"1234","transaction_amount":250,"transaction_amount_refunded":0,"coupon_amount":0,"transaction_details":{"net_received_amount":250,"total_paid_amount":250,"overpaid_amount":0,"installment_amount":250},"installments":1,"card":{}}]}]
     )
   end
 end


### PR DESCRIPTION
Get transaction by authorization (id)
or by external_reference (order_id)

Also adjusts inquire method signature in dlocal to match mercado_pago's

ECS-2589

mercado_pago:
Unit:
43 tests, 201 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
remote requests not currently working, all 500s :(

d_local:
Unit:
36 tests, 155 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
33 tests, 89 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.9697% passed