### PR TITLE
Payeezy name from `billing_address` on `purchase`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@
 * Global Collect: Add transaction inquire request [almalee24] #4669
 * Stripe PI: Add Level 3 support [almalee24] #4673
 * Braintree: return additional processor response [jcreiff] #4653
+* Payeezy: name from `billing_address` on `purchase` [naashton] #4674
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -241,7 +241,7 @@ module ActiveMerchant
       def add_network_tokenization(params, payment_method, options)
         nt_card = {}
         nt_card[:type] = 'D'
-        nt_card[:cardholder_name] = payment_method.first_name
+        nt_card[:cardholder_name] = payment_method.first_name || name_from_address(options)
         nt_card[:card_number] = payment_method.number
         nt_card[:exp_date] = format_exp_date(payment_method.month, payment_method.year)
         nt_card[:cvv] = payment_method.verification_value
@@ -256,6 +256,11 @@ module ActiveMerchant
 
       def format_exp_date(month, year)
         "#{format(month, :two_digits)}#{format(year, :two_digits)}"
+      end
+
+      def name_from_address(options)
+        return unless address = options[:billing_address]
+        return address[:name] if address[:name]
       end
 
       def add_address(params, options)

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -45,7 +45,7 @@ class RemotePayeezyTest < Test::Unit::TestCase
       '4761209980011439',
       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
       month: '11',
-      year: '2022',
+      year: Time.now.year + 1,
       eci: 5,
       source: :apple_pay,
       verification_value: 569
@@ -115,6 +115,23 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@options_standardized_stored_credentials))
     assert_match(/Transaction Normal/, response.message)
     assert_success response
+  end
+
+  def test_successful_purchase_with_apple_pay_name_from_billing_address
+    @apple_pay_card.first_name = nil
+    @apple_pay_card.last_name = nil
+    assert response = @gateway.purchase(@amount, @apple_pay_card, @options)
+    assert_success response
+    assert_equal 'Jim Smith', response.params['card']['cardholder_name']
+  end
+
+  def test_failed_purchase_with_apple_pay_no_name
+    @options[:billing_address] = nil
+    @apple_pay_card.first_name = nil
+    @apple_pay_card.last_name = nil
+    assert response = @gateway.purchase(@amount, @apple_pay_card, @options)
+    assert_failure response
+    assert_equal 'Bad Request (27) - Invalid Card Holder', response.message
   end
 
   def test_failed_purchase


### PR DESCRIPTION
Allow for the `billing_address` name value to be used if the `name` value is blank for the payment method

Unit:
45 tests, 206 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote: 45 tests, 180 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed