### PR TITLE
Reach: PSP Integration - Verify / Void / Refund

### DIFF
--- a/lib/active_merchant/billing/gateways/reach.rb
+++ b/lib/active_merchant/billing/gateways/reach.rb
@@ -69,6 +69,33 @@ module ActiveMerchant #:nodoc:
           gsub(%r((VerificationCode%22%3A)[\d]+), '\1[FILTERED]\2')
       end
 
+      def refund(amount, authorization, options = {})
+        post = {}
+        request = post[:request] = {}
+        request[:MerchantId] = @options[:merchant_id]
+        request[:OrderId] = authorization
+        request[:ReferenceId] = options[:reference_id]
+        request[:Amount] = amount
+
+        commit('refund', post)
+      end
+
+      def void(authorization, options = {})
+        post = {}
+        request = post[:request] = {}
+        request[:MerchantId] = @options[:merchant_id]
+        request[:OrderId] = authorization
+
+        commit('cancel', post)
+      end
+
+      def verify(credit_card, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, credit_card, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
       private
 
       def build_checkout_request(amount, payment, options)


### PR DESCRIPTION
## Description

This PR is based on [PR 4632](https://github.com/activemerchant/active_merchant/pull/4632)

This integration support the following payment operations:

Verify
Void
Refund

### Unit test


Finished in 40.346607 seconds.
5370 tests, 76698 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
133.10 tests/s, 1900.98 assertions/s

### Remote test
Finished in 11.168364 seconds.
12 tests, 27 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
1.07 tests/s, 2.42 assertions/s

### Rubocop
753 files inspected, no offenses detected