### PR TITLE
Litle/Vantiv: corrections to upgrade schema version and tests fixes

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -3,7 +3,7 @@ require 'nokogiri'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class LitleGateway < Gateway
-      SCHEMA_VERSION = '9.14'
+      SCHEMA_VERSION = '12.8'
 
       class_attribute :postlive_url
 
@@ -152,7 +152,7 @@ module ActiveMerchant #:nodoc:
           add_authentication(doc)
           add_descriptor(doc, options)
           doc.capture_(transaction_attributes(options)) do
-            doc.litleTxnId(transaction_id)
+            doc.cnpTxnId(transaction_id)
             doc.amount(money) if money
           end
         end
@@ -172,7 +172,7 @@ module ActiveMerchant #:nodoc:
           doc.send(refund_type(payment), transaction_attributes(options)) do
             if payment.is_a?(String)
               transaction_id, = split_authorization(payment)
-              doc.litleTxnId(transaction_id)
+              doc.cnpTxnId(transaction_id)
               doc.amount(money) if money
             elsif check?(payment)
               add_echeck_purchase_params(doc, money, payment, options)
@@ -194,11 +194,10 @@ module ActiveMerchant #:nodoc:
 
       def void(authorization, options = {})
         transaction_id, kind, money = split_authorization(authorization)
-
         request = build_xml_request do |doc|
           add_authentication(doc)
           doc.send(void_type(kind), transaction_attributes(options)) do
-            doc.litleTxnId(transaction_id)
+            doc.cnpTxnId(transaction_id)
             doc.amount(money) if void_type(kind) == :authReversal
           end
         end
@@ -373,7 +372,7 @@ module ActiveMerchant #:nodoc:
       def add_payment_method(doc, payment_method, options)
         if payment_method.is_a?(String)
           doc.token do
-            doc.litleToken(payment_method)
+            doc.cnpToken(payment_method)
             doc.expDate(format_exp_date(options[:basis_expiration_month], options[:basis_expiration_year])) if options[:basis_expiration_month] && options[:basis_expiration_year]
           end
         elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
@@ -541,7 +540,7 @@ module ActiveMerchant #:nodoc:
 
         parsed['duplicate'] = doc.at_xpath('//saleResponse').try(:[], 'duplicate') == 'true' if kind == :sale
 
-        doc.xpath("//litleOnlineResponse/#{kind}Response/*").each do |node|
+        doc.xpath("//cnpOnlineResponse/#{kind}Response/*").each do |node|
           if node.elements.empty?
             parsed[node.name.to_sym] = node.text
           else
@@ -554,7 +553,7 @@ module ActiveMerchant #:nodoc:
 
         if parsed.empty?
           %w(response message).each do |attribute|
-            parsed[attribute.to_sym] = doc.xpath('//litleOnlineResponse').attribute(attribute).value
+            parsed[attribute.to_sym] = doc.xpath('//cnpOnlineResponse').attribute(attribute).value
           end
         end
 
@@ -563,7 +562,6 @@ module ActiveMerchant #:nodoc:
 
       def commit(kind, request, money = nil)
         parsed = parse(kind, ssl_post(url, request, headers))
-
         options = {
           authorization: authorization_from(kind, parsed, money),
           test: test?,
@@ -581,7 +579,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(kind, parsed, money)
-        kind == :registerToken ? parsed[:litleToken] : "#{parsed[:litleTxnId]};#{kind};#{money}"
+        kind == :registerToken ? parsed[:cnpToken] : "#{parsed[:cnpTxnId]};#{kind};#{money}"
       end
 
       def split_authorization(authorization)
@@ -602,13 +600,13 @@ module ActiveMerchant #:nodoc:
         {
           merchantId: @options[:merchant_id],
           version: SCHEMA_VERSION,
-          xmlns: 'http://www.litle.com/schema'
+          xmlns: 'http://www.vantivcnp.com/schema'
         }
       end
 
       def build_xml_request
         builder = Nokogiri::XML::Builder.new
-        builder.__send__('litleOnlineRequest', root_attributes) do |doc|
+        builder.__send__('cnpOnlineRequest', root_attributes) do |doc|
           yield(doc)
         end
         builder.doc.root.to_xml

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -361,7 +361,7 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(failed_refund_response)
 
     assert_failure response
-    assert_equal 'No transaction found with specified litleTxnId', response.message
+    assert_equal 'No transaction found with specified transaction Id', response.message
     assert_equal '360', response.params['response']
   end
 
@@ -393,7 +393,7 @@ class LitleTest < Test::Unit::TestCase
     void = stub_comms do
       @gateway.void(response.authorization)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<authReversal.*<litleTxnId>100000000000000001</m, data)
