### PR TITLE
CommerceHub: Enabling multi-use public key encryption

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 == HEAD
 * Payu Latam - Update error code method to surface network code [yunnydang] #4773
 * CyberSource: Handling Canadian bank accounts [heavyblade] #4764
+* CommerceHub: Enabling multi-use public key encryption [jherreraa] #4771
 
 == Version 1.129.0 (May 3rd, 2023)
 * Adyen: Update selectedBrand mapping for Google Pay [jcreiff] #4763

--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -114,7 +114,7 @@ module ActiveMerchant #:nodoc:
         post[:transactionInteraction][:origin] = options[:origin] || 'ECOM'
         post[:transactionInteraction][:eciIndicator] = options[:eci_indicator] || 'CHANNEL_ENCRYPTED'
         post[:transactionInteraction][:posConditionCode] = options[:pos_condition_code] || 'CARD_NOT_PRESENT_ECOM'
-        post[:transactionInteraction][:posEntryMode] = options[:pos_entry_mode] || 'MANUAL'
+        post[:transactionInteraction][:posEntryMode] = (options[:pos_entry_mode] || 'MANUAL') unless options[:encryption_data].present?
         post[:transactionInteraction][:additionalPosInformation] = {}
         post[:transactionInteraction][:additionalPosInformation][:dataEntrySource] = options[:data_entry_source] || 'UNSPECIFIED'
       end
@@ -256,7 +256,12 @@ module ActiveMerchant #:nodoc:
         when NetworkTokenizationCreditCard
           add_decrypted_wallet(source, payment, options)
         when CreditCard
-          add_credit_card(source, payment, options)
+          if options[:encryption_data].present?
+            source[:sourceType] = 'PaymentCard'
+            source[:encryptionData] = options[:encryption_data]
+          else
+            add_credit_card(source, payment, options)
+          end
         when String
           add_payment_token(source, payment, options)
         end

--- a/test/remote/gateways/remote_commerce_hub_test.rb
+++ b/test/remote/gateways/remote_commerce_hub_test.rb
@@ -109,7 +109,7 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Unable to assign card to brand: Invalid.', response.message
+    assert_equal 'Unable to assign card to brand: Invalid', response.message
     assert_equal '104', response.error_code
   end
 
@@ -131,7 +131,7 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Unable to assign card to brand: Invalid.', response.message
+    assert_equal 'Unable to assign card to brand: Invalid', response.message
   end
 
   def test_successful_authorize_and_void
@@ -235,7 +235,7 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
   def test_failed_purchase_with_declined_apple_pay
     response = @gateway.purchase(@amount, @declined_apple_pay, @options)
     assert_failure response
-    assert_equal 'Unable to assign card to brand: Invalid.', response.message
+    assert_equal 'Unable to assign card to brand: Invalid', response.message
   end
 
   def test_transcript_scrubbing
@@ -259,5 +259,19 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:api_key], transcript)
     assert_scrubbed(@gateway.options[:api_secret], transcript)
     assert_scrubbed(@apple_pay.payment_cryptogram, transcript)
+  end
+
+  def test_successful_purchase_with_encrypted_credit_card
+    @options[:encryption_data] = {
+      keyId: '6d0b6b63-3658-4c90-b7a4-bffb8a928288',
+      encryptionType: 'RSA',
+      encryptionBlock: 'udJ89RebrHLVxa3ofdyiQ/RrF2Y4xKC/qw4NuV1JYrTDEpNeIq9ZimVffMjgkyKL8dlnB2R73XFtWA4klHrpn6LZrRumYCgoqAkBRJCrk09+pE5km2t2LvKtf/Bj2goYQNFA9WLCCvNGwhofp8bNfm2vfGsBr2BkgL+PH/M4SqyRHz0KGKW/NdQ4Mbdh4hLccFsPjtDnNidkMep0P02PH3Se6hp1f5GLkLTbIvDLPSuLa4eNgzb5/hBBxrq5M5+5n9a1PhQnVT1vPU0WbbWe1SGdGiVCeSYmmX7n+KkVmc1lw0dD7NXBjKmD6aGFAWGU/ls+7JVydedDiuz4E7HSDQ==',
+      encryptionBlockFields: 'card.cardData:16,card.nameOnCard:10,card.expirationMonth:2,card.expirationYear:4,card.securityCode:3',
+      encryptionTarget: 'MANUAL'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
   end
 end

--- a/test/unit/gateways/commerce_hub_test.rb
+++ b/test/unit/gateways/commerce_hub_test.rb
@@ -51,6 +51,7 @@ class CommerceHubTest < Test::Unit::TestCase
       assert_equal request['amount']['total'], (@amount / 100.0).to_f
       assert_equal request['source']['card']['cardData'], @credit_card.number
       assert_equal request['source']['card']['securityCode'], @credit_card.verification_value
+      assert_equal request['transactionInteraction']['posEntryMode'], 'MANUAL'
       assert_equal request['source']['card']['securityCodeIndicator'], 'PROVIDED'
     end.respond_with(successful_purchase_response)
 
@@ -345,6 +346,32 @@ class CommerceHubTest < Test::Unit::TestCase
     @gateway.send :add_reference_transaction_details, @post, authorization, {}, :refund
     assert_equal '922e-59fc86a36c03', @post[:referenceTransactionDetails][:referenceTransactionId]
     assert_equal 'CHARGES', @post[:referenceTransactionDetails][:referenceTransactionType]
+  end
+
+  def test_successful_purchase_when_encrypted_credit_card_present
+    @options[:order_id] = 'abc123'
+    @options[:encryption_data] = {
+      keyId: SecureRandom.uuid,
+      encryptionType: 'RSA',
+      encryptionBlock: SecureRandom.alphanumeric(20),
+      encryptionBlockFields: 'card.cardData:16,card.nameOnCard:8,card.expirationMonth:2,card.expirationYear:4,card.securityCode:3',
+      encryptionTarget: 'MANUAL'
+    }
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      refute_nil request['source']['encryptionData']
+      assert_equal request['source']['sourceType'], 'PaymentCard'
+      assert_equal request['source']['encryptionData']['keyId'], @options[:encryption_data][:keyId]
+      assert_equal request['source']['encryptionData']['encryptionType'], 'RSA'
+      assert_equal request['source']['encryptionData']['encryptionBlock'], @options[:encryption_data][:encryptionBlock]
+      assert_equal request['source']['encryptionData']['encryptionBlockFields'], @options[:encryption_data][:encryptionBlockFields]
+      assert_equal request['source']['encryptionData']['encryptionTarget'], 'MANUAL'
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
   end
 
   private


### PR DESCRIPTION
## Summary:

Changes the payment method so is possible to send an encrypted credit card following the CommerceHub Multi-User [public key methodology.](https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Online-Mobile-Digital/Secure-Data-Capture/Multi-Use-Public-Key/Multi-Use-Public-Key-Encryption.md&branch=main)

SER-555

**Note on the one failing test**: You need the proper account permissions and credentials to use the encrypted credit card.
## Tests

### Remote Test:
Finished in 288.325843 seconds.
25 tests, 63 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 38.640945 seconds.
5506 tests, 77384 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
760 files inspected, no offenses detected