### PR TITLE
Add rexml as a gem dependency

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('nokogiri', '~> 1.4')
+  s.add_dependency('rexml', '~> 3.2.5')
 
   s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('pry')

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -1144,7 +1144,7 @@ class PayflowTest < Test::Unit::TestCase
 
   def threeds_xpath_for_extdata(attr_name, tx_type: 'Authorization')
     xpath_prefix = xpath_prefix_for_transaction_type(tx_type)
-    %(string(#{xpath_prefix}/PayData/ExtData[@Name='#{attr_name}']/@Value)")
+    %(string(#{xpath_prefix}/PayData/ExtData[@Name='#{attr_name}']/@Value))
   end
 
   def authorize_buyer_auth_result_path


### PR DESCRIPTION
Rexml is no longer included with Ruby 3+, we therefore need to add the dependency explicitely. This fixes the issue encountered in https://github.com/activemerchant/active_merchant/pull/3852.

See https://www.ruby-lang.org/en/news/2020/09/25/ruby-3-0-0-preview1-released/