### PR TITLE
Element Gateway: Add all lodging fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@
 * Rapyd: send customer object on us payment types [Heavyblade] #4919
 * SecurionPay/Shift4_v2: authorization from [gasb150] #4913
 * Rapyd: Update recurrence_type field [yunnydang] #4922
+* Element: Add lodging fields [yunnydang] #4813
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -37,6 +37,7 @@ module ActiveMerchant #:nodoc:
             add_transaction(xml, money, options)
             add_terminal(xml, options)
             add_address(xml, options)
+            add_lodging(xml, options)
           end
         end
 
@@ -51,6 +52,7 @@ module ActiveMerchant #:nodoc:
             add_transaction(xml, money, options)
             add_terminal(xml, options)
             add_address(xml, options)
+            add_lodging(xml, options)
           end
         end
 
@@ -222,16 +224,44 @@ module ActiveMerchant #:nodoc:
         options[:market_code] || 'Default'
       end
 
+      def add_lodging(xml, options)
+        if lodging = options[:lodging]
+          xml.extendedParameters do
+            xml.ExtendedParameters do
+              xml.Key 'Lodging'
+              xml.Value('xsi:type' => 'Lodging') do
+                xml.LodgingAgreementNumber lodging[:agreement_number] if lodging[:agreement_number]
+                xml.LodgingCheckInDate lodging[:check_in_date] if lodging[:check_in_date]
+                xml.LodgingCheckOutDate lodging[:check_out_date] if lodging[:check_out_date]
+                xml.LodgingRoomAmount lodging[:room_amount] if lodging[:room_amount]
+                xml.LodgingRoomTax lodging[:room_tax] if lodging[:room_tax]
+                xml.LodgingNoShowIndicator lodging[:no_show_indicator] if lodging[:no_show_indicator]
+                xml.LodgingDuration lodging[:duration] if lodging[:duration]
+                xml.LodgingCustomerName lodging[:customer_name] if lodging[:customer_name]
+                xml.LodgingClientCode lodging[:client_code] if lodging[:client_code]
+                xml.LodgingExtraChargesDetail lodging[:extra_charges_detail] if lodging[:extra_charges_detail]
+                xml.LodgingExtraChargesAmounts lodging[:extra_charges_amounts] if lodging[:extra_charges_amounts]
+                xml.LodgingPrestigiousPropertyCode lodging[:prestigious_property_code] if lodging[:prestigious_property_code]
+                xml.LodgingSpecialProgramCode lodging[:special_program_code] if lodging[:special_program_code]
+                xml.LodgingChargeType lodging[:charge_type] if lodging[:charge_type]
+              end
+            end
+          end
+        end
+      end
+
       def add_terminal(xml, options)
         xml.terminal do
           xml.TerminalID options[:terminal_id] || '01'
+          xml.TerminalType options[:terminal_type] if options[:terminal_type]
           xml.CardPresentCode options[:card_present_code] || 'UseDefault'
-          xml.CardholderPresentCode 'UseDefault'
-          xml.CardInputCode 'UseDefault'
-          xml.CVVPresenceCode 'UseDefault'
-          xml.TerminalCapabilityCode 'UseDefault'
-          xml.TerminalEnvironmentCode 'UseDefault'
+          xml.CardholderPresentCode options[:card_holder_present_code] || 'UseDefault'
+          xml.CardInputCode options[:card_input_code] || 'UseDefault'
+          xml.CVVPresenceCode options[:cvv_presence_code] || 'UseDefault'
+          xml.TerminalCapabilityCode options[:terminal_capability_code] || 'UseDefault'
+          xml.TerminalEnvironmentCode options[:terminal_environment_code] || 'UseDefault'
           xml.MotoECICode 'NonAuthenticatedSecureECommerceTransaction'
+          xml.PartialApprovedFlag options[:partial_approved_flag] if options[:partial_approved_flag]
         end
       end
 

--- a/test/unit/gateways/element_test.rb
+++ b/test/unit/gateways/element_test.rb
@@ -166,6 +166,50 @@ class ElementTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_lodging_and_other_fields
+    lodging_options = {
+      order_id: '2',
+      billing_address: address.merge(zip: '87654'),
+      description: 'Store Purchase',
+      duplicate_override_flag: 'true',
+      lodging: {
+        agreement_number: 182726718192,
+        check_in_date: 20250910,
+        check_out_date: 20250915,
+        room_amount: 1000,
+        room_tax: 0,
+        no_show_indicator: 0,
+        duration: 5,
+        customer_name: 'francois dubois',
+        client_code: 'Default',
+        extra_charges_detail: '01',
+        extra_charges_amounts: 'Default',
+        prestigious_property_code: 'DollarLimit500',
+        special_program_code: 'Sale',
+        charge_type: 'Restaurant'
+      }
+    }
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, lodging_options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<LodgingAgreementNumber>182726718192</LodgingAgreementNumber>', data
+      assert_match '<LodgingCheckInDate>20250910</LodgingCheckInDate>', data
+      assert_match '<LodgingCheckOutDate>20250915</LodgingCheckOutDate>', data
+      assert_match '<LodgingRoomAmount>1000</LodgingRoomAmount>', data
+      assert_match '<LodgingRoomTax>0</LodgingRoomTax>', data
+      assert_match '<LodgingNoShowIndicator>0</LodgingNoShowIndicator>', data
+      assert_match '<LodgingDuration>5</LodgingDuration>', data
+      assert_match '<LodgingCustomerName>francois dubois</LodgingCustomerName>', data
+      assert_match '<LodgingClientCode>Default</LodgingClientCode>', data
+      assert_match '<LodgingExtraChargesDetail>01</LodgingExtraChargesDetail>', data
+      assert_match '<LodgingExtraChargesAmounts>Default</LodgingExtraChargesAmounts>', data
+      assert_match '<LodgingPrestigiousPropertyCode>DollarLimit500</LodgingPrestigiousPropertyCode>', data
+      assert_match '<LodgingSpecialProgramCode>Sale</LodgingSpecialProgramCode>', data
+      assert_match '<LodgingChargeType>Restaurant</LodgingChargeType>', data
+    end.respond_with(successful_purchase_response)
+    assert_success response
+  end
+
   def test_successful_purchase_with_payment_type
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(payment_type: 'NotUsed'))


### PR DESCRIPTION
Documentation for this can be found [here](https://developerengine.fisglobal.com/apis/express/express-xml/classes#lodging). I had to add support for a few more fields otherwise the lodging fields cannot be supported (they're extended parameters class). also with the tests files, new credentials were given and I had to clean up the remote tests specs to follow along with the new sandbox configurations. All tests are now passing and updated in this change.

Local:
5625 tests, 78037 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6622% passed

Unit:
27 tests, 149 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 
32 tests, 88 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed