### PR TITLE
Reach: Update store credentials to use a GSF

### DIFF
--- a/test/remote/gateways/remote_reach_test.rb
+++ b/test/remote/gateways/remote_reach_test.rb
@@ -142,6 +142,36 @@ class RemoteReachTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_store_credentials_with_payment_model_option
+    @options[:payment_model] = 'CIT-Subsequent-Unscheduled'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_success response
+
+    assert response.params['response']['Authorized']
+    assert response.params['response']['OrderId']
+  end
+
+  def test_successful_purchase_store_credentials_with_payment_model_option_mit
+    @options[:payment_model] = 'MIT-Subsequent-Scheduled'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_success response
+
+    assert response.params['response']['Authorized']
+    assert response.params['response']['OrderId']
+  end
+
+  def test_successful_purchase_store_credentials_with_payment_model_option_cit
+    @options[:payment_model] = 'CIT-One-Time'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_success response
+
+    assert response.params['response']['Authorized']
+    assert response.params['response']['OrderId']
+  end
+
   def test_successful_purchase_with_store_credentials
     @options[:stored_credential] = { initiator: 'cardholder', initial_transaction: true, reason_type: 'installment' }
     response = @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/reach_test.rb
+++ b/test/unit/gateways/reach_test.rb
@@ -163,6 +163,27 @@ class ReachTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_stored_credential_with_reach_payment_model
+    reach_options = [
+      'CIT-Setup-Scheduled',
+      'CIT-Setup-Unscheduled-MIT',
+      'CIT-Setup-Unscheduled',
+      'CIT-Subsequent-Unscheduled',
+      'MIT-Subsequent-Scheduled',
+      'MIT-Subsequent-Unscheduled'
+    ]
+
+    reach_options.each do |payment_model|
+      @options[:payment_model] = payment_model
+      stub_comms do
+        @gateway.purchase(@amount, @credit_card, @options)
+      end.check_request do |_endpoint, data, _headers|
+        request = JSON.parse(URI.decode_www_form(data)[0][1])
+        assert_equal payment_model, request['PaymentModel']
+      end.respond_with(successful_purchase_response)
+    end
+  end
+
   def test_stored_credential_with_wrong_combination_stored_credential_paramaters
     @options[:stored_credential] = { initiator: 'merchant', initial_transaction: true, reason_type: 'unschedule' }
     e = assert_raise ArgumentError do


### PR DESCRIPTION
Description
-------------------------

Reach has implemented stored credentials using the Spreedly’s determination and this commit Update this in order to use directly the options from Reach gateway using  GSF (payment_model)

SER-463

Unit test
-------------------------

Finished in 0.199618 seconds.
18 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
90.17 tests/s, 460.88 assertions/s

Remote test
-------------------------

Finished in 146.011021 seconds.
28 tests, 75 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
0.19 tests/s, 0.51 assertions/s

Rubocop
-------------------------

756 files inspected, no offenses detected