### PR TITLE
Adyen: add support for shopper_statement field for capture action

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@
 * Ebanx: Add transaction inquire request [almalee24] #4725
 * Ebanx: Add support for Elo & Hipercard [almalee24] #4702
 * CheckoutV2: Add Idempotency key support [yunnydang] #4728
+* Adyen: Add support for shopper_statement field for capture [yunnydang] #PR 4736
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -77,6 +77,7 @@ module ActiveMerchant #:nodoc:
         add_reference(post, authorization, options)
         add_splits(post, options)
         add_network_transaction_reference(post, options)
+        add_shopper_statement(post, options)
         commit('capture', post, options)
       end
 
@@ -297,6 +298,14 @@ module ActiveMerchant #:nodoc:
         post[:shopperIP] = options[:shopper_ip] if options[:shopper_ip]
         post[:shopperStatement] = options[:shopper_statement] if options[:shopper_statement]
         post[:additionalData][:updateShopperStatement] = options[:update_shopper_statement] if options[:update_shopper_statement]
+      end
+
+      def add_shopper_statement(post, options)
+        return unless options[:shopper_statement]
+
+        post[:additionalData] = {
+          shopperStatement: options[:shopper_statement]
+        }
       end
 
       def add_merchant_data(post, options)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1343,6 +1343,14 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success refund
   end
 
+  def test_successful_capture_with_shopper_statement
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge(shopper_statement: 'test1234'))
+    assert_success capture
+  end
+
   def test_purchase_with_skip_mpi_data
     options = {
       reference: '345123',

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -340,6 +340,14 @@ class AdyenTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_successful_capture_with_shopper_statement
+    stub_comms do
+      @gateway.capture(@amount, '7914775043909934', @options.merge(shopper_statement: 'test1234'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'test1234', JSON.parse(data)['additionalData']['shopperStatement']
+    end.respond_with(successful_capture_response)
+  end
+
   def test_successful_purchase_with_credit_card
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
shopper_statement is already a supported gateway field however Adyen is claiming that it works fine for auth, but not for capture. This is to fix/add to the capture action requests so that shopperStatement is nested within addtionalData and set properly.

Local:
5477 tests, 77201 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6531% passed

Unit:
105 tests, 531 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
132 tests, 443 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
90.9091% passed