### PR TITLE
Braintree: Update transaction hash method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -72,6 +72,7 @@
 * CybersourceREST - Refund | Credit [sinourain] #4700
 * Braintree - Add Paypal custom fields [yunnydang] #4713
 * BlueSnap - Add descriptor phone number field [yunnydang] #4717
+* Braintree - Update transaction hash to include processor_authorization_code [yunnydang] #4718
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -604,19 +604,20 @@ module ActiveMerchant #:nodoc:
         end
 
         {
-          'order_id'                => transaction.order_id,
-          'amount'                  => transaction.amount.to_s,
-          'status'                  => transaction.status,
-          'credit_card_details'     => credit_card_details,
-          'customer_details'        => customer_details,
-          'billing_details'         => billing_details,
-          'shipping_details'        => shipping_details,
-          'vault_customer'          => vault_customer,
-          'merchant_account_id'     => transaction.merchant_account_id,
-          'risk_data'               => risk_data,
-          'network_transaction_id'  => transaction.network_transaction_id || nil,
-          'processor_response_code' => response_code_from_result(result),
-          'recurring'               => transaction.recurring
+          'order_id'                     => transaction.order_id,
+          'amount'                       => transaction.amount.to_s,
+          'status'                       => transaction.status,
+          'credit_card_details'          => credit_card_details,
+          'customer_details'             => customer_details,
+          'billing_details'              => billing_details,
+          'shipping_details'             => shipping_details,
+          'vault_customer'               => vault_customer,
+          'merchant_account_id'          => transaction.merchant_account_id,
+          'risk_data'                    => risk_data,
+          'network_transaction_id'       => transaction.network_transaction_id || nil,
+          'processor_response_code'      => response_code_from_result(result),
+          'processor_authorization_code' => transaction.processor_authorization_code,
+          'recurring'                    => transaction.recurring
         }
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1191,6 +1191,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal '4002 Settlement Pending', response.message
   end
 
+  def test_successful_purchase_with_processor_authorization_code
+    assert response = @gateway.purchase(@amount, @credit_card)
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_not_nil response.params['braintree_transaction']['processor_authorization_code']
+  end
+
   def test_unsucessful_purchase_using_a_bank_account_token_not_verified
     bank_account = check({ account_number: '1000000002', routing_number: '011000015' })
     response = @gateway.store(bank_account, @options.merge(@check_required_options))


### PR DESCRIPTION
This PR is to update the transaction method to include the processor_authorization_code.

Local:
5462 tests, 77124 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6521% passed

Unit:
93 tests, 206 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
101 tests, 495 assertions, 4 failures, 4 errors, 0 pendings, 0 omissions, 0 notifications
92.0792% passed