### PR TITLE
CyberSourceRest: Add gateway specific fields handling

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -49,20 +49,20 @@ module ActiveMerchant #:nodoc:
         post = build_auth_request(money, payment, options)
         post[:processingInformation][:capture] = true if capture
 
-        commit('payments', post)
+        commit('payments', post, options)
       end
 
       def capture(money, authorization, options = {})
         payment = authorization.split('|').first
         post = build_reference_request(money, options)
 
-        commit("payments/#{payment}/captures", post)
+        commit("payments/#{payment}/captures", post, options)
       end
 
       def refund(money, authorization, options = {})
         payment = authorization.split('|').first
         post = build_reference_request(money, options)
-        commit("payments/#{payment}/refunds", post)
+        commit("payments/#{payment}/refunds", post, options)
       end
 
       def credit(money, payment, options = {})
@@ -111,9 +111,12 @@ module ActiveMerchant #:nodoc:
           add_customer_id(post, options)
           add_code(post, options)
           add_payment(post, payment, options)
+          add_mdd_fields(post, options)
           add_amount(post, amount)
           add_address(post, payment, options[:billing_address], options, :billTo)
           add_address(post, payment, options[:shipping_address], options, :shipTo)
+          add_business_rules_data(post, payment, options)
+          add_partner_solution_id(post)
           add_stored_credentials(post, payment, options)
         end.compact
       end
@@ -121,7 +124,9 @@ module ActiveMerchant #:nodoc:
       def build_reference_request(amount, options)
         { clientReferenceInformation: {}, orderInformation: {} }.tap do |post|
           add_code(post, options)
+          add_mdd_fields(post, options)
           add_amount(post, amount)
+          add_partner_solution_id(post)
         end.compact
       end
 
@@ -129,6 +134,7 @@ module ActiveMerchant #:nodoc:
         { clientReferenceInformation: {}, paymentInformation: {}, orderInformation: {} }.tap do |post|
           add_code(post, options)
           add_credit_card(post, payment)
+          add_mdd_fields(post, options)
           add_amount(post, amount)
           add_address(post, payment, options[:billing_address], options, :billTo)
           add_merchant_description(post, options)
@@ -320,7 +326,10 @@ module ActiveMerchant #:nodoc:
         JSON.parse(body)
       end
 
-      def commit(action, post)
+      def commit(action, post, options = {})
+        add_reconciliation_id(post, options)
+        add_sec_code(post, options)
+        add_invoice_number(post, options)
         response = parse(ssl_post(url(action), post.to_json, auth_headers(action, post)))
         Response.new(
           success_from(response),
@@ -400,6 +409,47 @@ module ActiveMerchant #:nodoc:
           'Signature' => get_http_signature(action, digest, http_method, date),
           'Digest' => digest
         }
+      end
+
+      def add_business_rules_data(post, payment, options)
+        post[:processingInformation][:authorizationOptions] = {}
+        unless payment.is_a?(NetworkTokenizationCreditCard)
+          post[:processingInformation][:authorizationOptions][:ignoreAvsResult] = 'true' if options[:ignore_avs].to_s == 'true'
+          post[:processingInformation][:authorizationOptions][:ignoreCvResult] = 'true' if options[:ignore_cvv].to_s == 'true'
+        end
+      end
+
+      def add_mdd_fields(post, options)
+        mdd_fields = options.select { |k, v| k.to_s.start_with?('mdd_field') && v.present? }
+        return unless mdd_fields.present?
+
+        post[:merchantDefinedInformation] = mdd_fields.map do |key, value|
+          { key: key, value: value }
+        end
+      end
+
+      def add_reconciliation_id(post, options)
+        return unless options[:reconciliation_id].present?
+
+        post[:clientReferenceInformation][:reconciliationId] = options[:reconciliation_id]
+      end
+
+      def add_sec_code(post, options)
+        return unless options[:sec_code].present?
+
+        post[:processingInformation][:bankTransferOptions] = { secCode: options[:sec_code] }
+      end
+
+      def add_invoice_number(post, options)
+        return unless options[:invoice_number].present?
+
+        post[:orderInformation][:invoiceDetails] = { invoiceNumber: options[:invoice_number] }
+      end
+
+      def add_partner_solution_id(post)
+        return unless application_id
+
+        post[:clientReferenceInformation][:partner] = { solutionId: application_id }
       end
     end
   end

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -274,6 +274,124 @@ class CyberSourceRestTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_credit_card_purchase_single_request_ignore_avs
+    stub_comms do
+      options = @options.merge(ignore_avs: true)
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, request_body, _headers|
+      json_body = JSON.parse(request_body)
+      assert_equal json_body['processingInformation']['authorizationOptions']['ignoreAvsResult'], 'true'
+      assert_nil json_body['processingInformation']['authorizationOptions']['ignoreCvResult']
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_successful_credit_card_purchase_single_request_without_ignore_avs
+    stub_comms do
+      # globally ignored AVS for gateway instance:
+      options = @options.merge(ignore_avs: false)
+      @gateway.options[:ignore_avs] = true
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, request_body, _headers|
+      json_body = JSON.parse(request_body)
+      assert_nil json_body['processingInformation']['authorizationOptions']['ignoreAvsResult']
+      assert_nil json_body['processingInformation']['authorizationOptions']['ignoreCvResult']
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_successful_credit_card_purchase_single_request_ignore_ccv
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(ignore_cvv: true))
+    end.check_request do |_endpoint, request_body, _headers|
+      json_body = JSON.parse(request_body)
+      assert_nil json_body['processingInformation']['authorizationOptions']['ignoreAvsResult']
+      assert_equal json_body['processingInformation']['authorizationOptions']['ignoreCvResult'], 'true'
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_successful_credit_card_purchase_single_request_without_ignore_ccv
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(ignore_cvv: false))
+    end.check_request do |_endpoint, request_body, _headers|
+      json_body = JSON.parse(request_body)
+      assert_nil json_body['processingInformation']['authorizationOptions']['ignoreAvsResult']
+      assert_nil json_body['processingInformation']['authorizationOptions']['ignoreCvResult']
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_authorize_includes_mdd_fields
+    stub_comms do
+      @gateway.authorize(100, @credit_card, order_id: '1', mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
+    end.check_request do |_endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      assert_equal json_data['merchantDefinedInformation'][0]['key'], 'mdd_field_2'
+      assert_equal json_data['merchantDefinedInformation'][0]['value'], 'CustomValue2'
+      assert_equal json_data['merchantDefinedInformation'].count, 2
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_capture_includes_mdd_fields
+    stub_comms do
+      @gateway.capture(100, '1846925324700976124593', order_id: '1', mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
+    end.check_request do |_endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      assert_equal json_data['merchantDefinedInformation'][0]['key'], 'mdd_field_2'
+      assert_equal json_data['merchantDefinedInformation'][0]['value'], 'CustomValue2'
+      assert_equal json_data['merchantDefinedInformation'].count, 2
+    end.respond_with(successful_capture_response)
+  end
+
+  def test_credit_includes_mdd_fields
+    stub_comms do
+      @gateway.credit(@amount, @credit_card, mdd_field_2: 'CustomValue2', mdd_field_3: 'CustomValue3')
+    end.check_request do |_endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      assert_equal json_data['merchantDefinedInformation'][0]['key'], 'mdd_field_2'
+      assert_equal json_data['merchantDefinedInformation'][0]['value'], 'CustomValue2'
+      assert_equal json_data['merchantDefinedInformation'].count, 2
+    end.respond_with(successful_credit_response)
+  end
+
+  def test_authorize_includes_reconciliation_id
+    stub_comms do
+      @gateway.authorize(100, @credit_card, order_id: '1', reconciliation_id: '181537')
+    end.check_request do |_endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      assert_equal json_data['clientReferenceInformation']['reconciliationId'], '181537'
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_bank_account_purchase_includes_sec_code
+    stub_comms do
+      @gateway.purchase(@amount, @bank_account, order_id: '1', sec_code: 'WEB')
+    end.check_request do |_endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      assert_equal json_data['processingInformation']['bankTransferOptions']['secCode'], 'WEB'
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_purchase_includes_invoice_number
+    stub_comms do
+      @gateway.purchase(100, @credit_card, invoice_number: '1234567')
+    end.check_request do |_endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      assert_equal json_data['orderInformation']['invoiceDetails']['invoiceNumber'], '1234567'
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_adds_application_id_as_partner_solution_id
+    partner_id = 'partner_id'
+    CyberSourceRestGateway.application_id = partner_id
+
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      assert_equal json_data['clientReferenceInformation']['partner']['solutionId'], partner_id
+    end.respond_with(successful_purchase_response)
+  ensure
+    CyberSourceRestGateway.application_id = nil
+  end
+
   private
 
   def parse_signature(signature)
@@ -379,6 +497,86 @@ class CyberSourceRestTest < Test::Unit::TestCase
         "status": "AUTHORIZED",
         "submitTimeUtc": "2023-01-29T17:13:31Z"
       }
+    RESPONSE
+  end
+
+  def successful_capture_response
+    <<-RESPONSE
+    {
+      "_links": {
+        "void": {
+          "method": "POST",
+          "href": "/pts/v2/captures/6799471903876585704951/voids"
+        },
+        "self": {
+          "method": "GET",
+          "href": "/pts/v2/captures/6799471903876585704951"
+        }
+      },
+      "clientReferenceInformation": {
+        "code": "TC50171_3"
+      },
+      "id": "6799471903876585704951",
+      "orderInformation": {
+        "amountDetails": {
+          "totalAmount": "102.21",
+          "currency": "USD"
+        }
+      },
+      "reconciliationId": "78243988SD9YL291",
+      "status": "PENDING",
+      "submitTimeUtc": "2023-03-27T19:59:50Z"
+    }
+    RESPONSE
+  end
+
+  def successful_credit_response
+    <<-RESPONSE
+    {
+      "_links": {
+        "void": {
+          "method": "POST",
+          "href": "/pts/v2/credits/6799499091686234304951/voids"
+        },
+        "self": {
+          "method": "GET",
+          "href": "/pts/v2/credits/6799499091686234304951"
+        }
+      },
+      "clientReferenceInformation": {
+        "code": "12345678"
+      },
+      "creditAmountDetails": {
+        "currency": "usd",
+        "creditAmount": "200.00"
+      },
+      "id": "6799499091686234304951",
+      "orderInformation": {
+        "amountDetails": {
+          "currency": "usd"
+        }
+      },
+      "paymentAccountInformation": {
+        "card": {
+          "type": "001"
+        }
+      },
+      "paymentInformation": {
+        "tokenizedCard": {
+          "type": "001"
+        },
+        "card": {
+          "type": "001"
+        }
+      },
+      "processorInformation": {
+        "approvalCode": "888888",
+        "responseCode": "100"
+      },
+      "reconciliationId": "70391830ZFKZI570",
+      "status": "PENDING",
+      "submitTimeUtc": "2023-03-27T20:45:09Z"
+    }
     RESPONSE
   end
 end


### PR DESCRIPTION
Summary:
In order to handle several gateway specific fields this commit add the following ones in the cybersource rest gateway file
- ignore_avs
- ignore_cvv
- mdd_fields
- reconciliation_id
- customer_id
- zero_amount_verify
- sec_code
- invoice number

Remote Test:
Finished in 36.507289 seconds.
35 tests, 108 assertions, 0 failures, 0 errors, 0 pendings,0 omissions, 0 notifications 100% passed

Unit Tests:
Finished in 0.06123 seconds.
27 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

RuboCop:
760 files inspected, no offenses detected