### PR TITLE
IPG: Update live url to correct endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Authorize.net: Truncate nameOnAccount for bank refunds [jcreiff] #4808
 * CheckoutV2: Add support for several customer data fields [rachelkirk] #4800
 * Worldpay: check payment_method responds to payment_cryptogram and eci [bbraschi] #4812
+* IPG: Update live url to correct endpoint [curiousepic] #4121
 
 == Version 1.130.0 (June 13th, 2023)
 * Payu Latam - Update error code method to surface network code [yunnydang] #4773

--- a/lib/active_merchant/billing/gateways/ipg.rb
+++ b/lib/active_merchant/billing/gateways/ipg.rb
@@ -2,7 +2,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class IpgGateway < Gateway
       self.test_url = 'https://test.ipg-online.com/ipgapi/services'
-      self.live_url = 'https://www5.ipg-online.com'
+      self.live_url = 'https://www5.ipg-online.com/ipgapi/services'
 
       self.supported_countries = %w(AR)
       self.default_currency = 'ARS'

--- a/test/remote/gateways/remote_ipg_test.rb
+++ b/test/remote/gateways/remote_ipg_test.rb
@@ -5,7 +5,7 @@ class RemoteIpgTest < Test::Unit::TestCase
     @gateway = IpgGateway.new(fixtures(:ipg))
 
     @amount = 100
-    @credit_card = credit_card('5165850000000008', brand: 'mastercard', verification_value: '123', month: '12', year: '2029')
+    @credit_card = credit_card('5165850000000008', brand: 'mastercard', verification_value: '987', month: '12', year: '2029')
     @declined_card = credit_card('4000300011112220', brand: 'mastercard', verification_value: '652', month: '12', year: '2022')
     @visa_card = credit_card('4704550000000005', brand: 'visa', verification_value: '123', month: '12', year: '2029')
     @options = {


### PR DESCRIPTION
The live_url for IPG was likely always incorrect, this updates it to hit the actual endpoint.

Also changes test data to prevent a scrub test failure.

Remote (same failures on master):
18 tests, 40 assertions, 8 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

Unit:
27 tests, 123 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications