### PR TITLE
CheckoutV2: Add store/unstore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -64,6 +64,7 @@
 * TrustCommerce: Update `authorization_from` to handle `store` response [jherreraa] #4691
 * TrustCommerce: Verify feature added [jherreraa] #4692
 * Rapyd: Add customer object to transactions [javierpedrozaing] #4664
+* CheckoutV2: Add store/unstore [gasb150] #4677
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -19,12 +19,14 @@ module ActiveMerchant #:nodoc:
       def initialize(options = {})
         @options = options
         @access_token = nil
-        begin
+
+        if options.has_key?(:secret_key)
           requires!(options, :secret_key)
-        rescue ArgumentError
+        else
           requires!(options, :client_id, :client_secret)
           @access_token = setup_access_token
         end
+
         super
       end
 
@@ -39,7 +41,6 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:capture] = false
         build_auth_or_purchase(post, amount, payment_method, options)
-
         options[:incremental_authorization] ? commit(:incremental_authorize, post, options[:incremental_authorization]) : commit(:authorize, post)
       end
 
@@ -86,7 +87,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify_payment(authorization, option = {})
-        commit(:verify_payment, authorization)
+        commit(:verify_payment, nil, authorization, :get)
       end
 
       def supports_scrubbing?
@@ -99,7 +100,34 @@ module ActiveMerchant #:nodoc:
           gsub(/("number\\":\\")\d+/, '\1[FILTERED]').
           gsub(/("cvv\\":\\")\d+/, '\1[FILTERED]').
           gsub(/("cryptogram\\":\\")\w+/, '\1[FILTERED]').
-          gsub(/(source\\":\{.*\\"token\\":\\")\d+/, '\1[FILTERED]')
+          gsub(/(source\\":\{.*\\"token\\":\\")\d+/, '\1[FILTERED]').
+          gsub(/("token\\":\\")\w+/, '\1[FILTERED]')
+      end
+
+      def store(payment_method, options = {})
+        post = {}
+        MultiResponse.run do |r|
+          if payment_method.is_a?(NetworkTokenizationCreditCard)
+            r.process { verify(payment_method, options) }
+            break r unless r.success?
+
+            r.params['source']['customer'] = r.params['customer']
+            r.process { response(:store, true, r.params['source']) }
+          else
+            r.process { tokenize(payment_method, options) }
+            break r unless r.success?
+
+            token = r.params['token']
+            add_payment_method(post, token, options)
+            post.merge!(post.delete(:source))
+            add_customer_data(post, options)
+            r.process { commit(:store, post) }
+          end
+        end
+      end
+
+      def unstore(id, options = {})
+        commit(:unstore, nil, id, :delete)
       end
 
       private
@@ -142,7 +170,8 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(post, payment_method, options, key = :source)
         post[key] = {}
-        if payment_method.is_a?(NetworkTokenizationCreditCard)
+        case payment_method
+        when NetworkTokenizationCreditCard
           token_type = token_type_from(payment_method)
           cryptogram = payment_method.payment_cryptogram
           eci = payment_method.eci || options[:eci]
@@ -153,7 +182,7 @@ module ActiveMerchant #:nodoc:
           post[key][:token_type] = token_type
           post[key][:cryptogram] = cryptogram if cryptogram
           post[key][:eci] = eci if eci
-        elsif payment_method.is_a?(CreditCard)
+        when CreditCard
           post[key][:type] = 'card'
           post[key][:name] = payment_method.name
           post[key][:number] = payment_method.number
@@ -169,7 +198,14 @@ module ActiveMerchant #:nodoc:
             post[key][:last_name] = payment_method.last_name if payment_method.last_name
           end
         end
-        unless payment_method.is_a?(String)
+        if payment_method.is_a?(String)
+          if /tok/.match?(payment_method)
+            post[:type] = 'token'
+            post[:token] = payment_method
+          else
+            add_source(post, options)
+          end
+        elsif payment_method.try(:year)
           post[key][:expiry_year] = format(payment_method.year, :four_digits)
           post[key][:expiry_month] = format(payment_method.month, :two_digits)
         end
@@ -280,11 +316,12 @@ module ActiveMerchant #:nodoc:
         response['access_token']
       end
 
-      def commit(action, post, authorization = nil)
+      def commit(action, post, authorization = nil, method = :post)
         begin
-          raw_response = (action == :verify_payment ? ssl_get("#{base_url}/payments/#{post}", headers) : ssl_post(url(post, action, authorization), post.to_json, headers))
+          raw_response = ssl_request(method, url(action, authorization), post.to_json, headers(action))
           response = parse(raw_response)
           response['id'] = response['_links']['payment']['href'].split('/')[-1] if action == :capture && response.key?('_links')
+          source_id = authorization if action == :unstore
         rescue ResponseError => e
           raise unless e.response.code.to_s =~ /4\d\d/
 
@@ -293,45 +330,62 @@ module ActiveMerchant #:nodoc:
 
         succeeded = success_from(action, response)
 
-        response(action, succeeded, response)
+        response(action, succeeded, response, source_id)
       end
 
-      def response(action, succeeded, response)
+      def response(action, succeeded, response, source_id = nil)
         successful_response = succeeded && action == :purchase || action == :authorize
         avs_result = successful_response ? avs_result(response) : nil
         cvv_result = successful_response ? cvv_result(response) : nil
-
+        authorization = authorization_from(response) unless action == :unstore
+        body = action == :unstore ? { response_code: response.to_s } : response
         Response.new(
           succeeded,
           message_from(succeeded, response),
-          response,
-          authorization: authorization_from(response),
-          error_code: error_code_from(succeeded, response),
+          body,
+          authorization: authorization,
+          error_code: error_code_from(succeeded, body),
           test: test?,
           avs_result: avs_result,
           cvv_result: cvv_result
         )
       end
 
-      def headers
+      def headers(action)
         auth_token = @access_token ? "Bearer #{@access_token}" : @options[:secret_key]
+        auth_token = @options[:public_key] if action == :tokens
         {
           'Authorization' => auth_token,
           'Content-Type' => 'application/json;charset=UTF-8'
         }
       end
 
-      def url(_post, action, authorization)
-        if %i[authorize purchase credit].include?(action)
+      def tokenize(payment_method, options = {})
+        post = {}
+        add_authorization_type(post, options)
+        add_payment_method(post, payment_method, options)
+        add_customer_data(post, options)
+        commit(:tokens, post[:source])
+      end
+
+      def url(action, authorization)
+        case action
+        when :authorize, :purchase, :credit
           "#{base_url}/payments"
-        elsif action == :capture
+        when :unstore, :store
+          "#{base_url}/instruments/#{authorization}"
+        when :capture
           "#{base_url}/payments/#{authorization}/captures"
-        elsif action == :refund
+        when :refund
           "#{base_url}/payments/#{authorization}/refunds"
-        elsif action == :void
+        when :void
           "#{base_url}/payments/#{authorization}/voids"
-        elsif action == :incremental_authorize
+        when :incremental_authorize
           "#{base_url}/payments/#{authorization}/authorizations"
+        when :tokens
+          "#{base_url}/tokens"
+        when :verify_payment
+          "#{base_url}/payments/#{authorization}"
         else
           "#{base_url}/payments/#{authorization}/#{action}"
         end
@@ -363,7 +417,12 @@ module ActiveMerchant #:nodoc:
 
       def success_from(action, response)
         return response['status'] == 'Pending' if action == :credit
+        return true if action == :unstore && response == 204
 
+        store_response = response['token'] || response['id']
+        if store_response
+          return true if (action == :tokens && store_response.match(/tok/)) || (action == :store && store_response.match(/src_/))
+        end
         response['response_summary'] == 'Approved' || response['approved'] == true || !response.key?('response_summary') && response.key?('action_id')
       end
 
@@ -414,6 +473,16 @@ module ActiveMerchant #:nodoc:
           'googlepay'
         when :apple_pay
           'applepay'
+        end
+      end
+
+      def handle_response(response)
+        case response.code.to_i
+        # to get the response code after unstore(delete instrument), because the body is nil
+        when 200...300
+          response.body || response.code
+        else
+          raise ResponseError.new(response)
         end
       end
     end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -198,6 +198,10 @@ checkout_v2:
   client_id: CLIENT_ID_FOR_OAUTH_TRANSACTIONS
   client_secret: CLIENT_SECRET_FOR_OAUTH_TRANSACTIONS
 
+checkout_v2_token:
+  secret_key: sk_sbox_xxxxxxxxxxxxxxxxx
+  public_key: pk_sbox_xxxxxxxxxxxxxxxxx
+
 citrus_pay:
   userid: CPF00001
   password: 7c70414732de7e0ba3a04db5f24fcec8

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -18,13 +18,16 @@ class CheckoutV2Test < Test::Unit::TestCase
       secret_key: '1111111111111'
     )
     @gateway_oauth = CheckoutV2Gateway.new({ client_id: 'abcd', client_secret: '1234' })
-
+    @gateway_api = CheckoutV2Gateway.new({
+      secret_key: '1111111111111',
+      public_key: '2222222222222'
+    })
     @credit_card = credit_card
     @amount = 100
   end
 
   def test_successful_purchase
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(successful_purchase_response)
 
@@ -34,7 +37,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_includes_avs_result
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(successful_purchase_response)
 
@@ -45,7 +48,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_includes_cvv_result
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(successful_purchase_response)
 
@@ -57,9 +60,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       '4242424242424242',
       { source: :network_token, brand: 'visa' }
     )
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, network_token)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
 
       assert_equal(request_data['source']['type'], 'network_token')
@@ -75,18 +78,18 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_passing_processing_channel_id
-    stub_comms do
+    stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, { processing_channel_id: '123456abcde' })
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
       assert_equal(request_data['processing_channel_id'], '123456abcde')
     end.respond_with(successful_purchase_response)
   end
 
   def test_successful_passing_incremental_authorization
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, { incremental_authorization: 'abcd1234' })
-    end.check_request do |endpoint, _data, _headers|
+    end.check_request do |_method, endpoint, _data, _headers|
       assert_include endpoint, 'abcd1234'
     end.respond_with(successful_incremental_authorize_response)
 
@@ -94,18 +97,18 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_passing_authorization_type
-    stub_comms do
+    stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, { authorization_type: 'Estimated' })
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
       assert_equal(request_data['authorization_type'], 'Estimated')
     end.respond_with(successful_purchase_response)
   end
 
   def test_successful_passing_exemption_and_challenge_indicator
-    stub_comms do
+    stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, { execute_threed: true, exemption: 'no_preference', challenge_indicator: 'trusted_listing' })
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
       assert_equal(request_data['3ds']['exemption'], 'no_preference')
       assert_equal(request_data['3ds']['challenge_indicator'], 'trusted_listing')
@@ -113,9 +116,9 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_passing_capture_type
-    stub_comms do
+    stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, 'abc', { capture_type: 'NonFinal' })
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
       assert_equal(request_data['capture_type'], 'NonFinal')
     end.respond_with(successful_capture_response)
@@ -126,9 +129,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       '4242424242424242',
       { source: :network_token, brand: 'visa', eci: '06' }
     )
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, network_token)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
 
       assert_equal(request_data['source']['type'], 'network_token')
@@ -148,9 +151,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       '5436031030606378',
       { source: :network_token, brand: 'master' }
     )
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, network_token)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
 
       assert_equal(request_data['source']['type'], 'network_token')
@@ -170,9 +173,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       '4242424242424242',
       { source: :apple_pay, eci: '05', payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA' }
     )
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, network_token)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
 
       assert_equal(request_data['source']['type'], 'network_token')
@@ -192,9 +195,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       '4242424242424242',
       { source: :android_pay, eci: '05', payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA' }
     )
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, network_token)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
 
       assert_equal(request_data['source']['type'], 'network_token')
@@ -214,9 +217,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       '4242424242424242',
       { source: :google_pay, eci: '05', payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA' }
     )
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, network_token)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
 
       assert_equal(request_data['source']['type'], 'network_token')
@@ -236,9 +239,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       '4242424242424242',
       { source: :google_pay }
     )
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, network_token)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
 
       assert_equal(request_data['source']['type'], 'network_token')
@@ -266,7 +269,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_authorize_includes_avs_result
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
     end.respond_with(successful_authorize_response)
 
