### PR TITLE
CyberSourceRest:  Add stored credentials support

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -114,6 +114,7 @@ module ActiveMerchant #:nodoc:
           add_amount(post, amount)
           add_address(post, payment, options[:billing_address], options, :billTo)
           add_address(post, payment, options[:shipping_address], options, :shipTo)
+          add_stored_credentials(post, payment, options)
         end.compact
       end
 
@@ -156,7 +157,6 @@ module ActiveMerchant #:nodoc:
 
       def add_amount(post, amount)
         currency = options[:currency] || currency(amount)
-
         post[:orderInformation][:amountDetails] = {
           totalAmount: localized_amount(amount, currency),
           currency: currency
@@ -251,6 +251,63 @@ module ActiveMerchant #:nodoc:
         merchant[:locality] = options[:merchant_descriptor_locality] if options[:merchant_descriptor_locality]
       end
 
+      def add_stored_credentials(post, payment, options)
+        return unless stored_credential = options[:stored_credential]
+
+        stored_credential = stored_credential_options(stored_credential, options.fetch(:reason_code, ''))
+        post[:processingInformation][:commerceIndicator] = stored_credential.fetch(:transaction_type, 'internet')
+        stored_credential[:initial_transaction] ? initial_transaction(post, stored_credential) : subsequent_transaction(post, stored_credential)
+      end
+
+      def stored_credential_options(options, reason_code)
+        transaction_type = options[:reason_type]
+        transaction_type = 'install' if transaction_type == 'installment'
+        initiator = options[:initiator] if options[:initiator]
+        initiator = 'customer' if initiator == 'cardholder'
+        stored_on_file = options[:reason_type] == 'recurring'
+        options.merge({
+          transaction_type: transaction_type,
+          initiator: initiator,
+          reason_code: reason_code,
+          stored_on_file: stored_on_file
+        })
+      end
+
+      def add_processing_information(initiator, merchant_initiated_transaction_hash = {})
+        {
+          authorizationOptions: {
+            initiator: {
+              type: initiator,
+              merchantInitiatedTransaction: merchant_initiated_transaction_hash,
+              storedCredentialUsed: true
+            }
+          }
+        }.compact
+      end
+
+      def initial_transaction(post, options)
+        processing_information = add_processing_information(options[:initiator], {
+          reason: options[:reason_code]
+        })
+
+        post[:processingInformation].merge!(processing_information)
+      end
+
+      def subsequent_transaction(post, options)
+        network_transaction_id = options[:network_transaction_id] || options.dig(:stored_credential, :network_transaction_id) || ''
+        processing_information = add_processing_information(options[:initiator], {
+          originalAuthorizedAmount: post.dig(:orderInformation, :amountDetails, :totalAmount),
+          previousTransactionID: network_transaction_id,
+          reason: options[:reason_code],
+          storedCredentialUsed: options[:stored_on_file]
+        })
+        post[:processingInformation].merge!(processing_information)
+      end
+
+      def network_transaction_id_from(response)
+        response.dig('processorInformation', 'networkTransactionId')
+      end
+
       def url(action)
         "#{(test? ? test_url : live_url)}/pts/v2/#{action}"
       end
@@ -272,6 +329,7 @@ module ActiveMerchant #:nodoc:
           authorization: authorization_from(response),
           avs_result: AVSResult.new(code: response.dig('processorInformation', 'avs', 'code')),
           # cvv_result: CVVResult.new(response['some_cvv_response_key']),
+          network_transaction_id: network_transaction_id_from(response),
           test: test?,
           error_code: error_code_from(response)
         )

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -13,6 +13,9 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
       month: 12,
       year: 2031)
 
+    @master_card = credit_card('2222420000001113', brand: 'master')
+    @discover_card = credit_card('6011111111111117', brand: 'discover')
+
     @apple_pay = network_tokenization_credit_card(
       '4111111111111111',
       payment_cryptogram: 'AceY+igABPs3jdwNaDg3MAACAAA=',
@@ -97,7 +100,6 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
 
   def test_successful_authorize
     response = @gateway.authorize(@amount, @visa_card, @options)
-
     assert_success response
     assert response.test?
     assert_equal 'AUTHORIZED', response.message
@@ -347,5 +349,78 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @bank_account, @options.except(:billing_address))
     assert_failure response
     assert_equal 'Declined - The request is missing one or more fields', response.params['message']
+  end
+
+  def stored_credential_options(*args, ntid: nil)
+    @options.merge(stored_credential: stored_credential(*args, network_transaction_id: ntid))
+  end
+
+  def test_purchase_using_stored_credential_initial_mit
+    options = stored_credential_options(:merchant, :internet, :initial)
+    options[:reason_code] = '4'
+    assert auth = @gateway.authorize(@amount, @visa_card, options)
+    assert_success auth
+    assert purchase = @gateway.purchase(@amount, @visa_card, options)
+    assert_success purchase
+  end
+
+  def test_purchase_using_stored_credential_recurring_cit
+    options = stored_credential_options(:cardholder, :recurring, :initial)
+    options[:reason_code] = '4'
+    assert auth = @gateway.authorize(@amount, @visa_card, options)
+    assert_success auth
+    used_store_credentials = stored_credential_options(:cardholder, :recurring, ntid: auth.network_transaction_id)
+    used_store_credentials[:reason_code] = '4'
+    assert purchase = @gateway.purchase(@amount, @visa_card, used_store_credentials)
+    assert_success purchase
+  end
+
+  def test_purchase_using_stored_credential_recurring_mit
+    options = stored_credential_options(:merchant, :recurring, :initial)
+    options[:reason_code] = '4'
+    assert auth = @gateway.authorize(@amount, @visa_card, options)
+    assert_success auth
+    used_store_credentials = stored_credential_options(:merchant, :recurring, ntid: auth.network_transaction_id)
+    used_store_credentials[:reason_code] = '4'
+    assert purchase = @gateway.purchase(@amount, @visa_card, used_store_credentials)
+    assert_success purchase
+  end
+
+  def test_purchase_using_stored_credential_installment_cit
+    options = stored_credential_options(:cardholder, :installment, :initial)
+    options[:reason_code] = '4'
+    assert auth = @gateway.authorize(@amount, @visa_card, options)
+    assert_success auth
+    used_store_credentials = stored_credential_options(:cardholder, :installment, ntid: auth.network_transaction_id)
+    used_store_credentials[:reason_code] = '4'
+    assert purchase = @gateway.purchase(@amount, @visa_card, used_store_credentials)
+    assert_success purchase
+  end
+
+  def test_purchase_using_stored_credential_installment_mit
+    options = stored_credential_options(:merchant, :installment, :initial)
+    options[:reason_code] = '4'
+    assert auth = @gateway.authorize(@amount, @visa_card, options)
+    assert_success auth
+    used_store_credentials = stored_credential_options(:merchant, :installment, ntid: auth.network_transaction_id)
+    used_store_credentials[:reason_code] = '4'
+    assert purchase = @gateway.purchase(@amount, @visa_card, used_store_credentials)
+    assert_success purchase
+  end
+
+  def test_failure_stored_credential_invalid_reason_code
+    options = stored_credential_options(:cardholder, :internet, :initial)
+    assert auth = @gateway.authorize(@amount, @master_card, options)
+    assert_equal(auth.params['status'], 'INVALID_REQUEST')
+    assert_equal(auth.params['message'], 'Declined - One or more fields in the request contains invalid data')
+    assert_equal(auth.params['details'].first['field'], 'processingInformation.authorizationOptions.initiator.merchantInitiatedTransaction.reason')
+  end
+
+  def test_auth_and_purchase_with_network_txn_id
+    options = stored_credential_options(:merchant, :recurring, :initial)
+    options[:reason_code] = '4'
+    assert auth = @gateway.authorize(@amount, @visa_card, options)
+    assert purchase = @gateway.purchase(@amount, @visa_card, options.merge(network_transaction_id: auth.network_transaction_id))
+    assert_success purchase
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -270,6 +270,7 @@ module ActiveMerchant
       stored_credential[:reason_type] = 'recurring' if args.include?(:recurring)
       stored_credential[:reason_type] = 'unscheduled' if args.include?(:unscheduled)
       stored_credential[:reason_type] = 'installment' if args.include?(:installment)
+      stored_credential[:reason_type] = 'internet' if args.include?(:internet)
 
       stored_credential[:initiator] = 'cardholder' if args.include?(:cardholder)
       stored_credential[:initiator] = 'merchant' if args.include?(:merchant)

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -233,6 +233,47 @@ class CyberSourceRestTest < Test::Unit::TestCase
     assert_equal "#{@gateway.class.test_url}/pts/v2/action", @gateway.send(:url, 'action')
   end
 
+  def test_stored_credential_cit_initial
+    @options[:stored_credential] = stored_credential(:cardholder, :internet, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal 'internet', request['processingInformation']['commerceIndicator']
+      assert_equal 'customer', request.dig('processingInformation', 'authorizationOptions', 'initiator', 'type')
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_cit
+    @options[:stored_credential] = stored_credential(:cardholder, :recurring)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal 'recurring', request['processingInformation']['commerceIndicator']
+      assert_equal 'customer', request.dig('processingInformation', 'authorizationOptions', 'initiator', 'type')
+      assert_equal true, request.dig('processingInformation', 'authorizationOptions', 'initiator', 'merchantInitiatedTransaction', 'storedCredentialUsed')
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_mit_ntid
+    @options[:stored_credential] = stored_credential(:merchant, :recurring, ntid: '123456789619999')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal 'recurring', request['processingInformation']['commerceIndicator']
+      assert_equal 'merchant', request.dig('processingInformation', 'authorizationOptions', 'initiator', 'type')
+      assert_equal true, request.dig('processingInformation', 'authorizationOptions', 'initiator', 'merchantInitiatedTransaction', 'storedCredentialUsed')
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   private
 
   def parse_signature(signature)


### PR DESCRIPTION
Description
-------------------------
This commit adds support for stored credentials to the CyberSourceRest gateway and according to their docs CyberSource has two type of flows [initial](https://developer.cybersource.com/docs/cybs/en-us/payments/developer/ctv/rest/payments/credentials-intro/credentials-maxtrix/credentials-maxtrix-initial.html) and [subsequent](https://developer.cybersource.com/docs/cybs/en-us/payments/developer/ctv/rest/payments/credentials-matrix/credentials-matrix-sub.html)

[GWI-558](https://spreedly.atlassian.net/browse/GWI-558)

Unit test
-------------------------
Finished in 0.0377 seconds.

15 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote test
-------------------------
Finished in 12.561448 seconds.

12 tests, 41 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop
-------------------------
760 files inspected, no offenses detected