### PR TITLE
Iveri: Adding support for 3DS global

### DIFF
--- a/test/remote/gateways/remote_iveri_test.rb
+++ b/test/remote/gateways/remote_iveri_test.rb
@@ -164,4 +164,36 @@ class RemoteIveriTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:cert_id], transcript)
   end
+
+  def test_successful_authorize_with_3ds_v1_options
+    @options[:three_d_secure] = {
+      version: '1.0',
+      cavv: 'FHhirTpN0Aefs4rIzTlheBByD77J',
+      eci: '02',
+      xid: SecureRandom.alphanumeric(28),
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_authorize_with_3ds_v2_options
+    @options[:three_d_secure] = {
+      version: '2.1.0',
+      cavv: 'FHhirTpN0Aefs4rIzTlheBByD77J',
+      eci: '02',
+      ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'Y',
+      authentication_response_status: 'Y'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal '100', response.params['amount']
+  end
 end


### PR DESCRIPTION
## Summary:

This PR adds support for third party three ds authentication data on the Iveri gateway.

## Test Execution:

Remote
Finished in 55.248089 seconds.
21 tests, 55 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit
Finished in 29.863581 seconds.
5342 tests, 76557 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## RuboCop:
749 files inspected, no offenses detected