### PR TITLE
Reach: fix amount handling to work with cents properly

### DIFF
--- a/test/remote/gateways/remote_reach_test.rb
+++ b/test/remote/gateways/remote_reach_test.rb
@@ -215,7 +215,7 @@ class RemoteReachTest < Test::Unit::TestCase
   def test_successful_refund_with_reference_id
     response = @gateway.refund(
       @amount,
-      '5cd04b6a-7189-4a71-a335-faea4de9e11d',
+      '7d689cc1-4478-4e92-8cd9-f05528cde2f4',
       { reference_id: 'REFUND_TAG' }
     )
 
@@ -226,7 +226,7 @@ class RemoteReachTest < Test::Unit::TestCase
   def test_successful_refund_with_order_id
     response = @gateway.refund(
       @amount,
-      '5cd04b6a-7189-4a71-a335-faea4de9e11d',
+      '7d689cc1-4478-4e92-8cd9-f05528cde2f4',
       { order_id: 'REFUND_TAG' }
     )
 


### PR DESCRIPTION
## Summary:

Provides proper format handling on reach gateway to receive amount as cents on authorize/purchase and refund.

## Remote Test:

Finished in 105.613556 seconds.
28 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## Unit Tests:
Finished in 30.429736 seconds.
5425 tests, 77010 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## RuboCop:
756 files inspected, no offenses detected