### PR TITLE
Rapyd: Add customer object to transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,7 @@
 * Tns: update test URL [almalee24] #4698
 * TrustCommerce: Update `authorization_from` to handle `store` response [jherreraa] #4691
 * TrustCommerce: Verify feature added [jherreraa] #4692
+* Rapyd: Add customer object to transactions [javierpedrozaing] #4664
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -46,9 +46,50 @@ class RemoteRapydTest < Test::Unit::TestCase
       xid: '00000000000000000501',
       eci: '02'
     }
+
+    @address_object = address(line_1: '123 State Street', line_2: 'Apt. 34', phone_number: '12125559999')
+
+    @customer_object = {
+      name: 'John Doe',
+      phone_number: '1234567890',
+      email: 'est@example.com',
+      addresses: [@address_object]
+    }
   end
 
   def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_authorize_with_customer_object
+    @options[:customer] = @customer_object
+    @options[:pm_type] = 'us_debit_mastercard_card'
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_purchase_with_customer_object
+    @options[:customer] = @customer_object
+    @options[:pm_type] = 'us_debit_mastercard_card'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_success_purchase_without_customer_fullname
+    @credit_card.first_name = ''
+    @credit_card.last_name = ''
+    @options[:pm_type] = 'us_debit_mastercard_card'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_success_purchase_without_address_object_customer
+    @options[:pm_type] = 'us_debit_discover_card'
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'SUCCESS', response.message

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -39,6 +39,15 @@ class RapydTest < Test::Unit::TestCase
     }
 
     @ewallet_id = 'ewallet_1a867a32b47158b30a8c17d42f12f3f1'
+
+    @address_object = address(line_1: '123 State Street', line_2: 'Apt. 34', phone_number: '12125559999')
+
+    @customer_object = {
+      name: 'John Doe',
+      phone_number: '1234567890',
+      email: 'est@example.com',
+      addresses: [@address_object]
+    }
   end
 
   def test_successful_purchase
@@ -64,7 +73,7 @@ class RapydTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_token
-    @options.merge(customer_id: 'cus_9e1b5a357b2b7f25f8dd98827fbc4f22')
+    @options[:customer_id] = 'cus_9e1b5a357b2b7f25f8dd98827fbc4f22'
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @authorization, @options)
     end.check_request do |_method, _endpoint, data, _headers|
@@ -206,6 +215,27 @@ class RapydTest < Test::Unit::TestCase
     assert_success unstore
     assert_equal true, unstore.params.dig('data', 'deleted')
     assert_equal customer_id, unstore.params.dig('data', 'id')
+  end
+
+  def test_failed_purchase_without_customer_object
+    @options[:pm_type] = 'us_debit_visa_card'
+    @gateway.expects(:ssl_request).returns(failed_purchase_response)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'ERROR_PROCESSING_CARD - [05]', response.params['status']['error_code']
+  end
+
+  def test_successful_purchase_with_customer_object
+    stub_comms(@gateway, :ssl_request) do
+      @options[:customer] = @customer_object
+      @options[:pm_type] = 'us_debit_mastercard_card'
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
+      assert_match(/"name":"Jim Reynolds"/, data)
+      assert_match(/"email":"test@example.com"/, data)
+      assert_match(/"phone_number":"5555555555"/, data)
+      assert_match(/"address1":"456 My Street","address2":"Apt 1","company":"Widgets Inc","city":"Ottawa","state":"ON","zip":"K1C2N6","country":"CA"/, data)
+    end
   end
 
   def test_successful_store_with_customer_object


### PR DESCRIPTION
Description
-------------------------
Rapyd Gateway send customer info on store transactions, with this commit it will be able to send customer on authorize and purchase transaction, when it use a US “PMT”s include the addresses object into the customer data in order to be able to perform US transactions properly.

GWI-489

Unit test
-------------------------

Finished in 0.123245 seconds.
22 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote test
-------------------------

Finished in 100.082672 seconds.
33 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
0.33 tests/s, 0.92 assertions/s

Rubocop
-------------------------

756 files inspected, no offenses detected