### PR TITLE
TrustCommerce: Update `authorization_from` to handle `store` response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -61,6 +61,7 @@
 * Adyen: Add support for `skip_mpi_data` flag [rachelkirk] #4654
 * Add Canadian Institution Numbers [jcreiff] #4687
 * Tns: update test URL [almalee24] #4698
+* TrustCommerce: Update `authorization_from` to handle `store` response [jherreraa] #4691
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -476,9 +476,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(action, data)
-        authorization = data['transid']
-        authorization = "#{authorization}|#{action}" if authorization && VOIDABLE_ACTIONS.include?(action)
-        authorization
+        case action
+        when 'store'
+          data['billingid']
+        when *VOIDABLE_ACTIONS
+          "#{data['transid']}|#{action}"
+        else
+          data['transid']
+        end
       end
 
       def split_authorization(authorization)

--- a/test/remote/gateways/remote_trust_commerce_test.rb
+++ b/test/remote/gateways/remote_trust_commerce_test.rb
@@ -182,11 +182,28 @@ class TrustCommerceTest < Test::Unit::TestCase
     assert_bad_data_response(response)
   end
 
+  def test_successful_unstore
+    assert store = @gateway.store(@credit_card)
+    assert_equal 'approved', store.params['status']
+    assert response = @gateway.unstore(store.params['billingid'])
+    assert_success response
+  end
+
   def test_unstore_failure
     assert response = @gateway.unstore('does-not-exist')
 
     assert_match %r{A field was longer or shorter than the server allows}, response.message
     assert_failure response
+  end
+
+  def test_successful_purchase_after_store
+    assert store = @gateway.store(@credit_card)
+    assert_success store
+    assert response = @gateway.purchase(@amount, store.params['billingid'], @options)
+    assert_equal 'Y', response.avs_result['code']
+    assert_match %r{The transaction was successful}, response.message
+
+    assert_success response
   end
 
   def test_successful_recurring


### PR DESCRIPTION
## Summary:

Fix Store/Unstore features

Remote tests
-------------------------------------------------------------------------- 
22 tests, 80 assertions, 3 failures, 0 errors, 0 pendings, 
0 omissions, 0 notifications 
86.3636% passed

Failing tests not related with changes

unit tests
-------------------------------------------------------------------------- 
20 tests, 64 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed