### PR TITLE
Add alternate alpha2 country code for Kosovo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * Redsys: enable NTID generation with zero-value verify [jcreiff] #4615
 * IPG: Add support for passing in `store_id` on transactions [aenand] #4619
 * Adyen: Field support for Level 2 and level 3 information [sainterman] #4617
+* Add alternate alpha2 country code for Kosovo [jcreiff] #4622
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/country.rb
+++ b/lib/active_merchant/country.rb
@@ -184,6 +184,7 @@ module ActiveMerchant #:nodoc:
       { alpha2: 'KP', name: 'Korea, Democratic People\'s Republic of', alpha3: 'PRK', numeric: '408' },
       { alpha2: 'KR', name: 'Korea, Republic of', alpha3: 'KOR', numeric: '410' },
       { alpha2: 'XK', name: 'Kosovo', alpha3: 'XKX', numeric: '900' },
+      { alpha2: 'QZ', name: 'Kosovo', alpha3: 'XKX', numeric: '900' },
       { alpha2: 'KW', name: 'Kuwait', alpha3: 'KWT', numeric: '414' },
       { alpha2: 'KG', name: 'Kyrgyzstan', alpha3: 'KGZ', numeric: '417' },
       { alpha2: 'LA', name: 'Lao People\'s Democratic Republic', alpha3: 'LAO', numeric: '418' },

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1501,6 +1501,17 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_void_references_original_authorization(void, auth)
   end
 
+  def test_successful_authorize_with_alternate_kosovo_code
+    @options[:billing_address][:country] = 'XK'
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Billing address problem (Country XK invalid)', response.message
+
+    @options[:billing_address][:country] = 'QZ'
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+  end
+
   private
 
   def stored_credential_options(*args, ntid: nil)

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -1256,7 +1256,7 @@ class AdyenTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       parsed = JSON.parse(data)
       additional_data = parsed['additionalData']
-      leve_3_keys = [ 'enhancedSchemeData.freightAmount', 'enhancedSchemeData.destinationStateProvinceCode',
+      leve_3_keys = ['enhancedSchemeData.freightAmount', 'enhancedSchemeData.destinationStateProvinceCode',
                      'enhancedSchemeData.shipFromPostalCode', 'enhancedSchemeData.orderDate', 'enhancedSchemeData.destinationPostalCode',
                      'enhancedSchemeData.destinationCountryCode', 'enhancedSchemeData.dutyAmount',
                      'enhancedSchemeData.itemDetailLine1.description', 'enhancedSchemeData.itemDetailLine1.productCode',


### PR DESCRIPTION
Kosovo's XK country code is considered invalid by Adyen, but the Adyen API will accept QZ as a valid value to represent Kosovo instead

CER-266