### PR TITLE
Reach: adding gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/reach.rb
+++ b/lib/active_merchant/billing/gateways/reach.rb
@@ -1,0 +1,162 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class ReachGateway < Gateway
+      # TODO: Things to check
+      # * The list of three digit fractions but only accept 2
+      # * Not sure the list of countries and currencies
+
+      self.test_url = 'https://checkout.rch.how/'
+      self.live_url = 'https://checkout.rch.io/'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = %i[visa diners_club american_express jcb master discover maestro]
+
+      self.homepage_url = 'https://www.withreach.com/'
+      self.display_name = 'Reach'
+      self.currencies_without_fractions = %w(BIF BYR CLF CLP CVE DJF GNF ISK JPY KMF KRW PYG RWF UGX UYI VND VUV XAF XOF XPF IDR MGA MRO)
+
+      API_VERSION = 'v2.22'.freeze
+      STANDARD_ERROR_CODE_MAPPING = {}
+      PAYMENT_METHOD_MAP = {
+        american_express: 'AMEX',
+        cabal: 'CABAL',
+        check: 'ACH',
+        dankort: 'DANKORT',
+        diners_club: 'DINERS',
+        discover: 'DISC',
+        elo: 'ELO',
+        jcb: 'JCB',
+        maestro: 'MAESTRO',
+        master: 'MC',
+        naranja: 'NARANJA',
+        visa: 'VISA'
+      }
+
+      def initialize(options = {})
+        requires!(options, :merchant_id, :secret)
+        super
+      end
+
+      def authorize(money, payment, options = {})
+        request = build_checkout_request(money, payment, options)
+        add_customer_data(request, options, payment)
+
+        post = { request: request, card: add_payment(payment) }
+        commit('checkout', post)
+      end
+
+      def purchase(money, payment, options = {})
+        options[:capture] = true
+        authorize(money, payment, options)
+      end
+
+      def capture(money, authorization, options = {})
+        post = { request: { MerchantId: @options[:merchant_id], OrderId: authorization } }
+        commit('capture', post)
+      end
+
+      private
+
+      def build_checkout_request(amount, payment, options)
+        {
+          MerchantId: @options[:merchant_id],
+          ReferenceId: options[:order_id],
+          ConsumerCurrency: options[:currency] || currency(options[:amount]),
+          Capture: options[:capture] || false,
+          PaymentMethod: PAYMENT_METHOD_MAP[payment.brand.to_sym],
+          Items: [
+            Sku: options[:item_sku] || SecureRandom.alphanumeric,
+            ConsumerPrice: amount,
+            Quantity: (options[:item_quantity] || 1)
+          ],
+          ViaAgent: true # Indicates this is server to server API call
+        }
+      end
+
+      def add_payment(payment)
+        {
+          Name: payment.name,
+          Number: payment.number,
+          Expiry: { Month: payment.month, Year: payment.year },
+          VerificationCode: payment.verification_value
+        }
+      end
+
+      def add_customer_data(request, options, payment)
+        address = options[:billing_address] || options[:address]
+
+        return if address.blank?
+
+        request[:Consumer] = {
+          Name: payment.respond_to?(:name) ? payment.name : address[:name],
+          Email: options[:email],
+          Address: address[:address1],
+          City: address[:city],
+          Country: address[:country]
+        }.compact
+      end
+
+      def sign_body(body)
+        Base64.strict_encode64(OpenSSL::HMAC.digest('sha256', @options[:secret].encode('utf-8'), body.encode('utf-8')))
+      end
+
+      def parse(body)
+        hash_response = URI.decode_www_form(body).to_h.transform_keys!(&:to_sym)
+        hash_response[:response] = JSON.parse(hash_response[:response], symbolize_names: true)
+
+        hash_response
+      end
+
+      def format_and_sign(post)
+        post[:request] = post[:request].to_json
+        post[:card] = post[:card].to_json if post[:card].present?
+        post[:signature] = sign_body(post[:request])
+        post
+      end
+
+      def commit(action, parameters)
+        body = post_data format_and_sign(parameters)
+        raw_response = ssl_post url(action), body
+        response = parse(raw_response)
+
+        Response.new(
+          success_from(response),
+          message_from(response) || '',
+          response,
+          authorization: authorization_from(response[:response]),
+          # avs_result: AVSResult.new(code: response['some_avs_response_key']),
+          # cvv_result: CVVResult.new(response['some_cvv_response_key']),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      rescue ActiveMerchant::ResponseError => e
+        Response.new(false, (e.response.body.present? ? e.response.body : e.response.msg), {}, test: test?)
+      end
+
+      def success_from(response)
+        response.dig(:response, :Error).blank?
+      end
+
+      def message_from(response)
+        success_from(response) ? '' : response.dig(:response, :Error, :ReasonCode)
+      end
+
+      def authorization_from(response)
+        response[:OrderId]
+      end
+
+      def post_data(params)
+        params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+      end
+
+      def error_code_from(response)
+        response[:response][:Error][:Code] unless success_from(response)
+      end
+
+      def url(action)
+        "#{test? ? test_url : live_url}#{API_VERSION}/#{action}"
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1120,6 +1120,10 @@ raven_pac_net:
   secret: "all good men die young"
   prn: 987743
 
+reach:
+  merchant_id: 'xxxxxxx'
+  secret: 'xxxxxxx' 
+
 realex:
   login: X
   password: Y

--- a/test/remote/gateways/remote_reach_test.rb
+++ b/test/remote/gateways/remote_reach_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+class RemoteReachTest < Test::Unit::TestCase
+  def setup
+    @gateway = ReachGateway.new(fixtures(:reach))
+    @amount = 100
+    @credit_card = credit_card('4444333322221111', {
+      month: 3,
+      year: 2030,
+      verification_value: 737
+    })
+    @declined_card = credit_card('4000300011112220')
+    @options = {
+      email: 'johndoe@reach.com',
+      order_id: '123',
+      description: 'Store Purchase',
+      currency: 'USD',
+      billing_address: {
+        address1: '1670',
+        address2: '1670 NW 82ND AVE',
+        city: 'Miami',
+        state: 'FL',
+        zip: '32191',
+        country: 'US'
+      }
+    }
+  end
+
+  def test_successful_authorize
+    response = @gateway.authorize(@amount, @credit_card, @options)
+
+    assert_success response
+    assert response.params['response'][:Authorized]
+    assert response.params['response'][:OrderId]
+  end
+
+  def test_failed_authorize
+    @options[:currency] = 'PPP'
+    @options.delete(:email)
+    response = @gateway.authorize(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert_equal 'Invalid ConsumerCurrency', response.message
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_success response
+    assert response.params['response'][:Authorized]
+    assert response.params['response'][:OrderId]
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'NotATestCard', response.message
+  end
+
+  # The Complete flag in the response returns false when capture is
+  # in progress
+  def test_successful_authorize_and_capture
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+
+    response = @gateway.capture(@amount, response.authorization)
+    assert_success response
+  end
+
+  def test_failed_capture
+    response = @gateway.capture(@amount, "#{@gateway.options[:merchant_id]}#123")
+
+    assert_failure response
+    assert_equal 'Not Found', response.message
+  end
+
+  def test_transcript_scrubbing
+    # transcript = capture_transcript(@gateway) do
+    #   @gateway.purchase(@amount, @credit_card, @options)
+    # end
+    # transcript = @gateway.scrub(transcript)
+    #
+    # assert_scrubbed(@credit_card.number, transcript)
+    # assert_scrubbed(@credit_card.verification_value, transcript)
+    # assert_scrubbed(@gateway.options[:password], transcript)
+  end
+end

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -33,7 +33,7 @@ class CardStreamTest < Test::Unit::TestCase
       three_d_secure: {
         enrolled: 'true',
         authentication_response_status: 'Y',
-        eci: 05,
+        eci: '05',
         cavv: 'Y2FyZGluYWxjb21tZXJjZWF1dGg',
         xid: '362DF058-6061-47F1-A504-CACCBDF422B7'
       }
@@ -330,7 +330,7 @@ class CardStreamTest < Test::Unit::TestCase
       assert_match(/threeDSRequired=Y/, data)
       assert_match(/threeDSEnrolled=Y/, data)
       assert_match(/threeDSAuthenticated=Y/, data)
-      assert_match(/threeDSECI=5/, data)
+      assert_match(/threeDSECI=05/, data)
       assert_match(/threeDSCAVV=Y2FyZGluYWxjb21tZXJjZWF1dGg/, data)
       assert_match(/threeDSXID=362DF058-6061-47F1-A504-CACCBDF422B7/, data)
     end

--- a/test/unit/gateways/reach_test.rb
+++ b/test/unit/gateways/reach_test.rb
@@ -1,0 +1,127 @@
+require 'test_helper'
+
+class ReachTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = ReachGateway.new(fixtures(:reach))
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      email: 'johndoe@reach.com',
+      order_id: '123',
+      currency: 'USD',
+      billing_address: {
+        address1: '1670',
+        address2: '1670 NW 82ND AVE',
+        city: 'Miami',
+        state: 'FL',
+        zip: '32191',
+        country: 'US'
+      }
+    }
+  end
+
+  def test_required_merchant_id_and_secret
+    error = assert_raises(ArgumentError) { ReachGateway.new }
+    assert_equal 'Missing required parameter: merchant_id', error.message
+  end
+
+  def test_supported_card_types
+    assert_equal ReachGateway.supported_cardtypes, %i[visa diners_club american_express jcb master discover maestro]
+  end
+
+  def test_should_be_able_format_a_request
+    post = {
+      request: { someId: 'abc123' },
+      card: { number: '12132323', name: 'John doe' }
+    }
+
+    formatted = @gateway.send :format_and_sign, post
+
+    refute_empty formatted[:signature]
+    assert_kind_of String, formatted[:request]
+    assert_kind_of String, formatted[:card]
+
+    assert_equal 'abc123', JSON.parse(formatted[:request])['someId']
+    assert_equal '12132323', JSON.parse(formatted[:card])['number']
+    assert formatted[:signature].present?
+  end
+
+  def test_successfully_build_a_purchase
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(URI.decode_www_form(data)[0][1])
+      card = JSON.parse(URI.decode_www_form(data)[1][1])
+
+      # request
+      assert_equal request['ReferenceId'], @options[:order_id]
+      assert_equal request['Consumer']['Email'], @options[:email]
+      assert_equal request['ConsumerCurrency'], @options[:currency]
+      assert_equal request['Capture'], false
+
+      # card
+      assert_equal card['Number'], @credit_card.number
+      assert_equal card['Name'], @credit_card.name
+      assert_equal card['VerificationCode'], @credit_card.verification_value
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_properly_set_capture_flag_on_purchase
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(URI.decode_www_form(data)[0][1])
+      assert_equal true, request['Capture']
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_sending_item_sku_and_item_price
+    @options[:item_sku] = '1212121212'
+    @options[:item_quantity] = 250
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(URI.decode_www_form(data)[0][1])
+
+      # request
+      assert_equal request['Items'].first['Sku'], @options[:item_sku]
+      assert_equal request['Items'].first['Quantity'], @options[:item_quantity]
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_successfull_retrieve_error_message
+    response = { response: { Error: { ReasonCode: 'is an error' } } }
+
+    message = @gateway.send(:message_from, response)
+    assert_equal 'is an error', message
+  end
+
+  def test_safe_retrieve_error_message
+    response = { response: { Error: { Code: 'is an error' } } }
+
+    message = @gateway.send(:message_from, response)
+    assert_nil message
+  end
+
+  def test_sucess_from_on_sucess_result
+    response = { response: { OrderId: '' } }
+
+    assert @gateway.send(:success_from, response)
+  end
+
+  def test_sucess_from_on_failure
+    response = { response: { Error: 'is an error' } }
+
+    refute @gateway.send(:success_from, response)
+  end
+
+  private
+
+  def successful_purchase_response
+    'response=%7B%22OrderId%22%3A%22e8f8c529-15c7-46c1-b28b-9d43bb5efe92%22%2C%22UnderReview%22%3Afalse%2C%22Expiry%22%3A%222022-11-03T12%3A47%3A21Z%22%2C%22Authorized%22%3Atrue%2C%22Completed%22%3Afalse%2C%22Captured%22%3Afalse%7D&signature=JqLa7Y68OYRgRcA5ALHOZwXXzdZFeNzqHma2RT2JWAg%3D'
+  end
+end


### PR DESCRIPTION
## Summary:

Adding Reach gateway with authorize, purchase and capture calls, also small correction on the CardStream local test to complain with Rubocop warnings.

## Tests

#### Remote Test:
Finished in 6.627757 seconds.
7 tests, 14 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

#### Unit Tests:
5365 tests, 76686 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

#### RuboCop:
753 files inspected, no offenses detected