### PR TITLE
Checkout_v2: Add idempotency key support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -81,6 +81,7 @@
 * Paymentez: Add transaction inquire request [aenand] #4729
 * Ebanx: Add transaction inquire request [almalee24] #4725
 * Ebanx: Add support for Elo & Hipercard [almalee24] #4702
+* CheckoutV2: Add Idempotency key support [yunnydang] #4728
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -819,4 +819,10 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'request_invalid: card_expired', response.message
     assert_equal 'request_invalid: card_expired', response.error_code
   end
+
+  def test_successful_purchase_with_idempotency_key
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(cko_idempotency_key: 'test123'))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
 end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -434,6 +434,17 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_optional_idempotency_key_header
+    stub_comms(@gateway, :ssl_request) do
+      options = {
+        cko_idempotency_key: 'test123'
+      }
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _url, _data, headers|
+      assert_equal 'test123', headers['Cko-Idempotency-Key']
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_successful_authorize_and_capture_with_metadata
     response = stub_comms(@gateway, :ssl_request) do
       options = {


### PR DESCRIPTION
This PR is to add the support for an optional idempotency key through the header during requests and should be available to all actions (purchase, authorize, and etc). I did note that the failing remote tests were sending back 401 unauthorized even when on the latest upstream master branch. Not sure what that is but here is also a [link to the docs](https://www.checkout.com/docs/payments/manage-payments/retry-a-payment) to save you a few clicks.

Test results can be found below:
Local:
5469 tests, 77162 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications 99.6526% passed

Unit:
54 tests, 300 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
89 tests, 213 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95.5056% passed