### PR TITLE
Payeezy: Update Stored Credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,7 @@
 * CybersourceRest: Add new gateway with authorize and purchase [heavyblade] #4690
 * Litle: Add prelive_url option [aenand] #4710
 * CommerceHub: Fixing verify status and prevent tokenization [heavyblade] #4716
+* Payeezy: Update Stored Credentials [almalee24] #4711
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -307,8 +307,7 @@ module ActiveMerchant
       end
 
       def original_transaction_id(options)
-        return options[:cardbrand_original_transaction_id] if options[:cardbrand_original_transaction_id]
-        return options[:stored_credential][:network_transaction_id] if options.dig(:stored_credential, :network_transaction_id)
+        return options[:cardbrand_original_transaction_id] || options.dig(:stored_credential, :network_transaction_id)
       end
 
       def initiator(options)


### PR DESCRIPTION
Payeezy requires sending original network transaction id to as cardbrand_original_transaction_id.

Unit:
47 tests, 217 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
46 tests, 184 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed