### PR TITLE
CheckoutV2: Set merchant_initiated value for Third Party Token

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -208,6 +208,7 @@ module ActiveMerchant #:nodoc:
           else
             add_source(post, options)
           end
+          post[:merchant_initiated] = true if options[:third_party_token_merchant_initiator] == 'merchant'
         elsif payment_method.try(:year)
           post[key][:expiry_year] = format(payment_method.year, :four_digits)
           post[key][:expiry_month] = format(payment_method.month, :two_digits)

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -789,6 +789,14 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_equal %w[AD AE AR AT AU BE BG BH BR CH CL CN CO CY CZ DE DK EE EG ES FI FR GB GR HK HR HU IE IS IT JO JP KW LI LT LU LV MC MT MX MY NL NO NZ OM PE PL PT QA RO SA SE SG SI SK SM TR US], @gateway.supported_countries
   end
 
+  def test_set_merchant_initiator_using_third_party_token_merchant_initiator
+    post = {}
+    @gateway.send(:add_payment_method, post, 'src_vhzsyc6mgl3etbxfnqqobdjh3i', { third_party_token_merchant_initiator: 'merchant' })
+    assert_equal post[:source][:type], 'id'
+    assert_equal post[:source][:id], 'src_vhzsyc6mgl3etbxfnqqobdjh3i'
+    assert_equal post[:merchant_initiated], true
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Summary:
------------------------------
Allow setting merchant_initiated value in case the payment method was a Third Party Token using the attribute `third_party_token_merchant_initiator`

SER-538

Remote Test:
------------------------------
Finished in 29.754991 seconds.
33 tests, 105 assertions, 0 failures, 0 errors, 0 pendings,0 omissions, 0 notifications 100% passed

Unit Tests:
------------------------------
Finished in 0.04074 seconds.
18 tests, 99 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

RuboCop:
------------------------------
760 files inspected, no offenses detected