### PR TITLE
Paymentez: Add inquire by transaction_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -78,6 +78,7 @@
 * Credorax: Set default ECI values for token transactions [sainterman] #4693
 * CyberSourceRest: Add ACH Support [edgarv09] #4722
 * CybersourceREST: Add capture request [heavyblade] #4726
+* Paymentez: Add transaction inquire request [aenand] #4729
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -137,6 +137,10 @@ module ActiveMerchant #:nodoc:
         commit_card('delete', post)
       end
 
+      def inquire(authorization, options = {})
+        commit_transaction('inquire', authorization)
+      end
+
       def supports_scrubbing?
         true
       end
@@ -232,12 +236,20 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit_raw(object, action, parameters)
-        url = "#{(test? ? test_url : live_url)}#{object}/#{action}"
-
-        begin
-          raw_response = ssl_post(url, post_data(parameters), headers)
-        rescue ResponseError => e
-          raw_response = e.response.body
+        if action == 'inquire'
+          url = "#{(test? ? test_url : live_url)}#{object}/#{parameters}"
+          begin
+            raw_response = ssl_get(url, headers)
+          rescue ResponseError => e
+            raw_response = e.response.body
+          end
+        else
+          url = "#{(test? ? test_url : live_url)}#{object}/#{action}"
+          begin
+            raw_response = ssl_post(url, post_data(parameters), headers)
+          rescue ResponseError => e
+            raw_response = e.response.body
+          end
         end
 
         begin

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -303,6 +303,15 @@ class RemotePaymentezTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_inquire_with_transaction_id
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    gateway_transaction_id = response.authorization
+    response = @gateway.inquire(gateway_transaction_id, @options)
+    assert_success response
+  end
+
   def test_invalid_login
     gateway = PaymentezGateway.new(application_code: '9z8y7w6x', app_key: '1a2b3c4d')
 

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -341,6 +341,18 @@ class PaymentezTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_successful_inquire_with_transaction_id
+    response = stub_comms(@gateway, :ssl_get) do
+      @gateway.inquire('CI-635')
+    end.check_request do |method, _endpoint, _data, _headers|
+      assert_match('https://ccapi-stg.paymentez.com/v2/transaction/CI-635', method)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert_equal 'CI-635', response.authorization
+    assert response.test?
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Get payment status by Paymentez transaction id

Unit:
30 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Remote:
34 tests, 73 assertions, 9 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 73.5294% passed
** These failures also existed on the main branch **