### PR TITLE
Cybersource: auto void r230

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,8 +11,9 @@
 * Braintree: Update mapping for billing address phone number [jcreiff] #4779
 * CommerceHub: Enabling multi-use public key encryption [jherreraa] #4771
 * Ogone: Enable 3ds Global for Ogone Gateway [javierpedrozaing] #4776
-* Borgun change default TrCurrencyExponent and MerchantReturnUrl [naashton] #4
 * Worldpay: Fix Google Pay [almalee24] #4774
+* Borgun change default TrCurrencyExponent and MerchantReturnUrl [naashton] #4788
+* CyberSource: Enable auto void on r230 [aenand] #4794
 
 == Version 1.129.0 (May 3rd, 2023)
 * Adyen: Update selectedBrand mapping for Google Pay [jcreiff] #4763


### PR DESCRIPTION
ECS-2870

Cybersource transactions that fail with a reasonCode of `230` are in a state where the gateway advises the merchant to decline but has not declined it themselves. Instead the transaction is pending capture which can create a mismatch in reporting.

This commit attempts to auto void transactions that have this response code and a flag that indicates the merchants would like to auto void these kinds of transactions. I wasn't able to add a remote test for this because the CYBS sandbox does not have a way to trigger this response code. 

Remote:
121 tests, 611 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95.8678% passed

5 test failures on master as well