### PR TITLE
DLocal: Add Network Tokens

### DIFF
--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -33,7 +33,7 @@ class CardStreamTest < Test::Unit::TestCase
       three_d_secure: {
         enrolled: 'true',
         authentication_response_status: 'Y',
-        eci: 05,
+        eci: '05',
         cavv: 'Y2FyZGluYWxjb21tZXJjZWF1dGg',
         xid: '362DF058-6061-47F1-A504-CACCBDF422B7'
       }
@@ -330,7 +330,7 @@ class CardStreamTest < Test::Unit::TestCase
       assert_match(/threeDSRequired=Y/, data)
       assert_match(/threeDSEnrolled=Y/, data)
       assert_match(/threeDSAuthenticated=Y/, data)
-      assert_match(/threeDSECI=5/, data)
+      assert_match(/threeDSECI=05/, data)
       assert_match(/threeDSCAVV=Y2FyZGluYWxjb21tZXJjZWF1dGg/, data)
       assert_match(/threeDSXID=362DF058-6061-47F1-A504-CACCBDF422B7/, data)
     end


### PR DESCRIPTION
Summary:
To support NetworkTokens this PR adds the 
needed parameters in the add_cart method 
and the supports_network_tokenization? 
method is set in true.

Unit Test:
Finished in 0.256649 seconds.
40 tests, 172 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Test:
Finished in 43.736933 seconds.
40 tests, 108 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

RuboCop:
750 files inspected, no offenses detected