### PR TITLE
Braintree: return additional processor response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@
 * Moneris: Add Google Pay [sinourain] #4666
 * Global Collect: Add transaction inquire request [almalee24] #4669
 * Stripe PI: Add Level 3 support [almalee24] #4673
+* Braintree: return additional processor response [jcreiff] #4653
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -480,6 +480,10 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def additional_processor_response_from_result(result)
+        result.transaction&.additional_processor_response
+      end
+
       def create_transaction(transaction_type, money, credit_card_or_vault_id, options)
         transaction_params = create_transaction_parameters(money, credit_card_or_vault_id, options)
         commit do
@@ -537,7 +541,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def transaction_hash(result)
-        return { 'processor_response_code' => response_code_from_result(result) } unless result.success?
+        unless result.success?
+          return { 'processor_response_code' => response_code_from_result(result),
+                   'additional_processor_response' => additional_processor_response_from_result(result) }
+        end
 
         transaction = result.transaction
         if transaction.vault_customer

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -632,7 +632,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, credit_card('51051051051051000'))
     assert_failure response
     assert_match %r{Credit card number is invalid\. \(81715\)}, response.message
-    assert_equal({ 'processor_response_code' => '91577' }, response.params['braintree_transaction'])
+    assert_equal('91577', response.params['braintree_transaction']['processor_response_code'])
+  end
+
+  def test_unsuccessful_purchase_with_additional_processor_response
+    assert response = @gateway.purchase(204700, @credit_card)
+    assert_failure response
+    assert_equal('2047 : Call Issuer. Pick Up Card.', response.params['braintree_transaction']['additional_processor_response'])
   end
 
   def test_authorize_and_capture
@@ -733,7 +739,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert failed_void = @gateway.void(auth.authorization)
     assert_failure failed_void
     assert_match('Transaction can only be voided if status is authorized', failed_void.message)
-    assert_equal({ 'processor_response_code' => '91504' }, failed_void.params['braintree_transaction'])
+    assert_equal('91504', failed_void.params['braintree_transaction']['processor_response_code'])
   end
 
   def test_failed_capture_with_invalid_transaction_id


### PR DESCRIPTION
Adds the `additional_processor_response` to the transaction hash for unsuccessful transactions

CER-284

LOCAL
5414 tests, 76942 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

756 files inspected, no offenses detected

REMOTE
100 tests, 491 assertions, 4 failures, 4 errors, 0 pendings, 0 omissions, 0 notifications 92% passed

These failures/errors are present on the master branch as well