### PR TITLE
Element/Vantiv: Add google pay and apple pay support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Element: Include Apple Pay - Google pay methods [jherrera] #4647
 * dLocal: Add transaction query API(s) request [almalee24] #4584
 * MercadoPago: Add transaction inquire request [molbrown] #4588
 * Worldpay: Add transaction inquire request [molbrown] #4592

--- a/test/remote/gateways/remote_element_test.rb
+++ b/test/remote/gateways/remote_element_test.rb
@@ -12,6 +12,28 @@ class RemoteElementTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase'
     }
+
+    @google_pay_network_token = network_tokenization_credit_card('4444333322221111',
+      month: '01',
+      year: Time.new.year + 2,
+      first_name: 'Jane',
+      last_name: 'Doe',
+      verification_value: '888',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      eci: '05',
+      transaction_id: '123456789',
+      source: :google_pay)
+
+    @apple_pay_network_token = network_tokenization_credit_card('4895370015293175',
+      month: '10',
+      year: Time.new.year + 2,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      payment_cryptogram: 'CeABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      eci: '07',
+      transaction_id: 'abc123',
+      source: :apple_pay)
   end
 
   def test_successful_purchase
@@ -118,6 +140,18 @@ class RemoteElementTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_merchant_descriptor
     response = @gateway.purchase(@amount, @credit_card, @options.merge(merchant_descriptor: 'Flowerpot Florists'))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_google_pay
+    response = @gateway.purchase(@amount, @google_pay_network_token, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_apple_pay
+    response = @gateway.purchase(@amount, @apple_pay_network_token, @options)
     assert_success response
     assert_equal 'Approved', response.message
   end


### PR DESCRIPTION
Summary:

This PR updates element/vantiv gateway to support apple/google pay transactions

Remote Tests

Finished in 35.250506 seconds.
31 tests, 86 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

756 files inspected, no offenses detected