### PR TITLE
Commerce hub new fields

### DIFF
--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -111,9 +111,12 @@ module ActiveMerchant #:nodoc:
 
       def add_transaction_interaction(post, options)
         post[:transactionInteraction] = {}
-        post[:transactionInteraction][:origin] = options[:transaction_origin] || 'ECOM'
+        post[:transactionInteraction][:origin] = options[:origin] || 'ECOM'
         post[:transactionInteraction][:eciIndicator] = options[:eci_indicator] || 'CHANNEL_ENCRYPTED'
         post[:transactionInteraction][:posConditionCode] = options[:pos_condition_code] || 'CARD_NOT_PRESENT_ECOM'
+        post[:transactionInteraction][:posEntryMode] = options[:pos_entry_mode] || 'MANUAL'
+        post[:transactionInteraction][:additionalPosInformation] = {}
+        post[:transactionInteraction][:additionalPosInformation][:dataEntrySource] = options[:data_entry_source] || 'UNSPECIFIED'
       end
 
       def add_transaction_details(post, options, action = nil)
@@ -190,14 +193,9 @@ module ActiveMerchant #:nodoc:
 
       def add_reference_transaction_details(post, authorization, options, action = nil)
         reference_details = {}
-        merchant_reference, transaction_id = authorization.include?('|') ? authorization.split('|') : [nil, authorization]
+        _merchant_reference, transaction_id = authorization.include?('|') ? authorization.split('|') : [nil, authorization]
 
-        if action == :refund
-          reference_details[:referenceTransactionId] = transaction_id
-        else
-          reference_details[merchant_reference.present? ? :referenceMerchantTransactionId : :referenceTransactionId] = merchant_reference.presence || transaction_id
-        end
-
+        reference_details[:referenceTransactionId] = transaction_id
         reference_details[:referenceTransactionType] = (options[:reference_transaction_type] || 'CHARGES') unless action == :capture
         post[:referenceTransactionDetails] = reference_details.compact
       end

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -114,6 +114,7 @@ module ActiveMerchant #:nodoc:
           add_amount(post, amount)
           add_address(post, payment, options[:billing_address], options, :billTo)
           add_address(post, payment, options[:shipping_address], options, :shipTo)
+          add_stored_credentials(post, payment, options)
         end.compact
       end
 
@@ -156,7 +157,6 @@ module ActiveMerchant #:nodoc:
 
       def add_amount(post, amount)
         currency = options[:currency] || currency(amount)
-
         post[:orderInformation][:amountDetails] = {
           totalAmount: localized_amount(amount, currency),
           currency: currency
@@ -251,6 +251,72 @@ module ActiveMerchant #:nodoc:
         merchant[:locality] = options[:merchant_descriptor_locality] if options[:merchant_descriptor_locality]
       end
 
+      def add_stored_credentials(post, payment, options)
+        stored_credential = options[:stored_credential]
+        if stored_credential
+          options = stored_credential_options(stored_credential, options.fetch(:reason_code, ''))
+          post[:processingInformation][:commerceIndicator] = options.fetch(:transaction_type, 'internet')
+          stored_credential[:initial_transaction] ? initial_transaction(post, options) : subsequent_transaction(post, options)
+        end
+      end
+
+      def stored_credential_options(options, reason_code)
+        transaction_type = options[:reason_type]
+        transaction_type = 'install' if transaction_type == 'installment'
+        initiator = options[:initiator] if  options[:initiator]
+        initiator = 'customer' if initiator == 'cardholder'
+        stored_on_file = options[:reason_type] == 'recurring'
+        options.merge({
+          transaction_type: transaction_type,
+          initiator: initiator,
+          reason_code: reason_code,
+          stored_on_file: stored_on_file
+        })
+      end
+
+      def add_processing_information(initiator, merchant_initiated_transaction_hash = {})
+        {
+          authorizationOptions: {
+            initiator: {
+              type: initiator,
+              merchantInitiatedTransaction: merchant_initiated_transaction_hash
+            }
+          }
+        }.compact
+      end
+
+      def initial_transaction(post, options)
+        processing_information = add_processing_information(options[:initiator], {
+          reason: options[:reason_code]
+        })
+
+        post[:processingInformation].merge!(processing_information)
+      end
+
+      def subsequent_transaction(post, options)
+        processor_information = add_processor_information(post, options)
+        network_transaction_id = processor_information ? processor_information[:transactionId] : ''
+        processing_information = add_processing_information(options[:initiator], {
+          originalAuthorizedAmount: post.dig(:orderInformation, :amountDetails, :totalAmount),
+          previousTransactionID: network_transaction_id,
+          reason: options[:reason_code],
+          storedCredentialUsed: options[:stored_on_file]
+        })
+        post[:processingInformation].merge!(processing_information)
+      end
+
+      def add_processor_information(post, options)
+        return unless ntid = options[:network_transaction_id] || options.dig(:stored_credential, :network_transaction_id)
+
+        post[:processorInformation] = {
+          transactionId: ntid
+        }
+      end
+
+      def network_transaction_id_from(response)
+        response.dig('processorInformation', 'networkTransactionId')
+      end
+
       def url(action)
         "#{(test? ? test_url : live_url)}/pts/v2/#{action}"
       end
@@ -272,6 +338,7 @@ module ActiveMerchant #:nodoc:
           authorization: authorization_from(response),
           avs_result: AVSResult.new(code: response.dig('processorInformation', 'avs', 'code')),
           # cvv_result: CVVResult.new(response['some_cvv_response_key']),
+          network_transaction_id: network_transaction_id_from(response),
           test: test?,
           error_code: error_code_from(response)
         )