@@ -277,7 +280,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_authorize_includes_cvv_result
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
     end.respond_with(successful_authorize_response)
 
@@ -285,9 +288,9 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_purchase_with_additional_fields
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, { descriptor_city: 'london', descriptor_name: 'sherlock' })
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"billing_descriptor\":{\"name\":\"sherlock\",\"city\":\"london\"}/, data)
     end.respond_with(successful_purchase_response)
 
@@ -297,16 +300,16 @@ class CheckoutV2Test < Test::Unit::TestCase
   def test_successful_purchase_passing_metadata_with_mada_card_type
     @credit_card.brand = 'mada'
 
-    stub_comms do
+    stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request_data = JSON.parse(data)
       assert_equal(request_data['metadata']['udf1'], 'mada')
     end.respond_with(successful_purchase_response)
   end
 
   def test_failed_purchase
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(failed_purchase_response)
     assert_failure response
@@ -314,14 +317,14 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_authorize_and_capture
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
     end.respond_with(successful_authorize_response)
 
     assert_success response
     assert_equal 'pay_fj3xswqe3emuxckocjx6td73ni', response.authorization
 
-    capture = stub_comms do
+    capture = stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, response.authorization)
     end.respond_with(successful_capture_response)
 
@@ -329,7 +332,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_authorize_and_capture_with_additional_options
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         card_on_file: true,
         transaction_indicator: 2,
