### PR TITLE
Ebanx: Remove default email

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -85,6 +85,7 @@
 * Adyen: Add support for shopper_statement field for capture [yunnydang] #4736
 * CheckoutV2: Update idempotency_key name [yunnydang] #4737
 * Payeezy: Enable external 3DS [jherreraa] #4715
+* Ebanx: Remove default email [aenand] #4747
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -155,7 +155,7 @@ module ActiveMerchant #:nodoc:
 
       def add_customer_data(post, payment, options)
         post[:payment][:name] = customer_name(payment, options)
-        post[:payment][:email] = options[:email] || 'unspecified@example.com'
+        post[:payment][:email] = options[:email]
         post[:payment][:document] = options[:document]
         post[:payment][:birth_date] = options[:birth_date] if options[:birth_date]
       end

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -24,7 +24,8 @@ class RemoteEbanxTest < Test::Unit::TestCase
         metadata_2: 'test2'
       },
       tags: EbanxGateway::TAGS,
-      soft_descriptor: 'ActiveMerchant'
+      soft_descriptor: 'ActiveMerchant',
+      email: 'neymar@test.com'
     }
 
     @hiper_card = credit_card('6062825624254001')
@@ -131,6 +132,13 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_failure response
     assert_equal 'Invalid card or card type', response.message
     assert_equal 'NOK', response.error_code
+  end
+
+  def test_failed_authorize_no_email
+    response = @gateway.authorize(@amount, @declined_card, @options.except(:email))
+    assert_failure response
+    assert_equal 'Field payment.email is required', response.message
+    assert_equal 'BP-DR-15', response.error_code
   end
 
   def test_successful_partial_capture_when_include_capture_amount_is_not_passed


### PR DESCRIPTION
ECS-2829

Ebanx requires that merchants pass in an email in
order to complete a transaction. Previously, ActiveMerchant was sending in a default email if one was not provided which causes Ebanx's fraud detection to mark these transactions as failed for fraud. This incorrect failure message has led to merchant frustration since they could not quickly know the root of the problem

Test Summary
Remote:
32 tests, 88 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96.875% passed