### PR TITLE
Improve error handling: OAuth

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 == HEAD
 * Adyen: Update selectedBrand mapping for Google Pay [jcreiff] #4763
 * Shift4: Add vendorReference field [jcreiff] #4762
+* Shift4: Add OAuth error [aenand] #4760
 
 == Version 1.128.0 (April 24th, 2023)
 * CheckoutV2: Add support for Shipping Address [nicolas-maalouf-cko] #4755

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -153,7 +153,7 @@ module ActiveMerchant #:nodoc:
         add_datetime(post, options)
 
         response = commit('accesstoken', post, request_headers('accesstoken', options))
-        raise ArgumentError, response.params.fetch('result', [{}]).first.dig('error', 'longText') unless response.success?
+        raise OAuthResponseError.new(response, response.params.fetch('result', [{}]).first.dig('error', 'longText')) unless response.success?
 
         response.params['result'].first['credential']['accessToken']
       end

--- a/lib/active_merchant/errors.rb
+++ b/lib/active_merchant/errors.rb
@@ -23,8 +23,11 @@ module ActiveMerchant #:nodoc:
     end
 
     def to_s
-      "Failed with #{response.code} #{response.message if response.respond_to?(:message)}"
+      "Failed with #{response.code if response.respond_to?(:code)} #{response.message if response.respond_to?(:message)}"
     end
+  end
+
+  class OAuthResponseError < ResponseError # :nodoc:
   end
 
   class ClientCertificateError < ActiveMerchantError # :nodoc

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -243,6 +243,13 @@ class RemoteShift4Test < Test::Unit::TestCase
     assert_include response.message, 'Invoice Not Found'
   end
 
+  def test_failed_access_token
+    gateway = Shift4Gateway.new({ client_guid: 'YOUR_CLIENT_ID', auth_token: 'YOUR_AUTH_TOKEN' })
+    assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway.setup_access_token
+    end
+  end
+
   private
 
   def response_result(response)

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -360,9 +360,11 @@ class Shift4Test < Test::Unit::TestCase
   def test_setup_access_token_should_rise_an_exception_under_unsuccessful_request
     @gateway.expects(:ssl_post).returns(failed_auth_response)
 
-    assert_raises(ArgumentError) do
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
       @gateway.setup_access_token
     end
+
+    assert_match(/Failed with  AuthToken not valid ENGINE22CE/, error.message)
   end
 
   def test_setup_access_token_should_successfully_extract_the_token_from_response
@@ -1012,6 +1014,24 @@ class Shift4Test < Test::Unit::TestCase
             "error": {
               "longText": "AuthToken not valid ENGINE22CE",
               "primaryCode": 9862,
+              "secondaryCode": 4,
+              "shortText ": "AuthToken"
+            },
+            "server": {
+              "name": "UTGAPI03CE"
+            }
+          }
+        ]
+      }
+    RESPONSE
+  end
+
+  def failed_auth_response_no_message
+    <<-RESPONSE
+      {
+        "result": [
+          {
+            "error": {
               "secondaryCode": 4,
               "shortText ": "AuthToken"
             },


### PR DESCRIPTION
ECS-2845

OAuth has become a standard authentication
mechanism for many gateways in recent years
however AM has not been updated to support error
handling when a merchant passes incorrect details
to the gateway.

In non OAuth flows we would return a failed response. This commit now raises a new exception type indicating that the request failed at the OAuth stage rather than the transaction stage of a request

Remote:
25 tests, 57 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92% passed