### PR TITLE
Adyen checkout endpoint POC

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen_checkout.rb
+++ b/lib/active_merchant/billing/gateways/adyen_checkout.rb
@@ -1,0 +1,110 @@
+require 'active_support/core_ext/hash/slice'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # This gateway uses the current Stripe {Payment Intents API}[https://stripe.com/docs/api/payment_intents].
+    # For the legacy API, see the Stripe gateway
+    class AdyenCheckoutGateway < AdyenGateway
+      self.test_url = 'https://checkout-test.adyen.com/'
+      self.live_url = 'checkout-live.adyenpayments.com/checkout/'
+
+      CHECKOUT_API_VERSION = 'v70'
+
+      LOCAL_PAYMENT_METHODS = %w[ideal directEbanking sepadirectdebit trustly onlineBanking_PL]
+
+      def initialize(options = {})
+        requires!(options, :api_key, :merchant_account)
+        @api_key, @prefix, @merchant_account = options.values_at(:api_key, :prefix, :merchant_account)
+        @options = options
+      end
+
+      def url(action)
+        if test?
+          "#{test_url}#{endpoint(action)}"
+        else
+          # Todo enforce requirement of prefix
+          "https://#{@prefix}-#{live_url}#{endpoint(action)}"
+        end
+      end
+
+      def endpoint(action)
+        # Todo add correct actions
+        "#{CHECKOUT_API_VERSION}/#{action}"
+      end
+
+      def request_headers(options)
+        headers = {
+          'Content-Type' => 'application/json',
+          'X-API-KEY' => @api_key.to_s
+        }
+        headers['Idempotency-Key'] = options[:idempotency_key] if options[:idempotency_key]
+        headers
+      end
+
+      def show_payment_methods(options)
+        post = init_post(options)
+        commit('paymentMethods', post, options)
+      end
+
+      def authorize(money, payment, options = {})
+        post = init_post(options)
+        add_payment_method(post, payment, options)
+        add_invoice(post, money, options)
+        add_return_url(post, options)
+        add_line_items(post, options)
+        add_extra_data(post, payment, options)
+        commit('payments', post, options)
+      end
+
+      def handle_redirect(redirect_result)
+        post = {
+          "details": {
+            "redirectResult": redirect_result
+          }
+        }
+        commit('payments/details', post, {})
+      end
+
+      def add_payment_method(post, payment_method, options)
+        if payment_method.is_a?(Hash)
+          post[:paymentMethod] = payment_method
+        else
+          card = {
+            expiryMonth: credit_card.month,
+            expiryYear: credit_card.year,
+            holderName: credit_card.name,
+            number: credit_card.number,
+            cvc: credit_card.verification_value,
+            type: 'scheme'
+          }
+
+          card.delete_if { |_k, v| v.blank? }
+          card[:holderName] ||= 'Not Provided'
+          requires!(card, :expiryMonth, :expiryYear, :holderName, :number)
+          post[:paymentMethod] = card
+        end
+      end
+
+      def add_return_url(post, options)
+        post[:returnUrl] = options[:return_url]
+      end
+
+      def add_line_items(post, options)
+        post[:lineItems] = options[:line_items] if options[:line_items]
+      end
+
+      def success_from(action, response, options)
+        case response.dig('resultCode')
+        when 'RedirectShopper'
+          return true if LOCAL_PAYMENT_METHODS.include?(response.dig('action', 'paymentMethodType'))
+
+          super
+        when 'Received', 'Authorised'
+          return true
+        else
+          false
+        end
+      end
+    end
+  end
+end

