### PR TITLE
Stripe PI: use MultiResponse in create_setup_intent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,6 +56,7 @@
 * Plexo: Add support for 5 new credit card brands (passcard, edenred, anda, tarjeta-d, sodexo) [edgarv09] #4652
 * Authorize.net: Google pay token support [sainterman] #4659
 * Credorax: Add support for Network Tokens [jherreraa] #4679
+* Stripe PI: use MultiResponse in create_setup_intent [jcreiff] #4683
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1204,6 +1204,13 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'Your card was declined.', verify.message
   end
 
+  def test_verify_stores_response_for_payment_method_creation
+    assert verify = @gateway.verify(@visa_card)
+
+    assert_equal 2, verify.responses.count
+    assert_match 'pm_', verify.responses.first.params['id']
+  end
+
   def test_moto_enabled_card_requires_action_when_not_marked
     options = {
       currency: 'GBP',


### PR DESCRIPTION
This change makes it possible to access the result of the call to `/payment_methods` alongside the ultimate result of the call to `/setup_intents` in the response 

CER-357

REMOTE
80 tests, 378 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

UNIT
5439 tests, 77065 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

756 files inspected, no offenses detected