### PR TITLE
fixed source.stored added in root by mistake, moved to its right place

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -206,7 +206,7 @@ module ActiveMerchant #:nodoc:
 
       def merchant_initiated_override(post, options)
         post[:merchant_initiated] = true
-        post[:'source.stored'] = true
+        post[:source][:stored] = true
         post[:previous_payment_id] = options[:merchant_initiated_transaction_id]
       end
 
@@ -214,7 +214,7 @@ module ActiveMerchant #:nodoc:
         if options[:stored_credential][:initial_transaction] == true
           post[:merchant_initiated] = false
         else
-          post[:'source.stored'] = true
+          post[:source][:stored] = true
           post[:previous_payment_id] = options[:stored_credential][:network_transaction_id] if options[:stored_credential][:network_transaction_id]
           post[:merchant_initiated] = true
         end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -386,8 +386,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       }
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(%r{"previous_payment_id":"pay_7jcf4ovmwnqedhtldca3fjli2y"}, data)
-      assert_match(%r{"source.stored":true}, data)
+      request = JSON.parse(data)
+      assert_equal request['previous_payment_id'], 'pay_7jcf4ovmwnqedhtldca3fjli2y'
+      assert_equal request['source']['stored'], true
     end.respond_with(successful_purchase_using_stored_credential_response)
 
     assert_success response
@@ -404,8 +405,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       }
       @gateway.purchase(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(%r{"previous_payment_id":"pay_7jcf4ovmwnqedhtldca3fjli2y"}, data)
-      assert_match(%r{"source.stored":true}, data)
+      request = JSON.parse(data)
+      assert_equal request['previous_payment_id'], 'pay_7jcf4ovmwnqedhtldca3fjli2y'
+      assert_equal request['source']['stored'], true
     end.respond_with(successful_purchase_using_stored_credential_response)
 
     assert_success response


### PR DESCRIPTION
Changed made in https://github.com/activemerchant/active_merchant/pull/4611 caused the issue I describe bellow:

I think `source.type` was added in a way that is setting the attribute in the root

![image](https://user-images.githubusercontent.com/1815383/201335248-0f380907-4d48-42e2-befc-e1bd4a38a146.png)
 instead of in 
```
    "source": {
        "type": "card",
         "stored": "true" 
```