### PR TITLE
Credorax: Update MIT logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,7 @@
 * Authorize.net: Google pay token support [sainterman] #4659
 * Credorax: Add support for Network Tokens [jherreraa] #4679
 * Stripe PI: use MultiResponse in create_setup_intent [jcreiff] #4683
+* Credorax: Correct NTID logic for MIT transactions [aenand] #4686
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -307,18 +307,14 @@ module ActiveMerchant #:nodoc:
         if stored_credential[:initiator] == 'merchant'
           case stored_credential[:reason_type]
           when 'recurring'
-            recurring_properties(post, stored_credential)
+            post[:a9] = stored_credential[:initial_transaction] ? '1' : '2'
           when 'installment', 'unscheduled'
             post[:a9] = '8'
           end
+          post[:g6] = stored_credential[:network_transaction_id] if stored_credential[:network_transaction_id]
         else
           post[:a9] = '9'
         end
-      end
-
-      def recurring_properties(post, stored_credential)
-        post[:a9] = stored_credential[:initial_transaction] ? '1' : '2'
-        post[:g6] = stored_credential[:network_transaction_id] if stored_credential[:network_transaction_id]
       end
 
       def add_customer_data(post, options)

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -546,7 +546,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
     assert_success purchase
     assert_equal '8', purchase.params['A9']
-    assert network_transaction_id = purchase.params['Z13']
+    assert network_transaction_id = purchase.params['Z50']
 
     used_options = stored_credential_options(:merchant, :installment, id: network_transaction_id)
     assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
@@ -570,7 +570,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
     assert_success purchase
     assert_equal '8', purchase.params['A9']
-    assert network_transaction_id = purchase.params['Z13']
+    assert network_transaction_id = purchase.params['Z50']
 
     used_options = stored_credential_options(:merchant, :unscheduled, id: network_transaction_id)
     assert purchase = @gateway.purchase(@amount, @credit_card, used_options)

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -1003,6 +1003,7 @@ class CredoraxTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/a9=8/, data)
+      assert_match(/g6=abc123/, data)
     end.respond_with(successful_authorize_response)
 
     assert_success response


### PR DESCRIPTION
Credorax is changing the requirements for MIT transactions in regards to NTIDs. Moving forward, all MIT transactions need to pass in the NTID if present. Additionally the NTID value is from the `Z50` flag and passed directly from the card scheme.

Credorax notification:
For any MIT transactions, this Trace ID must be stored from the original Card Holder initiated (CIT) transaction where the Card details were stored on file originally. When using Finaro gateway/acquiring this Trace ID is returned in the z50 parameter and must be sent in the g6 parameter for any subsequent MIT transactions, (if using an external token engine or your own token engine and the original CIT is not processed through Finaro, please liaise with your processor to obtain this Trace ID). Additionally, this original Card holder initiated transaction must be Fully authenticated with 3DSecure to comply with PSD2/SCA regulation in place. Please make sure that you comply with this for any customers saving their card details on file for subsequent MIT processed through Finaro

ECS-2650

Test Summary
51 tests, 175 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
88.2353% passed