### PR TITLE
CyberSource: update NT methods to allow for recurring AP

### DIFF
--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -718,6 +718,26 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(auth)
   end
 
+  def test_purchase_with_apple_pay_network_tokenization
+    credit_card = network_tokenization_credit_card('4111111111111111',
+      brand: 'visa',
+      eci: '05',
+      source: :apple_pay,
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+    @options[:stored_credential_overrides] = {
+      subsequent_auth_stored_credential: true,
+      type: 'apple_pay'
+    }
+    @options[:stored_credential] = {
+      initiator: 'merchant',
+      reason_type: 'unscheduled',
+      network_transaction_id: '016150703802094'
+    }
+
+    assert auth = @gateway.purchase(@amount, credit_card, @options)
+    assert_successful_response(auth)
+  end
+
   def test_successful_authorize_with_mdd_fields
     (1..20).each { |e| @options["mdd_field_#{e}".to_sym] = "value #{e}" }
 


### PR DESCRIPTION
CER-701

According to CyberSource, the cryptogram should be eliminated from the request and stored credentials should be set to merchant and unscheduled. Also in order for this to work, commerce_indicator must be `internet`.

Remote Tests:
122 tests, 609 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95.082% passed

Unit Tests:
132 tests, 628 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
* Didn’t add a unit test but I can if needed

Local Tests:
5541 tests, 77545 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed