### PR TITLE
Bogus: Add verify functionality

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -94,6 +94,7 @@
 * CyberSourceRest: Add gateway specific fields handling [jherreraa] #4746
 * IPG: Improve error handling [heavyblade] #4753
 * Shift4: Handle access token failed calls [heavyblade] #4745
+* Bogus: Add verify functionality [willemk] #4749
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -90,6 +90,10 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def verify(credit_card, options = {})
+        authorize(0, credit_card, options)
+      end
+
       def store(paysource, options = {})
         case normalize(paysource)
         when /1$/

--- a/test/unit/gateways/bogus_test.rb
+++ b/test/unit/gateways/bogus_test.rb
@@ -96,6 +96,17 @@ class BogusTest < Test::Unit::TestCase
     end
   end
 
+  def test_verify
+    assert @gateway.verify(credit_card(CC_SUCCESS_PLACEHOLDER)).success?
+    response = @gateway.verify(credit_card(CC_FAILURE_PLACEHOLDER))
+    refute response.success?
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
+    e = assert_raises(ActiveMerchant::Billing::Error) do
+      @gateway.verify(credit_card('123'))
+    end
+    assert_equal('Bogus Gateway: Use CreditCard number ending in 1 for success, 2 for exception and anything else for error', e.message)
+  end
+
   def test_store
     assert @gateway.store(credit_card(CC_SUCCESS_PLACEHOLDER)).success?
     response = @gateway.store(credit_card(CC_FAILURE_PLACEHOLDER))


### PR DESCRIPTION
## Summary

Add support for the `verify` functionality to the Bogus Gateway. 

While the [gateway template](https://github.com/activemerchant/active_merchant/blob/master/generators/gateway/templates/gateway.rb#L53) traditionally defines `verify` as an `authorize` + `void`, for the sake of the bogus gateway where responses are faked, this has been simplified to just an `authorize` since the `void` call is traditionally ignored. 