@@ -340,7 +343,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         }
       }
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"stored":"true"}, data)
       assert_match(%r{"payment_type":"Recurring"}, data)
       assert_match(%r{"previous_payment_id":"pay_123"}, data)
@@ -351,7 +354,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success response
     assert_equal 'pay_fj3xswqe3emuxckocjx6td73ni', response.authorization
 
-    capture = stub_comms do
+    capture = stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, response.authorization)
     end.respond_with(successful_capture_response)
 
@@ -359,7 +362,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_stored_credentials
-    initial_response = stub_comms do
+    initial_response = stub_comms(@gateway, :ssl_request) do
       initial_options = {
         stored_credential: {
           initial_transaction: true,
@@ -367,7 +370,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         }
       }
       @gateway.purchase(@amount, @credit_card, initial_options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"payment_type":"Recurring"}, data)
       assert_match(%r{"merchant_initiated":false}, data)
     end.respond_with(successful_purchase_initial_stored_credential_response)
@@ -376,7 +379,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_equal 'pay_7jcf4ovmwnqedhtldca3fjli2y', initial_response.params['id']
     network_transaction_id = initial_response.params['id']
 
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         stored_credential: {
           initial_transaction: false,
@@ -385,7 +388,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         }
       }
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
       assert_equal request['previous_payment_id'], 'pay_7jcf4ovmwnqedhtldca3fjli2y'
       assert_equal request['source']['stored'], true
@@ -396,7 +399,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_stored_credentials_merchant_initiated_transaction_id
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         stored_credential: {
           initial_transaction: false
@@ -404,7 +407,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         merchant_initiated_transaction_id: 'pay_7jcf4ovmwnqedhtldca3fjli2y'
       }
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
       assert_equal request['previous_payment_id'], 'pay_7jcf4ovmwnqedhtldca3fjli2y'
       assert_equal request['source']['stored'], true
@@ -415,7 +418,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_metadata
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         metadata: {
           coupon_code: 'NY2018',
@@ -423,7 +426,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         }
       }
       @gateway.purchase(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"coupon_code":"NY2018"}, data)
       assert_match(%r{"partner_id":"123989"}, data)
     end.respond_with(successful_purchase_using_stored_credential_response)
@@ -432,7 +435,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_authorize_and_capture_with_metadata
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         metadata: {
           coupon_code: 'NY2018',
@@ -440,7 +443,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         }
       }
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"coupon_code":"NY2018"}, data)
       assert_match(%r{"partner_id":"123989"}, data)
     end.respond_with(successful_authorize_response)
@@ -448,7 +451,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success response
     assert_equal 'pay_fj3xswqe3emuxckocjx6td73ni', response.authorization
 
-    capture = stub_comms do
+    capture = stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, response.authorization)
     end.respond_with(successful_capture_response)
 
@@ -456,14 +459,14 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_moto_transaction_is_properly_set
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         metadata: {
           manual_entry: true
         }
       }
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"payment_type":"MOTO"}, data)
     end.respond_with(successful_authorize_response)
 
@@ -471,13 +474,13 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_3ds_passed
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         execute_threed: true,
         callback_url: 'https://www.example.com'
       }
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"success_url"}, data)
       assert_match(%r{"failure_url"}, data)
     end.respond_with(successful_authorize_response)
@@ -502,7 +505,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_authorize_and_capture_with_3ds
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         execute_threed: true,
         attempt_n3d: true,
@@ -520,7 +523,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success response
     assert_equal 'pay_fj3xswqe3emuxckocjx6td73ni', response.authorization
 
-    capture = stub_comms do
+    capture = stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, response.authorization)
     end.respond_with(successful_capture_response)
 
@@ -528,7 +531,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_authorize_and_capture_with_3ds2
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         execute_threed: true,
         three_d_secure: {
@@ -545,7 +548,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success response
     assert_equal 'pay_fj3xswqe3emuxckocjx6td73ni', response.authorization
 
-    capture = stub_comms do
+    capture = stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, response.authorization)
     end.respond_with(successful_capture_response)
 
@@ -553,7 +556,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_failed_authorize
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
     end.respond_with(failed_authorize_response)
 
@@ -563,7 +566,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_failed_capture
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.capture(100, '')
     end.respond_with(failed_capture_response)
 
@@ -571,14 +574,14 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_void
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card)
     end.respond_with(successful_authorize_response)
 
     assert_success response
     assert_equal 'pay_fj3xswqe3emuxckocjx6td73ni', response.authorization
 
-    void = stub_comms do
+    void = stub_comms(@gateway, :ssl_request) do
       @gateway.void(response.authorization)
     end.respond_with(successful_void_response)
 
@@ -586,7 +589,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_void_with_metadata
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         metadata: {
           coupon_code: 'NY2018',
@@ -594,7 +597,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         }
       }
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"coupon_code":"NY2018"}, data)
       assert_match(%r{"partner_id":"123989"}, data)
     end.respond_with(successful_authorize_response)
@@ -602,7 +605,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success response
     assert_equal 'pay_fj3xswqe3emuxckocjx6td73ni', response.authorization
 
-    void = stub_comms do
+    void = stub_comms(@gateway, :ssl_request) do
       @gateway.void(response.authorization)
     end.respond_with(successful_void_response)
 
@@ -610,7 +613,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_failed_void
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.void('5d53a33d960c46d00f5dc061947d998c')
     end.respond_with(failed_void_response)
     assert_failure response
