### PR TITLE
Shift4: Handling access token failed calls

### DIFF
--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -153,6 +153,8 @@ module ActiveMerchant #:nodoc:
         add_datetime(post, options)
 
         response = commit('accesstoken', post, request_headers('accesstoken', options))
+        raise ArgumentError, response.params.fetch('result', [{}]).first.dig('error', 'longText') unless response.success?
+
         response.params['result'].first['credential']['accessToken']
       end
 


### PR DESCRIPTION
### Summary:
Adding changes to handle failed calls to get the access token by raising an exception that will be handled as 422

GWS-46

### Remote Test:
Finished in 172.659123 seconds.
24 tests, 56 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.6667% passed

### Unit Tests:
Finished in 40.296092 seconds.
5480 tests, 77260 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop: 
760 files inspected, no offenses detected