### PR TITLE
updating cabal BIN range

### DIFF
--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -8,6 +8,7 @@ module ActiveMerchant #:nodoc:
         'visa'               => ->(num) { num =~ /^4\d{12}(\d{3})?(\d{3})?$/ },
         'master'             => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), MASTERCARD_RANGES) },
         'elo'                => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), ELO_RANGES) },
+        'cabal'              => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 8), CABAL_RANGES) },
         'alelo'              => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), ALELO_RANGES) },
         'discover'           => ->(num) { num =~ /^(6011|65\d{2}|64[4-9]\d)\d{12,15}$/ },
         'american_express'   => ->(num) { num =~ /^3[47]\d{13}$/ },
@@ -26,7 +27,6 @@ module ActiveMerchant #:nodoc:
         'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818)\d{10}$/ },
         'alia'               => ->(num) { num =~ /^(504997|505878|601030|601073|505874)\d{10}$/ },
         'vr'                 => ->(num) { num =~ /^(627416|637036)\d{10}$/ },
-        'cabal'              => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 8), CABAL_RANGES) },
         'unionpay'           => ->(num) { (16..19).cover?(num&.size) && in_bin_range?(num.slice(0, 8), UNIONPAY_RANGES) },
         'carnet'             => lambda { |num|
           num&.size == 16 && (
@@ -210,7 +210,9 @@ module ActiveMerchant #:nodoc:
       CABAL_RANGES = [
         60420100..60440099,
         58965700..58965799,
-        60352200..60352299
+        60352200..60352299,
+        65027200..65027299,
+        65008700..65008700
       ]
 
       MADA_RANGES = [

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -306,6 +306,8 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'cabal', CreditCard.brand?('6044009000000000')
     assert_equal 'cabal', CreditCard.brand?('5896575500000000')
     assert_equal 'cabal', CreditCard.brand?('6035224400000000')
+    assert_equal 'cabal', CreditCard.brand?('6502723300000000')
+    assert_equal 'cabal', CreditCard.brand?('6500870000000000')
   end
 
   def test_should_detect_unionpay_card


### PR DESCRIPTION
DX-240

This adds a couple of Cabal 8 digit BIN ranges, and moves Cabal higher in the selection process since Discover has most of the BINs starting with 65

All local tests pass, did not run remote tests

5410 tests, 76915 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed