### PR TITLE
Adyen: Update Mastercard error messaging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * CyberSource: Handling Canadian bank accounts [heavyblade] #4764
 * CyberSource Rest: Fixing currency detection [heavyblade] #4777
 * CyberSource: Allow business rules for requests with network tokens [aenand] #4764
+* Adyen: Update Mastercard error messaging [kylene-spreedly] #4770
 
 == Version 1.129.0 (May 3rd, 2023)
 * Adyen: Update selectedBrand mapping for Google Pay [jcreiff] #4763

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -703,8 +703,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorize_message_from(response)
-        if response['refusalReason'] && response['additionalData'] && response['additionalData']['refusalReasonRaw']
-          "#{response['refusalReason']} | #{response['additionalData']['refusalReasonRaw']}"
+        if response['refusalReason'] && response['additionalData'] && (response['additionalData']['merchantAdviceCode'] || response['additionalData']['refusalReasonRaw'])
+          "#{response['refusalReason']} | #{response['additionalData']['merchantAdviceCode'] || response['additionalData']['refusalReasonRaw']}"
         else
           response['refusalReason'] || response['resultCode'] || response['message'] || response['result']
         end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -324,6 +324,24 @@ class AdyenTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failed_authorise_visa
+    @gateway.expects(:ssl_post).returns(failed_authorize_visa_response)
+
+    response = @gateway.send(:commit, 'authorise', {}, {})
+
+    assert_equal 'Refused | 01: Refer to card issuer', response.message
+    assert_failure response
+  end
+
+  def test_failed_authorise_mastercard
+    @gateway.expects(:ssl_post).returns(failed_authorize_mastercard_response)
+
+    response = @gateway.send(:commit, 'authorise', {}, {})
+
+    assert_equal 'Refused | 01 : New account information available', response.message
+    assert_failure response
+  end
+
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
     response = @gateway.capture(@amount, '7914775043909934')
@@ -1650,6 +1668,35 @@ class AdyenTest < Test::Unit::TestCase
        },
        "pspReference":"8514775559925128",
        "refusalReason":"3D Not Authenticated",
+       "resultCode":"Refused"
+     }
+    RESPONSE
+  end
+
+  def failed_authorize_visa_response
+    <<-RESPONSE
+    {
+      "additionalData":
+      {
+        "refusalReasonRaw": "01: Refer to card issuer"
+       },
+       "refusalReason": "Refused",
+       "pspReference":"8514775559925128",
+       "resultCode":"Refused"
+     }
+    RESPONSE
+  end
+
+  def failed_authorize_mastercard_response
+    <<-RESPONSE
+    {
+      "additionalData":
+      {
+        "refusalReasonRaw": "01: Refer to card issuer",
+        "merchantAdviceCode": "01 : New account information available"
+       },
+       "refusalReason": "Refused",
+       "pspReference":"8514775559925128",
        "resultCode":"Refused"
      }
     RESPONSE


### PR DESCRIPTION
Adyen error messaging uses the generic refusalReasonRaw field as part of the response message. Adyen offers a more detailed Mastercard-specific field called merchantAdviceCode that should be present for failed Mastercard transactions.

Adyen error messaging now checks for the merchantAdviceCode first. If it is not present (i.e. this is not a Mastercard transaction or it is a Mastercard transaction and this field is missing for some reason) then the default refusalReasonRaw field is used (like previous functionality).

ECS-2767

Unit:
107 tests, 539 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
132 tests, 443 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 90.9091% passed
*These 12 tests fail on master