+      assert_match(/<authReversal.*<cnpTxnId>100000000000000001</m, data)
     end.respond_with(successful_void_of_auth_response)
 
     assert_success void
@@ -409,7 +409,7 @@ class LitleTest < Test::Unit::TestCase
     void = stub_comms do
       @gateway.void(refund.authorization)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<void.*<litleTxnId>100000000000000003</m, data)
+      assert_match(/<void.*<cnpTxnId>100000000000000003</m, data)
     end.respond_with(successful_void_of_other_things_response)
 
     assert_success void
@@ -734,9 +734,9 @@ class LitleTest < Test::Unit::TestCase
 
   def successful_purchase_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <saleResponse id='1' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000006</litleTxnId>
+          <cnpTxnId>100000000000000006</cnpTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <responseTime>2014-03-31T11:34:39</responseTime>
@@ -747,15 +747,15 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>M</cardValidationResult>
           </fraudResult>
         </saleResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def duplicate_purchase_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <saleResponse id='1' duplicate='true' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000006</litleTxnId>
+          <cnpTxnId>100000000000000006</cnpTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <responseTime>2014-03-31T11:34:39</responseTime>
@@ -766,29 +766,29 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>M</cardValidationResult>
           </fraudResult>
         </saleResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_purchase_with_echeck_response
     %(
-      <litleOnlineResponse version='9.12' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <echeckSalesResponse id='42' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>621100411297330000</litleTxnId>
+          <cnpTxnId>621100411297330000</cnpTxnId>
           <orderId>42</orderId>
           <response>000</response>
           <responseTime>2018-01-09T14:02:20</responseTime>
           <message>Approved</message>
         </echeckSalesResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_authorize_stored_credentials
     %(
-      <litleOnlineResponse xmlns="http://www.litle.com/schema" version="9.14" response="0" message="Valid Format">
-        <authorizationResponse id="1" reportGroup="Default Report Group">
-          <litleTxnId>991939023768015826</litleTxnId>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
+        <authorizationResponse id='1' reportGroup='Default Report Group' customerId=''>
+          <cnpTxnId>100000000000000001</cnpTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <message>Approved</message>
@@ -796,15 +796,15 @@ class LitleTest < Test::Unit::TestCase
           <authCode>75045</authCode>
           <networkTransactionId>63225578415568556365452427825</networkTransactionId>
         </authorizationResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_purchase_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <saleResponse id='6' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>600000000000000002</litleTxnId>
+          <cnpTxnId>600000000000000002</cnpTxnId>
           <orderId>6</orderId>
           <response>110</response>
           <responseTime>2014-03-31T11:48:47</responseTime>
@@ -814,15 +814,15 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>P</cardValidationResult>
           </fraudResult>
         </saleResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_authorize_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <authorizationResponse id='1' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000001</litleTxnId>
+          <cnpTxnId>100000000000000001</cnpTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <responseTime>2014-03-31T12:21:56</responseTime>
@@ -833,15 +833,15 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>M</cardValidationResult>
           </fraudResult>
         </authorizationResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_authorize_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <authorizationResponse id='6' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>600000000000000001</litleTxnId>
+          <cnpTxnId>600000000000000001</cnpTxnId>
           <orderId>6</orderId>
           <response>110</response>
           <responseTime>2014-03-31T12:24:21</responseTime>
@@ -851,201 +851,201 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>P</cardValidationResult>
           </fraudResult>
         </authorizationResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_capture_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <captureResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000002</litleTxnId>
+          <cnpTxnId>100000000000000002</cnpTxnId>
           <response>000</response>
           <responseTime>2014-03-31T12:28:07</responseTime>
           <message>Approved</message>
         </captureResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_capture_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <captureResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>304546900824606360</litleTxnId>
+          <cnpTxnId>304546900824606360</cnpTxnId>
           <response>360</response>
           <responseTime>2014-03-31T12:30:53</responseTime>
           <message>No transaction found with specified litleTxnId</message>
         </captureResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_refund_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <creditResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000003</litleTxnId>
+          <cnpTxnId>100000000000000003</cnpTxnId>
           <response>000</response>
           <responseTime>2014-03-31T12:36:50</responseTime>
           <message>Approved</message>
         </creditResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_refund_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <creditResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>996483567570258360</litleTxnId>
+          <cnpTxnId>996483567570258360</cnpTxnId>
           <response>360</response>
           <responseTime>2014-03-31T12:42:41</responseTime>
-          <message>No transaction found with specified litleTxnId</message>
+          <message>No transaction found with specified transaction Id</message>
         </creditResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_credit_response
     %(
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-      <litleOnlineResponse version="9.14" response="0" message="Valid Format">
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <creditResponse id="1" reportGroup="Default Report Group">
-          <litleTxnId>908410935514139173</litleTxnId>
+          <cnpTxnId>908410935514139173</cnpTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <responseTime>2020-10-30T19:19:38.935</responseTime>
           <message>Approved</message>
         </creditResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_credit_response
     %(
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-      <litleOnlineResponse version="9.14" response="1" message="Error validating xml data against the schema: cvc-minLength-valid: Value '1234567890' with length = '10' is not facet-valid with respect to minLength '13' for type 'ccAccountNumberType'."/>
+      <cnpOnlineResponse version="12.8" response="1" message="Error validating xml data against the schema: cvc-minLength-valid: Value '1234567890' with length = '10' is not facet-valid with respect to minLength '13' for type 'ccAccountNumberType'."/>
     )
   end
 
   def successful_void_of_auth_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <authReversalResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>972619753208653000</litleTxnId>
+          <cnpTxnId>972619753208653000</cnpTxnId>
           <orderId>123</orderId>
           <response>000</response>
           <responseTime>2014-03-31T12:45:44</responseTime>
           <message>Approved</message>
         </authReversalResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_void_of_other_things_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <voidResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000004</litleTxnId>
+          <cnpTxnId>100000000000000004</cnpTxnId>
           <response>000</response>
           <responseTime>2014-03-31T12:44:52</responseTime>
           <message>Approved</message>
         </voidResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_void_of_echeck_response
     %(
-      <litleOnlineResponse version='9.12' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
-        <echeckVoidResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>986272331806746000</litleTxnId>
-          <response>000</response>
-          <responseTime>2018-01-09T14:20:00</responseTime>
-          <message>Approved</message>
-          <postDate>2018-01-09</postDate>
-        </echeckVoidResponse>
-      </litleOnlineResponse>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
+      <echeckVoidResponse id='' reportGroup='Default Report Group' customerId=''>
+        <cnpTxnId>986272331806746000</cnpTxnId>
+        <response>000</response>
+        <responseTime>2018-01-09T14:20:00</responseTime>
+        <message>Approved</message>
+        <postDate>2018-01-09</postDate>
+      </echeckVoidResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_void_of_authorization_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <authReversalResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>775712323632364360</litleTxnId>
+          <cnpTxnId>775712323632364360</cnpTxnId>
           <orderId>123</orderId>
           <response>360</response>
           <responseTime>2014-03-31T13:03:17</responseTime>
           <message>No transaction found with specified litleTxnId</message>
         </authReversalResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_void_of_other_things_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <voidResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>486912375928374360</litleTxnId>
+          <cnpTxnId>486912375928374360</cnpTxnId>
           <response>360</response>
           <responseTime>2014-03-31T12:55:46</responseTime>
           <message>No transaction found with specified litleTxnId</message>
         </voidResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_store_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <registerTokenResponse id='50' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>501000000000000001</litleTxnId>
+          <cnpTxnId>501000000000000001</cnpTxnId>
           <orderId>50</orderId>
-          <litleToken>1111222233330123</litleToken>
+          <cnpToken>1111222233330123</cnpToken>
           <response>801</response>
           <responseTime>2014-03-31T13:06:41</responseTime>
           <message>Account number was successfully registered</message>
           <bin>445711</bin>
           <type>VI</type>
         </registerTokenResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_store_paypage_response
     %(
-      <litleOnlineResponse version='8.2' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <registerTokenResponse id='99999' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>222358384397377801</litleTxnId>
+          <cnpTxnId>222358384397377801</cnpTxnId>
           <orderId>F12345</orderId>
-          <litleToken>1111222233334444</litleToken>
+          <cnpToken>1111222233334444</cnpToken>
           <response>801</response>
           <responseTime>2015-05-20T14:37:22</responseTime>
           <message>Account number was successfully registered</message>
         </registerTokenResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_store_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <registerTokenResponse id='51' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>510000000000000001</litleTxnId>
+          <cnpTxnId>510000000000000001</cnpTxnId>
           <orderId>51</orderId>
           <response>820</response>
           <responseTime>2014-03-31T13:10:51</responseTime>
           <message>Credit card number was invalid</message>
         </registerTokenResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def unsuccessful_xml_schema_validation_response
     %(
-    <litleOnlineResponse version='8.29' xmlns='http://www.litle.com/schema'
+      <cnpOnlineResponse version='12.8' xmlns='http://www.vantivcnp.com/schema'
                      response='1'
                      message='Error validating xml data against the schema on line 8\nthe length of the value is 10, but the required minimum is 13.'/>
 
@@ -1054,12 +1054,12 @@ class LitleTest < Test::Unit::TestCase
 
   def pre_scrub
     <<-REQUEST
-      opening connection to www.testlitle.com:443...
+      opening connection to www.testvantivcnp.com:443...
       opened
-      starting SSL for www.testlitle.com:443...
+      starting SSL for www.testvantivcnp.com:443...
       SSL established
-      <- "POST /sandbox/communicator/online HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.testlitle.com\r\nContent-Length: 406\r\n\r\n"
-      <- "<litleOnlineRequest xmlns=\"http://www.litle.com/schema\" merchantId=\"101\" version=\"9.4\">\n  <authentication>\n    <user>ACTIVE</user>\n    <password>MERCHANT</password>\n  </authentication>\n  <registerTokenRequest reportGroup=\"Default Report Group\">\n    <orderId/>\n    <accountNumber>4242424242424242</accountNumber>\n    <cardValidationNum>111</cardValidationNum>\n  </registerTokenRequest>\n</litleOnlineRequest>"
+      <- "POST /sandbox/communicator/online HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.testvantivcnp.com\r\nContent-Length: 406\r\n\r\n"
+      <- "<cnpOnlineRequest xmlns=\"http://www.vantivcnp.com/schema\" merchantId=\"101\" version=\"12.8\">\n <authentication>\n <user>ACTIVE</user>\n <password>MERCHANT</password>\n </authentication>\n <registerTokenRequest reportGroup=\"Default Report Group\">\n <orderId/>\n <accountNumber>4242424242424242</accountNumber>\n <cardValidationNum>111</cardValidationNum>\n </registerTokenRequest>\n</cnpOnlineRequest>"
       -> "HTTP/1.1 200 OK\r\n"
       -> "Date: Mon, 16 May 2016 03:07:36 GMT\r\n"
       -> "Server: Apache-Coyote/1.1\r\n"
@@ -1070,7 +1070,7 @@ class LitleTest < Test::Unit::TestCase
       -> "1bf\r\n"
       reading 447 bytes...
       -> ""
-      -> "<litleOnlineResponse version='10.1' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>\n  <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n    <litleTxnId>185074924759529000</litleTxnId>\n    <litleToken>1111222233334444</litleToken>\n    <response>000</response>\n    <responseTime>2016-05-15T23:07:36</responseTime>\n    <message>Approved</message>\n  </registerTokenResponse>\n</litleOnlineResponse>"
+      -> "<cnpOnlineResponse version='12.8' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'>\n <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n <cnpTxnId>185074924759529000</cnpTxnId>\n <cnpToken>1111222233334444</cnpToken>\n <response>000</response>\n <responseTime>2016-05-15T23:07:36</responseTime>\n <message>Approved</message>\n </registerTokenResponse>\n</cnpOnlineResponse>"
       read 447 bytes
       reading 2 bytes...
       -> ""
@@ -1084,12 +1084,12 @@ class LitleTest < Test::Unit::TestCase
 
   def post_scrub
     <<-REQUEST
-      opening connection to www.testlitle.com:443...
+      opening connection to www.testvantivcnp.com:443...
       opened
-      starting SSL for www.testlitle.com:443...
+      starting SSL for www.testvantivcnp.com:443...
       SSL established
-      <- "POST /sandbox/communicator/online HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.testlitle.com\r\nContent-Length: 406\r\n\r\n"
-      <- "<litleOnlineRequest xmlns=\"http://www.litle.com/schema\" merchantId=\"101\" version=\"9.4\">\n  <authentication>\n    <user>[FILTERED]</user>\n    <password>[FILTERED]</password>\n  </authentication>\n  <registerTokenRequest reportGroup=\"Default Report Group\">\n    <orderId/>\n    <accountNumber>[FILTERED]</accountNumber>\n    <cardValidationNum>[FILTERED]</cardValidationNum>\n  </registerTokenRequest>\n</litleOnlineRequest>"
+      <- "POST /sandbox/communicator/online HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.testvantivcnp.com\r\nContent-Length: 406\r\n\r\n"
+      <- "<cnpOnlineRequest xmlns=\"http://www.vantivcnp.com/schema\" merchantId=\"101\" version=\"12.8\">\n <authentication>\n <user>[FILTERED]</user>\n <password>[FILTERED]</password>\n </authentication>\n <registerTokenRequest reportGroup=\"Default Report Group\">\n <orderId/>\n <accountNumber>[FILTERED]</accountNumber>\n <cardValidationNum>[FILTERED]</cardValidationNum>\n </registerTokenRequest>\n</cnpOnlineRequest>"
       -> "HTTP/1.1 200 OK\r\n"
       -> "Date: Mon, 16 May 2016 03:07:36 GMT\r\n"
       -> "Server: Apache-Coyote/1.1\r\n"
@@ -1100,7 +1100,7 @@ class LitleTest < Test::Unit::TestCase
       -> "1bf\r\n"
       reading 447 bytes...
       -> ""
-      -> "<litleOnlineResponse version='10.1' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>\n  <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n    <litleTxnId>185074924759529000</litleTxnId>\n    <litleToken>1111222233334444</litleToken>\n    <response>000</response>\n    <responseTime>2016-05-15T23:07:36</responseTime>\n    <message>Approved</message>\n  </registerTokenResponse>\n</litleOnlineResponse>"
+      -> "<cnpOnlineResponse version='12.8' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'>\n <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n <cnpTxnId>185074924759529000</cnpTxnId>\n <cnpToken>1111222233334444</cnpToken>\n <response>000</response>\n <responseTime>2016-05-15T23:07:36</responseTime>\n <message>Approved</message>\n </registerTokenResponse>\n</cnpOnlineResponse>"
       read 447 bytes
       reading 2 bytes...
       -> ""


### PR DESCRIPTION
--------
Summary:

This PR updates the used schema to the latest version available according to the docs on https://vantiv.github.io/latest-versions/ Certification tests according to: http://support.worldpay.com/support/CNP-API/content/testauthincind.htm Failing tests not related with the upgrade, vantiv staff pending on inform the cause

unit tests
................
Finished in 0.400098 seconds.
----------------------------------------------------------------------------------------------------------------------
56 tests, 240 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
----------------------------------------------------------------------------------------------------------------------
139.97 tests/s, 599.85 assertions/s

remote tests

Finished in 46.196776 seconds.
---------------------------------------------------------------------------------------------------------------------- 
56 tests, 246 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96.4286% passed
----------------------------------------------------------------------------------------------------------------------
1.21 tests/s, 5.33 assertions/s

remote certification tests

Finished in 128.348246 seconds.
--------------------------------------------------------------------------------------------------------------------------- 44 tests, 404 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.7273% passed
--------------------------------------------------------------------------------------------------------------------------- 0.34 tests/s, 3.09 assertions/s

750 files inspected, no offenses detected