### PR TITLE
Update ct_payment URLs

### DIFF
--- a/lib/active_merchant/billing/gateways/ct_payment.rb
+++ b/lib/active_merchant/billing/gateways/ct_payment.rb
@@ -1,8 +1,8 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class CtPaymentGateway < Gateway
-      self.test_url = 'https://test.ctpaiement.ca/v1/'
-      self.live_url = 'https://www.ctpaiement.com/v1/'
+      self.test_url = 'https://test.terminal.payfacto.cloud/v1/'
+      self.live_url = 'https://terminal.payfacto.cloud/v1/'
 
       self.supported_countries = %w[US CA]
       self.default_currency = 'CAD'


### PR DESCRIPTION
ECS-2640

The Payfacto (formerly ct_payment) gateway is
changing domain names on October 4th. The new
URLs are not resolvable at the moment so we
cannot test them.

Remote:
All failing with timeout errors