### PR TITLE
CyberSourceRest: Fixing currency detection

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -112,7 +112,7 @@ module ActiveMerchant #:nodoc:
           add_code(post, options)
           add_payment(post, payment, options)
           add_mdd_fields(post, options)
-          add_amount(post, amount)
+          add_amount(post, amount, options)
           add_address(post, payment, options[:billing_address], options, :billTo)
           add_address(post, payment, options[:shipping_address], options, :shipTo)
           add_business_rules_data(post, payment, options)
@@ -125,7 +125,7 @@ module ActiveMerchant #:nodoc:
         { clientReferenceInformation: {}, orderInformation: {} }.tap do |post|
           add_code(post, options)
           add_mdd_fields(post, options)
-          add_amount(post, amount)
+          add_amount(post, amount, options)
           add_partner_solution_id(post)
         end.compact
       end
@@ -135,7 +135,7 @@ module ActiveMerchant #:nodoc:
           add_code(post, options)
           add_credit_card(post, payment)
           add_mdd_fields(post, options)
-          add_amount(post, amount)
+          add_amount(post, amount, options)
           add_address(post, payment, options[:billing_address], options, :billTo)
           add_merchant_description(post, options)
         end.compact
@@ -161,7 +161,7 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def add_amount(post, amount)
+      def add_amount(post, amount, options)
         currency = options[:currency] || currency(amount)
         post[:orderInformation][:amountDetails] = {
           totalAmount: localized_amount(amount, currency),

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -469,4 +469,14 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
   ensure
     ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
   end
+
+  def test_successful_purchase_in_australian_dollars
+    @options[:currency] = 'AUD'
+    response = @gateway.purchase(@amount, @visa_card, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_nil response.params['_links']['capture']
+    assert_equal 'AUD', response.params['orderInformation']['amountDetails']['currency']
+  end
 end

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -125,7 +125,7 @@ class CyberSourceRestTest < Test::Unit::TestCase
   def test_add_ammount_and_currency
     post = { orderInformation: {} }
 
-    @gateway.send :add_amount, post, 10221
+    @gateway.send :add_amount, post, 10221, {}
 
     assert_equal '102.21', post.dig(:orderInformation, :amountDetails, :totalAmount)
     assert_equal 'USD', post.dig(:orderInformation, :amountDetails, :currency)


### PR DESCRIPTION
## Summary:
Fix bug on Cybersource Rest to use other currencies different than USD.

### Remote Test:

Finished in 46.080483 seconds.
43 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 33.72359 seconds.
5506 tests, 77384 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
760 files inspected, no offenses detected