### PR TITLE
Checkout: Add support for several customer data fields

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -139,6 +139,7 @@ module ActiveMerchant #:nodoc:
         add_authorization_type(post, options)
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)
+        add_extra_customer_data(post, payment_method, options)
         add_shipping_address(post, options)
         add_stored_credential_options(post, options)
         add_transaction_data(post, options)
@@ -237,6 +238,15 @@ module ActiveMerchant #:nodoc:
           post[:source][:billing_address][:country] = address[:country] unless address[:country].blank?
           post[:source][:billing_address][:zip] = address[:zip] unless address[:zip].blank?
         end
+      end
+
+      # created a separate method for these fields because they should not be included
+      # in all transaction types that include methods with source and customer fields
+      def add_extra_customer_data(post, payment_method, options)
+        post[:source][:phone] = {}
+        post[:source][:phone][:number] = options[:phone] || options.dig(:billing_address, :phone) || options.dig(:billing_address, :phone_number)
+        post[:source][:phone][:country_code] = options[:phone_country_code] if options[:phone_country_code]
+        post[:customer][:name] = payment_method.name if payment_method.respond_to?(:name)
       end
 
       def add_shipping_address(post, options)

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -24,6 +24,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     })
     @credit_card = credit_card
     @amount = 100
+    @token = '2MPedsuenG2o8yFfrsdOBWmOuEf'
   end
 
   def test_successful_purchase
@@ -411,6 +412,36 @@ class CheckoutV2Test < Test::Unit::TestCase
 
     assert_success response
     assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_extra_customer_data
+    stub_comms(@gateway, :ssl_request) do
+      options = {
+        phone_country_code: '1',
+        billing_address: address
+      }
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['source']['phone']['number'], '(555)555-5555'
+      assert_equal request['source']['phone']['country_code'], '1'
+      assert_equal request['customer']['name'], 'Longbob Longsen'
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_no_customer_name_included_in_token_purchase
+    stub_comms(@gateway, :ssl_request) do
+      options = {
+        phone_country_code: '1',
+        billing_address: address
+      }
+      @gateway.purchase(@amount, @token, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['source']['phone']['number'], '(555)555-5555'
+      assert_equal request['source']['phone']['country_code'], '1'
+      refute_includes data, 'name'
+    end.respond_with(successful_purchase_response)
   end
 
   def test_successful_purchase_with_metadata
@@ -810,7 +841,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     alternate_credit_card = alternate_credit_card_class.new
 
     alternate_credit_card.expects(:credit_card?).returns(true)
-    alternate_credit_card.expects(:name).returns(@credit_card.name)
+    alternate_credit_card.expects(:name).at_least_once.returns(@credit_card.name)
     alternate_credit_card.expects(:number).returns(@credit_card.number)
     alternate_credit_card.expects(:verification_value).returns(@credit_card.verification_value)
     alternate_credit_card.expects(:first_name).at_least_once.returns(@credit_card.first_name)
@@ -826,7 +857,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     alternate_credit_card = alternate_credit_card_class.new
 
     alternate_credit_card.expects(:credit_card?).returns(true)
-    alternate_credit_card.expects(:name).returns(@credit_card.name)
+    alternate_credit_card.expects(:name).at_least_once.returns(@credit_card.name)
     alternate_credit_card.expects(:number).returns(@credit_card.number)
     alternate_credit_card.expects(:verification_value).returns(@credit_card.verification_value)
     alternate_credit_card.expects(:first_name).at_least_once.returns(@credit_card.first_name)


### PR DESCRIPTION
CER-595

Ran into a lot of tricky data collisions and had to do some finagling to make sure existing test cases would pass. I left open two possibilities for passing in the phone number depending on how users would like to pass it in: manually via options or via the phone number that’s attached to credit card billing data on the payment method.

It’s possible to pay with a stored payment method which would be a String. In this case there’s no name data attached so added some guarding against NoMethodErrors that were resulting from trying to call payment_method.name.

Remote Tests:
92 tests, 221 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96.7391% passed
*5 remote tests are failing on master but I fixed two of them

Unit Tests:
57 tests, 319 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Local Tests:
5516 tests, 77434 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed