### PR TITLE
BT: Add support for network tokens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * Adyen: Add option to elect which error message [aenand] #4843
 * Reach: Update list of supported countries [jcreiff] #4842
 * Paysafe: Truncate address fields [jcreiff] #4841
+* Braintree: Support third party Network Tokens [aenand] #4775
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rubocop', '~> 0.72.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 3.0.0', '<= 3.0.1'
+  gem 'braintree', '>= 4.12.0'
   gem 'jose', '~> 1.1.3'
   gem 'jwe'
   gem 'mechanize'

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -31,6 +31,12 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       },
       ach_mandate: ach_mandate
     }
+
+    @nt_credit_card = network_tokenization_credit_card('4111111111111111',
+                                                       brand: 'visa',
+                                                       eci: '05',
+                                                       source: :network_token,
+                                                       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
   end
 
   def test_credit_card_details_on_store
@@ -49,6 +55,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_authorize
     assert response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'authorized', response.params['braintree_transaction']['status']
+  end
+
+  def test_successful_authorize_with_nt
+    assert response = @gateway.authorize(@amount, @nt_credit_card, @options)
     assert_success response
     assert_equal '1000 Approved', response.message
     assert_equal 'authorized', response.params['braintree_transaction']['status']
@@ -672,25 +685,6 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       brand: 'visa',
       eci: '05',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
-
-    assert auth = @gateway.authorize(@amount, credit_card, @options)
-    assert_success auth
-    assert_equal '1000 Approved', auth.message
-    assert auth.authorization
-    assert capture = @gateway.capture(@amount, auth.authorization)
-    assert_success capture
-  end
-
-  def test_authorize_and_capture_with_android_pay_card
-    credit_card = network_tokenization_credit_card(
-      '4111111111111111',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      month: '01',
-      year: '2024',
-      source: :android_pay,
-      transaction_id: '123456789',
-      eci: '05'
     )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)


### PR DESCRIPTION
This PR adds support for network tokens to the Braintree gateway. The gateway class utilizes the Braintree SDK which added support for network tokens in major version 4. This commit updates the logic to add support for tagging NT as per the BT docs but does not require the CI tests to move to the new BT version. 

Question for reviewers: Should we wait for the BT ruby gem to get updated in the repo's CI tests before merging this?