### PR TITLE
Authorize.net: update mapping for billing address phone number

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * CyberSource Rest: Fixing currency detection [heavyblade] #4777
 * CyberSource: Allow business rules for requests with network tokens [aenand] #4764
 * Adyen: Update Mastercard error messaging [kylene-spreedly] #4770
+* Authorize.net: Update mapping for billing address phone number [jcreiff] #4778
 
 == Version 1.129.0 (May 3rd, 2023)
 * Adyen: Update selectedBrand mapping for Google Pay [jcreiff] #4763

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -604,6 +604,7 @@ module ActiveMerchant
           first_name, last_name = names_from(payment_source, address, options)
           state = state_from(address, options)
           full_address = "#{address[:address1]} #{address[:address2]}".strip
+          phone = address[:phone] || address[:phone_number] || ''
 
           xml.firstName(truncate(first_name, 50)) unless empty?(first_name)
           xml.lastName(truncate(last_name, 50)) unless empty?(last_name)
@@ -613,7 +614,7 @@ module ActiveMerchant
           xml.state(truncate(state, 40))
           xml.zip(truncate((address[:zip] || options[:zip]), 20))
           xml.country(truncate(address[:country], 60))
-          xml.phoneNumber(truncate(address[:phone], 25)) unless empty?(address[:phone])
+          xml.phoneNumber(truncate(phone, 25)) unless empty?(phone)
           xml.faxNumber(truncate(address[:fax], 25)) unless empty?(address[:fax])
         end
       end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -414,6 +414,16 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_phone_number
+    @options[:billing_address][:phone] = nil
+    @options[:billing_address][:phone_number] = '5554443210'
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'This transaction has been approved', response.message
+    assert response.authorization
+  end
+
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -940,6 +940,20 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_address_with_alternate_phone_number_field
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, billing_address: { address1: '164 Waverley Street', country: 'US', state: 'CO', phone_number: '(555)555-5555', fax: '(555)555-4444' })
+    end.check_request do |_endpoint, data, _headers|
+      parse(data) do |doc|
+        assert_equal 'CO', doc.at_xpath('//billTo/state').content, data
+        assert_equal '164 Waverley Street', doc.at_xpath('//billTo/address').content, data
+        assert_equal 'US', doc.at_xpath('//billTo/country').content, data
+        assert_equal '(555)555-5555', doc.at_xpath('//billTo/phoneNumber').content
+        assert_equal '(555)555-4444', doc.at_xpath('//billTo/faxNumber').content
+      end
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_address_with_empty_billing_address
     stub_comms do
       @gateway.authorize(@amount, @credit_card)


### PR DESCRIPTION
Adds a bit of logic to the Authorize.net gateway so that phone number can be passed via `billing_address[phone_number]` in addition to `billing_address[phone]` This is similar to #4138

CER-590

LOCAL
5503 tests, 77374 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

UNIT
121 tests, 681 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

REMOTE
84 tests, 301 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed