### PR TITLE
Checkout: Add support for `allow_upgrade` field

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -280,6 +280,7 @@ module ActiveMerchant #:nodoc:
           post[:'3ds'][:attempt_n3d] = options[:attempt_n3d] if options[:attempt_n3d]
           post[:'3ds'][:challenge_indicator] = options[:challenge_indicator] if options[:challenge_indicator]
           post[:'3ds'][:exemption] = options[:exemption] if options[:exemption]
+          post[:'3ds'][:allow_upgrade] = options[:allow_upgrade] if options[:allow_upgrade]
         end
 
         if options[:three_d_secure]

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -557,6 +557,15 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert auth.params['_links']['redirect']
   end
 
+  def test_allow_upgrade_with_direct_3ds
+    auth = @gateway.authorize(@amount, @threeds_card, @options.merge(execute_threed: true, allow_upgrade: true))
+
+    # using this assertion to show that the allow_upgrade field is accepted with the direct 3DS
+    # implementation. Remote test requests stay in pending state with direct 3DS so the entire
+    # flow is not able to be completed within one test.
+    assert_equal 'Y', auth.params['3ds']['enrolled']
+  end
+
   def test_failed_authorize
     response = @gateway.authorize(12314, @credit_card, @options)
     assert_failure response

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -115,6 +115,15 @@ class CheckoutV2Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_allow_upgrade
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, { execute_threed: true, allow_upgrade: true })
+    end.check_request do |_endpoint, data, _headers|
+      request_data = JSON.parse(data)
+      assert_equal(request_data['3ds']['allow_upgrade'], true)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_passing_capture_type
     stub_comms(@gateway, :ssl_request) do
       @gateway.capture(@amount, 'abc', { capture_type: 'NonFinal' })
@@ -518,6 +527,7 @@ class CheckoutV2Test < Test::Unit::TestCase
       options = {
         execute_threed: true,
         attempt_n3d: true,
+        allow_upgrade: true,
         three_d_secure: {
           version: '1.0.2',
           eci: '05',
@@ -543,6 +553,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     response = stub_comms(@gateway, :ssl_request) do
       options = {
         execute_threed: true,
+        allow_upgrade: true,
         three_d_secure: {
           version: '2.0.0',
           eci: '05',


### PR DESCRIPTION
CER-338

Whether to process this payment as 3D Secure if the authorization was soft declined due to 3DS authentication required

Remote:
74 tests, 188 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.6486% passed
*1 failing test is also failing on master, not due to my change

Unit:
51 tests, 281 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Local:
5441 tests, 77075 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed