### PR TITLE
Element: fix bug with billing address email

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Mundipagg: send authorization_secret_key on all transaction types [edgarv09] #4635
 * CommerceHub: Add new gateway [naashton] #4640
 * CyberSource: Update installment data method [rachelkirk] #4642
+* Element: fix bug with billing address email [jcreiff] #4644
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -248,6 +248,7 @@ module ActiveMerchant #:nodoc:
 
       def add_address(xml, options)
         if address = options[:billing_address] || options[:address]
+          address[:email] ||= options[:email]
           xml.address do
             xml.BillingAddress1 address[:address1] if address[:address1]
             xml.BillingAddress2 address[:address2] if address[:address2]

--- a/test/remote/gateways/remote_element_test.rb
+++ b/test/remote/gateways/remote_element_test.rb
@@ -50,6 +50,12 @@ class RemoteElementTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_billing_email
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(email: 'test@example.com'))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_purchase_with_card_present_code
     response = @gateway.purchase(@amount, @credit_card, @options.merge(card_present_code: 'Present'))
     assert_success response

--- a/test/unit/gateways/element_test.rb
+++ b/test/unit/gateways/element_test.rb
@@ -296,6 +296,16 @@ class ElementTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_billing_email
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(email: 'test@example.com'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<BillingEmail>test@example.com</BillingEmail>', data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_credit_with_extra_fields
     credit_options = @options.merge({ ticket_number: '1', market_code: 'FoodRestaurant', merchant_supplied_transaction_id: '123' })
     stub_comms do


### PR DESCRIPTION
Enables the `add_address` method to successfully find `email` whether it is nested at the top level of the `options` hash or within the `billing_address` object

CER-330

LOCAL
5411 tests, 76919 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
756 files inspected, no offenses detected

REMOTE
29 tests, 82 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed