### PR TITLE
Credorax: enable google pay apple pay

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -28,6 +28,11 @@ module ActiveMerchant #:nodoc:
       self.money_format = :cents
       self.supported_cardtypes = %i[visa master maestro american_express jcb discover diners_club]
 
+      NETWORK_TOKENIZATION_CARD_SOURCE = {
+        'apple_pay' => 'applepay',
+        'google_pay' => 'googlepay'
+      }
+
       RESPONSE_MESSAGES = {
         '00' => 'Approved or completed successfully',
         '01' => 'Refer to card issuer',
@@ -278,7 +283,8 @@ module ActiveMerchant #:nodoc:
       }
 
       def add_payment_method(post, payment_method)
-        post[:c1] = payment_method.name
+        post[:c1] = payment_method&.name || ''
+        post[:b21] = NETWORK_TOKENIZATION_CARD_SOURCE[payment_method.source.to_s] if payment_method.is_a? NetworkTokenizationCreditCard
         post[:b2] = CARD_TYPES[payment_method.brand] || ''
         post[:b1] = payment_method.number
         post[:b5] = payment_method.verification_value

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -6,10 +6,10 @@ class RemoteCredoraxTest < Test::Unit::TestCase
 
     @amount = 100
     @adviser_amount = 1000001
-    @credit_card = credit_card('4176661000001015', verification_value: '281', month: '12', year: '2022')
-    @fully_auth_card = credit_card('5223450000000007', brand: 'mastercard', verification_value: '090', month: '12', year: '2025')
-    @declined_card = credit_card('4176661000001111', verification_value: '681', month: '12', year: '2022')
-    @three_ds_card = credit_card('4761739000060016', verification_value: '212', month: '12', year: '2027')
+    @credit_card = credit_card('4176661000001015', verification_value: '281', month: '12')
+    @fully_auth_card = credit_card('5223450000000007', brand: 'mastercard', verification_value: '090', month: '12')
+    @declined_card = credit_card('4176661000001111', verification_value: '681', month: '12')
+    @three_ds_card = credit_card('4761739000060016', verification_value: '212', month: '12')
     @options = {
       order_id: '1',
       currency: 'EUR',
@@ -44,6 +44,49 @@ class RemoteCredoraxTest < Test::Unit::TestCase
         }
       }
     }
+
+    @apple_pay_card = network_tokenization_credit_card('4176661000001015',
+      month: 10,
+      year: Time.new.year + 2,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+      eci: '07',
+      transaction_id: 'abc123',
+      source: :apple_pay)
+
+    @google_pay_card = network_tokenization_credit_card('4176661000001015',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: Time.new.year + 2,
+      source: :google_pay,
+      transaction_id: '123456789',
+      eci: '05')
+  end
+
+  def test_successful_purchase_with_apple_pay
+    response = @gateway.purchase(@amount, @apple_pay_card, @options)
+    assert_success response
+    assert_equal '1', response.params['H9']
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_google_pay
+    response = @gateway.purchase(@amount, @google_pay_card, @options)
+    assert_success response
+    assert_equal '1', response.params['H9']
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_transcript_scrubbing_network_tokenization_card
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @apple_pay_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@apple_pay_card.number, transcript)
+    assert_scrubbed(@apple_pay_card.payment_cryptogram, transcript)
   end
 
   def test_invalid_login


### PR DESCRIPTION
Summary:
------------------------------
Enable the Credorax gateway to support payments via google pay and apple pay 

Remote Test:
------------------------------
54 tests, 66 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100% passed

Unit Tests:
------------------------------
5416 tests, 76949 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100% passed

RuboCop:
------------------------------
756 files inspected, no offenses detected