### PR TITLE
Adyen: Map Standard Error Codes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -140,6 +140,7 @@
 * Litle: Update homepage_url [gasb150] #4491
 * Priority: Update credential handling [therufs] #4571
 * Shift4: Fix authorization and remove `entryMode` from verify and store transactions [ajawadmirza] #4589
+* Adyen: Map standard error codes for `processing_error`, `config_error`, `invalid_amount`, and `incorrect_address` [ajawadmirza] #4593
 
 == Version 1.126.0 (April 15th, 2022)
 * Moneris: Add 3DS MPI field support [esmitperez] #4373

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -21,8 +21,12 @@ module ActiveMerchant #:nodoc:
       RECURRING_API_VERSION = 'v68'
 
       STANDARD_ERROR_CODE_MAPPING = {
+        '0' => STANDARD_ERROR_CODE[:processing_error],
+        '10' => STANDARD_ERROR_CODE[:config_error],
+        '100' => STANDARD_ERROR_CODE[:invalid_amount],
         '101' => STANDARD_ERROR_CODE[:incorrect_number],
         '103' => STANDARD_ERROR_CODE[:invalid_cvc],
+        '104' => STANDARD_ERROR_CODE[:incorrect_address],
         '131' => STANDARD_ERROR_CODE[:incorrect_address],
         '132' => STANDARD_ERROR_CODE[:incorrect_address],
         '133' => STANDARD_ERROR_CODE[:incorrect_address],


### PR DESCRIPTION
Added new error codes in mapping for `STANDARD_ERROR_CODE` so that for dispatch `known_error_list` can support passing of standard error codes instead of gateway error code numbers. Unit test for each failover errors are added as well.

SER-266

Unit:
5352 tests, 76613 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
750 files inspected, no offenses detected

Remote:
125 tests, 443 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96.8% passed