### PR TITLE
Shift4: Fix authorization and entryMode param

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -136,6 +136,7 @@
 * Shift4: Decline referral transactions and parse message for internal server errors [ajawadmirza] #4583
 * Litle: Update homepage_url [gasb150] #4491
 * Priority: Update credential handling [therufs] #4571
+* Shift4: Fix authorization and remove `entryMode` from verify and store transactions [ajawadmirza] #4589
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -14,7 +14,7 @@ module ActiveMerchant #:nodoc:
       RECURRING_TYPE_TRANSACTIONS = %w(recurring installment)
       TRANSACTIONS_WITHOUT_RESPONSE_CODE = %w(accesstoken add)
       SUCCESS_TRANSACTION_STATUS = %w(A)
-      DISALLOWED_ENTRY_MODE_ACTIONS = %w(capture refund)
+      DISALLOWED_ENTRY_MODE_ACTIONS = %w(capture refund add verify)
       URL_POSTFIX_MAPPING = {
         'accesstoken' => 'credentials',
         'add' => 'tokens',
@@ -292,7 +292,10 @@ module ActiveMerchant #:nodoc:
       def authorization_from(action, response)
         return unless success_from(action, response)
 
-        "#{response.dig('result', 0, 'card', 'token', 'value')}|#{response.dig('result', 0, 'transaction', 'invoice')}"
+        authorization = response.dig('result', 0, 'card', 'token', 'value').to_s
+        invoice = response.dig('result', 0, 'transaction', 'invoice')
+        authorization += "|#{invoice}" if invoice
+        authorization
       end
 
       def get_card_token(authorization)

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -43,6 +43,7 @@ class RemoteShift4Test < Test::Unit::TestCase
     response = @gateway.store(@credit_card, @options)
     assert_success response
     assert_not_empty response.authorization
+    assert_not_include response.authorization, '|'
 
     response = @gateway.authorize(@amount, response.authorization, @options)
     assert_success response

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -209,6 +209,7 @@ class Shift4Test < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       request = JSON.parse(data)
       assert_equal request['clerk']['numericId'], @extra_options[:clerk_id]
+      assert_nil request['card']['entryMode']
     end.respond_with(successful_store_response)
 
     assert response.success?
@@ -298,6 +299,7 @@ class Shift4Test < Test::Unit::TestCase
       assert_equal request['transaction']['cardOnFile']['transactionId'], card_on_file_fields[:transaction_id]
       assert_not_nil request['dateTime']
       assert !request['customer'].nil? && !request['customer'].empty?
+      assert_nil request['card']['entryMode']
     end.respond_with(successful_verify_response)
 
     assert_success response


### PR DESCRIPTION
Fixed authorization to remove `|` when invoice is not present and remove card entry modes from store and verify along with test cases.

SER-332
SER-331
SER-329

Unit:
5342 tests, 76557 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
749 files inspected, no offenses detected

Remote:
24 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed