### PR TITLE
ChekoutV2:Add store/unstore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -64,6 +64,7 @@
 * TrustCommerce: Update `authorization_from` to handle `store` response [jherreraa] #4691
 * TrustCommerce: Verify feature added [jherreraa] #4692
 * Rapyd: Add customer object to transactions [javierpedrozaing] #4664
+* CheckoutV2: Add store/unstore [gasb150] #4712
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -198,6 +198,10 @@ checkout_v2:
   client_id: CLIENT_ID_FOR_OAUTH_TRANSACTIONS
   client_secret: CLIENT_SECRET_FOR_OAUTH_TRANSACTIONS
 
+checkout_v2_token:
+  secret_key: sk_sbox_xxxxxxxxxxxxxxxxx
+  public_key: pk_sbox_xxxxxxxxxxxxxxxxx
+
 citrus_pay:
   userid: CPF00001
   password: 7c70414732de7e0ba3a04db5f24fcec8


### PR DESCRIPTION
Summary:
------------------------------
In order to use Third Party Vaulting (TPV), this commit adds store and unstore methods. For apple pay/google pay the actual credentials could work, but for credit cards, and bank account the credentials required are secret_api_key and public_api_key.

This commits also, refactor the initialize method removing the rescue ArgumentError, and modifing the commit method to use ssl_request.

Remote test
-----------------------
Finished in 164.163913 seconds.
88 tests, 216 assertions, 0 failures, 0 errors,
0 pendings, 0 omissions, 0 notifications
100% passed

Unit test
-----------------------
Finished in 0.046893 seconds.
53 tests, 297 assertions, 0 failures, 0 errors,
0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop
-----------------------
756 files inspected, no offenses detected