### PR TITLE
Payeezy: Handle nil and empty values for Apple Pay

### DIFF
--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -247,13 +247,13 @@ module ActiveMerchant
         nt_card[:card_number] = payment_method.number
         nt_card[:exp_date] = format_exp_date(payment_method.month, payment_method.year)
         nt_card[:cvv] = payment_method.verification_value
-        nt_card[:xid] = payment_method.payment_cryptogram
-        nt_card[:cavv] = payment_method.payment_cryptogram
+        nt_card[:xid] = payment_method.payment_cryptogram unless payment_method.payment_cryptogram.empty?
+        nt_card[:cavv] = payment_method.payment_cryptogram unless payment_method.payment_cryptogram.empty?
         nt_card[:wallet_provider_id] = 'APPLE_PAY'
 
         params['3DS'] = nt_card
         params[:method] = '3DS'
-        params[:eci_indicator] = payment_method.eci
+        params[:eci_indicator] = payment_method.eci.nil? ? '5' : payment_method.eci
       end
 
       def format_exp_date(month, year)

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -107,6 +107,19 @@ class PayeezyGateway < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_apple_pay_no_cryptogram
+    @apple_pay_card.payment_cryptogram = ''
+    @apple_pay_card.eci = nil
+    stub_comms do
+      @gateway.purchase(@amount, @apple_pay_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['eci_indicator'], '5'
+      assert_nil request['xid']
+      assert_nil request['cavv']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_failed_purchase_no_name
     @apple_pay_card.first_name = nil
     @apple_pay_card.last_name = nil


### PR DESCRIPTION
Payeezy support has indicated that passing empty or nil values in place of the `xid` and `cavv` may result in failed transactions for AMEX based AP tokens. They also informed us that the `eci_indicator` value should default to `5` instead of passing a nil value, following a similar pattern.

This PR ignores empty `payment_cryptogram` and defaults the `eci_indicator` to `5` if that value is `nil`.

Unit: 6 tests, 211 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote: 46 tests, 184 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed