### PR TITLE
Alelo: Improving credentials refresh process

### DIFF
--- a/lib/active_merchant/billing/gateways/alelo.rb
+++ b/lib/active_merchant/billing/gateways/alelo.rb
@@ -46,7 +46,9 @@ module ActiveMerchant #:nodoc:
         force_utf8(transcript.encode).
           gsub(%r((Authorization: Bearer )[\w -]+), '\1[FILTERED]').
           gsub(%r((client_id=|Client-Id:)[\w -]+), '\1[FILTERED]\2').
-          gsub(%r((client_secret=|Client-Secret:)[\w -]+), '\1[FILTERED]\2')
+          gsub(%r((client_secret=|Client-Secret:)[\w -]+), '\1[FILTERED]\2').
+          gsub(%r((access_token\":\")[^\"]*), '\1[FILTERED]').
+          gsub(%r((publicKey\":\")[^\"]*), '\1[FILTERED]')
       end
 
       private
@@ -207,7 +209,6 @@ module ActiveMerchant #:nodoc:
       rescue ActiveMerchant::ResponseError => e
         # Retry on a possible expired encryption key
         if try_again && %w(401 404).include?(e.response.code) && @options[:encryption_key].present?
-          @options.delete(:access_token)
           @options.delete(:encryption_key)
           commit(action, body, options, false)
         else

--- a/test/unit/transcripts/alelo_purchase
+++ b/test/unit/transcripts/alelo_purchase
@@ -14,6 +14,8 @@
 -> "Content-Encoding: gzip\r\n"
 -> "\r\n"
 -> xxxxxx some binary string xxxxx
+-> Decoded Response Body:
+-> { "token_type":"Bearer", "access_token":"AAIkODFiYjJlYWYtM2Q1OS00OTM5LTk4ZTctOTRiZjllZTQ2MzljYzd8XKy3u3vEEWIl6xiQGwMiCSkebtYZzHEZX8N8h4pXS1RtqPrxc9Vz6KszCIITgA0tiGkfjj1yl4n3Z9F4-zic5Va0EvvbHLCBzYiQJCmE5ezh9d_1I5I4ncDnKZa5", "expires_in":86400, "consented_on":1666785813, "scope":"/capture" }opening connection to api.alelo.com.br:443...
 starting SSL for sandbox-api.alelo.com.br:443...
 SSL established, protocol: TLSv1.2, cipher: DHE-RSA-AES256-GCM-SHA384
 <- "GET /alelo/sandbox/capture/key?format=json HTTP/1.1\r\nAccept: application/json\r\nX-Ibm-Client-Id: ed702c5c-117c-4bc6-989a-055ede547b6d\r\nX-Ibm-Client-Secret: uI3cG0nO5cI0lQ4mY2aF1eN4kV0jA4vC1bJ1rJ0gV2pW7aU4uC\r\nAuthorization: Bearer AAIkZWQ3MDJjNWMtMTE3Yy00YmM2LTk4OWEtMDU1ZWRlNTQ3YjZkT5y20AlJqCMxbP0m6e7NnLCghHw7E50NsrAopbwLbtZ7zbDeSVOfVdxkIMbT6XnQrOAN65uFJ_ZH9FLh4dIUV9KOzJyBYnf4YND493nATHFhQpepNvo41qu7rykjBkEw\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: sandbox-api.alelo.com.br\r\n\r\n"
@@ -38,6 +40,8 @@ SSL established, protocol: TLSv1.2, cipher: DHE-RSA-AES256-GCM-SHA384
 -> "X-RateLimit-Remaining: name=rate-limit,399;\r\n"
 -> "Content-Encoding: gzip\r\n"
 -> xxxxxx some binary string xxxxx
+-> Decoded Response Body:
+-> {"uuid":"81346b5b-7ce0-4e89-b049-5488b7c8a2b6","format":"BASE64","publicKey":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnWPNWBkwWKDzJmRxxue2fCTrTSMJAoPNn32fIhbw9rNO5GErDOKg5rWzGcIthcH9F2BKIOVZ9YAc0kRVZlsSef2anOxwhFsA6gvj4H4R6lkb8lM9ee9YKw+MrWebKvj78g7o/z7roQkzS6iGcV4/rg4jL819TAz9kHY3Vf2tJi5wW3lPoXawUpvBXGLU1ZPe1RGekFtzBHyFNWniiY7pXF2qRFdeGJ4vcVxfIcYEAV/Pz9vUyLCsscRVBxA24sgYKt8giIp2Ymr2tpsjNwI+bj3jhsej+vdI/CG5klooLW84MSn6LEcCpaG71OB9KN5dDsZ3yKCCLuhmljEX/Wza8QIDAQAB"}opening connection to api.alelo.com.br:443...
 <- "POST /alelo/sandbox/capture/transaction HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/json\r\nX-Ibm-Client-Id: ed702c5c-117c-4bc6-989a-055ede547b6d\r\nX-Ibm-Client-Secret: uI3cG0nO5cI0lQ4mY2aF1eN4kV0jA4vC1bJ1rJ0gV2pW7aU4uC\r\nAuthorization: Bearer AAIkZWQ3MDJjNWMtMTE3Yy00YmM2LTk4OWEtMDU1ZWRlNTQ3YjZkkyzyfNOK8fm61YM_NgGTTp09udTkhoeCdjHA7nMfXwCbTaiU3BJ6NwNkLqJ7ogfDG2cOhwnhVOmdCQ4wwLRwChUZJ__RHzxbt-MlhtQbGqUkF0i1ZwlNUrO7ElCXsyW0\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: sandbox-api.alelo.com.br\r\nContent-Length: 913\r\n\r\n"
 <- "{\"token\":\"eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0.Sy8e0y387LVWcv0P7nwKtu7DHKWww4fCnCx68OnjhmM9sbhmZ9FTQwznGfnSljWFYxXmQPy2PnvtsdvMsEPp5jUANMKTpp4aAGfS_1x31UBuMeRQT5NMlFG8lhCwbPmNtrEOyB2fZUQBsmePpTtdzzAn1tj_hY7XC2bqGkPJ2zS6K2jXqdtkGWeLSMjEDRdyjDuQ_ybFx6uHfYcN_ioXcetUU_MJ1Ai3snfBU-150fCKTmY0SJ09tWMLCyYmvL416L_ha2UmY3tZm1zvpkyRQ612t88ZCEeUK-ZXBYp7FJT-KAAogG49G-Nadj3PSe8jQdxoIZTP46knT3vYp6OmxQ._5Y3c8IjGVJEpkvk4rXwNA.H7LHUpASrZB7zf4Wj5og2l7OBIvgLb2zEdpEC2NVcQPW612oS5jMnUucd58NGDoNoQssxfpjJXse5K-2V7KYEkRlYoVN39gqrIYNesnqPqTmU2VvpQsarjPVO62DgOes3R-qAKkytR3uB3VqNdYmgzdhWf-5tKc8XwLRa41kIsWo6cL7KvKzNUNS_a083X5IUje7Gh4yuH21RzAYVH3diuWDX9QcrdFMZ0BQxE1SpddG8QBcyGgQGvMsfju3Q2kEDrXuJZUSURRiOHdGOpHcYaTjHiGv-Q-NNVNtlwcMhGguMW93_YG8m5gI8VyW8Nq_2epq9YqZwK2YC7XO9CAMxQCaak1ol3ZqR5eo_RO6_ZIUe5NY6NjSWCLqijrAnARbpBUnaXY8CJN4_xRpg3zgqg.gFksDAHH--hQMyWZtXyOfQ\",\"uuid\":\"53141521-afc8-4a08-af0c-f0382aef43c1\"}"
 -> "HTTP/1.1 200 OK\r\n"

--- a/test/unit/transcripts/alelo_purchase_scrubbed
+++ b/test/unit/transcripts/alelo_purchase_scrubbed
@@ -14,6 +14,8 @@
 -> "Content-Encoding: gzip\r\n"
 -> "\r\n"
 -> xxxxxx some binary string xxxxx
+-> Decoded Response Body:
+-> { "token_type":"Bearer", "access_token":"[FILTERED]", "expires_in":86400, "consented_on":1666785813, "scope":"/capture" }opening connection to api.alelo.com.br:443...
 starting SSL for sandbox-api.alelo.com.br:443...
 SSL established, protocol: TLSv1.2, cipher: DHE-RSA-AES256-GCM-SHA384
 <- "GET /alelo/sandbox/capture/key?format=json HTTP/1.1\r\nAccept: application/json\r\nX-Ibm-Client-Id:[FILTERED]\r\nX-Ibm-Client-Secret:[FILTERED]\r\nAuthorization: Bearer [FILTERED]\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: sandbox-api.alelo.com.br\r\n\r\n"
@@ -38,6 +40,8 @@ SSL established, protocol: TLSv1.2, cipher: DHE-RSA-AES256-GCM-SHA384
 -> "X-RateLimit-Remaining: name=rate-limit,399;\r\n"
 -> "Content-Encoding: gzip\r\n"
 -> xxxxxx some binary string xxxxx
+-> Decoded Response Body:
+-> {"uuid":"81346b5b-7ce0-4e89-b049-5488b7c8a2b6","format":"BASE64","publicKey":"[FILTERED]"}opening connection to api.alelo.com.br:443...
 <- "POST /alelo/sandbox/capture/transaction HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/json\r\nX-Ibm-Client-Id:[FILTERED]\r\nX-Ibm-Client-Secret:[FILTERED]\r\nAuthorization: Bearer [FILTERED]\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: sandbox-api.alelo.com.br\r\nContent-Length: 913\r\n\r\n"
 <- "{\"token\":\"eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0.Sy8e0y387LVWcv0P7nwKtu7DHKWww4fCnCx68OnjhmM9sbhmZ9FTQwznGfnSljWFYxXmQPy2PnvtsdvMsEPp5jUANMKTpp4aAGfS_1x31UBuMeRQT5NMlFG8lhCwbPmNtrEOyB2fZUQBsmePpTtdzzAn1tj_hY7XC2bqGkPJ2zS6K2jXqdtkGWeLSMjEDRdyjDuQ_ybFx6uHfYcN_ioXcetUU_MJ1Ai3snfBU-150fCKTmY0SJ09tWMLCyYmvL416L_ha2UmY3tZm1zvpkyRQ612t88ZCEeUK-ZXBYp7FJT-KAAogG49G-Nadj3PSe8jQdxoIZTP46knT3vYp6OmxQ._5Y3c8IjGVJEpkvk4rXwNA.H7LHUpASrZB7zf4Wj5og2l7OBIvgLb2zEdpEC2NVcQPW612oS5jMnUucd58NGDoNoQssxfpjJXse5K-2V7KYEkRlYoVN39gqrIYNesnqPqTmU2VvpQsarjPVO62DgOes3R-qAKkytR3uB3VqNdYmgzdhWf-5tKc8XwLRa41kIsWo6cL7KvKzNUNS_a083X5IUje7Gh4yuH21RzAYVH3diuWDX9QcrdFMZ0BQxE1SpddG8QBcyGgQGvMsfju3Q2kEDrXuJZUSURRiOHdGOpHcYaTjHiGv-Q-NNVNtlwcMhGguMW93_YG8m5gI8VyW8Nq_2epq9YqZwK2YC7XO9CAMxQCaak1ol3ZqR5eo_RO6_ZIUe5NY6NjSWCLqijrAnARbpBUnaXY8CJN4_xRpg3zgqg.gFksDAHH--hQMyWZtXyOfQ\",\"uuid\":\"53141521-afc8-4a08-af0c-f0382aef43c1\"}"
 -> "HTTP/1.1 200 OK\r\n"


### PR DESCRIPTION
## Description

This change aims to prevent the extra call to get the access_token when the ecryption key expires also adds a change to properly filter out the access_token and encryption_key

## Test

### Remote Tests:
Finished in 29.913157 seconds.
17 tests, 43 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 64.281953 seconds.
5376 tests, 76737 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Rubocop
83.63 tests/s, 1193.76 assertions/s
Running RuboCop...
Inspecting 750 files
