### PR TITLE
WorldPay: Update how we check for network tokens

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -997,7 +997,7 @@ module ActiveMerchant #:nodoc:
         when String
           token_type_and_details(payment_method)
         else
-          type = payment_method.respond_to?(:source) ? :network_token : :credit
+          type = payment_method.respond_to?(:source || :payment_cryptogram) ? :network_token : :credit
 
           { payment_type: type }
         end


### PR DESCRIPTION
Add payment_cryptogram as a added check to see if a payment method is a Network Token like Google Pay.

Remote:
100 tests, 416 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
109 tests, 637 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed