### PR TITLE
Kushki Gateway: Add support for the months and deferred fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -89,6 +89,7 @@
 * CyberSourceRest: Add stored credentials support [jherreraa] #4707
 * Payeezy: Add `last_name` for `add_network_tokenization` [naashton] #4743
 * Stripe PI: Tokenize payment method at Stripe for `verify` [aenand] #4748
+* Kushki: Add support for the months and deferred fields [yunnydang] #4752
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -83,6 +83,8 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method, options)
         add_full_response(post, options)
         add_metadata(post, options)
+        add_months(post, options)
+        add_deferred(post, options)
 
         commit(action, post)
       end
@@ -96,6 +98,8 @@ module ActiveMerchant #:nodoc:
         add_contact_details(post, options[:contact_details]) if options[:contact_details]
         add_full_response(post, options)
         add_metadata(post, options)
+        add_months(post, options)
+        add_deferred(post, options)
 
         commit(action, post)
       end
@@ -108,6 +112,8 @@ module ActiveMerchant #:nodoc:
         add_invoice(action, post, amount, options)
         add_full_response(post, options)
         add_metadata(post, options)
+        add_months(post, options)
+        add_deferred(post, options)
 
         commit(action, post)
       end
@@ -182,6 +188,20 @@ module ActiveMerchant #:nodoc:
 
       def add_metadata(post, options)
         post[:metadata] = options[:metadata] if options[:metadata]
+      end
+
+      def add_months(post, options)
+        post[:months] = options[:months] if options[:months]
+      end
+
+      def add_deferred(post, options)
+        return unless options[:deferred_grace_months] && options[:deferred_credit_type] && options[:deferred_months]
+
+        post[:deferred] = {
+          graceMonths: options[:deferred_grace_months],
+          creditType: options[:deferred_credit_type],
+          months: options[:deferred_months]
+        }
       end
 
       ENDPOINT = {

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -36,7 +36,11 @@ class RemoteKushkiTest < Test::Unit::TestCase
       metadata: {
         productos: 'bananas',
         nombre_apellido: 'Kirk'
-      }
+      },
+      months: 2,
+      deferred_grace_months: '05',
+      deferred_credit_type: '01',
+      deferred_months: 3
     }
 
     amount = 100 * (

--- a/test/unit/gateways/kushki_test.rb
+++ b/test/unit/gateways/kushki_test.rb
@@ -41,7 +41,11 @@ class KushkiTest < Test::Unit::TestCase
       metadata: {
         productos: 'bananas',
         nombre_apellido: 'Kirk'
-      }
+      },
+      months: 2,
+      deferred_grace_months: '05',
+      deferred_credit_type: '01',
+      deferred_months: 3
     }
 
     amount = 100 * (
@@ -58,6 +62,10 @@ class KushkiTest < Test::Unit::TestCase
       @gateway.purchase(amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
       assert_includes data, 'metadata'
+      assert_includes data, 'months'
+      assert_includes data, 'deferred_grace_month'
+      assert_includes data, 'deferred_credit_type'
+      assert_includes data, 'deferred_months'
     end.respond_with(successful_token_response, successful_charge_response)
 
     assert_success response


### PR DESCRIPTION
This PR will allow support for the months field and deferred fields. The [gateway documentation](https://api-docs.kushkipagos.com/docs/online-payments/card/operations/create-a-card-v-1-charge#request-body) has the deferred field as an object, however we believe it's more easy and intuitive to support them as individual GSFs.

Local:
5481 tests, 77221 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6533% passed

Unit:
17 tests, 109 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
16 tests, 51 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed