### PR TITLE
CyberSource: Handling Canadian bank accounts

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -705,8 +705,8 @@ module ActiveMerchant #:nodoc:
       def add_check(xml, check, options)
         xml.tag! 'check' do
           xml.tag! 'accountNumber', check.account_number
-          xml.tag! 'accountType', check.account_type[0]
-          xml.tag! 'bankTransitNumber', check.routing_number
+          xml.tag! 'accountType', check.account_type == 'checking' ? 'C' : 'S'
+          xml.tag! 'bankTransitNumber', format_routing_number(check.routing_number, options)
           xml.tag! 'secCode', options[:sec_code] if options[:sec_code]
         end
       end
@@ -1130,6 +1130,10 @@ module ActiveMerchant #:nodoc:
 
       def eligible_for_zero_auth?(payment_method, options = {})
         payment_method.is_a?(CreditCard) && options[:zero_amount_auth]
+      end
+
+      def format_routing_number(routing_number, options)
+        options[:currency] == 'CAD' && routing_number.length > 8 ? routing_number[-8..-1] : routing_number
       end
     end
   end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -372,6 +372,22 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
   end
 
+  # To properly run this test couple of test your account needs to be enabled to
+  # handle canadian bank accounts.
+  def test_successful_purchase_with_a_canadian_bank_account_full_number
+    bank_account = check({ account_number: '4100', routing_number: '011000015' })
+    @options[:currency] = 'CAD'
+    assert response = @gateway.purchase(10000, bank_account, @options)
+    assert_successful_response(response)
+  end
+
+  def test_successful_purchase_with_a_canadian_bank_account_8_digit_number
+    bank_account = check({ account_number: '4100', routing_number: '11000015' })
+    @options[:currency] = 'CAD'
+    assert response = @gateway.purchase(10000, bank_account, @options)
+    assert_successful_response(response)
+  end
+
   def test_successful_purchase_with_bank_account_savings_account
     bank_account = check({ account_number: '4100', routing_number: '011000015', account_type: 'savings' })
     assert response = @gateway.purchase(10000, bank_account, @options)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -1462,6 +1462,18 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_equal 'Payment method sodexo is not supported, check https://developer.cybersource.com/docs/cybs/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html', error.message
   end
 
+  def test_routing_number_formatting_with_regular_routing_number
+    assert_equal @gateway.send(:format_routing_number, '012345678', { currency: 'USD' }), '012345678'
+  end
+
+  def test_routing_number_formatting_with_canadian_routing_number
+    assert_equal @gateway.send(:format_routing_number, '12345678', { currency: 'USD' }), '12345678'
+  end
+
+  def test_routing_number_formatting_with_canadian_routing_number_and_padding
+    assert_equal @gateway.send(:format_routing_number, '012345678', { currency: 'CAD' }), '12345678'
+  end
+
   private
 
   def options_with_normalized_3ds(


### PR DESCRIPTION
### Summary:

Add changes to CyberSource to properly format Canadian routing numbers when payment method is bank account.

GWS-48

### Remote Test:
Finished in 114.912426 seconds.
121 tests, 611 assertions, 5 failures, 0 errors,
0 pendings, 0 omissions, 0 notifications
95.8678% passed

*Notes on erros*:
The test suite was ran with a single account rason for errors:
- 2 errors correspondsto account not enabled for canadian bank transactions.
- 2 errors correspond to outdated 3ds PAR values.
- 1 error related with account not enabled for async.

### Unit Tests:
Finished in 41.573188 seconds.
5501 tests, 77346 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
760 files inspected, no offenses detected