### PR TITLE
Worldpay: Add transaction inquire request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 == HEAD
 * dLocal: Add transaction query API(s) request [almalee24] #4584
 * MercadoPago: Add transaction inquire request [molbrown] #4588
+* Worldpay: Add transaction inquire request [molbrown] #4592
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -144,6 +144,11 @@ module ActiveMerchant #:nodoc:
         store_request(credit_card, options)
       end
 
+      def inquire(authorization, options = {})
+        order_id = order_id_from_authorization(authorization.to_s) || options[:order_id]
+        commit('direct_inquiry', build_order_inquiry_request(order_id, options), :ok, options)
+      end
+
       def supports_scrubbing
         true
       end
@@ -927,6 +932,8 @@ module ActiveMerchant #:nodoc:
         case action
         when 'store'
           raw[:token].present?
+        when 'direct_inquiry'
+          raw[:last_event].present?
         else
           false
         end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -1156,6 +1156,31 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_success purchase
   end
 
+  # There is a delay of up to 5 minutes for a transaction to be recorded by Worldpay. Inquiring
+  # too soon will result in an error "Order not ready". Leaving commented out due to included sleeps.
+  # def test_successful_inquire_with_order_id
+  #   order_id = @options[:order_id]
+  #   assert auth = @gateway.authorize(@amount, @credit_card, @options)
+  #   assert_success auth
+  #   assert auth.authorization
+  #   sleep 60
+
+  #   assert inquire = @gateway.inquire(nil, { order_id: order_id })
+  #   assert_success inquire
+  #   assert auth.authorization == inquire.authorization
+  # end
+
+  # def test_successful_inquire_with_authorization
+  #   assert auth = @gateway.authorize(@amount, @credit_card, @options)
+  #   assert_success auth
+  #   assert auth.authorization
+  #   sleep 60
+
+  #   assert inquire = @gateway.inquire(auth.authorization, {})
+  #   assert_success inquire
+  #   assert auth.authorization == inquire.authorization
+  # end
+
   private
 
   def risk_data

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1374,6 +1374,26 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_inquire_with_order_id
+    response = stub_comms do
+      @gateway.inquire(nil, { order_id: @options[:order_id].to_s })
+    end.check_request do |_endpoint, data, _headers|
+      assert_tag_with_attributes('orderInquiry', { 'orderCode' => @options[:order_id].to_s }, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+    assert_equal 'R50704213207145707', response.authorization
+  end
+
+  def test_successful_inquire_with_authorization
+    response = stub_comms do
+      @gateway.inquire(@options[:order_id].to_s, {})
+    end.check_request do |_endpoint, data, _headers|
+      assert_tag_with_attributes('orderInquiry', { 'orderCode' => @options[:order_id].to_s }, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+    assert_equal 'R50704213207145707', response.authorization
+  end
+
   private
 
   def assert_date_element(expected_date_hash, date_element)


### PR DESCRIPTION
Can derive orderCode from authorization, or pass it directly as :order_id option.

ECS-2615

Unit:
106 tests, 625 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
102 tests, 392 assertions, 20 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications 79.4118% passed
(failures match master branch, and may be due to credentials used)