### PR TITLE
Adyen: Add level 2 and 3 information

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -66,6 +66,8 @@ module ActiveMerchant #:nodoc:
         add_recurring_contract(post, options)
         add_network_transaction_reference(post, options)
         add_application_info(post, options)
+        add_level_2_data(post, options)
+        add_level_3_data(post, options)
         commit('authorise', post, options)
       end
 
@@ -246,6 +248,34 @@ module ActiveMerchant #:nodoc:
         add_merchant_data(post, options)
       end
 
+      def add_level_2_data(post, options)
+        post[:additionalData][:'enhancedSchemeData.totalTaxAmount'] = options[:total_tax_amount] if options[:total_tax_amount]
+        post[:additionalData][:'enhancedSchemeData.customerReference'] = options[:customer_reference] if options[:customer_reference]
+        post[:additionalData] = post[:additionalData].merge(options[:level_2_data]) if options[:level_2_data]
+      end
+
+      def add_level_3_data(post, options)
+        post[:additionalData][:'enhancedSchemeData.freightAmount'] = options[:freight_amount] if options[:freight_amount]
+        post[:additionalData][:'enhancedSchemeData.destinationStateProvinceCode'] = options[:destination_state_province_code] if options[:destination_state_province_code]
+        post[:additionalData][:'enhancedSchemeData.shipFromPostalCode'] = options[:ship_from_postal_code] if options[:ship_from_postal_code]
+        post[:additionalData][:'enhancedSchemeData.orderDate'] = options[:order_date] if options[:order_date]
+        post[:additionalData][:'enhancedSchemeData.destinationPostalCode'] = options[:destination_postal_code] if options[:destination_postal_code]
+        post[:additionalData][:'enhancedSchemeData.destinationCountryCode'] = options[:destination_country_code] if options[:destination_country_code]
+        post[:additionalData][:'enhancedSchemeData.dutyAmount'] = options[:duty_amount] if options[:duty_amount]
+        if options[:items]
+          options[:items].each.with_index(1) do |item, index|
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.description"] = item.description
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.productCode"] = item.product_code
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.quantity"] = item.quantity
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.unitOfMeasure"] = item.unit_of_measure
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.unitPrice"] = item.unit_price
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.discountAmount"] = item.discount_amount
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.totalAmount"] = item.total_amount
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.commodityCode"] = item.commodity_code
+          end
+        end
+      end
+      
       def add_shopper_data(post, options)
         post[:shopperEmail] = options[:email] if options[:email]
         post[:shopperEmail] = options[:shopper_email] if options[:shopper_email]

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -264,16 +264,17 @@ module ActiveMerchant #:nodoc:
         post[:additionalData][:'enhancedSchemeData.dutyAmount'] = options[:duty_amount] if options[:duty_amount]
         if options[:items]
           options[:items].each.with_index(1) do |item, index|
-            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.description"] = item.description
-            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.productCode"] = item.product_code
-            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.quantity"] = item.quantity
-            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.unitOfMeasure"] = item.unit_of_measure
-            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.unitPrice"] = item.unit_price
-            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.discountAmount"] = item.discount_amount
-            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.totalAmount"] = item.total_amount
-            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.commodityCode"] = item.commodity_code
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.description"] = item[:description]
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.productCode"] = item[:product_code]
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.quantity"] = item[:quantity]
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.unitOfMeasure"] = item[:unit_of_measure]
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.unitPrice"] = item[:unit_price]
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.discountAmount"] = item[:discount_amount]
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.totalAmount"] = item[:total_amount]
+            post[:additionalData][:"enhancedSchemeData.itemDetailLine#{index}.commodityCode"] = item[:commodity_code]
           end
         end
+        post[:additionalData] = post[:additionalData].merge(options[:level_3_data]) if options[:level_3_data]
       end
       
       def add_shopper_data(post, options)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1379,6 +1379,46 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_authorize_with_lvl_2_data
