### PR TITLE
TrustCommerce Verify feature added

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,7 @@
 * Add Canadian Institution Numbers [jcreiff] #4687
 * Tns: update test URL [almalee24] #4698
 * TrustCommerce: Update `authorization_from` to handle `store` response [jherreraa] #4691
+* TrustCommerce: Verify feature added [jherreraa] #4692
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -248,6 +248,11 @@ module ActiveMerchant #:nodoc:
         commit(action, parameters)
       end
 
+      def verify(credit_card, options = {})
+        add_creditcard(options, credit_card)
+        commit('verify', options)
+      end
+
       # recurring() a TrustCommerce account that is activated for Citadel, TrustCommerce's
       # hosted customer billing info database.
       #

--- a/test/remote/gateways/remote_trust_commerce_test.rb
+++ b/test/remote/gateways/remote_trust_commerce_test.rb
@@ -202,7 +202,12 @@ class TrustCommerceTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, store.params['billingid'], @options)
     assert_equal 'Y', response.avs_result['code']
     assert_match %r{The transaction was successful}, response.message
+  end
 
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card)
+    assert_equal 'approved', response.params['status']
+    assert_match %r{The transaction was successful}, response.message
     assert_success response
   end
 


### PR DESCRIPTION
## Summary:

Enable verify feature on TrustCommerce Gateway

Remote tests
-------------------------------------------------------------------------- 
22 tests, 78 assertions, 3 failures, 0 errors, 0 pendings, 
0 omissions, 0 notifications 86.3636% passed

Failing tests not related with changes

unit tests
-------------------------------------------------------------------------- 
20 tests, 64 assertions, 0 failures, 0 errors, 0 pendings, 
0 omissions, 0 notifications 100% passed