### PR TITLE
Reach: Fixing store credentials and Exception issues

### DIFF
--- a/lib/active_merchant/billing/gateways/reach.rb
+++ b/lib/active_merchant/billing/gateways/reach.rb
@@ -114,14 +114,12 @@ module ActiveMerchant #:nodoc:
       private
 
       def build_checkout_request(amount, payment, options)
-        raise ArgumentError.new("Payment method #{payment.brand} is not supported, check https://docs.withreach.com/docs/credit-cards#technical-considerations") if PAYMENT_METHOD_MAP[payment.brand.to_sym].blank?
-
         {
           MerchantId: @options[:merchant_id],
           ReferenceId: options[:order_id],
           ConsumerCurrency: options[:currency] || currency(options[:amount]),
           Capture: options[:capture] || false,
-          PaymentMethod: PAYMENT_METHOD_MAP[payment.brand.to_sym],
+          PaymentMethod: PAYMENT_METHOD_MAP.fetch(payment.brand.to_sym, 'unsupported'),
           Items: [
             Sku: options[:item_sku] || SecureRandom.alphanumeric,
             ConsumerPrice: amount,

--- a/lib/active_merchant/billing/gateways/reach.rb
+++ b/lib/active_merchant/billing/gateways/reach.rb
@@ -153,10 +153,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_stored_credentials(request, options)
-        request[:PaymentModel] = payment_model(options)
-        raise ArgumentError, 'Unexpected combination of stored credential fields' if request[:PaymentModel].nil?
-
-        request[:DeviceFingerprint] = options[:device_fingerprint] if options[:device_fingerprint] && request[:PaymentModel].match?(/CIT-/)
+        request[:PaymentModel] = payment_model(options) || ''
+        request[:DeviceFingerprint] = options[:device_fingerprint] if options[:device_fingerprint]
       end
 
       def payment_model(options)

--- a/lib/active_merchant/billing/gateways/reach.rb
+++ b/lib/active_merchant/billing/gateways/reach.rb
@@ -166,21 +166,21 @@ module ActiveMerchant #:nodoc:
           initial_transaction: {
             'cardholder' => {
               'installment' => 'CIT-Setup-Scheduled',
-              'unschedule' => 'CIT-Setup-Unscheduled-MIT',
+              'unscheduled' => 'CIT-Setup-Unscheduled-MIT',
               'recurring' => 'CIT-Setup-Unscheduled'
             }
           },
           no_initial_transaction: {
             'cardholder' => {
-              'unschedule' => 'CIT-Subsequent-Unscheduled'
+              'unscheduled' => 'CIT-Subsequent-Unscheduled'
             },
             'merchant' => {
               'recurring' => 'MIT-Subsequent-Scheduled',
-              'unschedule' => 'MIT-Subsequent-Unscheduled'
+              'unscheduled' => 'MIT-Subsequent-Unscheduled'
             }
           }
         }
-        initial = (stored_credential[:initial_transaction] ? :initial_transaction : :no_initial_transaction)
+        initial = stored_credential[:initial_transaction] ? :initial_transaction : :no_initial_transaction
         payment_model_options[initial].dig(stored_credential[:initiator], stored_credential[:reason_type])
       end
 

--- a/lib/active_merchant/billing/gateways/reach.rb
+++ b/lib/active_merchant/billing/gateways/reach.rb
@@ -82,21 +82,24 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(amount, authorization, options = {})
-        post = {}
-        request = post[:request] = {}
-        request[:MerchantId] = @options[:merchant_id]
-        request[:OrderId] = authorization
-        request[:ReferenceId] = options[:reference_id]
-        request[:Amount] = amount
-
+        post = {
+          request: {
+            MerchantId: @options[:merchant_id],
+            OrderId: authorization,
+            ReferenceId: options[:order_id] || options[:reference_id],
+            Amount: amount
+          }
+        }
         commit('refund', post)
       end
 
       def void(authorization, options = {})
-        post = {}
-        request = post[:request] = {}
-        request[:MerchantId] = @options[:merchant_id]
-        request[:OrderId] = authorization
+        post = {
+          request: {
+            MerchantId: @options[:merchant_id],
+            OrderId: authorization
+          }
+        }
 
         commit('cancel', post)
       end

--- a/test/remote/gateways/remote_reach_test.rb
+++ b/test/remote/gateways/remote_reach_test.rb
@@ -173,7 +173,7 @@ class RemoteReachTest < Test::Unit::TestCase
     @options[:stored_credential] = { initiator: 'cardholder', initial_transaction: true, reason_type: 'installment' }
     purchase = @gateway.purchase(@amount, @credit_card, @options)
 
-    @options[:stored_credential] = { initiator: 'merchant', initial_transaction: false, reason_type: 'unschedule', network_transaction_id: purchase.network_transaction_id }
+    @options[:stored_credential] = { initiator: 'merchant', initial_transaction: false, reason_type: 'unscheduled', network_transaction_id: purchase.network_transaction_id }
     response = @gateway.purchase(@amount, @credit_card, @options)
 
     assert_success response
@@ -183,7 +183,7 @@ class RemoteReachTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase_with_store_credentials_mit_and_network_transaction_id
-    @options[:stored_credential] = { initiator: 'merchant', initial_transaction: false, reason_type: 'unschedule', network_transaction_id: 'uhh123' }
+    @options[:stored_credential] = { initiator: 'merchant', initial_transaction: false, reason_type: 'unscheduled', network_transaction_id: 'uhh123' }
     response = @gateway.purchase(@amount, @credit_card, @options)
 
     assert_failure response

--- a/test/remote/gateways/remote_reach_test.rb
+++ b/test/remote/gateways/remote_reach_test.rb
@@ -9,6 +9,12 @@ class RemoteReachTest < Test::Unit::TestCase
       year: 2030,
       verification_value: 737
     })
