### PR TITLE
WorldPay: Update xml tag for Credit Cards

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -28,21 +28,6 @@ module ActiveMerchant #:nodoc:
         network_token: 'NETWORKTOKEN'
       }
 
-      CARD_CODES = {
-        'visa'             => 'VISA-SSL',
-        'master'           => 'ECMC-SSL',
-        'discover'         => 'DISCOVER-SSL',
-        'american_express' => 'AMEX-SSL',
-        'jcb'              => 'JCB-SSL',
-        'maestro'          => 'MAESTRO-SSL',
-        'diners_club'      => 'DINERS-SSL',
-        'elo'              => 'ELO-SSL',
-        'naranja'          => 'NARANJA-SSL',
-        'cabal'            => 'CABAL-SSL',
-        'unionpay'         => 'CHINAUNIONPAY-SSL',
-        'unknown'          => 'CARD-SSL'
-      }
-
       AVS_CODE_MAP = {
         'A' => 'M', # Match
         'B' => 'P', # Postcode matches, address not verified
@@ -646,7 +631,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_card_details(xml, payment_method, options)
-        xml.tag! card_code_for(payment_method) do
+        xml.tag! 'CARD-SSL' do
           add_card(xml, payment_method, options)
         end
       end
@@ -1032,10 +1017,6 @@ module ActiveMerchant #:nodoc:
         return 3 if three_decimal_currency?(currency)
 
         return 2
-      end
-
-      def card_code_for(payment_method)
-        CARD_CODES[card_brand(payment_method)] || CARD_CODES['unknown']
       end
 
       def eligible_for_0_auth?(payment_method, options = {})

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -201,7 +201,7 @@ class WorldpayTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       assert_match(/4242424242424242/, data)
       assert_no_match(/cardHolderName/, data)
-      assert_match(/VISA-SSL/, data)
+      assert_match(/CARD-SSL/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
     assert_equal 'R50704213207145707', response.authorization
@@ -1174,7 +1174,7 @@ class WorldpayTest < Test::Unit::TestCase
       assert_match %r(4242424242424242), data
       assert_no_match %r(<order>), data
       assert_no_match %r(<paymentDetails>), data
-      assert_no_match %r(<VISA-SSL>), data
+      assert_no_match %r(<CARD-SSL>), data
     end.respond_with(successful_store_response)
 
     assert_success response
@@ -2136,7 +2136,7 @@ class WorldpayTest < Test::Unit::TestCase
           <amount value="100" exponent="2" currencyCode="HKD"/>
           <orderContent>Products Products Products</orderContent>
           <paymentDetails>
-            <VISA-SSL>
+            <CARD-SSL>
               <cardNumber>4242424242424242</cardNumber>
               <expiryDate>
                 <date month="09" year="2011"/>
@@ -2156,7 +2156,7 @@ class WorldpayTest < Test::Unit::TestCase
                   <telephoneNumber>(555)555-5555</telephoneNumber>
                 </address>
               </cardAddress>
-            </VISA-SSL>
+            </CARD-SSL>
             <session id="asfasfasfasdgvsdzvxzcvsd" shopperIPAddress="127.0.0.1"/>
           </paymentDetails>
           <shopper>
@@ -2179,7 +2179,7 @@ class WorldpayTest < Test::Unit::TestCase
             <description>Purchase</description>
             <amount value="100" currencyCode="GBP" exponent="2"/>
             <paymentDetails>
-              <VISA-SSL>
+              <CARD-SSL>
                 <cardNumber>4111111111111111</cardNumber>
                 <expiryDate>
                   <date month="09" year="2016"/>
@@ -2195,7 +2195,7 @@ class WorldpayTest < Test::Unit::TestCase
                     <countryCode>US</countryCode>
                   </address>
                 </cardAddress>
-              </VISA-SSL>
+              </CARD-SSL>
             </paymentDetails>
             <shopper>
               <shopperEmailAddress>wow@example.com</shopperEmailAddress>
@@ -2214,7 +2214,7 @@ class WorldpayTest < Test::Unit::TestCase
             <description>Purchase</description>
             <amount value="100" currencyCode="GBP" exponent="2"/>
             <paymentDetails>
-              <VISA-SSL>
+              <CARD-SSL>
                 <cardNumber>[FILTERED]</cardNumber>
                 <expiryDate>
                   <date month="09" year="2016"/>
@@ -2230,7 +2230,7 @@ class WorldpayTest < Test::Unit::TestCase
                     <countryCode>US</countryCode>
                   </address>
                 </cardAddress>
-              </VISA-SSL>
+              </CARD-SSL>
             </paymentDetails>
             <shopper>
               <shopperEmailAddress>wow@example.com</shopperEmailAddress>


### PR DESCRIPTION
Update the xml tag for Credit Cards to be CARD-SSL instead of being specific to card brand.

Remote:
100 tests, 416 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
109 tests, 637 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed