### PR TITLE
CommerceHub: Fixing verify status and prevent tokenization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,7 @@
 * Rapyd: Add customer object to transactions [javierpedrozaing] #4664
 * CybersourceRest: Add new gateway with authorize and purchase [heavyblade] #4690
 * Litle: Add prelive_url option [aenand] #4710
+* CommerceHub: Fixing verify status and prevent tokenization [heavyblade] #4716
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512


### PR DESCRIPTION
### Summary:
* SER-495: Fix success detection to verify
* SER-507: set default `create_token` for purchase and authorize transactions

### Remote Test:
Finished in 290.029817 seconds.
23 tests, 64 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 46.103032 seconds.
5458 tests, 77155 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
760 files inspected, no offenses detected