### PR TITLE
Credorax/finaro use eci on network tokens

### DIFF
--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -66,7 +66,6 @@ class RemoteCredoraxTest < Test::Unit::TestCase
 
     @nt_credit_card = network_tokenization_credit_card('4176661000001015',
       brand: 'visa',
-      eci: '07',
       source: :network_token,
       payment_cryptogram: 'AgAAAAAAosVKVV7FplLgQRYAAAA=')
   end

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -1081,7 +1081,7 @@ class CredoraxTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @apple_pay_card)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/b21=applepay/, data)
-      assert_not_match(/token_eci=/, data)
+      assert_match(/token_eci=07/, data)
       assert_not_match(/token_crypto=/, data)
     end.respond_with(successful_purchase_response)
     assert_success response


### PR DESCRIPTION
[Credorax] Use ECI on purchase, credit and authorization from options object

To enable network tokenization the token_eci field must be present so this PR adds conditions and default values
Currently the add_network_tokenization_card method is expecting the ECI field to come in the payment_method.
This change allows users to use network tokenization with default and custom values for the token_eci field.