@@ -623,9 +626,9 @@ class CheckoutV2Test < Test::Unit::TestCase
       source_id: 'ca_spwmped4qmqenai7hcghquqle4',
       account_holder_type: 'individual'
     }
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.credit(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
       assert_equal request['instruction']['funds_transfer_type'], options[:funds_transfer_type]
       assert_equal request['source']['type'], options[:source_type]
@@ -638,14 +641,14 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_refund
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(successful_purchase_response)
 
     assert_success response
     assert_equal 'pay_bgv5tmah6fmuzcmcrcro6exe6m', response.authorization
 
-    refund = stub_comms do
+    refund = stub_comms(@gateway, :ssl_request) do
       @gateway.refund(@amount, response.authorization)
     end.respond_with(successful_refund_response)
 
@@ -653,7 +656,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_refund_with_metadata
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       options = {
         metadata: {
           coupon_code: 'NY2018',
@@ -661,7 +664,7 @@ class CheckoutV2Test < Test::Unit::TestCase
         }
       }
       @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
+    end.check_request do |_method, _endpoint, data, _headers|
       assert_match(%r{"coupon_code":"NY2018"}, data)
       assert_match(%r{"partner_id":"123989"}, data)
     end.respond_with(successful_purchase_response)
@@ -669,7 +672,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success response
     assert_equal 'pay_bgv5tmah6fmuzcmcrcro6exe6m', response.authorization
 
-    refund = stub_comms do
+    refund = stub_comms(@gateway, :ssl_request) do
       @gateway.refund(@amount, response.authorization)
     end.respond_with(successful_refund_response)
 
@@ -677,7 +680,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.refund(nil, '')
     end.respond_with(failed_refund_response)
 
@@ -685,7 +688,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_successful_verify
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.verify(@credit_card)
     end.respond_with(successful_verify_response)
     assert_success response
@@ -693,11 +696,38 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_failed_verify
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.verify(@credit_card)
     end.respond_with(failed_verify_response)
     assert_failure response
     assert_equal 'request_invalid: card_number_invalid', response.message
+  end
+
+  def test_successful_store
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.store(@credit_card)
+    end.check_request do |_method, endpoint, data, _headers|
+      if /tokens/.match?(endpoint)
+        assert_match(%r{"type":"card"}, data)
+        assert_match(%r{"number":"4242424242424242"}, data)
+        assert_match(%r{"cvv":"123"}, data)
+        assert_match('/tokens', endpoint)
+      elsif /instruments/.match?(endpoint)
+        assert_match(%r{"type":"token"}, data)
+        assert_match(%r{"token":"tok_}, data)
+      end
+    end.respond_with(succesful_token_response, succesful_store_response)
+  end
+
+  def test_successful_tokenize
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.send(:tokenize, @credit_card)
+    end.check_request do |_action, endpoint, data, _headers|
+      assert_match(%r{"type":"card"}, data)
+      assert_match(%r{"number":"4242424242424242"}, data)
+      assert_match(%r{"cvv":"123"}, data)
+      assert_match('/tokens', endpoint)
+    end.respond_with(succesful_token_response)
   end
 
   def test_transcript_scrubbing
@@ -709,7 +739,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_invalid_json
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(invalid_json_response)
 
@@ -718,7 +748,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_error_code_returned
-    response = stub_comms do
+    response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card)
     end.respond_with(error_code_response)
 
@@ -727,7 +757,7 @@ class CheckoutV2Test < Test::Unit::TestCase
   end
 
   def test_4xx_error_message
-    @gateway.expects(:ssl_post).raises(error_4xx_response)
+    @gateway.expects(:ssl_request).raises(error_4xx_response)
 
     assert response = @gateway.purchase(@amount, @credit_card)
 
@@ -772,6 +802,12 @@ class CheckoutV2Test < Test::Unit::TestCase
   def successful_purchase_response
     %(
       {"id":"pay_bgv5tmah6fmuzcmcrcro6exe6m","action_id":"act_bgv5tmah6fmuzcmcrcro6exe6m","amount":200,"currency":"USD","approved":true,"status":"Authorized","auth_code":"127172","eci":"05","scheme_id":"096091887499308","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_fzp3cwkf4ygebbmvrxdhyrwmbm","type":"card","billing_address":{"address_line1":"456 My Street","address_line2":"Apt 1","city":"Ottawa","state":"ON","zip":"K1C2N6","country":"CA"},"expiry_month":6,"expiry_year":2025,"name":"Longbob Longsen","scheme":"Visa","last4":"4242","fingerprint":"9F3BAD2E48C6C8579F2F5DC0710B7C11A8ACD5072C3363A72579A6FB227D64BE","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_tz76qzbwr44ezdfyzdvrvlwogy","email":"longbob.longsen@example.com","name":"Longbob Longsen"},"processed_on":"2020-09-11T13:58:32Z","reference":"1","processing":{"acquirer_transaction_id":"9819327011","retrieval_reference_number":"861613285622"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_bgv5tmah6fmuzcmcrcro6exe6m"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_bgv5tmah6fmuzcmcrcro6exe6m/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_bgv5tmah6fmuzcmcrcro6exe6m/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_bgv5tmah6fmuzcmcrcro6exe6m/voids"}}}
+    )
+  end
+
+  def succesful_store_response
+    %(
+      {"id":"src_vzzqipykt5ke5odazx5d7nikii","type":"card","fingerprint":"9F3BAD2E48C6C8579F2F5DC0710B7C11A8ACD5072C3363A72579A6FB227D64BE","expiry_month":6,"expiry_year":2025,"scheme":"VISA","last4":"4242","bin":"424242","card_type":"CREDIT","card_category":"CONSUMER","issuer_country":"GB","product_id":"F","product_type":"Visa Classic","customer":{"id":"cus_gmthnluatgounpoiyzbmn5fvua", "email":"longbob.longsen@example.com"}}
     )
   end
 
@@ -1033,6 +1069,10 @@ class CheckoutV2Test < Test::Unit::TestCase
     %(
       {"id":"pay_tkvif5mf54eerhd3ysuawfcnt4","requested_on":"2019-08-14T18:13:54Z","source":{"id":"src_lot2ch4ygk3ehi4fugxmk7r2di","type":"card","expiry_month":12,"expiry_year":2020,"name":"Jane Doe","scheme":"Visa","last4":"0907","fingerprint":"E4048195442B0059D73FD47F6E1961A02CD085B0B34B7703CE4A93750DB5A0A1","bin":"457382","avs_check":"S","cvv_check":"Y"},"amount":100,"currency":"USD","payment_type":"Regular","reference":"Dvy8EMaEphrMWolKsLVHcUqPsyx","status":"Authorized","approved":true,"3ds":{"downgraded":false,"enrolled":"Y","authentication_response":"Y","cryptogram":"ce49b5c1-5d3c-4864-bd16-2a8c","xid":"95202312-f034-48b4-b9b2-54254a2b49fb","version":"2.1.0"},"risk":{"flagged":false},"customer":{"id":"cus_zt5pspdtkypuvifj7g6roy7p6y","name":"Jane Doe"},"billing_descriptor":{"name":"","city":"London"},"payment_ip":"127.0.0.1","metadata":{"Udf5":"ActiveMerchant"},"eci":"05","scheme_id":"638284745624527","actions":[{"id":"act_tkvif5mf54eerhd3ysuawfcnt4","type":"Authorization","response_code":"10000","response_summary":"Approved"}],"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_tkvif5mf54eerhd3ysuawfcnt4"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_tkvif5mf54eerhd3ysuawfcnt4/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_tkvif5mf54eerhd3ysuawfcnt4/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_tkvif5mf54eerhd3ysuawfcnt4/voids"}}}
     )
+  end
+
+  def succesful_token_response
+    %({"type":"card","token":"tok_267wy4hwrpietkmbbp5iswwhvm","expires_on":"2023-01-03T20:18:49.0006481Z","expiry_month":6,"expiry_year":2025,"name":"Longbob Longsen","scheme":"VISA","last4":"4242","bin":"424242","card_type":"CREDIT","card_category":"CONSUMER","issuer_country":"GB","product_id":"F","product_type":"Visa Classic"})
   end
 
   def failed_verify_payment_response


### PR DESCRIPTION
 Summary:
    ------------------------------
    In order to use Third Party Vaulting (TPV), this commit adds store and unstore methods.

Remote test
    -----------------------
    Finished in 240.268913 seconds.
    82 tests, 203 assertions, 2 failures, 0 errors,
    0 pendings, 0 omissions, 0 notifications
    97.561% passed

Unit test
    -----------------------
    Finished in 0.268913 seconds.
    52 tests, 289 assertions, 0 failures, 0 errors,
    0 pendings, 0 omissions, 0 notifications
    100% passed

Rubocop
    -----------------------
    756 files inspected, no offenses detected