### PR TITLE
IPG Gateway: override store id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Alelo: Trigger access token refresh on 404 [curiousepic] #4614
 * DLocal: Add Network Tokens [gasb150] #4608
 * Redsys: enable NTID generation with zero-value verify [jcreiff] #4615
+* IPG: Add support for passing in `store_id` on transactions [aenand] #4619
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/test/remote/gateways/remote_ipg_test.rb
+++ b/test/remote/gateways/remote_ipg_test.rb
@@ -100,6 +100,13 @@ class RemoteIpgTest < Test::Unit::TestCase
     assert_equal 'SGS-050005', response.error_code
   end
 
+  def test_failed_purchase_with_passed_in_store_id
+    # passing in a bad store id results in a 401 unauthorized error
+    assert_raises(ActiveMerchant::ResponseError) do
+      @gateway.purchase(@amount, @declined_card, @options.merge({ store_id: '1234' }))
+    end
+  end
+
   def test_successful_authorize_and_capture
     order_id = generate_unique_id
     response = @gateway.authorize(@amount, @credit_card, @options.merge!({ order_id: order_id }))

--- a/test/unit/gateways/ipg_test.rb
+++ b/test/unit/gateways/ipg_test.rb
@@ -118,6 +118,17 @@ class IpgTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_store_id
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge({ store_id: '1234' }))
+    end.check_request do |_endpoint, data, _headers|
+      doc = REXML::Document.new(data)
+      assert_match('1234', REXML::XPath.first(doc, '//v1:StoreId').text)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_payment_token
     payment_token = 'ABC123'
 


### PR DESCRIPTION
ECS-2655

The IPG gateway requires a `store_id` to be
used as part of the authentication. This
value is correlates to a given merchant and
is currently saved on the gateway initalize.
By saving it only then, it prevents merchants
with submerchants from using this gateway.

This commit adds a new optional field that
will override the saved `store_id` with one
passed in for that merchant.

Test Summary
Remote:
18 tests, 54 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed