### PR TITLE
POC: Ebanx V2

### DIFF
--- a/lib/active_merchant/billing/gateways/ebanx/ebanx_v2.rb
+++ b/lib/active_merchant/billing/gateways/ebanx/ebanx_v2.rb
@@ -1,0 +1,53 @@
+module ActiveMerchant
+  module Billing
+    module EbanxV2
+      attr_accessor :gateway_version
+
+      @test_url = 'https://sandbox.ebanxpay.com/channels/spreedly/'
+      @live_url = 'https://api.ebanxpay.com/channels/spreedly/'
+
+      def get_gateway_version(parameters)
+        return unless test?
+
+        headers = { 'x-ebanx-client-user-agent': "ActiveMerchant/#{ActiveMerchant::VERSION}" }
+        headers['authorization'] = @options[:integration_key]
+        headers['content-type'] = "application/json"
+
+        processing_type = parameters[:processing_type]
+
+        add_processing_type_to_commit_headers(headers, processing_type) if processing_type == 'local'
+
+        response = parse(ssl_get(get_url, headers))
+
+        @gateway_version = response['gateway'] || 'v1'
+      end
+
+      def get_url
+        if test?
+          'https://sandbox.ebanxpay.com/channels/spreedly/flow'
+        else
+          'https://api.ebanxpay.com/channels/spreedly/flow'
+        end
+      end
+
+      def new_headers(params)
+        headers = { 'x-ebanx-client-user-agent': "ActiveMerchant/#{ActiveMerchant::VERSION}" }
+        headers['authorization'] = @options[:integration_key]
+        headers['content-type'] = "application/json"
+
+        processing_type = params[:options][:processing_type] if params[:options].present? && params[:options][:processing_type].present?
+        add_processing_type_to_headers(headers, processing_type) if processing_type && processing_type == 'local'
+
+        headers
+      end
+      
+      def url_for_v2(is_test_env, action, parameters)
+        hostname = is_test_env ? @test_url : @live_url
+
+        return "#{hostname}#{URL_MAP[action]}/#{parameters[:hash]}" if requires_http_get(action)
+
+        "#{hostname}#{URL_MAP[action]}"
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -323,7 +323,10 @@ direc_pay:
 
 # Working credentials, no need to replace
 ebanx:
-  integration_key: 1231000
+  integration_key: test_ik_EXeKqadSh7RG79Ou-udqxQ
+
+ebanx_v2:
+  integration_key: test_ik_8siRsfSaYc0UZozPfMD2ug
 
 efsnet:
   login: X

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class RemoteEbanxTest < Test::Unit::TestCase
   def setup
     @gateway = EbanxGateway.new(fixtures(:ebanx))
+    @gateway_v2 = EbanxGateway.new(fixtures(:ebanx_v2))
 
     @amount = 100
     @credit_card = credit_card('4111111111111111')
@@ -34,6 +35,12 @@ class RemoteEbanxTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Accepted', response.message
+  end
+
+  def test_successful_purchase_v2
+    response = @gateway_v2.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Accepted', response.message
   end


### PR DESCRIPTION
This commit creates a mixin for EBANX V2 so that
the gateway can begin to experiment with altering
the gateway's integration. By having a mixin, consumers of AM can continue to extend the base class and have a bit of visibility into the changes that EBANX is trying out.

Once a change has "graduated", it should be moved from the mixin to the base class