### PR TITLE
Redsys: Add supported countries

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys.rb
+++ b/lib/active_merchant/billing/gateways/redsys.rb
@@ -39,7 +39,7 @@ module ActiveMerchant #:nodoc:
       self.live_url = 'https://sis.redsys.es/sis/operaciones'
       self.test_url = 'https://sis-t.redsys.es:25443/sis/operaciones'
 
-      self.supported_countries = ['ES']
+      self.supported_countries = %w[ES FR GB IT PL PT]
       self.default_currency    = 'EUR'
       self.money_format        = :cents
 

--- a/test/unit/gateways/redsys_sha256_test.rb
+++ b/test/unit/gateways/redsys_sha256_test.rb
@@ -391,7 +391,7 @@ class RedsysSHA256Test < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal ['ES'], RedsysGateway.supported_countries
+    assert_equal %w[ES FR GB IT PL PT], RedsysGateway.supported_countries
   end
 
   def test_supported_cardtypes

--- a/test/unit/gateways/redsys_test.rb
+++ b/test/unit/gateways/redsys_test.rb
@@ -346,7 +346,7 @@ class RedsysTest < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal ['ES'], RedsysGateway.supported_countries
+    assert_equal %w[ES FR GB IT PL PT], RedsysGateway.supported_countries
   end
 
   def test_supported_cardtypes


### PR DESCRIPTION
This updates the list of countries that Redsys supports by adding France (FR), Great Britain (GB), Italy (IT), Poland (PL), and Portugal (PT)

CER-643
5527 tests, 77497 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

760 files inspected, no offenses detected