### PR TITLE
EBANX: add soft_descriptor field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,6 +41,7 @@
 * Openpay: set URL by merchant country [edgarv09] #4637
 * Alelo: Improving credentials refresh process [heavyblade] #4616
 * Decidir: Add transaction inquire request [almalee24] #4649
+* EBANX: add soft_descriptor field [jcreiff] #4658
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -59,7 +59,7 @@ module ActiveMerchant #:nodoc:
         add_operation(post)
         add_invoice(post, money, options)
         add_customer_data(post, payment, options)
-        add_card_or_token(post, payment)
+        add_card_or_token(post, payment, options)
         add_address(post, options)
         add_customer_responsible_person(post, payment, options)
         add_additional_data(post, options)
@@ -73,7 +73,7 @@ module ActiveMerchant #:nodoc:
         add_operation(post)
         add_invoice(post, money, options)
         add_customer_data(post, payment, options)
-        add_card_or_token(post, payment)
+        add_card_or_token(post, payment, options)
         add_address(post, options)
         add_customer_responsible_person(post, payment, options)
         add_additional_data(post, options)
@@ -188,10 +188,11 @@ module ActiveMerchant #:nodoc:
         post[:payment][:order_number] = options[:order_id][0..39] if options[:order_id]
       end
 
-      def add_card_or_token(post, payment)
+      def add_card_or_token(post, payment, options)
         payment, brand = payment.split('|') if payment.is_a?(String)
         post[:payment][:payment_type_code] = payment.is_a?(String) ? brand : CARD_BRAND[payment.brand.to_sym]
         post[:payment][:creditcard] = payment_details(payment)
+        post[:payment][:creditcard][:soft_descriptor] = options[:soft_descriptor] if options[:soft_descriptor]
       end
 
       def add_payment_details(post, payment)

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -23,7 +23,8 @@ class RemoteEbanxTest < Test::Unit::TestCase
         metadata_1: 'test',
         metadata_2: 'test2'
       },
-      tags: EbanxGateway::TAGS
+      tags: EbanxGateway::TAGS,
+      soft_descriptor: 'ActiveMerchant'
     }
   end
 

--- a/test/unit/gateways/ebanx_test.rb
+++ b/test/unit/gateways/ebanx_test.rb
@@ -36,6 +36,16 @@ class EbanxTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_soft_descriptor
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge(soft_descriptor: 'ActiveMerchant'))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match %r{"soft_descriptor\":\"ActiveMerchant\"}, data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_request).returns(failed_purchase_response)
 


### PR DESCRIPTION
This field can be optionally passed in with the `creditcard` hash

LOCAL:
5421 tests, 76971 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

756 files inspected, no offenses detected

REMOTE:
26 tests, 70 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.1538% passed
- This test also fails on the master branch

CER-317