### PR TITLE
CommerceHub: setting transactionReferenceId for refunds

### DIFF
--- a/test/remote/gateways/remote_commerce_hub_test.rb
+++ b/test/remote/gateways/remote_commerce_hub_test.rb
@@ -128,7 +128,7 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
-    assert_equal "order_id=#{@options[:order_id]}", response.authorization
+    assert_match(/#{@options[:order_id]}|\w*/, response.authorization)
 
     response = @gateway.void(response.authorization, @options)
     assert_success response
@@ -189,7 +189,7 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    response = @gateway.refund(nil, '123', @options)
+    response = @gateway.refund(nil, 'abc123|123', @options)
     assert_failure response
     assert_equal 'Referenced transaction is invalid or not found', response.message
   end


### PR DESCRIPTION
## Summary:
Updating the refund reference to only use referenceTransactionId

SER-523

## Tests
### Remote Test:
Finished in 291.397602 seconds.
23 tests, 64 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.6522% passed

### Unit Tests:
Finished in 37.637689 seconds.
5474 tests, 77230 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
760 files inspected, no offenses detected