### PR TITLE
Checkout: Add Shipping Address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* CheckoutV2: Add support for Shipping Address [nicolas-maalouf-cko] #4755
 * Element: Include Apple Pay - Google pay methods [jherrera] #4647
 * dLocal: Add transaction query API(s) request [almalee24] #4584
 * MercadoPago: Add transaction inquire request [molbrown] #4588

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -49,6 +49,7 @@ module ActiveMerchant #:nodoc:
         post[:capture_type] = options[:capture_type] || 'Final'
         add_invoice(post, amount, options)
         add_customer_data(post, options)
+        add_shipping_address(post, options)
         add_metadata(post, options)
 
         commit(:capture, post, options, authorization)
@@ -121,6 +122,7 @@ module ActiveMerchant #:nodoc:
             add_payment_method(post, token, options)
             post.merge!(post.delete(:source))
             add_customer_data(post, options)
+            add_shipping_address(post, options)
             r.process { commit(:store, post, options) }
           end
         end
@@ -137,6 +139,7 @@ module ActiveMerchant #:nodoc:
         add_authorization_type(post, options)
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)
+        add_shipping_address(post, options)
         add_stored_credential_options(post, options)
         add_transaction_data(post, options)
         add_3ds(post, options)
@@ -233,6 +236,19 @@ module ActiveMerchant #:nodoc:
           post[:source][:billing_address][:state] = address[:state] unless address[:state].blank?
           post[:source][:billing_address][:country] = address[:country] unless address[:country].blank?
           post[:source][:billing_address][:zip] = address[:zip] unless address[:zip].blank?
+        end
+      end
+
+      def add_shipping_address(post, options)
+        if address = options[:shipping_address]
+          post[:shipping] = {}
+          post[:shipping][:address] = {}
+          post[:shipping][:address][:address_line1] = address[:address1] unless address[:address1].blank?
+          post[:shipping][:address][:address_line2] = address[:address2] unless address[:address2].blank?
+          post[:shipping][:address][:city] = address[:city] unless address[:city].blank?
+          post[:shipping][:address][:state] = address[:state] unless address[:state].blank?
+          post[:shipping][:address][:country] = address[:country] unless address[:country].blank?
+          post[:shipping][:address][:zip] = address[:zip] unless address[:zip].blank?
         end
       end
 


### PR DESCRIPTION
# Short Summary: 
Add Shipping Address details based on the Checkout.com [API reference](https://api-reference.checkout.com/#operation/requestAPaymentOrPayout)

# Tests:

## Unit Tests:
Finished in 21.159827 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------
5492 tests, 77316 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## Remote Tests:
Finished in 55.268942 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------
89 tests, 211 assertions, 1 failures, 3 errors, 0 pendings, 0 omissions, 0 notifications
95.5056% passed

Test that failed is due to Sandbox account not supporting credit (payouts) simulation:
test_successful_credit

