### PR TITLE
Enable the Credorax gateway to support payments via network_token

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -30,7 +30,8 @@ module ActiveMerchant #:nodoc:
 
       NETWORK_TOKENIZATION_CARD_SOURCE = {
         'apple_pay' => 'applepay',
-        'google_pay' => 'googlepay'
+        'google_pay' => 'googlepay',
+        'network_token' => 'vts_mdes_token'
       }
 
       RESPONSE_MESSAGES = {
@@ -284,12 +285,18 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(post, payment_method)
         post[:c1] = payment_method&.name || ''
-        post[:b21] = NETWORK_TOKENIZATION_CARD_SOURCE[payment_method.source.to_s] if payment_method.is_a? NetworkTokenizationCreditCard
+        add_network_tokenization_card(post, payment_method) if payment_method.is_a? NetworkTokenizationCreditCard
         post[:b2] = CARD_TYPES[payment_method.brand] || ''
         post[:b1] = payment_method.number
         post[:b5] = payment_method.verification_value
         post[:b4] = format(payment_method.year, :two_digits)
         post[:b3] = format(payment_method.month, :two_digits)
+      end
+
+      def add_network_tokenization_card(post, payment_method)
+        post[:b21] = NETWORK_TOKENIZATION_CARD_SOURCE[payment_method.source.to_s]
+        post[:token_eci] = payment_method&.eci if payment_method.source.to_s == 'network_token'
+        post[:token_crypto] = payment_method&.payment_cryptogram if payment_method.source.to_s == 'network_token'
       end
 
       def add_stored_credential(post, options)

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -62,7 +62,13 @@ class RemoteCredoraxTest < Test::Unit::TestCase
       year: Time.new.year + 2,
       source: :google_pay,
       transaction_id: '123456789',
-      eci: '05')
+      eci: '07')
+
+    @nt_credit_card = network_tokenization_credit_card('4176661000001015',
+      brand: 'visa',
+      eci: '07',
+      source: :network_token,
+      payment_cryptogram: 'AgAAAAAAosVKVV7FplLgQRYAAAA=')
   end
 
   def test_successful_purchase_with_apple_pay
@@ -74,6 +80,13 @@ class RemoteCredoraxTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_google_pay
     response = @gateway.purchase(@amount, @google_pay_card, @options)
+    assert_success response
+    assert_equal '1', response.params['H9']
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_network_token
+    response = @gateway.purchase(@amount, @nt_credit_card, @options)
     assert_success response
     assert_equal '1', response.params['H9']
     assert_equal 'Succeeded', response.message

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -42,6 +42,23 @@ class CredoraxTest < Test::Unit::TestCase
         }
       }
     }
+
+    @nt_credit_card = network_tokenization_credit_card('4176661000001015',
+      brand: 'visa',
+      eci: '07',
+      source: :network_token,
+      payment_cryptogram: 'AgAAAAAAosVKVV7FplLgQRYAAAA=')
+
+    @apple_pay_card = network_tokenization_credit_card('4176661000001015',
+      month: 10,
+      year: Time.new.year + 2,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+      eci: '07',
+      transaction_id: 'abc123',
+      source: :apple_pay)
   end
 
   def test_supported_card_types
@@ -1047,6 +1064,26 @@ class CredoraxTest < Test::Unit::TestCase
     @gateway.add_3ds_2_optional_fields(post, options)
 
     assert_equal post, {}
+  end
+
+  def test_successful_purchase_with_network_token
+    response = stub_comms do
+      @gateway.purchase(@amount, @nt_credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/b21=vts_mdes_token&token_eci=07&token_crypto=AgAAAAAAosVKVV7FplLgQRYAAAA%3D/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_other_than_network_token
+    response = stub_comms do
+      @gateway.purchase(@amount, @apple_pay_card)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/b21=applepay/, data)
+      assert_not_match(/token_eci=/, data)
+      assert_not_match(/token_crypto=/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
   end
 
   private


### PR DESCRIPTION
Summary:
------------------------------
Enable the Credorax gateway to support payments via network_token 

Remote Test:
------------------------------
51 tests, 163 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
76.4706% passed

tests failures not related with the changes

Unit Tests:
------------------------------
82 tests, 393 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
------------------------------
756 files inspected, no offenses detected