### PR TITLE
Openpay: able to set endpoint URL by merchant country flag

### DIFF
--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -1,8 +1,15 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class OpenpayGateway < Gateway
-      self.live_url = 'https://api.openpay.mx/v1/'
-      self.test_url = 'https://sandbox-api.openpay.mx/v1/'
+      class_attribute :mx_live_url, :mx_test_url
+      class_attribute :co_live_url, :co_test_url
+
+      self.co_live_url = 'https://api.openpay.co/v1/'
+      self.co_test_url = 'https://sandbox-api.openpay.co/v1/'
+      self.mx_live_url = 'https://api.openpay.mx/v1/'
+      self.mx_test_url = 'https://sandbox-api.openpay.mx/v1/'
+      self.live_url = self.co_live_url
+      self.test_url = self.co_test_url
 
       self.supported_countries = %w(CO MX)
       self.supported_cardtypes = %i[visa master american_express carnet]
@@ -22,6 +29,16 @@ module ActiveMerchant #:nodoc:
         @api_key = options[:key]
         @merchant_id = options[:merchant_id]
         super
+      end
+
+      def gateway_url(options = {})
+        country = options[:merchant_country] || @options[:merchant_country]
+
+        if country == 'MX'
+          test? ? mx_test_url : mx_live_url
+        else
+          test? ? co_test_url : co_live_url
+        end
       end
 
       def purchase(money, creditcard, options = {})
@@ -192,7 +209,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def http_request(method, resource, parameters = {}, options = {})
-        url = (test? ? self.test_url : self.live_url) + @merchant_id + '/' + resource
+        url = gateway_url(options) + @merchant_id + '/' + resource
         raw_response = nil
         begin
           raw_response = ssl_request(method, url, (parameters ? parameters.to_json : nil), headers(options))

--- a/test/remote/gateways/remote_openpay_test.rb
+++ b/test/remote/gateways/remote_openpay_test.rb
@@ -16,6 +16,19 @@ class RemoteOpenpayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
+    @options[:email] = '%d@example.org' % Time.now
+    @options[:name] = 'Customer name'
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_nil response.message
+  end
+
+  def test_successful_purchase_with_mexico_url
+    @options[:email] = '%d@example.org' % Time.now
+    @options[:name] = 'Customer name'
+    credentials = fixtures(:openpay).merge(merchant_country: 'MX')
+    @gateway = OpenpayGateway.new(credentials)
+
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_nil response.message
@@ -31,7 +44,7 @@ class RemoteOpenpayTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'The card was declined', response.message
+    assert_equal 'The card was declined by the bank', response.message
   end
 
   def test_successful_refund
@@ -69,7 +82,7 @@ class RemoteOpenpayTest < Test::Unit::TestCase
   def test_unsuccessful_authorize
     assert response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'The card was declined', response.message
+    assert_equal 'The card was declined by the bank', response.message
   end
 
   def test_successful_capture

--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -31,6 +31,40 @@ class OpenpayTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_mexico_url
+    gateway = OpenpayGateway.new(
+      key: 'key',
+      merchant_id: 'merchant_id',
+      merchant_country: 'MX'
+    )
+
+    gateway.expects(:ssl_request).returns(successful_purchase_response)
+    assert_equal gateway.gateway_url, OpenpayGateway.mx_test_url
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_success response
+
+    assert_equal 'tay1mauq3re4iuuk8bm4', response.authorization
+    assert response.test?
+  end
+
+  def test_default_url_when_merchant_country_is_not_present
+    gateway = OpenpayGateway.new(
+      key: 'key',
+      merchant_id: 'merchant_id'
+    )
+    assert_equal 'https://sandbox-api.openpay.co/v1/', gateway.gateway_url
+  end
+
+  def test_set_mexico_url_using_merchant_country_flag
+    gateway = OpenpayGateway.new(
+      key: 'key',
+      merchant_id: 'merchant_id',
+      merchant_country: 'MX'
+    )
+    assert_equal 'https://sandbox-api.openpay.mx/v1/', gateway.gateway_url
+  end
+
   def test_unsuccessful_request
     @gateway.expects(:ssl_request).returns(failed_purchase_response)
 


### PR DESCRIPTION
Summary:
Add support to set service URL by setting the merchant country flag, with this capability openpay knows from which region is happening the transaction.

Remote:
25 tests, 83 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96% passed

Unit:
22 tests, 113 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
753 files inspected, no offenses detected