### PR TITLE
CheckoutV2: Add support for `merchant_initiated_transaction_id`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@
 * Beanstream: Adding Third Party 3DS fields [heavyblade] #4602
 * Borgun: Add support for 3DS preauth [ajawadmirza] #4603
 * Accept both formats of Canadian routing numbers [molbrown] #4568
+* DLocal: Add support for `original_order_id` [rachelkirk] #4605
+* CheckoutV2: Add support for `merchant_initiated_transaction_id` [rachelkirk] #4611
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -266,6 +266,18 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_stored_credentials_merchant_initiated_transaction_id
+    stored_options = @options.merge(
+      stored_credential: {
+        reason_type: 'installment'
+      },
+      merchant_initiated_transaction_id: 'pay_7emayabnrtjkhkrbohn4m2zyoa321'
+    )
+    response = @gateway.purchase(@amount, @credit_card, stored_options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_moto_flag
     response = @gateway.authorize(@amount, @credit_card, @options.merge(transaction_indicator: 3))
     assert_success response

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -394,6 +394,24 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_stored_credentials_merchant_initiated_transaction_id
+    response = stub_comms do
+      options = {
+        stored_credential: {
+          initial_transaction: false
+        },
+        merchant_initiated_transaction_id: 'pay_7jcf4ovmwnqedhtldca3fjli2y'
+      }
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r{"previous_payment_id":"pay_7jcf4ovmwnqedhtldca3fjli2y"}, data)
+      assert_match(%r{"source.stored":true}, data)
+    end.respond_with(successful_purchase_using_stored_credential_response)
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_metadata
     response = stub_comms do
       options = {


### PR DESCRIPTION
CER-219

For this field, the customer should provide a previous network transaction id from the CheckoutV2 gateway. It is the customer’s responsibility to store and manage the network transaction ids. When a value is present, this field should override the existing stored credential logic and add the stored credential values to the transaction request.

Local:
5363 tests, 76675 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
50 tests, 278 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
74 tests, 188 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.6486% passed
Note: Failing test is also failing on master and unrelated to this change.