### PR TITLE
Orbital: integration improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,8 @@
 * Adyen: Field support for Level 2 and level 3 information [sainterman] #4617
 * Add alternate alpha2 country code for Kosovo [jcreiff] #4622
 * CyberSource: Add support for several fields [rachelkirk] #4623
+* Reach: adding gateway [cristian] #4618
+* Orbital: integration improvements [molbrown] #4626
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -349,6 +349,15 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_false response.authorization.blank?
   end
 
+  def test_successful_purchase_with_commercial_echeck
+    commercial_echeck = check(account_number: '072403004', account_type: 'checking', account_holder_type: 'business', routing_number: '072403004')
+
+    assert response = @echeck_gateway.purchase(20, commercial_echeck, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
   def test_successful_purchase_with_mit_stored_credentials
     mit_stored_credentials = {
       mit_msg_type: 'MUSE',
@@ -974,6 +983,26 @@ class BrandSpecificOrbitalTests < RemoteOrbitalGatewayTest
           zip: '03105',
           country: 'US'
         }
+      },
+      discover: {
+        card: {
+          number: '6011016011016011',
+          verification_value: '613',
+          brand: 'discover'
+        },
+        three_d_secure: {
+          eci: '6',
+          cavv: 'Asju1ljfl86bAAAAAACm9zU6aqY=',
+          ds_transaction_id: '32b274ee-582d-4232-b20a-363f2acafa5a'
+        },
+        address: {
+          address1: '1 Northeastern Blvd',
+          address2: '',
+          city: 'Bedford',
+          state: 'NH',
+          zip: '03109',
+          country: 'US'
+        }
       }
     }
   end
@@ -1021,6 +1050,22 @@ class BrandSpecificOrbitalTests < RemoteOrbitalGatewayTest
   def test_successful_3ds_purchase_with_american_express
     cc = brand_specific_card(@brand_specific_fixtures[:american_express][:card])
     options = brand_specific_3ds_options(@brand_specific_fixtures[:american_express])
+
+    assert response = @three_ds_gateway.purchase(100, cc, options)
+    assert_success_with_authorization(response)
+  end
+
+  def test_successful_3ds_authorization_with_discover
+    cc = brand_specific_card(@brand_specific_fixtures[:discover][:card])
+    options = brand_specific_3ds_options(@brand_specific_fixtures[:discover])
+
+    assert response = @three_ds_gateway.authorize(100, cc, options)
+    assert_success_with_authorization(response)
+  end
+
+  def test_successful_3ds_purchase_with_discover
+    cc = brand_specific_card(@brand_specific_fixtures[:discover][:card])
+    options = brand_specific_3ds_options(@brand_specific_fixtures[:discover])
 
     assert response = @three_ds_gateway.purchase(100, cc, options)
     assert_success_with_authorization(response)


### PR DESCRIPTION
Orbital adapter is currently failing certification based on missing support for these changes. Adds:

- Support for commercial echeck (BankAccountType = 'X')
- Support for Discover 3DS (DigitalTokenCryptogram)

Unit:
144 tests, 817 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
122 tests, 509 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

ECS-2144