### PR TITLE
Bambora: Adding support for Third party 3DS.

### DIFF
--- a/test/remote/gateways/remote_beanstream_test.rb
+++ b/test/remote/gateways/remote_beanstream_test.rb
@@ -403,6 +403,35 @@ class RemoteBeanstreamTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:api_key], clean_transcript)
   end
 
+  def test_successful_authorize_with_3ds_v1_options
+    @options[:three_d_secure] = {
+      version: '1.0',
+      cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
+      eci: '05',
+      xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
+    assert response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_authorize_with_3ds_v2_options
+    @options[:three_d_secure] = {
+      version: '2.2.0',
+      cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
+      eci: '05',
+      ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'Y',
+      authentication_response_status: 'Y'
+    }
+
+    assert response = @gateway.purchase(@amount, @visa, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   private
 
   def generate_single_use_token(credit_card)


### PR DESCRIPTION
## Summary:

This PR adds support for third party 3DS2 authentication data on the Bambora (formerly Beanstream) gateway.

## Test Execution:

### Remote
Finished in 124.551138 seconds.
45 tests, 198 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.3333% passed

### Unit
Finished in 36.493983 seconds.
5354 tests, 76627 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
750 files inspected, no offenses detected