### PR TITLE
Braintree: Update Ruby Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rubocop', '~> 0.62.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 3.0.0', '<= 3.0.1'
+  gem 'braintree', '~> 4.11.0'
   gem 'jose', '~> 1.1.3'
   gem 'jwe'
   gem 'mechanize'


### PR DESCRIPTION
Update Braintree Ruby Gem to 4.11.0

Unit:
94 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed  Remote:
103 tests, 550 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed