### PR TITLE
Payeezy: Add apple pay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Reach: adding gateway [cristian] #4618
 * Orbital: integration improvements [molbrown] #4626
 * iVeri: add new url [almalee24] #4630
+* Payeezy: Enable Apple Pay support [naashton] #4631
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -178,6 +178,8 @@ module ActiveMerchant
           add_echeck(params, payment_method, options)
         elsif payment_method.is_a? String
           add_token(params, payment_method, options)
+        elsif payment_method.is_a? NetworkTokenizationCreditCard
+          add_network_tokenization(params, payment_method, options)
         else
           add_creditcard(params, payment_method)
         end
@@ -231,6 +233,22 @@ module ActiveMerchant
         card[:exp_date] = format_exp_date(payment_method.month, payment_method.year)
         card[:cvv] = payment_method.verification_value if payment_method.verification_value?
         card
+      end
+
+      def add_network_tokenization(params, payment_method, options)
+        nt_card = {}
+        nt_card[:type] = 'D'
+        nt_card[:cardholder_name] = payment_method.first_name
+        nt_card[:card_number] = payment_method.number
+        nt_card[:exp_date] = format_exp_date(payment_method.month, payment_method.year)
+        nt_card[:cvv] = payment_method.verification_value
+        nt_card[:xid] = payment_method.payment_cryptogram
+        nt_card[:cavv] = payment_method.payment_cryptogram
+        nt_card[:wallet_provider_id] = 'APPLE_PAY'
+
+        params['3DS'] = nt_card
+        params[:method] = '3DS'
+        params[:eci_indicator] = payment_method.eci
       end
 
       def format_exp_date(month, year)

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -41,6 +41,15 @@ class RemotePayeezyTest < Test::Unit::TestCase
         initiator: 'cardholder'
       }
     }
+    @apple_pay_card = network_tokenization_credit_card(
+      '4761209980011439',
+      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+      month: '11',
+      year: '2022',
+      eci: 5,
+      source: :apple_pay,
+      verification_value: 569
+    )
   end
 
   def test_successful_store
@@ -69,6 +78,11 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert_match(/Transaction Normal/, response.message)
     assert_equal '100', response.params['bank_resp_code']
     assert_equal nil, response.error_code
+    assert_success response
+  end
+
+  def test_successful_purchase_with_apple_pay
+    assert response = @gateway.purchase(@amount, @apple_pay_card, @options)
     assert_success response
   end
 


### PR DESCRIPTION
Integrate apple pay in payeezy implementation along with tests.

[Payeezy DPAN implementation](https://developer.payeezy.com/payeezy-api/apis/post/transactions-7) which is akin to our `NetworkTokenizationCreditCard` object

SER-336

Rubocop:
750 files inspected, no offenses detected

Unit: 43 tests, 201 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote: 42 tests, 172 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed