### PR TITLE
Plexo: add 5 credit card brands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@
 * Stripe: add reverse_transfer to void transactions [jcreiff] #4668
 * Global Collect: fix bug on transaction inquire request [almalee24] #4676
 * Credorax: Support google pay and apple pay [edgarv09] #4661
+* Plexo: Add support for 5 new credit card brands (passcard, edenred, anda, tarjeta-d, sodexo) [edgarv09] #4652
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -34,6 +34,10 @@ module ActiveMerchant #:nodoc:
     # * Confiable
     # * Mada
     # * BpPlus
+    # * Passcard
+    # * Edenred
+    # * Anda
+    # * Creditos directos (Tarjeta D)
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -122,6 +126,10 @@ module ActiveMerchant #:nodoc:
       # * +'confiable'+
       # * +'mada'+
       # * +'bp_plus'+
+      # * +'passcard'+
+      # * +'edenred'+
+      # * +'anda'+
+      # * +'tarjeta-d'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -24,7 +24,7 @@ module ActiveMerchant #:nodoc:
         },
         'maestro_no_luhn'    => ->(num) { num =~ /^(501080|501081|501082)\d{6,13}$/ },
         'forbrugsforeningen' => ->(num) { num =~ /^600722\d{10}$/ },
-        'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818)\d{10}$/ },
+        'sodexo'             => ->(num) { num =~ /^(606071|603389|606070|606069|606068|600818|505864|505865)\d{10}$/ },
         'alia'               => ->(num) { num =~ /^(504997|505878|601030|601073|505874)\d{10}$/ },
         'vr'                 => ->(num) { num =~ /^(627416|637036)\d{10}$/ },
         'unionpay'           => ->(num) { (16..19).cover?(num&.size) && in_bin_range?(num.slice(0, 8), UNIONPAY_RANGES) },
@@ -41,8 +41,14 @@ module ActiveMerchant #:nodoc:
         'synchrony' => ->(num) { num =~ /^700600\d{10}$/ },
         'routex' => ->(num) { num =~ /^(700676|700678)\d{13}$/ },
         'mada' => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), MADA_RANGES) },
-        'bp_plus' => ->(num) { num =~ /^(7050\d\s\d{9}\s\d{3}$|705\d\s\d{8}\s\d{5}$)/ }
+        'bp_plus' => ->(num) { num =~ /^(7050\d\s\d{9}\s\d{3}$|705\d\s\d{8}\s\d{5}$)/ },
+        'passcard' => ->(num) { num =~ /^628026\d{10}$/ },
+        'edenred' => ->(num) { num =~ /^637483\d{10}$/ },
+        'anda' => ->(num) { num =~ /^603199\d{10}$/ },
+        'tarjeta-d' => ->(num) { num =~ /^601828\d{10}$/ }
       }
+
+      SODEXO_NO_LUHN = ->(num) { num =~ /^(505864|505865)\d{10}$/ }
 
       # http://www.barclaycard.co.uk/business/files/bin_rules.pdf
       ELECTRON_RANGES = [
@@ -388,16 +394,22 @@ module ActiveMerchant #:nodoc:
             %w[1 2 3 success failure error].include?(number)
         end
 
+        def sodexo_no_luhn?(numbers)
+          SODEXO_NO_LUHN.call(numbers)
+        end
+
         def valid_by_algorithm?(brand, numbers) #:nodoc:
           case brand
           when 'naranja'
             valid_naranja_algo?(numbers)
           when 'creditel'
             valid_creditel_algo?(numbers)
-          when 'alia', 'confiable', 'maestro_no_luhn'
+          when 'alia', 'confiable', 'maestro_no_luhn', 'anda', 'tarjeta-d'
             true
-          when 'bp_plus'
-            valid_bp_plus_algo?(numbers)
+          when 'sodexo'
+            sodexo_no_luhn?(numbers) ? true : valid_luhn?(numbers)
+          when 'bp_plus', 'passcard', 'edenred'
+            valid_luhn_non_zero_check_digit?(numbers)
           else
             valid_luhn?(numbers)
           end
@@ -463,7 +475,7 @@ module ActiveMerchant #:nodoc:
           (10 - (sum % 10)) % 10 == check_digit.to_i
         end
 
-        def valid_bp_plus_algo?(numbers)
+        def valid_luhn_non_zero_check_digit?(numbers)
           return valid_luhn?(numbers.delete(' ')) if numbers[5] == ' '
 
           check_digit = numbers[-1]

--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = ['UY']
       self.default_currency = 'UYU'
-      self.supported_cardtypes = %i[visa master american_express discover]
+      self.supported_cardtypes = %i[visa master american_express discover passcard edenred anda tarjeta-d]
 
       self.homepage_url = 'https://www.plexo.com.uy'
       self.display_name = 'Plexo'

--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -158,4 +158,109 @@ class RemotePlexoTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@gateway.options[:api_key], transcript)
   end
+
+  def test_successful_purchase_passcard
+    credit_card = credit_card('6280260025383009', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_edenred
+    credit_card = credit_card('6374830000000823', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_anda
+    credit_card = credit_card('6031991248204901', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+  end
+
+  # This test is omitted until Plexo confirms that the transaction will indeed
+  # be declined as indicated in the documentation.
+  def test_successful_purchase_and_declined_refund_anda
+    omit
+    credit_card = credit_card('6031997614492616', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    purchase = @gateway.purchase(@amount, credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @cancel_options)
+    assert_failure refund
+    assert_equal 'An internal error occurred. Contact support.', refund.message
+  end
+
+  # This test is omitted until Plexo confirms that the transaction will indeed
+  # be declined as indicated in the documentation.
+  def test_successful_purchase_and_declined_cancellation_anda
+    omit
+    credit_card = credit_card('6031998427187914', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    purchase = @gateway.purchase(@amount, credit_card, @options)
+    assert_success purchase
+
+    assert void = @gateway.void(purchase.authorization, @cancel_options)
+    assert_failure void
+  end
+
+  def test_successful_purchase_tarjetad
+    credit_card = credit_card('6018287227431046', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+  end
+
+  def test_failure_purchase_tarjetad
+    credit_card = credit_card('6018282227431033', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_failure response
+    assert_equal 'denied', response.params['status']
+    assert_equal '10', response.error_code
+  end
+
+  def test_successful_purchase_sodexo
+    credit_card = credit_card('5058645584812145', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+  end
+
+  # This test is omitted until Plexo confirms that the transaction will indeed
+  # be declined as indicated in the documentation.
+  def test_successful_purchase_and_declined_refund_sodexo
+    omit
+    credit_card = credit_card('5058647731868699', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    purchase = @gateway.purchase(@amount, credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @cancel_options)
+    assert_failure refund
+    assert_equal 'An internal error occurred. Contact support.', refund.message
+  end
+
+  def test_successful_purchase_and_declined_cancellation_sodexo
+    credit_card = credit_card('5058646599260130', month: '12', year: '2024',
+      verification_value: '111', first_name: 'Santiago', last_name: 'Navatta')
+
+    purchase = @gateway.purchase(@amount, credit_card, @options)
+    assert_success purchase
+
+    assert void = @gateway.void(purchase.authorization, @cancel_options)
+    assert_success void
+  end
 end

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -257,6 +257,61 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_equal 'olimpica', CreditCard.brand?('6368530000000000')
   end
 
+  def test_should_detect_sodexo_no_luhn_card
+    number1 = '5058645584812145'
+    number2 = '5058655584812145'
+    assert_equal 'sodexo', CreditCard.brand?(number1)
+    assert CreditCard.valid_number?(number1)
+    assert_equal 'sodexo', CreditCard.brand?(number2)
+    assert CreditCard.valid_number?(number2)
+  end
+
+  def test_should_validate_sodexo_no_luhn_card
+    assert_true CreditCard.valid_number?('5058645584812145')
+    assert_false CreditCard.valid_number?('5058665584812110')
+  end
+
+  def test_should_detect_passcard_card
+    assert_equal 'passcard', CreditCard.brand?('6280260025383009')
+    assert_equal 'passcard', CreditCard.brand?('6280260025383280')
+    assert_equal 'passcard', CreditCard.brand?('6280260025383298')
+    assert_equal 'passcard', CreditCard.brand?('6280260025383306')
+    assert_equal 'passcard', CreditCard.brand?('6280260025383314')
+  end
+
+  def test_should_validate_passcard_card
+    assert_true CreditCard.valid_number?('6280260025383009')
+    # numbers with invalid formats
+    assert_false CreditCard.valid_number?('6280_26002538_0005')
+    # numbers that are luhn-invalid
+    assert_false CreditCard.valid_number?('6280260025380991')
+  end
+
+  def test_should_detect_edenred_card
+    assert_equal 'edenred', CreditCard.brand?('6374830000000823')
+    assert_equal 'edenred', CreditCard.brand?('6374830000000799')
+    assert_equal 'edenred', CreditCard.brand?('6374830000000807')
+    assert_equal 'edenred', CreditCard.brand?('6374830000000815')
+    assert_equal 'edenred', CreditCard.brand?('6374830000000823')
+  end
+
+  def test_should_validate_edenred_card
+    assert_true CreditCard.valid_number?('6374830000000369')
+    # numbers with invalid formats
+    assert_false CreditCard.valid_number?('6374 8300000 00369')
+    # numbers that are luhn-invalid
+    assert_false CreditCard.valid_number?('6374830000000111')
+  end
+
+  def test_should_detect_anda_card
+    assert_equal 'anda', CreditCard.brand?('6031998427187914')
+  end
+
+  # Creditos directos a.k.a tarjeta d
+  def test_should_detect_tarjetad_card
+    assert_equal 'tarjeta-d', CreditCard.brand?('6018282227431033')
+  end
+
   def test_should_detect_creditel_card
     assert_equal 'creditel', CreditCard.brand?('6019330047539016')
   end


### PR DESCRIPTION
This change adds 5 new credit card brands (passcard, edenred, anda, tarjeta-d, sodexo bins ) and allows plexo gateway to use it.

Remote Tests:
Finished in 45.329665 seconds.
28 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 3 omissions, 0 notifications 100% passed

Unit Tests:
Finished in 0.013674 seconds.d
20 tests, 115 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop
756 files inspected, no offenses detected