### PR TITLE
Worldpay: check payment_method responds to payment_cryptogram and eci

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 == HEAD
 * Redsys: Add supported countries [jcreiff] #4811
 * Authorize.net: Truncate nameOnAccount for bank refunds [jcreiff] #4808
+* Worldpay: check payment_method responds to payment_cryptogram and eci [bbraschi] #4812
 
 == Version 1.130.0 (June 13th, 2023)
 * Payu Latam - Update error code method to surface network code [yunnydang] #4773

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -997,10 +997,16 @@ module ActiveMerchant #:nodoc:
         when String
           token_type_and_details(payment_method)
         else
-          type = payment_method.respond_to?(:source) ? :network_token : :credit
+          type = network_token?(payment_method) ? :network_token : :credit
 
           { payment_type: type }
         end
+      end
+
+      def network_token?(payment_method)
+        payment_method.respond_to?(:source) &&
+          payment_method.respond_to?(:payment_cryptogram) &&
+          payment_method.respond_to?(:eci)
       end
 
       def token_type_and_details(token)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -150,6 +150,34 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal payment, :network_token
   end
 
+  def test_payment_type_returns_network_token_if_the_payment_method_responds_to_source_payment_cryptogram_and_eci
+    payment_method = mock
+    payment_method.stubs(source: nil, payment_cryptogram: nil, eci: nil)
+    result = @gateway.send(:payment_details, payment_method)
+    assert_equal({ payment_type: :network_token }, result)
+  end
+
+  def test_payment_type_returns_credit_if_the_payment_method_does_not_responds_to_source
+    payment_method = mock
+    payment_method.stubs(payment_cryptogram: nil, eci: nil)
+    result = @gateway.send(:payment_details, payment_method)
+    assert_equal({ payment_type: :credit }, result)
+  end
+
+  def test_payment_type_returns_credit_if_the_payment_method_does_not_responds_to_payment_cryptogram
+    payment_method = mock
+    payment_method.stubs(source: nil, eci: nil)
+    result = @gateway.send(:payment_details, payment_method)
+    assert_equal({ payment_type: :credit }, result)
+  end
+
+  def test_payment_type_returns_credit_if_the_payment_method_does_not_responds_to_eci
+    payment_method = mock
+    payment_method.stubs(source: nil, payment_cryptogram: nil)
+    result = @gateway.send(:payment_details, payment_method)
+    assert_equal({ payment_type: :credit }, result)
+  end
+
   def test_payment_type_for_credit_card
     payment = @gateway.send(:payment_details, @credit_card)[:payment_type]
     assert_equal payment, :credit


### PR DESCRIPTION
The https://github.com/activemerchant/active_merchant/commit/51c1f2d0333c53b89a8fb12189838694e5b09e6b commit resulted in `ActiveMerchant::Billing::WorldpayGateway#payment_details` to handle a payment method as a network token when the payment method responds to `:source`. However, there are payment methods that respond to `:source` but do not behave as a network token.

More specifically, `ActiveMerchant::Billing::WorldpayGateway#add_network_tokenization_card` expects that the payment method responds to `:source`, `:payment_cryptogram` and `:eci`.

Hence, this PR restricts the conditions under which `ActiveMerchant::Billing::WorldpayGateway#payment_details` handles a payment method as a network token to when the payment method responds to `:source`, `:payment_cryptogram` and `:eci` as well.

### Tests

#### Unit Tests
```
bundle exec rake test:units TEST=test/unit/gateways/worldpay_test.rb
```
```
Finished in 0.130999 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
113 tests, 645 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
862.60 tests/s, 4923.70 assertions/s
```

#### Remote Tests
```
bundle exec rake test:remote TEST=test/remote/gateways/remote_worldpay_test.rb
```

```
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
100 tests, 363 assertions, 26 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
74% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
Same test outcome as in `master`. 