### PR TITLE
Moneris: Fix google pay (update apple pay)

### DIFF
--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -9,6 +9,8 @@ module ActiveMerchant #:nodoc:
     # Response Values", available at Moneris' {eSelect Plus Documentation
     # Centre}[https://www3.moneris.com/connect/en/documents/index.html].
     class MonerisGateway < Gateway
+      WALLETS = %w(APP GPP)
+
       self.test_url = 'https://esqa.moneris.com/gateway2/servlet/MpgRequest'
       self.live_url = 'https://www3.moneris.com/gateway2/servlet/MpgRequest'
 
@@ -47,7 +49,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_payment_source(post, creditcard_or_datakey, options)
         post[:amount] = amount(money)
-        post[:order_id] = options[:order_id]
+        post[:order_id] = format_order_id(post[:wallet_indicator], options[:order_id])
         post[:address] = options[:billing_address] || options[:address]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
         add_external_mpi_fields(post, options)
@@ -71,7 +73,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_payment_source(post, creditcard_or_datakey, options)
         post[:amount] = amount(money)
-        post[:order_id] = options[:order_id]
+        post[:order_id] = format_order_id(post[:wallet_indicator], options[:order_id])
         post[:address] = options[:billing_address] || options[:address]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
         add_external_mpi_fields(post, options)
@@ -436,6 +438,18 @@ module ActiveMerchant #:nodoc:
           'google_pay' => 'GPP',
           'android_pay' => 'ANP'
         }[token_source]
+      end
+
+      def format_order_id(wallet_indicator_code, order_id = nil)
+        # Truncate (max 100 characters) order id for
+        # google pay and apple pay (specific wallets / token sources)
+        return truncate_order_id(order_id) if WALLETS.include?(wallet_indicator_code)
+
+        order_id
+      end
+
+      def truncate_order_id(order_id = nil)
+        order_id.present? ? order_id[0, 100] : SecureRandom.alphanumeric(100)
       end
 
       def message_from(message)

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -15,6 +15,15 @@ class MonerisRemoteTest < Test::Unit::TestCase
     @no_liability_shift_eci = 7
 
     @credit_card = credit_card('4242424242424242', verification_value: '012')
+    @network_tokenization_credit_card = network_tokenization_credit_card(
+      '4242424242424242',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      verification_value: nil
+    )
+    @apple_pay_credit_card = @network_tokenization_credit_card
+    @apple_pay_credit_card.source = :apple_pay
+    @google_pay_credit_card = @network_tokenization_credit_card
+    @google_pay_credit_card.source = :google_pay
     @visa_credit_card_3ds = credit_card('4606633870436092', verification_value: '012')
     @options = {
       order_id: generate_unique_id,
@@ -104,38 +113,74 @@ class MonerisRemoteTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_network_tokenization
-    @credit_card = network_tokenization_credit_card(
-      '4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil
-    )
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert response = @gateway.purchase(@amount, @network_tokenization_credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
     assert_false response.authorization.blank?
   end
 
   def test_successful_purchase_with_network_tokenization_apple_pay_source
-    @credit_card = network_tokenization_credit_card(
-      '4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil,
-      source: :apple_pay
-    )
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert response = @gateway.purchase(@amount, @apple_pay_credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_network_tokenization_apple_pay_source_with_nil_order_id
+    @options[:order_id] = nil
+    assert response = @gateway.purchase(@amount, @apple_pay_credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
     assert_false response.authorization.blank?
   end
 
   def test_successful_purchase_with_network_tokenization_google_pay_source
-    @credit_card = network_tokenization_credit_card(
-      '4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil,
-      source: :google_pay
-    )
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert response = @gateway.purchase(@amount, @google_pay_credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_network_tokenization_google_pay_source_with_nil_order_id
+    @options[:order_id] = nil
+    assert response = @gateway.purchase(@amount, @google_pay_credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_authorize_with_network_tokenization
+    assert response = @gateway.authorize(@amount, @network_tokenization_credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_authorize_with_network_tokenization_apple_pay_source
+    assert response = @gateway.authorize(@amount, @apple_pay_credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_authorize_with_network_tokenization_apple_pay_source_with_nil_order_id
+    @options[:order_id] = nil
+    assert response = @gateway.authorize(@amount, @apple_pay_credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_authorize_with_network_tokenization_google_pay_source
+    assert response = @gateway.authorize(@amount, @google_pay_credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_authorize_with_network_tokenization_google_pay_source_with_nil_order_id
+    @options[:order_id] = nil
+    assert response = @gateway.authorize(@amount, @google_pay_credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
     assert_false response.authorization.blank?


### PR DESCRIPTION
Description
-------------------------
Truncate google pay and apple pay order id to 100 (max length of characters that google pay / apple pay accepts)

Unit test
-------------------------
Finished in 27.168945 seconds.
5439 tests, 77066 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote test
-------------------------
200.19 tests/s, 2836.55 assertions/s

Rubocop
-------------------------
756 files inspected, no offenses detected