### PR TITLE
Litle update the successful_from method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -100,6 +100,7 @@
 * IPG: Improve error handling [heavyblade] #4753
 * Shift4: Handle access token failed calls [heavyblade] #4745
 * Bogus: Add verify functionality [willemk] #4749
+* Litle: Update successful_from method [almalee24] #4765
 
 == Version 1.127.0 (September 20th, 2022)
 * BraintreeBlue: Add venmo profile_id [molbrown] #4512

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -572,13 +572,24 @@ module ActiveMerchant #:nodoc:
           cvv_result: parsed[:fraudResult_cardValidationResult]
         }
 
-        Response.new(success_from(kind, parsed), parsed[:message], parsed, options)
+        Response.new(success_from(kind, parsed), message_from(parsed), parsed, options)
       end
 
       def success_from(kind, parsed)
-        return (parsed[:response] == '000') unless kind == :registerToken
+        return %w(000 001 010).any?(parsed[:response]) unless kind == :registerToken
 
         %w(000 801 802).include?(parsed[:response])
+      end
+
+      def message_from(parsed)
+        case parsed[:response]
+        when '010'
+          return "#{parsed[:message]}: The authorized amount is less than the requested amount."
+        when '001'
+          return "#{parsed[:message]}: This is sent to acknowledge that the submitted transaction has been received."
+        else
+          parsed[:message]
+        end
       end
 
       def authorization_from(kind, parsed, money)


### PR DESCRIPTION
Add 001 and 010 to be considered successful responses for Litle.

Remote
57 tests, 251 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Unit
58 tests, 255 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed