### PR TITLE
Shift4: add vendorReference field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-* Adyen: update selectedBrand mapping for Google Pay [jcreiff] #4763
+* Adyen: Update selectedBrand mapping for Google Pay [jcreiff] #4763
+* Shift4: Add vendorReference field [jcreiff] #4762
 
 == Version 1.128.0 (April 24th, 2023)
 * CheckoutV2: Add support for Shipping Address [nicolas-maalouf-cko] #4755

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -185,6 +185,7 @@ module ActiveMerchant #:nodoc:
         post[:transaction] = {}
         post[:transaction][:invoice] = options[:invoice] || Time.new.to_i.to_s[1..3] + rand.to_s[2..7]
         post[:transaction][:notes] = options[:notes] if options[:notes].present?
+        post[:transaction][:vendorReference] = options[:order_id]
 
         add_purchase_card(post[:transaction], options)
         add_card_on_file(post[:transaction], options)

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -18,7 +18,8 @@ class RemoteShift4Test < Test::Unit::TestCase
       tax: '2',
       customer_reference: 'D019D09309F2',
       destination_postal_code: '94719',
-      product_descriptors: %w(Hamburger Fries Soda Cookie)
+      product_descriptors: %w(Hamburger Fries Soda Cookie),
+      order_id: '123456'
     }
     @customer_address = {
       address1: '65 Easy St',
@@ -76,6 +77,12 @@ class RemoteShift4Test < Test::Unit::TestCase
   def test_successful_purchase_with_extra_options
     response = @gateway.purchase(@amount, @credit_card, @options.merge(@extra_options))
     assert_success response
+  end
+
+  def test_successful_purchase_passes_vendor_reference
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(@extra_options))
+    assert_success response
+    assert_equal response_result(response)['transaction']['vendorReference'], @extra_options[:order_id]
   end
 
   def test_successful_purchase_with_stored_credential_framework

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -13,7 +13,8 @@ class Shift4Test < Test::Unit::TestCase
       tax: '2',
       customer_reference: 'D019D09309F2',
       destination_postal_code: '94719',
-      product_descriptors: %w(Hamburger Fries Soda Cookie)
+      product_descriptors: %w(Hamburger Fries Soda Cookie),
+      order_id: '123456'
     }
     @customer_address = {
       address1: '123 Street',
@@ -63,6 +64,7 @@ class Shift4Test < Test::Unit::TestCase
       request = JSON.parse(data)
       assert_equal request['clerk']['numericId'], @extra_options[:clerk_id]
       assert_equal request['transaction']['notes'], @extra_options[:notes]
+      assert_equal request['transaction']['vendorReference'], @extra_options[:order_id]
       assert_equal request['amount']['tax'], @extra_options[:tax].to_f
       assert_equal request['amount']['total'], (@amount / 100.0).to_s
       assert_equal request['transaction']['purchaseCard']['customerReference'], @extra_options[:customer_reference]


### PR DESCRIPTION
This change maps `options[:order_id]` to Shift4's `vendorReference` field

CER-563

LOCAL
5498 tests, 77341 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

760 files inspected, no offenses detected

GATEWAY UNIT TESTS
25 tests, 154 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

GATEWAY REMOTE TESTS
25 tests, 58 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92% passed
(These failures also exist on the master branch)