--- a/test/remote/gateways/remote_commerce_hub_test.rb
+++ b/test/remote/gateways/remote_commerce_hub_test.rb
@@ -4,7 +4,7 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
   def setup
     # Uncomment the sleep if you want to run the entire set of remote tests without
     # getting 'The transaction limit was exceeded. Please try again!' errors
-    # sleep 5
+    sleep 10
 
     @gateway = CommerceHubGateway.new(fixtures(:commerce_hub))
 
@@ -32,11 +32,37 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
       source: :apple_pay,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
     @declined_card = credit_card('4000300011112220', month: '02', year: '2035', verification_value: '123')
+    @master_card = credit_card('5454545454545454', brand: 'master')
     @options = {}
   end
 
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_gsf_mit
+    stored_credential_options = {
+      initial_transaction: true,
+      reason_type: 'recurring',
+      initiator: 'merchant'
+    }
+    @options.merge!(data_entry_source: 'ELECTRONIC_PAYMENT_TERMINAL', pos_entry_mode: 'CONTACTLESS', stored_credential: stored_credential_options)
+    response = @gateway.purchase(@amount, @master_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_cit_with_gsf
+    stored_credential_options = {
+      initial_transaction: true,
+      reason_type: 'cardholder',
+      initiator: 'unscheduled'
+    }
+    @options[:eci_indicator] = 'CHANNEL_ENCRYPTED'
+    @options[:stored_credential] = stored_credential_options
+    response = @gateway.purchase(@amount, @master_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
   end
@@ -116,19 +142,6 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
-
-    response = @gateway.void(response.authorization, @options)
-    assert_success response
-    assert_equal 'Approved', response.message
-  end
-
-  def test_successful_authorize_and_void_using_store_id_as_reference
-    @options[:order_id] = SecureRandom.hex(16)
-
-    response = @gateway.authorize(@amount, @credit_card, @options)
-    assert_success response
-    assert_equal 'Approved', response.message
-    assert_match(/#{@options[:order_id]}|\w*/, response.authorization)
 
     response = @gateway.void(response.authorization, @options)
     assert_success response

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -13,6 +13,9 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
       month: 12,
       year: 2031)
 
+    @master_card = credit_card('2222420000001113', brand: 'master')
+    @discover_card = credit_card('6011111111111117', brand: 'discover')
+
     @apple_pay = network_tokenization_credit_card(
       '4111111111111111',
       payment_cryptogram: 'AceY+igABPs3jdwNaDg3MAACAAA=',
@@ -97,7 +100,6 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
 
   def test_successful_authorize
     response = @gateway.authorize(@amount, @visa_card, @options)
-
     assert_success response
     assert response.test?
     assert_equal 'AUTHORIZED', response.message

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -270,6 +270,7 @@ module ActiveMerchant
       stored_credential[:reason_type] = 'recurring' if args.include?(:recurring)
       stored_credential[:reason_type] = 'unscheduled' if args.include?(:unscheduled)
       stored_credential[:reason_type] = 'installment' if args.include?(:installment)
+      stored_credential[:reason_type] = 'internet' if args.include?(:internet)
 
       stored_credential[:initiator] = 'cardholder' if args.include?(:cardholder)
       stored_credential[:initiator] = 'merchant' if args.include?(:merchant)

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -233,6 +233,47 @@ class CyberSourceRestTest < Test::Unit::TestCase
     assert_equal "#{@gateway.class.test_url}/pts/v2/action", @gateway.send(:url, 'action')
   end
 
+  def test_stored_credential_cit_initial
+    @options[:stored_credential] = stored_credential(:cardholder, :internet, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal 'internet', request['processingInformation']['commerceIndicator']
+      assert_equal 'customer', request.dig('processingInformation', 'authorizationOptions', 'initiator', 'type')
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_cit
+    @options[:stored_credential] = stored_credential(:cardholder, :recurring)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal 'recurring', request['processingInformation']['commerceIndicator']
+      assert_equal 'customer', request.dig('processingInformation', 'authorizationOptions', 'initiator', 'type')
+      assert_equal true, request.dig('processingInformation', 'authorizationOptions', 'initiator', 'merchantInitiatedTransaction', 'storedCredentialUsed')
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_mit_ntid
+    @options[:stored_credential] = stored_credential(:merchant, :recurring, ntid: '123456789619999')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal 'recurring', request['processingInformation']['commerceIndicator']
+      assert_equal 'merchant', request.dig('processingInformation', 'authorizationOptions', 'initiator', 'type')
+      assert_equal true, request.dig('processingInformation', 'authorizationOptions', 'initiator', 'merchantInitiatedTransaction', 'storedCredentialUsed')
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   private
 
   def parse_signature(signature)


### PR DESCRIPTION
This commit add new fields for transactions with stored credentials options
and remove the current referenceMerchantTransactionId in order to use
referenceTransactionId

[SER-504](https://spreedly.atlassian.net/browse/SER-504)
[SER-536](https://spreedly.atlassian.net/browse/SER-536)