### PR TITLE
Pin: Update 3DS to include new parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Braintree: Update card verfification payload if billing address fields are not present [yunnydang] #5142
 * DLocal: Update the phone and ip fields [yunnydang] #5143
 * CheckoutV2: Add support for risk data fields [yunnydang] #5147
+* Pin Payments: Add new 3DS params mentioned in Pin Payments docs [hudakh] #4720
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -82,6 +82,11 @@ module ActiveMerchant #:nodoc:
         commit(:put, "charges/#{CGI.escape(token)}/void", {}, options)
       end
 
+      # Verify a previously authorized charge.
+      def verify_3ds(session_token, options = {})
+        commit(:get, "/charges/verify?session_token=#{session_token}", nil, options)
+      end
+
       # Updates the credit card for the customer.
       def update(token, creditcard, options = {})
         post = {}
@@ -183,10 +188,16 @@ module ActiveMerchant #:nodoc:
       def add_3ds(post, options)
         if options[:three_d_secure]
           post[:three_d_secure] = {}
-          post[:three_d_secure][:version] = options[:three_d_secure][:version] if options[:three_d_secure][:version]
-          post[:three_d_secure][:eci] = options[:three_d_secure][:eci] if options[:three_d_secure][:eci]
-          post[:three_d_secure][:cavv] = options[:three_d_secure][:cavv] if options[:three_d_secure][:cavv]
-          post[:three_d_secure][:transaction_id] = options[:three_d_secure][:ds_transaction_id] || options[:three_d_secure][:xid]
+          if options[:three_d_secure][:enabled]
+            post[:three_d_secure][:enabled] = true
+            post[:three_d_secure][:fallback_ok] = options[:three_d_secure][:fallback_ok] unless options[:three_d_secure][:fallback_ok].nil?
+            post[:three_d_secure][:callback_url] = options[:three_d_secure][:callback_url] if options[:three_d_secure][:callback_url]
+          else
+            post[:three_d_secure][:version] = options[:three_d_secure][:version] if options[:three_d_secure][:version]
+            post[:three_d_secure][:eci] = options[:three_d_secure][:eci] if options[:three_d_secure][:eci]
+            post[:three_d_secure][:cavv] = options[:three_d_secure][:cavv] if options[:three_d_secure][:cavv]
+            post[:three_d_secure][:transaction_id] = options[:three_d_secure][:ds_transaction_id] || options[:three_d_secure][:xid]
+          end
         end
       end
 
@@ -271,6 +282,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(parameters = {})
+        return nil unless parameters
+
         parameters.to_json
       end
     end

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -14,6 +14,12 @@ class PinTest < Test::Unit::TestCase
       ip: '127.0.0.1'
     }
 
+    @three_d_secure = {
+      enabled: true,
+      fallback_ok: true,
+      callback_url: 'https://yoursite.com/authentication_complete'
+    }
+
     @three_d_secure_v1 = {
       version: '1.0.2',
       eci: '05',
@@ -365,6 +371,14 @@ class PinTest < Test::Unit::TestCase
     @gateway.send(:add_creditcard, post, 'cus_XZg1ULpWaROQCOT5PdwLkQ')
     assert_equal 'cus_XZg1ULpWaROQCOT5PdwLkQ', post[:customer_token]
     assert_false post.has_key?(:card)
+  end
+
+  def test_add_3ds
+    post = {}
+    @gateway.send(:add_3ds, post, @options.merge(three_d_secure: @three_d_secure))
+    assert_equal true, post[:three_d_secure][:enabled]
+    assert_equal true, post[:three_d_secure][:fallback_ok]
+    assert_equal 'https://yoursite.com/authentication_complete', post[:three_d_secure][:callback_url]
   end
 
   def test_add_3ds_v1


### PR DESCRIPTION
Pin: Update 3DS secure to include new parameters

We have found we cannot use 3DS secure with Pin as the parameters do not match those documented by Pin. This closes #4719. 

Test Summary
Local: 5476 tests, 77236 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Unit: 44 tests, 145 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote: 21 tests, 65 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed