### PR TITLE
Credorax: Pass Network Transaction ID on MIT

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -294,13 +294,18 @@ module ActiveMerchant #:nodoc:
         if stored_credential[:initiator] == 'merchant'
           case stored_credential[:reason_type]
           when 'recurring'
-            stored_credential[:initial_transaction] ? post[:a9] = '1' : post[:a9] = '2'
+            recurring_properties(post, stored_credential)
           when 'installment', 'unscheduled'
             post[:a9] = '8'
           end
         else
           post[:a9] = '9'
         end
+      end
+
+      def recurring_properties(post, stored_credential)
+        post[:a9] = stored_credential[:initial_transaction] ? '1' : '2'
+        post[:g6] = stored_credential[:network_transaction_id] if stored_credential[:network_transaction_id]
       end
 
       def add_customer_data(post, options)

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -448,7 +448,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_success purchase
   end
 
-  def test_purchase_using_stored_credential_recurring_mit
+  def test_failed_purchase_using_stored_credential_recurring_mit
     initial_options = stored_credential_options(:merchant, :recurring, :initial)
     assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
     assert_success purchase
@@ -456,6 +456,19 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert network_transaction_id = purchase.params['Z13']
 
     used_options = stored_credential_options(:merchant, :recurring, id: network_transaction_id)
+    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_failure purchase
+    assert_match 'Parameter g6 is invalid', purchase.message
+  end
+
+  def test_successful_purchase_using_stored_credential_recurring_mit
+    initial_options = stored_credential_options(:merchant, :recurring, :initial)
+    assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success purchase
+    assert_equal '1', purchase.params['A9']
+    assert initial_network_transaction_id = purchase.params['Z50']
+
+    used_options = stored_credential_options(:merchant, :recurring, id: initial_network_transaction_id)
     assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
     assert_success purchase
   end

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -888,7 +888,7 @@ class CredoraxTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=1/, data)
     end.respond_with(successful_authorize_response)
-
+    assert_match(/z50=abc123/, successful_authorize_response)
     assert_success response
   end
 
@@ -997,6 +997,7 @@ class CredoraxTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=2/, data)
+      assert_match(/g6=abc123/, data)
     end.respond_with(successful_authorize_response)
 
     assert_success response
@@ -1069,7 +1070,7 @@ class CredoraxTest < Test::Unit::TestCase
   end
 
   def successful_authorize_response
-    'M=SPREE978&O=2&T=03%2F09%2F2016+03%3A08%3A58&V=413&a1=90f7449d555f7bed0a2c5d780475f0bf&a2=2&a4=100&a9=6&z1=8a829449535154bc0153595952a2517a&z13=606944188284&z14=U&z15=100&z2=0&z3=Transaction+has+been+executed+successfully.&z4=006597&z5=0&z6=00&z9=X&K=00effd2c80ab7ecd45b499c0bbea3d20'
+    'M=SPREE978&O=2&T=03%2F09%2F2016+03%3A08%3A58&V=413&a1=90f7449d555f7bed0a2c5d780475f0bf&a2=2&a4=100&a9=6&z1=8a829449535154bc0153595952a2517a&z13=606944188284&z14=U&z15=100&z2=0&z3=Transaction+has+been+executed+successfully.&z4=006597&z5=0&z6=00&z9=X&K=00effd2c80ab7ecd45b499c0bbea3d20z50=abc123'
   end
 
   def failed_authorize_response


### PR DESCRIPTION
Summary:

This PR adds support to pass network transaction id on merchant initiated transactions/subsequent transactions
Failing test not related to PR changes.

Test Execution:
Remote
Finished in 315.286053 seconds.
------------------------------------------------------------------------------------------ 
46 tests 157 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 86.9565% passed
------------------------------------------------------------------------------------------ 
0.15 tests/s, 0.49 assertions/s

Unit
Finished in 0.063884 seconds.
------------------------------------------------------------------------------------------ 
80 tests, 382 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
------------------------------------------------------------------------------------------ 
1252.27 tests/s, 5979.59 assertions/s

RuboCop:
750 files inspected, no offenses detected