### PR TITLE
VPos: Adding Panal Credit Card type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 == HEAD
 * Stripe Payment Intents: Add support for new card on file field [aenand] #4807
 * Commerce Hub: Add `physicalGoodsIndicator` and `schemeReferenceTransactionId` GSFs [sinourain] #4786
+* VPos: Adding Panal Credit Card type [jherreraa] #4814
 
 == Version 1.131.0 (June 21, 2023)
 * Redsys: Add supported countries [jcreiff] #4811

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -38,6 +38,7 @@ module ActiveMerchant #:nodoc:
     # * Edenred
     # * Anda
     # * Creditos directos (Tarjeta D)
+    # * Panal
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -130,6 +131,7 @@ module ActiveMerchant #:nodoc:
       # * +'edenred'+
       # * +'anda'+
       # * +'tarjeta-d'+
+      # * +'panal'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -46,7 +46,8 @@ module ActiveMerchant #:nodoc:
         'edenred' => ->(num) { num =~ /^637483\d{10}$/ },
         'anda' => ->(num) { num =~ /^603199\d{10}$/ },
         'tarjeta-d' => ->(num) { num =~ /^601828\d{10}$/ },
-        'hipercard' => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), HIPERCARD_RANGES) }
+        'hipercard' => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), HIPERCARD_RANGES) },
+        'panal' => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), PANAL_RANGES) }
       }
 
       SODEXO_NO_LUHN = ->(num) { num =~ /^(505864|505865)\d{10}$/ }
@@ -182,7 +183,8 @@ module ActiveMerchant #:nodoc:
         (601256..601276),
         (601640..601652),
         (601689..601700),
-        (602011..602050),
+        (602011..602048),
+        [602050],
         (630400..630499),
         (639000..639099),
         (670000..679999),
@@ -246,6 +248,8 @@ module ActiveMerchant #:nodoc:
         384100..384100, 384140..384140, 384160..384160, 606282..606282, 637095..637095,
         637568..637568, 637599..637599, 637609..637609, 637612..637612
       ]
+
+      PANAL_RANGES = [[602049]]
 
       def self.included(base)
         base.extend(ClassMethods)

--- a/lib/active_merchant/billing/gateways/vpos.rb
+++ b/lib/active_merchant/billing/gateways/vpos.rb
@@ -9,7 +9,7 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = ['PY']
       self.default_currency = 'PYG'
-      self.supported_cardtypes = %i[visa master]
+      self.supported_cardtypes = %i[visa master panal]
 
       self.homepage_url = 'https://comercios.bancard.com.py'
       self.display_name = 'vPOS'

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -502,6 +502,10 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_false electron_test.call('42496200000000000')
   end
 
+  def test_should_detect_panal_card
+    assert_equal 'panal', CreditCard.brand?('6020490000000000')
+  end
+
   def test_credit_card?
     assert credit_card.credit_card?
   end


### PR DESCRIPTION
## Summary:
Add the Panal credit card type and enables it for VPos gateway

SER-605

## Tests:

### Unit Tests:
Finished in 38.864306 seconds.
5542 tests, 77546 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
760 files inspected, no offenses detected

*Note*: Remote tests for this change are not present because wasn't possible to get test cards.