### PR TITLE
CardConnect: Add Stored Credential

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Accept both formats of Canadian routing numbers [molbrown] #4568
 * DLocal: Add support for `original_order_id` [rachelkirk] #4605
 * CheckoutV2: Add support for `merchant_initiated_transaction_id` [rachelkirk] #4611
+* CardConnect: Add stored credential & pass any valid `ecomind` field [ajawadmirza] #4609
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -61,6 +61,8 @@ module ActiveMerchant #:nodoc:
         '60' => STANDARD_ERROR_CODE[:pickup_card]
       }
 
+      SCHEDULED_PAYMENT_TYPES = %w(recurring installment)
+
       def initialize(options = {})
         requires!(options, :merchant_id, :username, :password)
         require_valid_domain!(options, :domain)
@@ -89,6 +91,7 @@ module ActiveMerchant #:nodoc:
           add_customer_data(post, options)
           add_three_ds_mpi_data(post, options)
           add_additional_data(post, options)
+          add_stored_credential(post, options)
           post[:capture] = 'Y'
           commit('auth', post)
         end
@@ -104,6 +107,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_three_ds_mpi_data(post, options)
         add_additional_data(post, options)
+        add_stored_credential(post, options)
         commit('auth', post)
       end
 
@@ -188,7 +192,11 @@ module ActiveMerchant #:nodoc:
 
       def add_invoice(post, options)
         post[:orderid] = options[:order_id]
-        post[:ecomind] = (options[:recurring] ? 'R' : 'E')
+        post[:ecomind] = if options[:ecomind]
+                           options[:ecomind].capitalize
+                         else
+                           (options[:recurring] ? 'R' : 'E')
+                         end
       end
 
       def add_payment(post, payment)
@@ -247,6 +255,14 @@ module ActiveMerchant #:nodoc:
         post[:secureflag]  = three_d_secure[:eci]
         post[:securevalue] = three_d_secure[:cavv]
         post[:securedstid] = three_d_secure[:ds_transaction_id]
+      end
+
+      def add_stored_credential(post, options)
+        return unless stored_credential = options[:stored_credential]
+
+        post[:cof] = stored_credential[:initiator] == 'merchant' ? 'M' : 'C'
+        post[:cofscheduled] = SCHEDULED_PAYMENT_TYPES.include?(stored_credential[:reason_type]) ? 'Y' : 'N'
+        post[:cofpermission] = stored_credential[:initial_transaction] ? 'Y' : 'N'
       end
 
       def headers

--- a/test/remote/gateways/remote_card_connect_test.rb
+++ b/test/remote/gateways/remote_card_connect_test.rb
@@ -154,6 +154,31 @@ class RemoteCardConnectTest < Test::Unit::TestCase
     assert_success purchase_response
   end
 
+  def test_successful_purchase_using_stored_credential_framework
+    stored_credential_options = {
+      initial_transaction: true,
+      reason_type: 'recurring',
+      initiator: 'merchant'
+    }
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_options }))
+    assert_success response
+    assert_equal response.params['cof'], 'M'
+
+    stored_credential_options = {
+      initial_transaction: false,
+      reason_type: 'recurring',
+      initiator: 'merchant'
+    }
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ stored_credential: stored_credential_options }))
+    assert_success response
+    assert_equal response.params['cof'], 'M'
+  end
+
+  def test_successful_purchase_with_telephonic_ecomind
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ ecomind: 'T' }))
+    assert_success response
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response


### PR DESCRIPTION
Added stored credential implementation and fixed `ecomind` field to pass any valid value as per the documentation (`T`, `R`, `E`) along with remote and unit tests.

SER-376

Unit:
5363 tests, 76675 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
750 files inspected, no offenses detected

Remote:
25 tests, 57 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed