### PR TITLE
Mundipagg: authorization_secret_key GSF is not sent on all txn types

### DIFF
--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -60,11 +60,13 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:code] = authorization
         add_invoice(post, money, options)
+        add_auth_key(post, options)
         commit('capture', post, authorization)
       end
 
       def refund(money, authorization, options = {})
         add_invoice(post = {}, money, options)
+        add_auth_key(post, options)
         commit('refund', post, authorization)
       end
 
@@ -77,6 +79,7 @@ module ActiveMerchant #:nodoc:
         options.update(name: payment.name)
         options = add_customer(options) unless options[:customer_id]
         add_payment(post, payment, options)
+        add_auth_key(post, options)
         commit('store', post, options[:customer_id])
       end
 

--- a/test/remote/gateways/remote_mundipagg_test.rb
+++ b/test/remote/gateways/remote_mundipagg_test.rb
@@ -5,7 +5,7 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     @gateway = MundipaggGateway.new(fixtures(:mundipagg))
 
     @amount = 100
-    @credit_card = credit_card('4000100011112224')
+    @credit_card = credit_card('4000000000000010')
     @declined_card = credit_card('4000300011112220')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
 
@@ -66,7 +66,7 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     @options.delete(:billing_address)
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
-    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+    assert_equal 'Transação capturada com sucesso', response.message
   end
 
   def test_successful_purchase_with_more_options
@@ -85,21 +85,21 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     @options.update(holder_document: '93095135270')
     response = @gateway.purchase(@amount, @sodexo_voucher, @options)
     assert_success response
-    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+    assert_equal 'Transação capturada com sucesso', response.message
   end
 
   def test_successful_purchase_with_vr_voucher
     @options.update(holder_document: '93095135270')
     response = @gateway.purchase(@amount, @vr_voucher, @options)
     assert_success response
-    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+    assert_equal 'Transação capturada com sucesso', response.message
   end
 
   def test_successful_purchase_with_submerchant
     options = @options.update(@submerchant_options)
     response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
-    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+    assert_equal 'Transação capturada com sucesso', response.message
   end
 
   def test_failed_purchase
@@ -131,7 +131,7 @@ class RemoteMundipaggTest < Test::Unit::TestCase
     options = @options.update(@submerchant_options)
     response = @gateway.authorize(@amount, @credit_card, options)
     assert_success response
-    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+    assert_equal 'Transação authorizada com sucesso', response.message
   end
 
   def test_failed_authorize
@@ -262,7 +262,7 @@ class RemoteMundipaggTest < Test::Unit::TestCase
   def test_successful_purchase_with_api_key_overwrite
     response = @gateway.purchase(@amount, @credit_card, @options.merge(@authorization_secret_options))
     assert_success response
-    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+    assert_equal 'Transação capturada com sucesso', response.message
   end
 
   def test_failed_store_with_top_level_errors
@@ -308,13 +308,13 @@ class RemoteMundipaggTest < Test::Unit::TestCase
   def test_successful_purchase_with(card)
     response = @gateway.purchase(@amount, card, @options)
     assert_success response
-    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', response.message
+    assert_equal 'Transação capturada com sucesso', response.message
   end
 
   def test_failed_purchase_with(card)
     response = @gateway.purchase(105200, card, @options)
     assert_failure response
-    assert_equal 'Simulator|Transação de simulada negada por falta de crédito, utilizado para realizar simulação de autorização parcial.', response.message
+    assert_equal 'Transação não autorizada', response.message
   end
 
   def test_successful_authorize_and_capture_with(card)
@@ -323,13 +323,13 @@ class RemoteMundipaggTest < Test::Unit::TestCase
 
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
-    assert_equal 'Simulator|Transação de simulação capturada com sucesso', capture.message
+    assert_equal 'Transação capturada com sucesso', capture.message
   end
 
   def test_failed_authorize_with(card)
     response = @gateway.authorize(105200, card, @options)
     assert_failure response
-    assert_equal 'Simulator|Transação de simulada negada por falta de crédito, utilizado para realizar simulação de autorização parcial.', response.message
+    assert_equal 'Transação não autorizada', response.message
   end
 
   def test_partial_capture_with(card)
@@ -367,7 +367,7 @@ class RemoteMundipaggTest < Test::Unit::TestCase
   def test_successful_verify_with(card)
     response = @gateway.verify(card, @options)
     assert_success response
-    assert_match %r{Simulator|Transação de simulação autorizada com sucesso}, response.message
+    assert_match %r{Transação authorizada com sucesso}, response.message
   end
 
   def test_successful_store_and_purchase_with(card)
@@ -376,6 +376,6 @@ class RemoteMundipaggTest < Test::Unit::TestCase
 
     assert purchase = @gateway.purchase(@amount, store.authorization, @options)
     assert_success purchase
-    assert_equal 'Simulator|Transação de simulação autorizada com sucesso', purchase.message
+    assert_equal 'Transação capturada com sucesso', purchase.message
   end
 end


### PR DESCRIPTION
Description
-------------------------
The authorization_secret_key GSF is set to be only sent on auth purchase transactions (the default), but this field is used for authenticating transactions and should be passed for every transaction type.

auth key field is added to transactions that do not currently include it the remote test was updated due to outdated test card numbers

Unit test
-------------------------
Finished in 0.029899 seconds.
32 tests, 164 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote test
-------------------------
Finished in 30.504306 seconds.
41 tests, 91 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 85.3659% passed

Rubocop
-------------------------
753 files inspected, 11 offenses detected, 11 offenses corrected