### PR TITLE
Alelo: Adding homologation changes

### DIFF
--- a/lib/active_merchant/billing/gateways/alelo.rb
+++ b/lib/active_merchant/billing/gateways/alelo.rb
@@ -3,8 +3,11 @@ require 'jose'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class AleloGateway < Gateway
+      class_attribute :prelive_url
+
       self.test_url = 'https://sandbox-api.alelo.com.br/alelo/sandbox/'
-      self.live_url = 'https://desenvolvedor.alelo.com.br'
+      self.live_url = 'https://api.alelo.com.br/alelo/prd/'
+      self.prelive_url = 'https://api.homologacaoalelo.com.br/alelo/uat/'
 
       self.supported_countries = ['BR']
       self.default_currency = 'BRL'
@@ -22,7 +25,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_order(post, options)
         add_amount(post, money)
-        add_payment(post, payment, options)
+        add_payment(post, payment)
         add_geolocation(post, options)
         add_extra_data(post, options)
 
@@ -56,11 +59,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_amount(post, money)
-        post[:amount] = amount(money)
+        post[:amount] = amount(money).to_f
       end
 
       def add_order(post, options)
-        post[:request_id] = options[:order_id]
+        post[:requestId] = options[:order_id]
       end
 
       def add_extra_data(post, options)
@@ -82,12 +85,12 @@ module ActiveMerchant #:nodoc:
         })
       end
 
-      def add_payment(post, payment, options)
+      def add_payment(post, payment)
         post.merge!({
           cardNumber: payment.number,
           cardholderName: payment.name,
           expirationMonth: payment.month,
-          expirationYear: format(payment.year, :two_digits),
+          expirationYear: format(payment.year, :two_digits).to_i,
           securityCode: payment.verification_value
         })
       end
@@ -110,7 +113,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def remote_encryption_key(access_token)
-        response = parse(ssl_get(url('capture/key?format=json'), request_headers(access_token)))
+        response = parse(ssl_get(url('capture/key'), request_headers(access_token)))
         Response.new(true, response[:publicKey], response)
       end
 
@@ -118,20 +121,24 @@ module ActiveMerchant #:nodoc:
         multiresp = MultiResponse.new
         access_token = @options[:access_token]
         key = @options[:encryption_key]
+        uuid = @options[:encryption_uuid]
 
         if access_token.blank?
           multiresp.process { fetch_access_token }
           access_token = multiresp.message
           key = nil
+          uuid = nil
         end
 
         if key.blank?
           multiresp.process { remote_encryption_key(access_token) }
           key = multiresp.message
+          uuid = multiresp.params['uuid']
         end
 
         {
           key: key,
+          uuid: uuid,
           access_token: access_token,
           multiresp: multiresp.responses.present? ? multiresp : nil
         }
@@ -153,7 +160,7 @@ module ActiveMerchant #:nodoc:
 
         encrypted_body = {
           token: token,
-          uuid: options[:uuid] || SecureRandom.uuid
+          uuid: credentials[:uuid]
         }
 
         encrypted_body.to_json
@@ -183,16 +190,17 @@ module ActiveMerchant #:nodoc:
           message_from(response),
           response,
           authorization: authorization_from(response, options),
-          avs_result: AVSResult.new(code: response['some_avs_response_key']),
-          cvv_result: CVVResult.new(response['some_cvv_response_key']),
           test: test?
         )
 
         return resp unless credentials[:multiresp].present?
 
         multiresp = credentials[:multiresp]
-        resp.params['access_token'] = credentials[:access_token]
-        resp.params['encryption_key'] = credentials[:key]
+        resp.params.merge!({
+          'access_token' => credentials[:access_token],
+          'encryption_key' => credentials[:key],
+          'encryption_uuid' => credentials[:uuid]
+        })
         multiresp.process { resp }
 
         multiresp
@@ -224,10 +232,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response, options)
-        [options[:uuid]].join('#')
+        [response[:requestId]].join('#')
       end
 
       def url(action)
+        return prelive_url if @options[:url_override] == 'prelive'
+
         "#{test? ? test_url : live_url}#{action}"
       end
 

--- a/test/remote/gateways/remote_alelo_test.rb
+++ b/test/remote/gateways/remote_alelo_test.rb
@@ -76,7 +76,7 @@ class RemoteAleloTest < Test::Unit::TestCase
 
   def test_successful_purchase
     set_credentials!
-    @options[:uuid] = '53141521-afc8-4a08-af0c-f0382aef43c1'
+    @gateway.options[:encryption_uuid] = '53141521-afc8-4a08-af0c-f0382aef43c1'
     response = @gateway.purchase(@amount, @credit_card, @options)
 
     assert_success response
@@ -84,7 +84,7 @@ class RemoteAleloTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_no_predefined_credentials
-    @options[:uuid] = '53141521-afc8-4a08-af0c-f0382aef43c1'
+    @gateway.options[:encryption_uuid] = '53141521-afc8-4a08-af0c-f0382aef43c1'
     response = @gateway.purchase(@amount, @credit_card, @options)
 
     assert_success response
@@ -95,7 +95,7 @@ class RemoteAleloTest < Test::Unit::TestCase
 
   def test_unsuccessful_purchase_with_merchant_discredited
     set_credentials!
-    @options[:uuid] = '7c82f46e-64f7-4745-9c60-335a689b8e90'
+    @gateway.options[:encryption_uuid] = '7c82f46e-64f7-4745-9c60-335a689b8e90'
     response = @gateway.purchase(@amount, @credit_card, @options)
 
     assert_failure response
@@ -104,7 +104,7 @@ class RemoteAleloTest < Test::Unit::TestCase
 
   def test_unsuccessful_purchase_with_insuffieicent_funds
     set_credentials!
-    @options[:uuid] = 'a36aa740-d505-4d47-8aa6-6c31c7526a68'
+    @gateway.options[:encryption_uuid] = 'a36aa740-d505-4d47-8aa6-6c31c7526a68'
     response = @gateway.purchase(@amount, @credit_card, @options)
 
     assert_failure response
@@ -113,7 +113,7 @@ class RemoteAleloTest < Test::Unit::TestCase
 
   def test_unsuccessful_purchase_with_invalid_fields
     set_credentials!
-    @options[:uuid] = 'd7aff4a6-1ea1-4e74-b81a-934589385958'
+    @gateway.options[:encryption_uuid] = 'd7aff4a6-1ea1-4e74-b81a-934589385958'
     response = @gateway.purchase(@amount, @declined_card, @options)
 
     assert_failure response
@@ -122,20 +122,11 @@ class RemoteAleloTest < Test::Unit::TestCase
 
   def test_unsuccessful_purchase_with_blocked_card
     set_credentials!
-    @options[:uuid] = 'd2a0350d-e872-47bf-a543-2d36c2ad693e'
+    @gateway.options[:encryption_uuid] = 'd2a0350d-e872-47bf-a543-2d36c2ad693e'
     response = @gateway.purchase(@amount, @declined_card, @options)
 
     assert_failure response
     assert_match %r(Bloqueado), response.message
-  end
-
-  def test_successful_without_uuid_purchase
-    set_credentials!
-    SecureRandom.expects(:uuid).returns('53141521-afc8-4a08-af0c-f0382aef43c1')
-    response = @gateway.purchase(@amount, @credit_card, @options)
-
-    assert_success response
-    assert_match %r(Confirmada), response.message
   end
 
   def test_successful_purchase_with_geolocalitation
@@ -162,7 +153,7 @@ class RemoteAleloTest < Test::Unit::TestCase
   def test_transcript_scrubbing
     set_credentials!
     transcript = capture_transcript(@gateway) do
-      @options[:uuid] = '53141521-afc8-4a08-af0c-f0382aef43c1'
+      @gateway.options[:encryption_uuid] = '53141521-afc8-4a08-af0c-f0382aef43c1'
       @gateway.purchase(@amount, @credit_card, @options)
     end
     transcript = @gateway.scrub(transcript)
@@ -193,10 +184,12 @@ class RemoteAleloTest < Test::Unit::TestCase
       credentials = @gateway.send :ensure_credentials, {}
       AleloCredentials.instance.access_token = credentials[:access_token]
       AleloCredentials.instance.key = credentials[:key]
+      AleloCredentials.instance.uuid = credentials[:uuid]
     end
 
     @gateway.options[:access_token] = AleloCredentials.instance.access_token
     @gateway.options[:encryption_key] = AleloCredentials.instance.key
+    @gateway.options[:encryption_uuid] = AleloCredentials.instance.uuid
   end
 end
 
@@ -205,5 +198,5 @@ end
 class AleloCredentials
   include Singleton
 
-  attr_accessor :access_token, :key
+  attr_accessor :access_token, :key, :uuid
 end

--- a/test/remote/gateways/remote_alelo_test_certification.rb
+++ b/test/remote/gateways/remote_alelo_test_certification.rb
@@ -1,0 +1,136 @@
+require 'test_helper'
+require 'singleton'
+
+class RemoteAleloTestCertification < Test::Unit::TestCase
+  def setup
+    @gateway = AleloGateway.new(fixtures(:alelo_certification))
+    @amount = 1000
+    @cc_alimentacion = credit_card('5098870005467012', {
+      month: 8,
+      year: 2027,
+      first_name: 'Longbob',
+      last_name: 'Longsen',
+      verification_value: 747,
+      brand: 'mc'
+    })
+    @cc_snack = credit_card('5067580024660011', {
+      month: 8,
+      year: 2027,
+      first_name: 'Longbob',
+      last_name: 'Longsen',
+      verification_value: 576,
+      brand: 'mc'
+    })
+    @options = {
+      order_id: SecureRandom.uuid,
+      establishment_code: '1040471819',
+      sub_merchant_mcc: '5499',
+      player_identification: '7',
+      description: 'Store Purchase',
+      external_trace_number: '123456'
+    }
+  end
+
+  def test_failure_purchase_with_wrong_cvv_ct05
+    set_credentials!
+    @cc_snack.verification_value = 999
+    response = @gateway.purchase(@amount, @cc_snack, @options)
+
+    assert_failure response
+    assert_match %r{incorreto}i, response.message
+  end
+
+  def test_failure_with_incomplete_required_options_ct06
+    set_credentials!
+    @options.delete(:establishment_code)
+    response = @gateway.purchase(@amount, @cc_alimentacion, @options)
+
+    assert_failure response
+    assert_match %r{Erro ao validar dados}i, response.message
+  end
+
+  def test_failure_refund_with_non_existent_uuid_ct07
+    set_credentials!
+    response = @gateway.refund(@amount, SecureRandom.uuid, {})
+
+    assert_failure response
+    assert_match %r{RequestId informado, não encontrado!}, response.message
+  end
+
+  def test_successful_purchase_with_alimentazao_cc_ct08
+    response = @gateway.purchase(@amount, @cc_alimentacion, @options)
+
+    assert_success response
+    assert_match %r{confirmada}i, response.message
+  end
+
+  # Testing High value transaction disables the test credit card
+  #
+  # def test_successful_purchase_with_alimentazao_cc_ct08_B_high_value
+  #   response = @gateway.purchase(10_000_000, @cc_alimentacion, @options)
+  #   assert_failure response
+  # end
+
+  def test_successful_refund_ct09
+    set_credentials!
+    purchase = @gateway.purchase(@amount, @cc_alimentacion, @options)
+    response = @gateway.refund(@amount, purchase.authorization, {})
+
+    assert_success response
+    assert_match %r{Transação Estornada com sucesso}, response.message
+  end
+
+  def test_failure_with_non_exitent_establishment_code_ct10
+    @options[:establishment_code] = '0987654321'
+    @options[:sub_merchant_mcc] = '5411'
+
+    response = @gateway.purchase(@amount, @cc_alimentacion, @options)
+
+    assert_failure response
+    assert_match %r{no adquirente}i, response.message
+  end
+
+  def test_failure_when_cc_expired_ct11
+    @cc_alimentacion.year = 2020
+    set_credentials!
+
+    response = @gateway.purchase(@amount, @cc_alimentacion, @options)
+
+    assert_failure response
+  end
+
+  def test_failure_refund_with_purchase_already_refunded_ct12
+    set_credentials!
+    purchase = @gateway.purchase(@amount, @cc_alimentacion, @options)
+    assert_success purchase
+
+    response = @gateway.refund(@amount, purchase.authorization, {})
+    assert_success response
+
+    response = @gateway.refund(@amount, purchase.authorization, {})
+    assert_failure response
+  end
+
+  private
+
+  def set_credentials!
+    if AleloCredentials.instance.access_token.nil?
+      credentials = @gateway.send :ensure_credentials, {}
+      AleloCredentials.instance.access_token = credentials[:access_token]
+      AleloCredentials.instance.key = credentials[:key]
+      AleloCredentials.instance.uuid = credentials[:uuid]
+    end
+
+    @gateway.options[:access_token] = AleloCredentials.instance.access_token
+    @gateway.options[:encryption_key] = AleloCredentials.instance.key
+    @gateway.options[:encryption_uuid] = AleloCredentials.instance.uuid
+  end
+end
+
+# A simple singleton so an access token and key can
+# be shared among several tests
+class AleloCredentials
+  include Singleton
+
+  attr_accessor :access_token, :key, :uuid
+end


### PR DESCRIPTION
## Summary:

Adding changes to properly use the encryption key UUID on transactions, update types for amount and expiration year.

Adding a separate file for the remote tests that represents the tests cases used for certification

## Unit Test:

Finished in 39.980662 seconds.
5343 tests, 76567 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## Remote Test:

test/remote/gateways/remote_alelo_test.rb
Finished in 35.552773 seconds.
17 tests, 43 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

test/remote/gateways/remote_alelo_test_certification.rb Finished in 49.461157 seconds.
14 tests, 38 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## RuboCop:
750 files inspected, no offenses detected