### PR TITLE
TrustCommerce Verify feature added

### DIFF
--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -249,8 +249,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(credit_card, options = {})
-        add_creditcard(options, credit_card)
-        commit('verify', options)
+        parameters = {}
+        add_creditcard(parameters, credit_card)
+        commit('verify', parameters)
       end
 
       # recurring() a TrustCommerce account that is activated for Citadel, TrustCommerce's

--- a/test/remote/gateways/remote_trust_commerce_test.rb
+++ b/test/remote/gateways/remote_trust_commerce_test.rb
@@ -211,6 +211,13 @@ class TrustCommerceTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_failed_verify_with_invalid_card
+    assert response = @gateway.verify(@declined_credit_card)
+    assert_equal 'baddata', response.params['status']
+    assert_match %r{A field was improperly formatted}, response.message
+    assert_failure response
+  end
+
   def test_successful_recurring
     assert response = @gateway.recurring(@amount, @credit_card, periodicity: :weekly)
 


### PR DESCRIPTION
## Summary

Enable verify feature on TrustCommerce Gateway

Remote tests
-------------------------------------------------------------------------- 
21 tests, 74 assertions, 3 failures, 0 errors, 0 pendings, 
0 omissions, 0 notifications 85.7143% passed

Failing tests not related with changes

Unit tests
-------------------------------------------------------------------------- 
22 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 
0 omissions, 0 notifications 100% passed