### PR TITLE
Authorize.net: truncate nameOnAccount for bank refunds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 == HEAD
 * Redsys: Add supported countries [jcreiff] #4811
+* Authorize.net: Truncate nameOnAccount for bank refunds [jcreiff] #4808
 
 == Version 1.130.0 (June 13th, 2023)
 * Payu Latam - Update error code method to surface network code [yunnydang] #4773

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -362,7 +362,7 @@ module ActiveMerchant
                   xml.accountType(options[:account_type])
                   xml.routingNumber(options[:routing_number])
                   xml.accountNumber(options[:account_number])
-                  xml.nameOnAccount("#{options[:first_name]} #{options[:last_name]}")
+                  xml.nameOnAccount(truncate("#{options[:first_name]} #{options[:last_name]}", 22))
                 end
               else
                 xml.creditCard do

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -835,6 +835,18 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_match %r{The transaction cannot be found}, refund.message, 'Only allowed to refund transactions that have settled.  This is the best we can do for now testing wise.'
   end
 
+  def test_successful_echeck_refund_truncates_long_account_name
+    check_with_long_name = check(name: 'Michelangelo Donatello-Raphael')
+    purchase = @gateway.purchase(@amount, check_with_long_name, @options)
+    assert_success purchase
+
+    @options.update(first_name: check_with_long_name.first_name, last_name: check_with_long_name.last_name, routing_number: check_with_long_name.routing_number,
+                    account_number: check_with_long_name.account_number, account_type: check_with_long_name.account_type)
+    refund = @gateway.refund(@amount, purchase.authorization, @options)
+    assert_failure refund
+    assert_match %r{The transaction cannot be found}, refund.message, 'Only allowed to refund transactions that have settled.  This is the best we can do for now testing wise.'
+  end
+
   def test_failed_credit
     response = @gateway.credit(@amount, @declined_card, @options)
     assert_failure response


### PR DESCRIPTION
The API specification requires that the string be no longer than 22 characters; refunds will fail if this limit is exceeded

CER-670

REMOTE
85 tests, 304 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

UNIT
122 tests, 688 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

LOCAL
5525 tests, 77482 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

760 files inspected, no offenses detected