### PR TITLE
Borgun support for GBP currency

### DIFF
--- a/lib/active_merchant/billing/gateways/borgun.rb
+++ b/lib/active_merchant/billing/gateways/borgun.rb
@@ -96,6 +96,7 @@ module ActiveMerchant #:nodoc:
       CURRENCY_CODES['ISK'] = '352'
       CURRENCY_CODES['EUR'] = '978'
       CURRENCY_CODES['USD'] = '840'
+      CURRENCY_CODES['GBP'] = '826'
 
       def add_3ds_fields(post, options)
         post[:ThreeDSMessageId] = options[:three_ds_message_id] if options[:three_ds_message_id]


### PR DESCRIPTION
Add support to Borgun for GPB based on [ISO
4217](https://en.wikipedia.org/wiki/ISO_4217)

Unit:

Remote: