### PR TITLE
CommerceHub: Update fields for transactions with sotred credentials

### DIFF
--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -111,9 +111,12 @@ module ActiveMerchant #:nodoc:
 
       def add_transaction_interaction(post, options)
         post[:transactionInteraction] = {}
-        post[:transactionInteraction][:origin] = options[:transaction_origin] || 'ECOM'
+        post[:transactionInteraction][:origin] = options[:origin] || 'ECOM'
         post[:transactionInteraction][:eciIndicator] = options[:eci_indicator] || 'CHANNEL_ENCRYPTED'
         post[:transactionInteraction][:posConditionCode] = options[:pos_condition_code] || 'CARD_NOT_PRESENT_ECOM'
+        post[:transactionInteraction][:posEntryMode] = options[:pos_entry_mode] || 'MANUAL'
+        post[:transactionInteraction][:additionalPosInformation] = {}
+        post[:transactionInteraction][:additionalPosInformation][:dataEntrySource] = options[:data_entry_source] || 'UNSPECIFIED'
       end
 
       def add_transaction_details(post, options, action = nil)
@@ -190,14 +193,9 @@ module ActiveMerchant #:nodoc:
 
       def add_reference_transaction_details(post, authorization, options, action = nil)
         reference_details = {}
-        merchant_reference, transaction_id = authorization.include?('|') ? authorization.split('|') : [nil, authorization]
+        _merchant_reference, transaction_id = authorization.include?('|') ? authorization.split('|') : [nil, authorization]
 
-        if action == :refund
-          reference_details[:referenceTransactionId] = transaction_id
-        else
-          reference_details[merchant_reference.present? ? :referenceMerchantTransactionId : :referenceTransactionId] = merchant_reference.presence || transaction_id
-        end
-
+        reference_details[:referenceTransactionId] = transaction_id
         reference_details[:referenceTransactionType] = (options[:reference_transaction_type] || 'CHARGES') unless action == :capture
         post[:referenceTransactionDetails] = reference_details.compact
       end

--- a/test/unit/gateways/commerce_hub_test.rb
+++ b/test/unit/gateways/commerce_hub_test.rb
@@ -157,7 +157,7 @@ class CommerceHubTest < Test::Unit::TestCase
       @gateway.void('abc123|authorization123', @options)
     end.check_request do |_endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_equal 'abc123', request['referenceTransactionDetails']['referenceMerchantTransactionId']
+      assert_equal 'authorization123', request['referenceTransactionDetails']['referenceTransactionId']
       assert_equal 'CHARGES', request['referenceTransactionDetails']['referenceTransactionType']
       assert_nil request['transactionDetails']['captureFlag']
     end.respond_with(successful_void_and_refund_response)
@@ -192,6 +192,49 @@ class CommerceHubTest < Test::Unit::TestCase
     end.respond_with(successful_void_and_refund_response)
 
     assert_success response
+  end
+
+  def test_successful_purchase_cit_with_gsf
+    options = stored_credential_options(:cardholder, :unscheduled, :initial)
+    options[:data_entry_source] = 'MOBILE_WEB'
+    options[:pos_entry_mode] = 'MANUAL'
+    options[:pos_condition_code] = 'CARD_PRESENT'
+    response = stub_comms do
+      @gateway.purchase(@amount, 'authorization123', options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['transactionInteraction']['origin'], 'ECOM'
+      assert_equal request['transactionInteraction']['eciIndicator'], 'CHANNEL_ENCRYPTED'
+      assert_equal request['transactionInteraction']['posConditionCode'], 'CARD_PRESENT'
+      assert_equal request['transactionInteraction']['posEntryMode'], 'MANUAL'
+      assert_equal request['transactionInteraction']['additionalPosInformation']['dataEntrySource'], 'MOBILE_WEB'
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
+  def test_successful_purchase_mit_with_gsf
+    options = stored_credential_options(:merchant, :recurring)
+    options[:origin] = 'POS'
+    options[:pos_entry_mode] = 'MANUAL'
+    options[:data_entry_source] = 'MOBILE_WEB'
+    response = stub_comms do
+      @gateway.purchase(@amount, 'authorization123', options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['transactionInteraction']['origin'], 'POS'
+      assert_equal request['transactionInteraction']['eciIndicator'], 'CHANNEL_ENCRYPTED'
+      assert_equal request['transactionInteraction']['posConditionCode'], 'CARD_NOT_PRESENT_ECOM'
+      assert_equal request['transactionInteraction']['posEntryMode'], 'MANUAL'
+      assert_equal request['transactionInteraction']['additionalPosInformation']['dataEntrySource'], 'MOBILE_WEB'
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
+  def stored_credential_options(*args, ntid: nil)
+    {
+      order_id: '#1001',
+      stored_credential: stored_credential(*args, ntid: ntid)
+    }
   end
 
   def test_successful_store
@@ -285,17 +328,7 @@ class CommerceHubTest < Test::Unit::TestCase
 
     @gateway.send :add_reference_transaction_details, @post, authorization, {}, :capture
     assert_equal '922e-59fc86a36c03', @post[:referenceTransactionDetails][:referenceTransactionId]
-    assert_nil @post[:referenceTransactionDetails][:referenceMerchantTransactionId]
     assert_nil @post[:referenceTransactionDetails][:referenceTransactionType]
-  end
-
-  def test_add_reference_transaction_details_capture_order_id
-    authorization = 'abc123|922e-59fc86a36c03'
-
-    @gateway.send :add_reference_transaction_details, @post, authorization, {}, :capture
-    assert_equal 'abc123', @post[:referenceTransactionDetails][:referenceMerchantTransactionId]
-    assert_nil @post[:referenceTransactionDetails][:referenceTransactionType]
-    assert_nil @post[:referenceTransactionDetails][:referenceTransactionId]
   end
 
   def test_add_reference_transaction_details_void_reference_id
@@ -306,25 +339,8 @@ class CommerceHubTest < Test::Unit::TestCase
     assert_equal 'CHARGES', @post[:referenceTransactionDetails][:referenceTransactionType]
   end
 
-  def test_add_reference_transaction_details_void_order_id
-    authorization = 'abc123|922e-59fc86a36c03'
-
-    @gateway.send :add_reference_transaction_details, @post, authorization, {}, :void
-    assert_equal 'abc123', @post[:referenceTransactionDetails][:referenceMerchantTransactionId]
-    assert_equal 'CHARGES', @post[:referenceTransactionDetails][:referenceTransactionType]
-    assert_nil @post[:referenceTransactionDetails][:referenceTransactionId]
-  end
-
   def test_add_reference_transaction_details_refund_reference_id
     authorization = '|922e-59fc86a36c03'
-
-    @gateway.send :add_reference_transaction_details, @post, authorization, {}, :refund
-    assert_equal '922e-59fc86a36c03', @post[:referenceTransactionDetails][:referenceTransactionId]
-    assert_equal 'CHARGES', @post[:referenceTransactionDetails][:referenceTransactionType]
-  end
-
-  def test_add_reference_transaction_details_refund_order_id
-    authorization = 'abc123|922e-59fc86a36c03'
 
     @gateway.send :add_reference_transaction_details, @post, authorization, {}, :refund
     assert_equal '922e-59fc86a36c03', @post[:referenceTransactionDetails][:referenceTransactionId]


### PR DESCRIPTION
Description
-------------------------
This commit add new fields for transactions with stored credentials options and remove the current referenceMerchantTransactionId in order to use referenceTransactionId

[SER-504](https://spreedly.atlassian.net/browse/SER-504) 
[SER-536](https://spreedly.atlassian.net/browse/SER-536)

Unit test
-------------------------
Finished in 0.01392 seconds.

22 tests, 147 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

1580.46 tests/s, 10560.34 assertions/s

Remote test
-------------------------
Finished in 296.371956 seconds.

24 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

0.08 tests/s, 0.21 assertions/s

Rubocop
-------------------------
760 files inspected, no offenses detected