### PR TITLE
Reach: Fix bug CIT-Setup-Unscheduled

### DIFF
--- a/lib/active_merchant/billing/gateways/reach.rb
+++ b/lib/active_merchant/billing/gateways/reach.rb
@@ -165,7 +165,7 @@ module ActiveMerchant #:nodoc:
             'cardholder' => {
               'installment' => 'CIT-Setup-Scheduled',
               'unschedule' => 'CIT-Setup-Unscheduled-MIT',
-              'recurring' => 'CIT-Setup-Unschedule'
+              'recurring' => 'CIT-Setup-Unscheduled'
             }
           },
           no_initial_transaction: {

--- a/test/unit/gateways/reach_test.rb
+++ b/test/unit/gateways/reach_test.rb
@@ -134,7 +134,7 @@ class ReachTest < Test::Unit::TestCase
       [
         { { initial_transaction: true, initiator: 'cardholder', reason_type: 'installment' } => 'CIT-Setup-Scheduled' },
         { { initial_transaction: true, initiator: 'cardholder', reason_type: 'unschedule' } => 'CIT-Setup-Unscheduled-MIT' },
-        { { initial_transaction: true, initiator: 'cardholder', reason_type: 'recurring' } => 'CIT-Setup-Unschedule' },
+        { { initial_transaction: true, initiator: 'cardholder', reason_type: 'recurring' } => 'CIT-Setup-Unscheduled' },
         { { initial_transaction: false, initiator: 'cardholder', reason_type: 'unschedule' } => 'CIT-Subsequent-Unscheduled' },
         { { initial_transaction: false, initiator: 'merchant', reason_type: 'recurring' } => 'MIT-Subsequent-Scheduled' },
         { { initial_transaction: false, initiator: 'merchant', reason_type: 'unschedule' } => 'MIT-Subsequent-Unscheduled' }


### PR DESCRIPTION
Summary:
    ------------------------------
    In order to perform 'CIT-Setup-Unscheduled' this commit fix typo
    from 'CIT-Setup-Unschedule' to 'CIT-Setup-Unscheduled'

    Remote Tests:
    ------------------------------
    Finished in 36.906747 seconds.
    16 tests, 42 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed

    Unit Tests:
    ------------------------------
    Finished in 2.793742 seconds.
    16 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed

    Rubocop:
    ------------------------------
    753 files inspected, no offenses detected