### PR TITLE
CardStream: Fix failing rubocop

### DIFF
--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -33,7 +33,7 @@ class CardStreamTest < Test::Unit::TestCase
       three_d_secure: {
         enrolled: 'true',
         authentication_response_status: 'Y',
-        eci: 05,
+        eci: 5,
         cavv: 'Y2FyZGluYWxjb21tZXJjZWF1dGg',
         xid: '362DF058-6061-47F1-A504-CACCBDF422B7'
       }


### PR DESCRIPTION
Fixed failing rubocop on `card_stream` unit test.

Unit:
5360 tests, 76662 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
750 files inspected, no offenses detected