+    level_2_data = {
+      total_tax_amount: '160',
+      customer_reference: '101'
+    }
+    assert response = @gateway.authorize(@amount, @avs_credit_card, @options.merge(level_2_data))
+    assert response.test?
+    refute response.authorization.blank?
+    assert_success response
+  end
+
+  def test_successful_authorize_with_lvl_3_data
+    level_3_data = {
+      total_tax_amount: '12800',
+      customer_reference: '101',
+      freight_amount: '300',
+      destination_state_province_code: 'NYC',
+      ship_from_postal_code: '1082GM',
+      order_date: '101216',
+      destination_postal_code: '1082GM',
+      destination_country_code: 'NLD',
+      duty_amount: '500',
+      items: [
+        {
+        description: 'T16 Test products 1',
+        product_code: 'TEST120',
+        commodity_code: 'COMMCODE1',
+        quantity: '5',
+        unit_of_measure: 'm',
+        unit_price: '1000',
+        discount_amount: '60',
+        total_amount: '4940'
+        }
+      ]
+    }
+    assert response = @gateway.authorize(@amount, @avs_credit_card, @options.merge(level_3_data))
+    assert response.test?
+    assert_success response
+  end
+
   def test_successful_cancel_or_refund
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -1233,13 +1233,21 @@ class AdyenTest < Test::Unit::TestCase
       destination_state_province_code: 'NYC',
       ship_from_postal_code: '1082GM',
       order_date: '101216',
-      destination_postal_code: '1082GM'
+      destination_postal_code: '1082GM',
       destination_country_code: 'NLD',
-      duty_amount: '500'
-      items: [{
+      duty_amount: '500',
+      items: [
+        {
         description: 'T16 Test products 1',
-        product_code: 'TEST120'
-      }]
+        product_code: 'TEST120',
+        commodity_code: 'COMMCODE1',
+        quantity: '5',
+        unit_of_measure: 'm',
+        unit_price: '1000',
+        discount_amount: '60',
+        total_amount: '4940'
+        }
+      ]
     }
 
     response = stub_comms do
@@ -1249,6 +1257,22 @@ class AdyenTest < Test::Unit::TestCase
       additional_data = parsed['additionalData']
       assert additional_data['enhancedSchemeData.totalTaxAmount']
       assert additional_data['enhancedSchemeData.customerReference']
+      assert additional_data['enhancedSchemeData.freightAmount']
+      assert additional_data['enhancedSchemeData.destinationStateProvinceCode']
+      assert additional_data['enhancedSchemeData.shipFromPostalCode']
+      assert additional_data['enhancedSchemeData.orderDate']
+      assert additional_data['enhancedSchemeData.destinationPostalCode']
+      assert additional_data['enhancedSchemeData.destinationCountryCode']
+      assert additional_data['enhancedSchemeData.dutyAmount']
+      assert additional_data['enhancedSchemeData.itemDetailLine1.description']
+      assert additional_data['enhancedSchemeData.itemDetailLine1.productCode']
+      assert additional_data['enhancedSchemeData.itemDetailLine1.commodityCode']
+      assert additional_data['enhancedSchemeData.itemDetailLine1.quantity']
+      assert additional_data['enhancedSchemeData.itemDetailLine1.unitOfMeasure']
+      assert additional_data['enhancedSchemeData.itemDetailLine1.unitPrice']
+      assert additional_data['enhancedSchemeData.itemDetailLine1.discountAmount']
+      assert additional_data['enhancedSchemeData.itemDetailLine1.totalAmount']
+      assert additional_data['enhancedSchemeData.itemDetailLine1.commodityCode']
     end.respond_with(successful_authorize_response)
     assert_success response
   end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -929,7 +929,7 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_shopper_data
     post = { card: { billingAddress: {} } }
-    @gateway.send(:shopper_data, post, @options)
+    @gateway.send(:add_shopper_data, post, @options)
     assert_equal 'john.smith@test.com', post[:shopperEmail]
     assert_equal '77.110.174.153', post[:shopperIP]
   end


### PR DESCRIPTION
Summary:
To be able to add level II and III information to Adyen transactions
the Aden gateway is updated
Created 2 methods: add_level_2_data and add_level_3_data
These methods are used by authorize method

Unit Test:
Finished in 0.032293 seconds.
103 tests, 532 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Test:
Finished in 752.767143 seconds.
127 tests, 398 assertions, 11 failures, 10 errors, 0 pendings, 0 omissions, 0 notifications
83.4646% passed