### PR TITLE
Worlpay: Fix Google Pay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * CommerceHub: Enabling multi-use public key encryption [jherreraa] #4771
 * Ogone: Enable 3ds Global for Ogone Gateway [javierpedrozaing] #4776
 * Borgun change default TrCurrencyExponent and MerchantReturnUrl [naashton] #4
+* Worldpay: Fix Google Pay [almalee24] #4774
 
 == Version 1.129.0 (May 3rd, 2023)
 * Adyen: Update selectedBrand mapping for Google Pay [jcreiff] #4763

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -683,7 +683,8 @@ module ActiveMerchant #:nodoc:
             'year' => format(payment_method.year, :four_digits_year)
           )
         end
-        xml.cardHolderName card_holder_name(payment_method, options)
+        name = card_holder_name(payment_method, options)
+        xml.cardHolderName name if name.present?
         xml.cvc payment_method.verification_value
 
         add_address(xml, (options[:billing_address] || options[:address]), options)
@@ -995,10 +996,10 @@ module ActiveMerchant #:nodoc:
         case payment_method
         when String
           token_type_and_details(payment_method)
-        when NetworkTokenizationCreditCard
-          { payment_type: :network_token }
         else
-          { payment_type: :credit }
+          type = payment_method.respond_to?(:source) ? :network_token : :credit
+
+          { payment_type: type }
         end
       end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -6,6 +6,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     @cftgateway = WorldpayGateway.new(fixtures(:world_pay_gateway_cft))
 
     @amount = 100
+    @year = (Time.now.year + 2).to_s[-2..-1].to_i
     @credit_card = credit_card('4111111111111111')
     @amex_card = credit_card('3714 496353 98431')
     @elo_credit_card = credit_card('4514 1600 0000 0008',
@@ -17,7 +18,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       brand: 'elo')
     @credit_card_with_two_digits_year = credit_card('4111111111111111',
       month: 10,
-      year: 22)
+      year: @year)
     @cabal_card = credit_card('6035220000000006')
     @naranja_card = credit_card('5895620000000002')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -145,11 +145,35 @@ class WorldpayTest < Test::Unit::TestCase
     }
   end
 
+  def test_payment_type_for_network_card
+    payment = @gateway.send(:payment_details, @nt_credit_card)[:payment_type]
+    assert_equal payment, :network_token
+  end
+
+  def test_payment_type_for_credit_card
+    payment = @gateway.send(:payment_details, @credit_card)[:payment_type]
+    assert_equal payment, :credit
+  end
+
   def test_successful_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/4242424242424242/, data)
+      assert_match(/cardHolderName/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+    assert_equal 'R50704213207145707', response.authorization
+  end
+
+  def test_successful_authorize_without_name
+    credit_card = credit_card('4242424242424242', first_name: nil, last_name: nil)
+    response = stub_comms do
+      @gateway.authorize(@amount, credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/4242424242424242/, data)
+      assert_no_match(/cardHolderName/, data)
+      assert_match(/VISA-SSL/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
     assert_equal 'R50704213207145707', response.authorization


### PR DESCRIPTION
Ensure that we don't send cardHolderName if empty and that Google Pay and Apple Pay fall into the network tokenization code path and not the credit card path.

Remote Tests:
100 tests, 416 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit Tests:
107 tests, 633 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed