### PR TITLE
Commerce_hub: Add Apple Pay and Google Pay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * CommerceHub: Add new gateway [naashton] #4640
 * CyberSource: Update installment data method [rachelkirk] #4642
 * Element: fix bug with billing address email [jcreiff] #4644
+* CommerceHub: Add Apple Pay and Google Pay [gasb150] #4648
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512


### PR DESCRIPTION
Summary:
------------------------------
In order to perform transactions using Apple Pay and Google Pay this commit adds the fields required and optionals to made succesful requests.

Remote Tests:
------------------------------
Finished in 76.906747 seconds.
18 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit Tests:
------------------------------
Finished in 0.093742 seconds.
12 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
------------------------------
756 files inspected, no offenses detected