### PR TITLE
Payeezy: Ignore `xid` for AP Amex

### DIFF
--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -247,7 +247,7 @@ module ActiveMerchant
         nt_card[:card_number] = payment_method.number
         nt_card[:exp_date] = format_exp_date(payment_method.month, payment_method.year)
         nt_card[:cvv] = payment_method.verification_value
-        nt_card[:xid] = payment_method.payment_cryptogram unless payment_method.payment_cryptogram.empty?
+        nt_card[:xid] = payment_method.payment_cryptogram unless payment_method.payment_cryptogram.empty? || payment_method.brand.include?('american_express')
         nt_card[:cavv] = payment_method.payment_cryptogram unless payment_method.payment_cryptogram.empty?
         nt_card[:wallet_provider_id] = 'APPLE_PAY'
 

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -50,6 +50,16 @@ class RemotePayeezyTest < Test::Unit::TestCase
       source: :apple_pay,
       verification_value: 569
     )
+    @apple_pay_card_amex = network_tokenization_credit_card(
+      '373953192351004',
+      brand: 'american_express',
+      payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
+      month: '11',
+      year: Time.now.year + 1,
+      eci: 5,
+      source: :apple_pay,
+      verification_value: 569
+    )
   end
 
   def test_successful_store
@@ -83,6 +93,11 @@ class RemotePayeezyTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_apple_pay
     assert response = @gateway.purchase(@amount, @apple_pay_card, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_apple_pay_amex
+    assert response = @gateway.purchase(@amount, @apple_pay_card_amex, @options)
     assert_success response
   end
 


### PR DESCRIPTION
Payeezy has stated the inclusion of `xid` values for AP (Amex underlying) transactions could result in failures. Add guard to ignore adding this field if the underlying is `american_express`

Unit: 49 tests, 227 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote: 47 tests, 186 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed