### PR TITLE
AM: Fixing year dependant failing tests

### DIFF
--- a/test/unit/gateways/alelo_test.rb
+++ b/test/unit/gateways/alelo_test.rb
@@ -76,7 +76,7 @@ class AleloTest < Test::Unit::TestCase
       assert_equal @credit_card.number, request[:cardNumber]
       assert_equal @credit_card.name, request[:cardholderName]
       assert_equal @credit_card.month, request[:expirationMonth]
-      assert_equal 23, request[:expirationYear]
+      assert_equal @credit_card.year - 2000, request[:expirationYear]
       assert_equal '3', request[:captureType]
       assert_equal @credit_card.verification_value, request[:securityCode]
       assert_equal @options[:establishment_code], request[:establishmentCode]

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -133,7 +133,7 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['dpan'], '4444333322221111'
     assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['cryptogram'], 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['eci'], '05'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], '0124'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], "01#{payment.year.to_s[-2..-1]}"
     assert_equal 'TOKENIZED_CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
   end
 
@@ -147,7 +147,7 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_equal post['mobilePaymentMethodSpecificInput']['authorizationMode'], 'FINAL_AUTHORIZATION'
     assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
     assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['pan'], '4444333322221111'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], '0124'
+    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], "01#{payment.year.to_s[-2..-1]}"
     assert_equal 'CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
   end
 


### PR DESCRIPTION
### Summary
Changes a couple of tests that depend on date year

### Unit test
Finished in 40.268913 seconds.
5424 tests, 77006 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Rubocop
756 files inspected, no offenses detected