### PR TITLE
Cybersource: Add business rules for NT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Payu Latam - Update error code method to surface network code [yunnydang] #4773
 * CyberSource: Handling Canadian bank accounts [heavyblade] #4764
 * CyberSource Rest: Fixing currency detection [heavyblade] #4777
+* CyberSource: Allow business rules for requests with network tokens [aenand] #4764
 
 == Version 1.129.0 (May 3rd, 2023)
 * Adyen: Update selectedBrand mapping for Google Pay [jcreiff] #4763

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -519,11 +519,9 @@ module ActiveMerchant #:nodoc:
       def add_business_rules_data(xml, payment_method, options)
         prioritized_options = [options, @options]
 
-        unless network_tokenization?(payment_method)
-          xml.tag! 'businessRules' do
-            xml.tag!('ignoreAVSResult', 'true') if extract_option(prioritized_options, :ignore_avs).to_s == 'true'
-            xml.tag!('ignoreCVResult', 'true') if extract_option(prioritized_options, :ignore_cvv).to_s == 'true'
-          end
+        xml.tag! 'businessRules' do
+          xml.tag!('ignoreAVSResult', 'true') if extract_option(prioritized_options, :ignore_avs).to_s == 'true'
+          xml.tag!('ignoreCVResult', 'true') if extract_option(prioritized_options, :ignore_cvv).to_s == 'true'
         end
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -413,10 +413,8 @@ module ActiveMerchant #:nodoc:
 
       def add_business_rules_data(post, payment, options)
         post[:processingInformation][:authorizationOptions] = {}
-        unless payment.is_a?(NetworkTokenizationCreditCard)
-          post[:processingInformation][:authorizationOptions][:ignoreAvsResult] = 'true' if options[:ignore_avs].to_s == 'true'
-          post[:processingInformation][:authorizationOptions][:ignoreCvResult] = 'true' if options[:ignore_cvv].to_s == 'true'
-        end
+        post[:processingInformation][:authorizationOptions][:ignoreAvsResult] = 'true' if options[:ignore_avs].to_s == 'true'
+        post[:processingInformation][:authorizationOptions][:ignoreCvResult] = 'true' if options[:ignore_cvv].to_s == 'true'
       end
 
       def add_mdd_fields(post, options)

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -165,6 +165,42 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     assert_nil response.params['_links']['capture']
   end
 
+  def test_successful_purchase_with_credit_card_ignore_avs
+    @options[:ignore_avs] = 'true'
+    response = @gateway.purchase(@amount, @visa_card, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_nil response.params['_links']['capture']
+  end
+
+  def test_successful_purchase_with_network_token_ignore_avs
+    @options[:ignore_avs] = 'true'
+    response = @gateway.purchase(@amount, @apple_pay, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_nil response.params['_links']['capture']
+  end
+
+  def test_successful_purchase_with_credit_card_ignore_cvv
+    @options[:ignore_cvv] = 'true'
+    response = @gateway.purchase(@amount, @visa_card, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_nil response.params['_links']['capture']
+  end
+
+  def test_successful_purchase_with_network_token_ignore_cvv
+    @options[:ignore_cvv] = 'true'
+    response = @gateway.purchase(@amount, @apple_pay, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_nil response.params['_links']['capture']
+  end
+
   def test_successful_refund
     purchase = @gateway.purchase(@amount, @visa_card, @options)
     response = @gateway.refund(@amount, purchase.authorization, @options)


### PR DESCRIPTION
ECS-2849

A previous commit from 2015 restricted the ability to pass business rules such as `ignoreAVSResult` and `ignoreCVResult` on API requests with NetworkTokenization cards. Merchants are now asking for this to be allowed on requests with payment methods such as NT/AP/GP and the remote tests seem to indicate we can add these fields for these types of payment methods.

Remote:
119 tests, 607 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.479% passed