### PR TITLE
Remove raise ArgumentError on get requests

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -85,8 +85,6 @@ module ActiveMerchant
           result =
             case method
             when :get
-              raise ArgumentError, 'GET requests do not support a request body' if body
-
               http.get(endpoint.request_uri, headers)
             when :post
               debug body

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -87,13 +87,6 @@ class ConnectionTest < Test::Unit::TestCase
     assert_equal 'success', response.body
   end
 
-  def test_get_raises_argument_error_if_passed_data
-    assert_raises(ArgumentError) do
-      Net::HTTP.any_instance.expects(:start).returns(true)
-      @connection.request(:get, 'data', {})
-    end
-  end
-
   def test_request_raises_when_request_method_not_supported
     assert_raises(ArgumentError) do
       Net::HTTP.any_instance.expects(:start).returns(true)


### PR DESCRIPTION
The case for initiating a GET request raises a frivolous ArgumentError when the code already ignores any attempt to pass in a body to the request.