### PR TITLE
Adyen: Add support for `skip_mpi_data` flag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -58,6 +58,7 @@
 * Credorax: Add support for Network Tokens [jherreraa] #4679
 * Stripe PI: use MultiResponse in create_setup_intent [jcreiff] #4683
 * Credorax: Correct NTID logic for MIT transactions [aenand] #4686
+* Adyen: Add support for `skip_mpi_data` flag [rachelkirk] #4654
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -435,7 +435,7 @@ module ActiveMerchant #:nodoc:
         elsif payment.is_a?(Check)
           add_bank_account(post, payment, options, action)
         else
-          add_mpi_data_for_network_tokenization_card(post, payment) if payment.is_a?(NetworkTokenizationCreditCard)
+          add_mpi_data_for_network_tokenization_card(post, payment, options) if payment.is_a?(NetworkTokenizationCreditCard)
           add_card(post, payment)
         end
       end
@@ -486,7 +486,9 @@ module ActiveMerchant #:nodoc:
         post[:originalReference] = original_reference
       end
 
-      def add_mpi_data_for_network_tokenization_card(post, payment)
+      def add_mpi_data_for_network_tokenization_card(post, payment, options)
+        return if options[:skip_mpi_data] == 'Y'
+
         post[:mpiData] = {}
         post[:mpiData][:authenticationResponse] = 'Y'
         post[:mpiData][:cavv] = payment.payment_cryptogram


### PR DESCRIPTION
CER-333

This change will allow for recurring payments with Apple Pay on Adyen by eliminating mpi data hash from request after initial payment.

Unit:
104 tests, 528 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
131 tests, 440 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90.8397% passed
*Failing tests mostly related to 3DS/Store transactions, also failing on master. Newly added remote test passes.

Local:
5430 tests, 77037 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed