### PR TITLE
Close stale issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'Message to comment on stale issues. If none provided, will not mark issues stale'
+          stale-pr-message: 'Message to comment on stale PRs. If none provided, will not mark PRs stale'
+          days-before-close: 21
+          exempt-draft-pr: true
+          debug-only: true


### PR DESCRIPTION
The ActiveMerchant repository often has old issues and PRs that have gone stale. This makes it hard
to keep track of new requests. This commit adds
the `stale` GHA in debug only mode to have a dry run of auto-closing issues and PRs.

Issues will be able to live for 60 days without activity and PRs fro 21 days (excluding draft PRs).

Docs: https://github.com/marketplace/actions/close-stale-issues