+    @not_supported_cc = credit_card('4444333322221111', {
+      month: 3,
+      year: 2030,
+      verification_value: 737,
+      brand: 'alelo'
+    })
     @declined_card = credit_card('4000300011112220')
     @options = {
       email: 'johndoe@reach.com',
@@ -189,6 +195,14 @@ class RemoteReachTest < Test::Unit::TestCase
     assert_failure response
 
     assert_equal response.message, 'InvalidPreviousNetworkPaymentReference'
+  end
+
+  def test_failed_purchase_payment_model_nil
+    @options[:stored_credential] = { initiator: 'merchant', initial_transaction: false, reason_type: 'installment', network_transaction_id: 'uhh123' }
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert_equal 'Invalid PaymentModel', response.message
   end
 
   def test_failed_capture

--- a/test/remote/gateways/remote_reach_test.rb
+++ b/test/remote/gateways/remote_reach_test.rb
@@ -191,11 +191,22 @@ class RemoteReachTest < Test::Unit::TestCase
     assert_equal 'Not Found', response.message
   end
 
-  def test_successful_refund
+  def test_successful_refund_with_reference_id
     response = @gateway.refund(
       @amount,
       '5cd04b6a-7189-4a71-a335-faea4de9e11d',
       { reference_id: 'REFUND_TAG' }
+    )
+
+    assert_success response
+    assert response.params['response']['RefundId'].present?
+  end
+
+  def test_successful_refund_with_order_id
+    response = @gateway.refund(
+      @amount,
+      '5cd04b6a-7189-4a71-a335-faea4de9e11d',
+      { order_id: 'REFUND_TAG' }
     )
 
     assert_success response

--- a/test/remote/gateways/remote_reach_test.rb
+++ b/test/remote/gateways/remote_reach_test.rb
@@ -45,6 +45,13 @@ class RemoteReachTest < Test::Unit::TestCase
     assert_equal 'Invalid ConsumerCurrency', response.message
   end
 
+  def test_failed_authorize_with_not_supported_payment_method
+    response = @gateway.authorize(@amount, @not_supported_cc, @options)
+
+    assert_failure response
+    assert_equal 'PaymentMethodUnsupported', response.error_code
+  end
+
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
 

--- a/test/unit/gateways/reach_test.rb
+++ b/test/unit/gateways/reach_test.rb
@@ -133,11 +133,11 @@ class ReachTest < Test::Unit::TestCase
     cases =
       [
         { { initial_transaction: true, initiator: 'cardholder', reason_type: 'installment' } => 'CIT-Setup-Scheduled' },
-        { { initial_transaction: true, initiator: 'cardholder', reason_type: 'unschedule' } => 'CIT-Setup-Unscheduled-MIT' },
+        { { initial_transaction: true, initiator: 'cardholder', reason_type: 'unscheduled' } => 'CIT-Setup-Unscheduled-MIT' },
         { { initial_transaction: true, initiator: 'cardholder', reason_type: 'recurring' } => 'CIT-Setup-Unscheduled' },
-        { { initial_transaction: false, initiator: 'cardholder', reason_type: 'unschedule' } => 'CIT-Subsequent-Unscheduled' },
+        { { initial_transaction: false, initiator: 'cardholder', reason_type: 'unscheduled' } => 'CIT-Subsequent-Unscheduled' },
         { { initial_transaction: false, initiator: 'merchant', reason_type: 'recurring' } => 'MIT-Subsequent-Scheduled' },
-        { { initial_transaction: false, initiator: 'merchant', reason_type: 'unschedule' } => 'MIT-Subsequent-Unscheduled' }
+        { { initial_transaction: false, initiator: 'merchant', reason_type: 'unscheduled' } => 'MIT-Subsequent-Unscheduled' }
       ]
 
     cases.each do |stored_credential_case|

--- a/test/unit/gateways/reach_test.rb
+++ b/test/unit/gateways/reach_test.rb
@@ -202,10 +202,9 @@ class ReachTest < Test::Unit::TestCase
   def succesful_query_response
     'response=%7B%22Meta%22%3A%20null%2C%20%22Rate%22%3A%201.000000000000%2C%20%22Items%22%3A%20%5B%7B%22Sku%22%3A%20%22RLaP7OsSZjbR2pJK%22%2C%20%22Quantity%22%3A%201%2C%20%22ConsumerPrice%22%3A%20100.00%2C%20%22MerchantPrice%22%3A%20100.00%7D%5D%2C%20%22Store%22%3A%20null%2C%20%22Times%22%3A%20%7B%22Created%22%3A%20%222022-12-05T17%3A48%3A18.830991Z%22%2C%20%22Processed%22%3A%20null%2C%20%22Authorized%22%3A%20%222022-12-05T17%3A48%3A19.855608Z%22%7D%2C%20%22Action%22%3A%20null%2C%20%22Expiry%22%3A%20%222022-12-12T17%3A48%3A19.855608Z%22%2C%20%22Reason%22%3A%20null%2C%20%22Charges%22%3A%20null%2C%20%22OrderId%22%3A%20%226ec68268-a4a5-44dd-8997-e76df4aa9c97%22%2C%20%22Payment%22%3A%20%7B%22Class%22%3A%20%22Card%22%2C%20%22Expiry%22%3A%20%222030-03%22%2C%20%22Method%22%3A%20%22VISA%22%2C%20%22AccountIdentifier%22%3A%20%22444433******1111%22%2C%20%22NetworkPaymentReference%22%3A%20%22546646904394415%22%7D%2C%20%22Refunds%22%3A%20%5B%5D%2C%20%22Consumer%22%3A%20%7B%22City%22%3A%20%22Miami%22%2C%20%22Name%22%3A%20%22Longbob%20Longsen%22%2C%20%22Email%22%3A%20%22johndoe%40reach.com%22%2C%20%22Address%22%3A%20%221670%22%2C%20%22Country%22%3A%20%22US%22%2C%20%22EffectiveIpAddress%22%3A%20%22181.78.14.203%22%7D%2C%20%22Shipping%22%3A%20null%2C%20%22Consignee%22%3A%20null%2C%20%22Discounts%22%3A%20null%2C%20%22Financing%22%3A%20null%2C%20%22Chargeback%22%3A%20false%2C%20%22ContractId%22%3A%20null%2C%20%22MerchantId%22%3A%20%22testMerchantId%22%2C%20%22OrderState%22%3A%20%22PaymentAuthorized%22%2C%20%22RateOfferId%22%3A%20%22c754012f-e0fc-4630-9cb5-11c3450f462e%22%2C%20%22ReferenceId%22%3A%20%22123%22%2C%20%22UnderReview%22%3A%20false%2C%20%22ConsumerTotal%22%3A%20100.00%2C%20%22MerchantTotal%22%3A%20100.00%2C%20%22TransactionId%22%3A%20%22e08f6501-2607-4be1-9dba-97d6780dfe9a%22%2C%20%22ConsumerCurrency%22%3A%20%22USD%22%7D&signature=no%2BEojgxrO5JK4wt4EWtbuY9M7h1eVQ9SLezu10X%2Bn4%3D'
   end
-end
 
-def pre_scrubbed
-  <<-PRE_SCRUBBED
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
     <- "POST /v2.21/checkout HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: checkout.rch.how\r\nContent-Length: 756\r\n\r\n"
     <- "request=%7B%22MerchantId%22%3A%22Some-30value-4for3-9test35-f93086cd7crednet1%22%2C%22ReferenceId%22%3A%22123%22%2C%22ConsumerCurrency%22%3A%22USD%22%2C%22Capture%22%3Atrue%2C%22PaymentMethod%22%3A%22VISA%22%2C%22Items%22%3A%5B%7B%22Sku%22%3A%22d99oJA8rkwgQANFJ%22%2C%22ConsumerPrice%22%3A100%2C%22Quantity%22%3A1%7D%5D%2C%22ViaAgent%22%3Atrue%2C%22Consumer%22%3A%7B%22Name%22%3A%22Longbob+Longsen%22%2C%22Email%22%3A%22johndoe%40reach.com%22%2C%22Address%22%3A%221670%22%2C%22City%22%3A%22Miami%22%2C%22Country%22%3A%22US%22%7D%7D&card=%7B%22Name%22%3A%22Longbob+Longsen%22%2C%22Number%22%3A%224444333322221111%22%2C%22Expiry%22%3A%7B%22Month%22%3A3%2C%22Year%22%3A2030%7D%2C%22VerificationCode%22%3A737%7D&signature=5nimSignatUre%3D"
     -> "HTTP/1.1 200 OK\r\n"
@@ -222,11 +221,11 @@ def pre_scrubbed
     -> "response=%7B%22OrderId%22%3A%22621a0c76-69fb-4c05-854a-e7e731759ad3%22%2C%22UnderReview%22%3Afalse%2C%22Authorized%22%3Atrue%2C%22Completed%22%3Afalse%2C%22Captured%22%3Afalse%7D&signature=23475signature23123%3D"
     read 235 bytes
     Conn close
-  PRE_SCRUBBED
-end
+    PRE_SCRUBBED
+  end
 
-def post_scrubbed
-  <<-POST_SRCUBBED
+  def post_scrubbed
+    <<-POST_SRCUBBED
     <- "POST /v2.21/checkout HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: checkout.rch.how\r\nContent-Length: 756\r\n\r\n"
     <- "request=%7B%22MerchantId%22%3A%22[FILTERED]%22%2C%22ReferenceId%22%3A%22123%22%2C%22ConsumerCurrency%22%3A%22USD%22%2C%22Capture%22%3Atrue%2C%22PaymentMethod%22%3A%22VISA%22%2C%22Items%22%3A%5B%7B%22Sku%22%3A%22d99oJA8rkwgQANFJ%22%2C%22ConsumerPrice%22%3A100%2C%22Quantity%22%3A1%7D%5D%2C%22ViaAgent%22%3Atrue%2C%22Consumer%22%3A%7B%22Name%22%3A%22Longbob+Longsen%22%2C%22Email%22%3A%22johndoe%40reach.com%22%2C%22Address%22%3A%221670%22%2C%22City%22%3A%22Miami%22%2C%22Country%22%3A%22US%22%7D%7D&card=%7B%22Name%22%3A%22Longbob+Longsen%22%2C%22Number%22%3A%22[FILTERED]%22%2C%22Expiry%22%3A%7B%22Month%22%3A3%2C%22Year%22%3A2030%7D%2C%22VerificationCode%22%3A[FILTERED]%7D&signature=[FILTERED]"
     -> "HTTP/1.1 200 OK\r\n"
@@ -243,5 +242,6 @@ def post_scrubbed
     -> "response=%7B%22OrderId%22%3A%22621a0c76-69fb-4c05-854a-e7e731759ad3%22%2C%22UnderReview%22%3Afalse%2C%22Authorized%22%3Atrue%2C%22Completed%22%3Afalse%2C%22Captured%22%3Afalse%7D&signature=[FILTERED]"
     read 235 bytes
     Conn close
-  POST_SRCUBBED
+    POST_SRCUBBED
+  end
 end


### PR DESCRIPTION
## Summary:

This PR solves 5 issues:

1) Remove exception for no allowed store credentials combination and leave the field empty.

2) Remove exception for not supported card brand and sent instead a not supported string.

3) Fixes a Typo on stored credentials code and test related with 'unscheduled' transactions.

4) Uses the order_id (transaction token) to populate the ReferenceId field.

5) Fixes and add the corresponding tests for 1 to 3.

## Test

### Remote Test:
Finished in 136.495605 seconds.
27 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 33.332219 seconds.
5419 tests, 76964 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
756 files inspected, no offenses detected