### PR TITLE
Revert "Rexml is no longer a default gem in Ruby 3."

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('nokogiri', '~> 1.4')
-  s.add_dependency('rexml')
 
   s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('pry')


### PR DESCRIPTION
Reverts activemerchant/active_merchant#3852. This broke CI. Will need to investigate.