--- a/test/remote/gateways/remote_adyen_checkout_test.rb
+++ b/test/remote/gateways/remote_adyen_checkout_test.rb
@@ -1,0 +1,122 @@
+require 'test_helper'
+require 'pry'
+
+class RemoteAdyenTest < Test::Unit::TestCase
+  def setup
+    @gateway = AdyenCheckoutGateway.new(fixtures(:adyen_checkout))
+
+    @options = {
+      reference: '345123',
+      email: 'john.smith@test.com',
+      ip: '77.110.174.153',
+      shopper_reference: 'John Smith',
+      billing_address: address(country: 'US', state: 'CA'),
+      order_id: '123',
+      stored_credential: { reason_type: 'unscheduled' },
+      return_url: 'https://example.com/',
+      currency: 'EUR'
+    }
+
+    @credit_card = credit_card('4111111145551142',
+      month: 3,
+      year: 2030,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'visa')
+
+    @ideal_payment_method = {
+      issuer: '1161',
+      type: 'ideal'
+    }
+
+    @klarna_payment_method = {
+      type: 'klarna'
+    }
+
+    @sofort_payment_method = {
+      type: 'directEbanking'
+    }
+
+    @sepa_payment_method = {
+      "type": 'sepadirectdebit',
+      "sepa.ownerName": 'Test name',
+      "sepa.ibanNumber": 'DE87123456781234567890'
+    }
+
+    @polish_payment_method = {
+      type: 'onlineBanking_PL',
+      issuer: '181'
+    }
+
+    @trustly_payment_method = {
+      type: 'trustly'
+    }
+
+    @amount = 100
+  end
+
+  def test_successful_authorize_with_ideal
+    response = @gateway.authorize(@amount, @ideal_payment_method, @options)
+    assert_success response
+    assert_equal 'RedirectShopper', response.message
+    assert_equal 'ideal', response.params.dig('action', 'paymentMethodType')
+  end
+
+  def test_successful_authorize_with_sofort
+    response = @gateway.authorize(@amount, @sofort_payment_method, @options)
+    assert_success response
+    assert_equal 'RedirectShopper', response.message
+    assert_equal 'directEbanking', response.params.dig('action', 'paymentMethodType')
+  end
+
+  def test_successful_authorize_with_sepa
+    response = @gateway.authorize(@amount, @sepa_payment_method, @options)
+    assert_success response
+    assert_equal 'Received', response.message
+  end
+
+  def test_successful_authorize_with_trustly
+    response = @gateway.authorize(@amount, @trustly_payment_method, @options.merge(currency: 'SEK'))
+    assert_success response
+    assert_equal 'RedirectShopper', response.message
+    assert_equal 'trustly', response.params.dig('action', 'paymentMethodType')
+  end
+
+  def test_successful_authorize_with_polish_banking
+    response = @gateway.authorize(1000, @polish_payment_method, @options.merge(currency: 'PLN'))
+    assert_success response
+    assert_equal 'RedirectShopper', response.message
+    assert_equal 'onlineBanking_PL', response.params.dig('action', 'paymentMethodType')
+  end
+
+  # Does not work with "Invalid open invoice request."
+  # def test_successful_authorize_with_klarna
+  #   @options.merge!({
+  #     "line_items": [
+  #       {
+  #         "quantity":"1",
+  #         "taxPercentage":"2100",
+  #         "description":"Shoes",
+  #         "id":"Item #1",
+  #         "amountIncludingTax":"400",
+  #         "productUrl": "URL_TO_PURCHASED_ITEM",
+  #         "imageUrl": "URL_TO_PICTURE_OF_PURCHASED_ITEM"
+  #      },
+  #      {
+  #         "quantity":"2",
+  #         "taxPercentage":"2100",
+  #         "description":"Socks",
+  #         "id":"Item #2",
+  #         "amountIncludingTax":"300",
+  #         "productUrl": "URL_TO_PURCHASED_ITEM",
+  #         "imageUrl": "URL_TO_PICTURE_OF_PURCHASED_ITEM"
+  #      }
+  #     ]
+  #   })
+  #   response = @gateway.authorize(@amount, @klarna_payment_method, @options)
+  #   assert_success response
+  #   assert_equal 'RedirectShopper', response.message
+  #   assert_equal 'klarna', response.params.dig('action', 'paymentMethodType')
+  # end
+end


### PR DESCRIPTION
POC to add the Adyen checkout endpoint. This is
the future Adyen integration with support for card as well as LPM payments.
Note: card payments require reaching out to Adyen
to allow.