### PR TITLE
Shift4: Update refund request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Adyen: Map standard error codes for `processing_error`, `config_error`, `invalid_amount`, and `incorrect_address` [ajawadmirza] #4593
 * MerchantE: Add support for recurring transactions [naashton] #4594
 * CyberSource: Add support for `discount_management_indicator`, `purchase_tax_amount`, `installment_total_amount`, and `installment_annual_interest_rate` fields. [rachelkirk] #4595
+* Shift4: Remove `customer` from refund and `clerk` from store requests [ajawadmirza] #4596
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -99,7 +99,6 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_clerk(post, options)
         add_transaction(post, options)
-        add_customer(post, authorization, options)
         add_card(action, post, get_card_token(authorization), options)
         add_card_present(post, options)
 
@@ -129,7 +128,6 @@ module ActiveMerchant #:nodoc:
         action = 'add'
 
         add_datetime(post, options)
-        add_clerk(post, options)
         add_card(action, post, credit_card, options)
         add_customer(post, credit_card, options)
 

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -208,8 +208,8 @@ class Shift4Test < Test::Unit::TestCase
       @gateway.store(@credit_card, @options.merge(@extra_options.except(:tax)))
     end.check_request do |_endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_equal request['clerk']['numericId'], @extra_options[:clerk_id]
       assert_nil request['card']['entryMode']
+      assert_nil request['clerk']
     end.respond_with(successful_store_response)
 
     assert response.success?
@@ -224,6 +224,7 @@ class Shift4Test < Test::Unit::TestCase
       assert_equal request['card']['present'], 'N'
       assert_equal request['card']['expirationDate'], '1235'
       assert_nil request['card']['entryMode']
+      assert_nil request['customer']
     end.respond_with(successful_refund_response)
 
     assert response.success?


### PR DESCRIPTION
Updated refund request to remove `customer` object from the request along with test to verify the implementation.

SER-343
SER-344

Unit:
5352 tests, 76621 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
750 files inspected, no offenses detected

Remote:
24 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed