### PR TITLE
D Local: Add support for `original_order_id` field

### DIFF
--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -87,6 +87,7 @@ module ActiveMerchant #:nodoc:
         add_card(post, card, action, options)
         add_additional_data(post, options)
         post[:order_id] = options[:order_id] || generate_unique_id
+        post[:original_order_id] = options[:original_order_id] if options[:original_order_id]
         post[:description] = options[:description] if options[:description]
       end
 

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -94,6 +94,13 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_match purchase_payment_id, check_payment_id
   end
 
+  def test_successful_purchase_with_original_order_id
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(original_order_id: '123ABC'))
+    assert_success response
+    assert_match 'The payment was paid', response.message
+    assert_match '123ABC', response.params['original_order_id']
+  end
+
   def test_successful_purchase_with_more_options
     options = @options.merge(
       order_id: '1',

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -74,6 +74,14 @@ class DLocalTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_original_order_id
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(original_order_id: '123ABC'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal '123ABC', JSON.parse(data)['original_order_id']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 


### PR DESCRIPTION
CER-212

Remote:
34 tests, 92 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.0588% passed
*Failing test is also failing on master

Unit:
37 tests, 158 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Local:
5355 tests, 76630 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

NOTE: I looked into test cards on the DLocal docs to try to fix the failing test, and all card payments are supposed to pass by default in sandbox mode. The only reason for failure should be if you pass in a code in the description. I'm not sure why this particular card type is causing a failure.