### PR TITLE
Reach: Fixing bug when using union pay card

### DIFF
--- a/lib/active_merchant/billing/gateways/reach.rb
+++ b/lib/active_merchant/billing/gateways/reach.rb
@@ -30,6 +30,7 @@ module ActiveMerchant #:nodoc:
         maestro: 'MAESTRO',
         master: 'MC',
         naranja: 'NARANJA',
+        union_pay: 'UNIONPAY',
         visa: 'VISA'
       }
 
@@ -110,6 +111,8 @@ module ActiveMerchant #:nodoc:
       private
 
       def build_checkout_request(amount, payment, options)
+        raise ArgumentError.new("Payment method #{payment.brand} is not supported, check https://docs.withreach.com/docs/credit-cards#technical-considerations") if PAYMENT_METHOD_MAP[payment.brand.to_sym].blank?
+
         {
           MerchantId: @options[:merchant_id],
           ReferenceId: options[:order_id],

--- a/test/unit/gateways/reach_test.rb
+++ b/test/unit/gateways/reach_test.rb
@@ -185,6 +185,14 @@ class ReachTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_raises_exceptio_when_card_brand_is_not_allowed
+    error = assert_raises(ArgumentError) do
+      @credit_card.brand = 'alelo'
+      @gateway.authorize(@amount, @credit_card, @options)
+    end
+    assert_equal 'Payment method alelo is not supported, check https://docs.withreach.com/docs/credit-cards#technical-considerations', error.message
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
## Summary:

This change aims to fix an bug related with the way to handle not supported card brands.

## Tests:

Finished in 130.664153 seconds.
25 tests, 66 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Finished in 35.408869 seconds.
5415 tests, 76945 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

152.93 tests/s, 2173.04 assertions/s
Inspecting 756 files
756 files inspected, no offenses detected