### PR TITLE
CyberSource: Refactor and add support for several fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@
 * IPG: Add support for passing in `store_id` on transactions [aenand] #4619
 * Adyen: Field support for Level 2 and level 3 information [sainterman] #4617
 * Add alternate alpha2 country code for Kosovo [jcreiff] #4622
+* CyberSource: Add support for several fields [rachelkirk] #4623
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -62,7 +62,21 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       ignore_cvv: 'true',
       commerce_indicator: 'internet',
       user_po: 'ABC123',
-      taxable: true
+      taxable: true,
+      sales_slip_number: '456',
+      airline_agent_code: '7Q',
+      tax_management_indicator: 1,
+      installment_grace_period_duration: '1',
+      invoice_amount: '3',
+      original_amount: '4',
+      reference_data_code: 'ABC123',
+      invoice_number: '123',
+      mobile_remote_payment_type: 'A1',
+      vat_tax_rate: '1'
+    }
+
+    @capture_options = {
+      gratuity_amount: '3.50'
     }
 
     @subscription_options = {
@@ -209,7 +223,14 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_authorization_with_installment_data
-    options = @options.merge(installment_total_count: 2, installment_total_amount: 0.50, installment_plan_type: 1, first_installment_date: '300101', installment_annual_interest_rate: 1.09)
+    options = @options.merge(
+      installment_total_count: 2,
+      installment_total_amount: 0.50,
+      installment_plan_type: 1,
+      first_installment_date: '300101',
+      installment_annual_interest_rate: 1.09,
+      installment_grace_period_duration: 1
+    )
     assert response = @gateway.authorize(@amount, @credit_card, options)
     assert_successful_response(response)
     assert !response.authorization.blank?
@@ -229,6 +250,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_successful_authorization_with_airline_agent_code
     options = @options.merge(airline_agent_code: '7Q')
+    assert response = @gateway.authorize(@amount, @credit_card, options)
+    assert_successful_response(response)
+  end
+
+  def test_successful_authorization_with_tax_mgmt_indicator
+    options = @options.merge(tax_management_indicator: '3')
     assert response = @gateway.authorize(@amount, @credit_card, options)
     assert_successful_response(response)
   end
@@ -527,7 +554,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(auth)
 
-    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert capture = @gateway.capture(@amount, auth.authorization, @capture_options)
     assert_successful_response(capture)
   end
 
@@ -690,6 +717,8 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(capture)
   end
 
+  # this test should probably be removed, the fields do not appear to be part of the
+  # most current XSD file, also they are not added to the request correctly as top level fields
   def test_merchant_description
     merchant_options = {
       merchantInformation: {


### PR DESCRIPTION
CER-243

This PR refactors the order of some methods to prevent XML parse errors. It also adds support for the following fields:

installment_gracePeriodDuration
taxManagementIndicator
purchaseTotals_invoiceAmount
purchaseTotals_originalAmount
invoiceHeader_referenceDataCode
invoiceHeader_invoiceNumber
ccCaptureService_gratuityAmount
ccAuthService_mobileRemotePaymentType
otherTax_vatTaxRate

Local:
5371 tests, 76705 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
118 tests, 600 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96.6102% passed
There is one additional remote test failure due to the fields not being added at the top level.

Unit:
123 tests, 588 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed