### PR TITLE
Adyen: update selectedBrand mapping for Google Pay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Adyen: update selectedBrand mapping for Google Pay [jcreiff] #4763
 
 == Version 1.128.0 (April 24th, 2023)
 * CheckoutV2: Add support for Shipping Address [nicolas-maalouf-cko] #4755

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -223,7 +223,7 @@ module ActiveMerchant #:nodoc:
       NETWORK_TOKENIZATION_CARD_SOURCE = {
         'apple_pay' => 'applepay',
         'android_pay' => 'androidpay',
-        'google_pay' => 'paywithgoogle'
+        'google_pay' => 'googlepay'
       }
 
       def add_extra_data(post, payment, options)


### PR DESCRIPTION
Adyen advised that `googlepay` is the correct value to send for `selectedBrand`

CER-550

LOCAL
5498 tests, 77340 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

760 files inspected, no offenses detected

GATEWAY - UNIT TESTS
105 tests, 531 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

GATEWAY - REMOTE TESTS
132 tests, 443 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 90.9091% passed