### PR TITLE
Litle: Add prelive url

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,6 +65,7 @@
 * TrustCommerce: Verify feature added [jherreraa] #4692
 * Rapyd: Add customer object to transactions [javierpedrozaing] #4664
 * CybersourceRest: Add new gateway with authorize and purchase [heavyblade] #4690
+* Litle: Add prelive_url option [aenand] #4710
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -5,9 +5,10 @@ module ActiveMerchant #:nodoc:
     class LitleGateway < Gateway
       SCHEMA_VERSION = '9.14'
 
-      class_attribute :postlive_url
+      class_attribute :postlive_url, :prelive_url
 
       self.test_url = 'https://www.testvantivcnp.com/sandbox/communicator/online'
+      self.prelive_url = 'https://payments.vantivprelive.com/vap/communicator/online'
       self.postlive_url = 'https://payments.vantivpostlive.com/vap/communicator/online'
       self.live_url = 'https://payments.vantivcnp.com/vap/communicator/online'
 
@@ -616,6 +617,7 @@ module ActiveMerchant #:nodoc:
 
       def url
         return postlive_url if @options[:url_override].to_s == 'postlive'
+        return prelive_url if @options[:url_override].to_s == 'prelive'
 
         test? ? test_url : live_url
       end


### PR DESCRIPTION
This commit adds a prelive URL to the Vantiv/Litle gateway. It relies on the existing url_override logic to set the prelive_url

Test Summary
Remote:
56 tests, 226 assertions, 13 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 76.7857% passed