### PR TITLE
Revert "CyberSource: Refactor to better adhere to XSD"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,7 +33,6 @@
 * iVeri: add new url [almalee24] #4630
 * Payeezy: Enable Apple Pay support [naashton] #4631
 * Payeezy: Scrub Cryptogram [naashton] #4633
-* CyberSource: Refactor several methods to better adhere to XSD [rachelkirk] #4634
 * Checkout: Fix for `[:source][:stored]` in stored credentials [marioarranzr] #4629
 * Mundipagg: send authorization_secret_key on all transaction types [edgarv09] #4635
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -312,9 +312,9 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new indent: 2
         add_customer_id(xml, options)
         add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
+        add_other_tax(xml, options)
         add_threeds_2_ucaf_data(xml, creditcard_or_reference, options)
         add_decision_manager_fields(xml, options)
-        add_other_tax(xml, options)
         add_mdd_fields(xml, options)
         add_auth_service(xml, creditcard_or_reference, options)
         add_threeds_services(xml, options)
@@ -374,9 +374,9 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new indent: 2
         add_customer_id(xml, options)
         add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
+        add_other_tax(xml, options)
         add_threeds_2_ucaf_data(xml, payment_method_or_reference, options)
         add_decision_manager_fields(xml, options)
-        add_other_tax(xml, options)
         add_mdd_fields(xml, options)
         if (!payment_method_or_reference.is_a?(String) && card_brand(payment_method_or_reference) == 'check') || reference_is_a_check?(payment_method_or_reference)
           add_check_service(xml)
@@ -681,7 +681,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_other_tax(xml, options)
-        return unless %i[vat_tax_rate local_tax_amount national_tax_amount national_tax_indicator].any? { |gsf| options.include?(gsf) }
+        return unless options[:local_tax_amount] || options[:national_tax_amount] || options[:national_tax_indicator]
 
         xml.tag! 'otherTax' do
           xml.tag! 'vatTaxRate', options[:vat_tax_rate] if options[:vat_tax_rate]
@@ -953,10 +953,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_installments(xml, options)
-        return unless %i[installment_total_count installment_total_amount installment_plan_type first_installment_date installment_annual_interest_rate installment_grace_period_duration].any? { |gsf| options.include?(gsf) }
+        return unless options[:installment_total_count]
 
         xml.tag! 'installment' do
-          xml.tag!('totalCount', options[:installment_total_count]) if options[:installment_total_count]
+          xml.tag! 'totalCount', options[:installment_total_count]
           xml.tag!('totalAmount', options[:installment_total_amount]) if options[:installment_total_amount]
           xml.tag!('planType', options[:installment_plan_type]) if options[:installment_plan_type]
           xml.tag!('firstInstallmentDate', options[:first_installment_date]) if options[:first_installment_date]

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -66,6 +66,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       sales_slip_number: '456',
       airline_agent_code: '7Q',
       tax_management_indicator: 1,
+      installment_grace_period_duration: '1',
       invoice_amount: '3',
       original_amount: '4',
       reference_data_code: 'ABC123',
@@ -230,14 +231,6 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       installment_annual_interest_rate: 1.09,
       installment_grace_period_duration: 1
     )
-    assert response = @gateway.authorize(@amount, @credit_card, options)
-    assert_successful_response(response)
-    assert !response.authorization.blank?
-  end
-
-  def test_successful_authorization_with_less_installment_data
-    options = @options.merge(installment_grace_period_duration: '1')
-
     assert response = @gateway.authorize(@amount, @credit_card, options)
     assert_successful_response(response)
     assert !response.authorization.blank?

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -263,15 +263,6 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_authorization_response)
   end
 
-  def test_authorize_includes_less_installment_data
-    stub_comms do
-      @gateway.authorize(100, @credit_card, order_id: '1', installment_grace_period_duration: 3)
-    end.check_request do |_endpoint, data, _headers|
-      assert_xml_valid_to_xsd(data)
-      assert_match(/<installment>\s+<gracePeriodDuration>3<\/gracePeriodDuration>\s+<\/installment>/, data)
-    end.respond_with(successful_authorization_response)
-  end
-
   def test_authorize_includes_customer_id
     stub_comms do
       @gateway.authorize(100, @credit_card, customer_id: '5afefb801188d70023b7debb')


### PR DESCRIPTION
This reverts commit 77d6e0b38c769d3026b058b168e5dd65954716d0.

Local Tests
5399 tests, 76828 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit Tests
123 tests, 588 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests
118 tests, 602 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.4576% passed
*same 3 are failing on master