### PR TITLE
DLocal: Add save field on card object

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * Redsys: Set appropriate request fields for stored credentials with CITs and MITs [BritneyS] #4784
 * Stripe & Stripe PI: Validate API Key [almalee24] #4801
 * Add BIN for Maestro [jcreiff] #4799
+* D_Local: Add save field on card object [yunnydang] #4805
 
 == Version 1.129.0 (May 3rd, 2023)
 * Adyen: Update selectedBrand mapping for Google Pay [jcreiff] #4763

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -188,6 +188,7 @@ module ActiveMerchant #:nodoc:
         post[:card][:installments] = options[:installments] if options[:installments]
         post[:card][:installments_id] = options[:installments_id] if options[:installments_id]
         post[:card][:force_type] = options[:force_type].to_s.upcase if options[:force_type]
+        post[:card][:save] = options[:save] if options[:save]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -50,6 +50,15 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_match 'The payment was paid', response.message
   end
 
+  def test_successful_purchase_with_save_option
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(save: true))
+    assert_success response
+    assert_equal true, response.params['card']['save']
+    assert_equal 'CREDIT', response.params['card']['type']
+    assert_not_empty response.params['card']['card_id']
+    assert_match 'The payment was paid', response.message
+  end
+
   def test_successful_purchase_with_network_tokens
     credit_card = network_tokenization_credit_card('4242424242424242',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -36,6 +36,14 @@ class DLocalTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_purchase_with_save
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(save: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal true, JSON.parse(data)['card']['save']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 


### PR DESCRIPTION
Add the save field to card object, documentation found [here](https://docs.dlocal.com/docs/saving-cards#save-a-card-on-a-payment)

Local:
5512 tests, 77364 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6553% passed

Unit:
44 tests, 191 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
39 tests, 105 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.8718% passed