### PR TITLE
Update required Ruby version

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -17,8 +17,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - 2.5
-          - 2.6
           - 2.7
         gemfile:
           - gemfiles/Gemfile.rails50

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - "lib/active_merchant/billing/gateways/paypal_express.rb"
     - "vendor/**/*"
   ExtraDetails: false
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
 # Active Merchant gateways are not amenable to length restrictions
 Metrics/ClassLength:
@@ -33,7 +33,7 @@ Layout/DotPosition:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Naming/PredicateName:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,11 +2,14 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-* Paysafe: Map order_id to merchantRefNum [jcreiff] #4839
-* Stripe PI: Gate sending NTID [almalee24] #4828
+
+== Version 1.134.0 (July 25, 2023)
+* Update required Ruby version [almalee24] #4823
 
 == Version 1.133.0 (July 20, 2023)
 * CyberSource: remove credentials from tests [bbraschi] #4836
+* Paysafe: Map order_id to merchantRefNum [jcreiff] #4839
+* Stripe PI: Gate sending NTID [almalee24] #4828
 
 == Version 1.132.0 (July 20, 2023)
 * Stripe Payment Intents: Add support for new card on file field [aenand] #4807

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', platforms: :jruby
-gem 'rubocop', '~> 0.62.0', require: false
+gem 'rubocop', '~> 0.72.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = 'tobi@leetsoft.com'
   s.homepage = 'http://activemerchant.org/'
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.7'
 
   s.files = Dir['CHANGELOG', 'README.md', 'MIT-LICENSE', 'CONTRIBUTORS', 'lib/**/*', 'vendor/**/*']
   s.require_path = 'lib'

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: '2.5.0'
+    version: '2.7.0'
 
 dependencies:
   cache_directories:

--- a/lib/active_merchant/billing/check.rb
+++ b/lib/active_merchant/billing/check.rb
@@ -7,8 +7,8 @@ module ActiveMerchant #:nodoc:
     # You may use Check in place of CreditCard with any gateway that supports it.
     class Check < Model
       attr_accessor :first_name, :last_name,
-        :bank_name, :routing_number, :account_number,
-        :account_holder_type, :account_type, :number
+                    :bank_name, :routing_number, :account_number,
+                    :account_holder_type, :account_type, :number
 
       # Used for Canadian bank accounts
       attr_accessor :institution_number, :transit_number

--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -139,7 +139,9 @@ module ActiveMerchant #:nodoc:
 
       def build_request_url(action, id = nil)
         base_url = (test? ? test_url : live_url)
-        base_url + ENDPOINTS[action].to_s % { id: id }
+        endpoint = ENDPOINTS[action].to_s
+        endpoint = id.present? ? endpoint % { id: id } : endpoint
+        base_url + endpoint
       end
 
       def add_referrer_data(post)

--- a/lib/active_merchant/billing/gateways/alelo.rb
+++ b/lib/active_merchant/billing/gateways/alelo.rb
@@ -144,9 +144,9 @@ module ActiveMerchant #:nodoc:
           access_token: access_token,
           multiresp: multiresp.responses.present? ? multiresp : nil
         }
-      rescue ResponseError => error
+      rescue ResponseError => e
         # retry to generate a new access_token when the provided one is expired
-        raise error unless try_again && %w(401 404).include?(error.response.code) && @options[:access_token].present?
+        raise e unless try_again && %w(401 404).include?(e.response.code) && @options[:access_token].present?
 
         @options.delete(:access_token)
         @options.delete(:encryption_key)

--- a/lib/active_merchant/billing/gateways/authorize_net_arb.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_arb.rb
@@ -393,9 +393,13 @@ module ActiveMerchant #:nodoc:
         test_mode = test? || message =~ /Test Mode/
         success = response[:result_code] == 'Ok'
 
-        Response.new(success, message, response,
+        Response.new(
+          success,
+          message,
+          response,
           test: test_mode,
-          authorization: response[:subscription_id])
+          authorization: response[:subscription_id]
+        )
       end
 
       def recurring_parse(action, xml)

--- a/lib/active_merchant/billing/gateways/axcessms.rb
+++ b/lib/active_merchant/billing/gateways/axcessms.rb
@@ -71,9 +71,13 @@ module ActiveMerchant #:nodoc:
         message = "#{response[:reason]} - #{response[:return]}"
         authorization = response[:unique_id]
 
-        Response.new(success, message, response,
+        Response.new(
+          success,
+          message,
+          response,
           authorization: authorization,
-          test: (response[:mode] != 'LIVE'))
+          test: (response[:mode] != 'LIVE')
+        )
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -89,11 +89,13 @@ module ActiveMerchant #:nodoc:
           response = json_error(raw_response)
         end
 
-        Response.new(success?(response),
+        Response.new(
+          success?(response),
           response['message'],
           response,
           test: test?,
-          authorization: response['code_auth'])
+          authorization: response['code_auth']
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -413,11 +413,15 @@ module ActiveMerchant #:nodoc:
       def post(data, use_profile_api = nil)
         response = parse(ssl_post((use_profile_api ? SECURE_PROFILE_URL : self.live_url), data))
         response[:customer_vault_id] = response[:customerCode] if response[:customerCode]
-        build_response(success?(response), message_from(response), response,
+        build_response(
+          success?(response),
+          message_from(response),
+          response,
           test: test? || response[:authCode] == 'TEST',
           authorization: authorization_from(response),
           cvv_result: CVD_CODES[response[:cvdId]],
-          avs_result: { code: AVS_CODES.include?(response[:avsId]) ? AVS_CODES[response[:avsId]] : response[:avsId] })
+          avs_result: { code: AVS_CODES.include?(response[:avsId]) ? AVS_CODES[response[:avsId]] : response[:avsId] }
+        )
       end
 
       def recurring_post(data)

--- a/lib/active_merchant/billing/gateways/blue_pay.rb
+++ b/lib/active_merchant/billing/gateways/blue_pay.rb
@@ -344,9 +344,13 @@ module ActiveMerchant #:nodoc:
         success = parsed[:status] != 'error'
         message = parsed[:status]
 
-        Response.new(success, message, parsed,
+        Response.new(
+          success,
+          message,
+          parsed,
           test: test?,
-          authorization: parsed[:rebill_id])
+          authorization: parsed[:rebill_id]
+        )
       end
 
       def parse(body)
@@ -364,11 +368,15 @@ module ActiveMerchant #:nodoc:
         # normalize message
         message = message_from(parsed)
         success = parsed[:response_code] == '1'
-        Response.new(success, message, parsed,
+        Response.new(
+          success,
+          message,
+          parsed,
           test: test?,
           authorization: (parsed[:rebid] && parsed[:rebid] != '' ? parsed[:rebid] : parsed[:transaction_id]),
           avs_result: { code: parsed[:avs_result_code] },
-          cvv_result: parsed[:card_code])
+          cvv_result: parsed[:card_code]
+        )
       end
 
       def message_from(parsed)

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -193,15 +193,20 @@ module ActiveMerchant #:nodoc:
             }
           }, options)[:credit_card]
 
-          result = @braintree_gateway.customer.update(vault_id,
+          result = @braintree_gateway.customer.update(
+            vault_id,
             first_name: creditcard.first_name,
             last_name: creditcard.last_name,
             email: scrub_email(options[:email]),
             phone: phone_from(options),
-            credit_card: credit_card_params)
-          Response.new(result.success?, message_from_result(result),
+            credit_card: credit_card_params
+          )
+          Response.new(
+            result.success?,
+            message_from_result(result),
             braintree_customer: (customer_hash(@braintree_gateway.customer.find(vault_id), :include_credit_cards) if result.success?),
-            customer_vault_id: (result.customer.id if result.success?))
+            customer_vault_id: (result.customer.id if result.success?)
+          )
         end
       end
 
@@ -271,13 +276,16 @@ module ActiveMerchant #:nodoc:
             device_data: options[:device_data]
           }.merge credit_card_params
           result = @braintree_gateway.customer.create(merge_credit_card_options(parameters, options))
-          Response.new(result.success?, message_from_result(result),
+          Response.new(
+            result.success?,
+            message_from_result(result),
             {
               braintree_customer: (customer_hash(result.customer, :include_credit_cards) if result.success?),
               customer_vault_id: (result.customer.id if result.success?),
               credit_card_token: (result.customer.credit_cards[0].token if result.success?)
             },
-            authorization: (result.customer.id if result.success?))
+            authorization: (result.customer.id if result.success?)
+          )
         end
       end
 
@@ -371,8 +379,8 @@ module ActiveMerchant #:nodoc:
 
       def commit(&block)
         yield
-      rescue Braintree::BraintreeError => ex
-        Response.new(false, ex.class.to_s)
+      rescue Braintree::BraintreeError => e
+        Response.new(false, e.class.to_s)
       end
 
       def message_from_result(result)
@@ -901,13 +909,16 @@ module ActiveMerchant #:nodoc:
         message = message_from_result(result)
         message = not_verified_reason(result.payment_method) unless verified
 
-        Response.new(verified, message,
+        Response.new(
+          verified,
+          message,
           {
             customer_vault_id: options[:customer],
             bank_account_token: result.payment_method&.token,
             verified: verified
           },
-          authorization: result.payment_method&.token)
+          authorization: result.payment_method&.token
+        )
       end
 
       def not_verified_reason(bank_account)

--- a/lib/active_merchant/billing/gateways/card_connect.rb
+++ b/lib/active_merchant/billing/gateways/card_connect.rb
@@ -146,9 +146,12 @@ module ActiveMerchant #:nodoc:
 
       def unstore(authorization, options = {})
         account_id, profile_id = authorization.split('|')
-        commit('profile', {},
+        commit(
+          'profile',
+          {},
           verb: :delete,
-          path: "/#{profile_id}/#{account_id}/#{@options[:merchant_id]}")
+          path: "/#{profile_id}/#{account_id}/#{@options[:merchant_id]}"
+        )
       end
 
       def supports_scrubbing?

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -1068,12 +1068,16 @@ module ActiveMerchant #:nodoc:
 
         message = auto_void?(authorization_from(response, action, amount, options), response, message, options)
 
-        Response.new(success, message, response,
+        Response.new(
+          success,
+          message,
+          response,
           test: test?,
           authorization: authorization,
           fraud_review: in_fraud_review?(response),
           avs_result: { code: response[:avsCode] },
-          cvv_result: response[:cvCode])
+          cvv_result: response[:cvCode]
+        )
       end
 
       def auto_void?(authorization, response, message, options = {})

--- a/lib/active_merchant/billing/gateways/data_cash.rb
+++ b/lib/active_merchant/billing/gateways/data_cash.rb
@@ -235,23 +235,23 @@ module ActiveMerchant
             # a predefined one
             xml.tag! :ExtendedPolicy do
               xml.tag! :cv2_policy,
-                notprovided: POLICY_REJECT,
-                notchecked: POLICY_REJECT,
-                matched: POLICY_ACCEPT,
-                notmatched: POLICY_REJECT,
-                partialmatch: POLICY_REJECT
+                       notprovided: POLICY_REJECT,
+                       notchecked: POLICY_REJECT,
+                       matched: POLICY_ACCEPT,
+                       notmatched: POLICY_REJECT,
+                       partialmatch: POLICY_REJECT
               xml.tag! :postcode_policy,
-                notprovided: POLICY_ACCEPT,
-                notchecked: POLICY_ACCEPT,
-                matched: POLICY_ACCEPT,
-                notmatched: POLICY_REJECT,
-                partialmatch: POLICY_ACCEPT
+                       notprovided: POLICY_ACCEPT,
+                       notchecked: POLICY_ACCEPT,
+                       matched: POLICY_ACCEPT,
+                       notmatched: POLICY_REJECT,
+                       partialmatch: POLICY_ACCEPT
               xml.tag! :address_policy,
-                notprovided: POLICY_ACCEPT,
-                notchecked: POLICY_ACCEPT,
-                matched: POLICY_ACCEPT,
-                notmatched: POLICY_REJECT,
-                partialmatch: POLICY_ACCEPT
+                       notprovided: POLICY_ACCEPT,
+                       notchecked: POLICY_ACCEPT,
+                       matched: POLICY_ACCEPT,
+                       notmatched: POLICY_REJECT,
+                       partialmatch: POLICY_ACCEPT
             end
           end
         end
@@ -260,9 +260,13 @@ module ActiveMerchant
       def commit(request)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, request))
 
-        Response.new(response[:status] == '1', response[:reason], response,
+        Response.new(
+          response[:status] == '1',
+          response[:reason],
+          response,
           test: test?,
-          authorization: "#{response[:datacash_reference]};#{response[:authcode]};#{response[:ca_reference]}")
+          authorization: "#{response[:datacash_reference]};#{response[:authcode]};#{response[:ca_reference]}"
+        )
       end
 
       def format_date(month, year)

--- a/lib/active_merchant/billing/gateways/efsnet.rb
+++ b/lib/active_merchant/billing/gateways/efsnet.rb
@@ -145,11 +145,15 @@ module ActiveMerchant #:nodoc:
       def commit(action, parameters)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(action, parameters), 'Content-Type' => 'text/xml'))
 
-        Response.new(success?(response), message_from(response[:result_message]), response,
+        Response.new(
+          success?(response),
+          message_from(response[:result_message]),
+          response,
           test: test?,
           authorization: authorization_from(response, parameters),
           avs_result: { code: response[:avs_response_code] },
-          cvv_result: response[:cvv_response_code])
+          cvv_result: response[:cvv_response_code]
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/element.rb
+++ b/lib/active_merchant/billing/gateways/element.rb
@@ -363,7 +363,6 @@ module ActiveMerchant #:nodoc:
           xml['soap'].Envelope('xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
                                'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
                                'xmlns:soap' => 'http://schemas.xmlsoap.org/soap/envelope/') do
-
             xml['soap'].Body do
               yield(xml)
             end

--- a/lib/active_merchant/billing/gateways/epay.rb
+++ b/lib/active_merchant/billing/gateways/epay.rb
@@ -174,17 +174,21 @@ module ActiveMerchant #:nodoc:
         response = send("do_#{action}", params)
 
         if action == :authorize
-          Response.new response['accept'].to_i == 1,
+          Response.new(
+            response['accept'].to_i == 1,
             response['errortext'],
             response,
             test: test?,
             authorization: response['tid']
+          )
         else
-          Response.new response['result'] == 'true',
+          Response.new(
+            response['result'] == 'true',
             messages(response['epay'], response['pbs']),
             response,
             test: test?,
             authorization: params[:transaction]
+          )
         end
       end
 

--- a/lib/active_merchant/billing/gateways/evo_ca.rb
+++ b/lib/active_merchant/billing/gateways/evo_ca.rb
@@ -279,11 +279,15 @@ module ActiveMerchant #:nodoc:
         response = parse(data)
         message = message_from(response)
 
-        Response.new(success?(response), message, response,
+        Response.new(
+          success?(response),
+          message,
+          response,
           test: test?,
           authorization: response['transactionid'],
           avs_result: { code: response['avsresponse'] },
-          cvv_result: response['cvvresponse'])
+          cvv_result: response['cvvresponse']
+        )
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/eway.rb
+++ b/lib/active_merchant/billing/gateways/eway.rb
@@ -111,11 +111,13 @@ module ActiveMerchant #:nodoc:
         raw_response = ssl_post(url, post_data(parameters))
         response = parse(raw_response)
 
-        Response.new(success?(response),
+        Response.new(
+          success?(response),
           message_from(response[:ewaytrxnerror]),
           response,
           authorization: response[:ewaytrxnnumber],
-          test: test?)
+          test: test?
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -222,9 +222,13 @@ module ActiveMerchant #:nodoc:
           end
         response = parse(raw)
 
-        EwayResponse.new(response[:success], response[:message], response,
+        EwayResponse.new(
+          response[:success],
+          response[:message],
+          response,
           test: test?,
-          authorization: response[:auth_code])
+          authorization: response[:auth_code]
+        )
       end
 
       # Where we build the full SOAP 1.2 request using builder

--- a/lib/active_merchant/billing/gateways/exact.rb
+++ b/lib/active_merchant/billing/gateways/exact.rb
@@ -158,11 +158,15 @@ module ActiveMerchant #:nodoc:
       def commit(action, request)
         response = parse(ssl_post(self.live_url, build_request(action, request), POST_HEADERS))
 
-        Response.new(successful?(response), message_from(response), response,
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
           test: test?,
           authorization: authorization_from(response),
           avs_result: { code: response[:avs] },
-          cvv_result: response[:cvv2])
+          cvv_result: response[:cvv2]
+        )
       rescue ResponseError => e
         case e.response.code
         when '401'

--- a/lib/active_merchant/billing/gateways/federated_canada.rb
+++ b/lib/active_merchant/billing/gateways/federated_canada.rb
@@ -121,11 +121,15 @@ module ActiveMerchant #:nodoc:
         response = parse(data)
         message = message_from(response)
 
-        Response.new(success?(response), message, response,
+        Response.new(
+          success?(response),
+          message,
+          response,
           test: test?,
           authorization: response['transactionid'],
           avs_result: { code: response['avsresponse'] },
-          cvv_result: response['cvvresponse'])
+          cvv_result: response['cvvresponse']
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -354,12 +354,16 @@ module ActiveMerchant #:nodoc:
           response = parse_error(e.response)
         end
 
-        Response.new(successful?(response), message_from(response), response,
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
           test: test?,
           authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
           avs_result: { code: response[:avs] },
           cvv_result: response[:cvv2],
-          error_code: standard_error_code(response))
+          error_code: standard_error_code(response)
+        )
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4_v27.rb
@@ -380,12 +380,16 @@ module ActiveMerchant #:nodoc:
           response = parse_error(e.response)
         end
 
-        Response.new(successful?(response), message_from(response), response,
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
           test: test?,
           authorization: successful?(response) ? response_authorization(action, response, credit_card) : '',
           avs_result: { code: response[:avs] },
           cvv_result: response[:cvv2],
-          error_code: standard_error_code(response))
+          error_code: standard_error_code(response)
+        )
       end
 
       def headers(method, url, request)

--- a/lib/active_merchant/billing/gateways/garanti.rb
+++ b/lib/active_merchant/billing/gateways/garanti.rb
@@ -219,11 +219,13 @@ module ActiveMerchant #:nodoc:
 
         success = success?(response)
 
-        Response.new(success,
+        Response.new(
+          success,
           success ? 'Approved' : "Declined (Reason: #{response[:reason_code]} - #{response[:error_msg]} - #{response[:sys_err_msg]})",
           response,
           test: test?,
-          authorization: response[:order_id])
+          authorization: response[:order_id]
+        )
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/iats_payments.rb
+++ b/lib/active_merchant/billing/gateways/iats_payments.rb
@@ -185,8 +185,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(action, parameters)
-        response = parse(ssl_post(url(action), post_data(action, parameters),
-          { 'Content-Type' => 'application/soap+xml; charset=utf-8' }))
+        response = parse(
+          ssl_post(
+            url(action),
+            post_data(action, parameters),
+            { 'Content-Type' => 'application/soap+xml; charset=utf-8' }
+          )
+        )
 
         Response.new(
           success_from(response),

--- a/lib/active_merchant/billing/gateways/inspire.rb
+++ b/lib/active_merchant/billing/gateways/inspire.rb
@@ -172,11 +172,14 @@ module ActiveMerchant #:nodoc:
 
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
-        Response.new(response['response'] == '1', message_from(response), response,
+        Response.new(
+          response['response'] == '1',
+          message_from(response), response,
           authorization: response['transactionid'],
           test: test?,
           cvv_result: response['cvvresponse'],
-          avs_result: { code: response['avsresponse'] })
+          avs_result: { code: response['avsresponse'] }
+        )
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/instapay.rb
+++ b/lib/active_merchant/billing/gateways/instapay.rb
@@ -140,10 +140,14 @@ module ActiveMerchant #:nodoc:
         data = ssl_post self.live_url, post_data(action, parameters)
         response = parse(data)
 
-        Response.new(response[:success], response[:message], response,
+        Response.new(
+          response[:success],
+          response[:message],
+          response,
           authorization: response[:transaction_id],
           avs_result: { code: response[:avs_result] },
-          cvv_result: response[:cvv_result])
+          cvv_result: response[:cvv_result]
+        )
       end
 
       def post_data(action, parameters = {})

--- a/lib/active_merchant/billing/gateways/iridium.rb
+++ b/lib/active_merchant/billing/gateways/iridium.rb
@@ -376,22 +376,32 @@ module ActiveMerchant #:nodoc:
 
       def commit(request, options)
         requires!(options, :action)
-        response = parse(ssl_post(test? ? self.test_url : self.live_url, request,
-          { 'SOAPAction' => 'https://www.thepaymentgateway.net/' + options[:action],
-           'Content-Type' => 'text/xml; charset=utf-8' }))
+        response = parse(
+          ssl_post(
+            test? ? self.test_url : self.live_url, request,
+            {
+              'SOAPAction' => 'https://www.thepaymentgateway.net/' + options[:action],
+              'Content-Type' => 'text/xml; charset=utf-8'
+            }
+          )
+        )
 
         success = response[:transaction_result][:status_code] == '0'
         message = response[:transaction_result][:message]
         authorization = success ? [options[:order_id], response[:transaction_output_data][:cross_reference], response[:transaction_output_data][:auth_code]].compact.join(';') : nil
 
-        Response.new(success, message, response,
+        Response.new(
+          success,
+          message,
+          response,
           test: test?,
           authorization: authorization,
           avs_result: {
             street_match: AVS_CODE[ response[:transaction_output_data][:address_numeric_check_result] ],
             postal_match: AVS_CODE[ response[:transaction_output_data][:post_code_check_result] ]
           },
-          cvv_result: CVV_CODE[ response[:transaction_output_data][:cv2_check_result] ])
+          cvv_result: CVV_CODE[ response[:transaction_output_data][:cv2_check_result] ]
+        )
       end
 
       def parse(xml)

--- a/lib/active_merchant/billing/gateways/itransact.rb
+++ b/lib/active_merchant/billing/gateways/itransact.rb
@@ -387,11 +387,15 @@ module ActiveMerchant #:nodoc:
         # the Base64 encoded payload signature!
         response = parse(ssl_post(self.live_url, post_data(payload), 'Content-Type' => 'text/xml'))
 
-        Response.new(successful?(response), response[:error_message], response,
+        Response.new(
+          successful?(response),
+          response[:error_message],
+          response,
           test: test?,
           authorization: response[:xid],
           avs_result: { code: response[:avs_response] },
-          cvv_result: response[:cvv_response])
+          cvv_result: response[:cvv_response]
+        )
       end
 
       def post_data(payload)

--- a/lib/active_merchant/billing/gateways/ixopay.rb
+++ b/lib/active_merchant/billing/gateways/ixopay.rb
@@ -286,8 +286,8 @@ module ActiveMerchant #:nodoc:
         response =
           begin
             parse(ssl_post(url, request, headers(request)))
-          rescue StandardError => error
-            parse(error.response.body)
+          rescue StandardError => e
+            parse(e.response.body)
           end
 
         Response.new(

--- a/lib/active_merchant/billing/gateways/jetpay.rb
+++ b/lib/active_merchant/billing/gateways/jetpay.rb
@@ -284,13 +284,15 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url, request))
 
         success = success?(response)
-        Response.new(success,
+        Response.new(
+          success,
           success ? 'APPROVED' : message_from(response),
           response,
           test: test?,
           authorization: authorization_from(response, money, token),
           avs_result: { code: response[:avs] },
-          cvv_result: response[:cvv2])
+          cvv_result: response[:cvv2]
+        )
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -295,14 +295,16 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url, request))
 
         success = success?(response)
-        Response.new(success,
+        Response.new(
+          success,
           success ? 'APPROVED' : message_from(response),
           response,
           test: test?,
           authorization: authorization_from(response, money, token),
           avs_result: AVSResult.new(code: response[:avs]),
           cvv_result: CVVResult.new(response[:cvv2]),
-          error_code: success ? nil : error_code_from(response))
+          error_code: success ? nil : error_code_from(response)
+        )
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/linkpoint.rb
+++ b/lib/active_merchant/billing/gateways/linkpoint.rb
@@ -263,11 +263,15 @@ module ActiveMerchant #:nodoc:
       def commit(money, creditcard, options = {})
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(money, creditcard, options)))
 
-        Response.new(successful?(response), response[:message], response,
+        Response.new(
+          successful?(response),
+          response[:message],
+          response,
           test: test?,
           authorization: response[:ordernum],
           avs_result: { code: response[:avs].to_s[2, 1] },
-          cvv_result: response[:avs].to_s[3, 1])
+          cvv_result: response[:avs].to_s[3, 1]
+        )
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
+++ b/lib/active_merchant/billing/gateways/merchant_e_solutions.rb
@@ -189,11 +189,15 @@ module ActiveMerchant #:nodoc:
             { 'error_code' => '404', 'auth_response_text' => e.to_s }
           end
 
-        Response.new(success_from(response), message_from(response), response,
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
           authorization: authorization_from(response),
           test: test?,
           cvv_result: response['cvv2_result'],
-          avs_result: { code: response['avs_result'] })
+          avs_result: { code: response['avs_result'] }
+        )
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/merchant_ware.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware.rb
@@ -290,19 +290,26 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, request, v4 = false)
         begin
-          data = ssl_post(url(v4), request,
+          data = ssl_post(
+            url(v4),
+            request,
             'Content-Type' => 'text/xml; charset=utf-8',
-            'SOAPAction'   => soap_action(action, v4))
+            'SOAPAction'   => soap_action(action, v4)
+          )
           response = parse(action, data)
         rescue ActiveMerchant::ResponseError => e
           response = parse_error(e.response)
         end
 
-        Response.new(response[:success], response[:message], response,
+        Response.new(
+          response[:success],
+          response[:message],
+          response,
           test: test?,
           authorization: authorization_from(response),
           avs_result: { code: response['AVSResponse'] },
-          cvv_result: response['CVResponse'])
+          cvv_result: response['CVResponse']
+        )
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
+++ b/lib/active_merchant/billing/gateways/merchant_ware_version_four.rb
@@ -261,19 +261,26 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, request)
         begin
-          data = ssl_post(url, request,
+          data = ssl_post(
+            url,
+            request,
             'Content-Type' => 'text/xml; charset=utf-8',
-            'SOAPAction'   => soap_action(action))
+            'SOAPAction'   => soap_action(action)
+          )
           response = parse(action, data)
         rescue ActiveMerchant::ResponseError => e
           response = parse_error(e.response, action)
         end
 
-        Response.new(response[:success], response[:message], response,
+        Response.new(
+          response[:success],
+          response[:message],
+          response,
           test: test?,
           authorization: authorization_from(response),
           avs_result: { code: response['AvsResponse'] },
-          cvv_result: response['CvResponse'])
+          cvv_result: response['CvResponse']
+        )
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -302,12 +302,16 @@ module ActiveMerchant #:nodoc:
         success = SUCCESS_CODES.include?(response[:cmd_status])
         message = success ? 'Success' : message_from(response)
 
-        Response.new(success, message, response,
+        Response.new(
+          success,
+          message,
+          response,
           test: test?,
           authorization: authorization_from(response),
           avs_result: { code: response[:avs_result] },
           cvv_result: response[:cvv_result],
-          error_code: success ? nil : STANDARD_ERROR_CODE_MAPPING[response[:dsix_return_code]])
+          error_code: success ? nil : STANDARD_ERROR_CODE_MAPPING[response[:dsix_return_code]]
+        )
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/metrics_global.rb
+++ b/lib/active_merchant/billing/gateways/metrics_global.rb
@@ -175,12 +175,16 @@ module ActiveMerchant #:nodoc:
         #   (TESTMODE) Successful Sale
         test_mode = test? || message =~ /TESTMODE/
 
-        Response.new(success?(response), message, response,
+        Response.new(
+          success?(response),
+          message,
+          response,
           test: test_mode,
           authorization: response[:transaction_id],
           fraud_review: fraud_review?(response),
           avs_result: { code: response[:avs_result_code] },
-          cvv_result: response[:card_code])
+          cvv_result: response[:card_code]
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/migs.rb
+++ b/lib/active_merchant/billing/gateways/migs.rb
@@ -281,12 +281,16 @@ module ActiveMerchant #:nodoc:
         cvv_result_code = response[:CSCResultCode]
         cvv_result_code = 'P' if cvv_result_code == 'Unsupported'
 
-        Response.new(success?(response), response[:Message], response,
+        Response.new(
+          success?(response),
+          response[:Message],
+          response,
           test: test?,
           authorization: response[:TransactionNo],
           fraud_review: fraud_review?(response),
           avs_result: { code: avs_response_code },
-          cvv_result: cvv_result_code)
+          cvv_result: cvv_result_code
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/money_movers.rb
+++ b/lib/active_merchant/billing/gateways/money_movers.rb
@@ -113,11 +113,15 @@ module ActiveMerchant #:nodoc:
         response = parse(data)
         message = message_from(response)
 
-        Response.new(success?(response), message, response,
+        Response.new(
+          success?(response),
+          message,
+          response,
           test: test?,
           authorization: response['transactionid'],
           avs_result: { code: response['avsresponse'] },
-          cvv_result: response['cvvresponse'])
+          cvv_result: response['cvvresponse']
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/nab_transact.rb
+++ b/lib/active_merchant/billing/gateways/nab_transact.rb
@@ -233,16 +233,24 @@ module ActiveMerchant #:nodoc:
       def commit(action, request)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, build_request(action, request)))
 
-        Response.new(success?(response), message_from(response), response,
+        Response.new(
+          success?(response),
+          message_from(response),
+          response,
           test: test?,
-          authorization: authorization_from(action, response))
+          authorization: authorization_from(action, response)
+        )
       end
 
       def commit_periodic(action, request)
         response = parse(ssl_post(test? ? self.test_periodic_url : self.live_periodic_url, build_periodic_request(action, request)))
-        Response.new(success?(response), message_from(response), response,
+        Response.new(
+          success?(response),
+          message_from(response),
+          response,
           test: test?,
-          authorization: authorization_from(action, response))
+          authorization: authorization_from(action, response)
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/net_registry.rb
+++ b/lib/active_merchant/billing/gateways/net_registry.rb
@@ -144,8 +144,12 @@ module ActiveMerchant
         # get gateway response
         response = parse(ssl_post(self.live_url, post_data(action, params)))
 
-        Response.new(response['status'] == 'approved', message_from(response), response,
-          authorization: authorization_from(response, action))
+        Response.new(
+          response['status'] == 'approved',
+          message_from(response),
+          response,
+          authorization: authorization_from(response, action)
+        )
       end
 
       def post_data(action, params)

--- a/lib/active_merchant/billing/gateways/netbilling.rb
+++ b/lib/active_merchant/billing/gateways/netbilling.rb
@@ -193,11 +193,15 @@ module ActiveMerchant #:nodoc:
       def commit(action, parameters)
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
-        Response.new(success?(response), message_from(response), response,
+        Response.new(
+          success?(response),
+          message_from(response),
+          response,
           test: test_response?(response),
           authorization: response[:trans_id],
           avs_result: { code: response[:avs_code] },
-          cvv_result: response[:cvv2_code])
+          cvv_result: response[:cvv2_code]
+        )
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code =~ /^[67]\d\d$/
 

--- a/lib/active_merchant/billing/gateways/network_merchants.rb
+++ b/lib/active_merchant/billing/gateways/network_merchants.rb
@@ -200,11 +200,15 @@ module ActiveMerchant #:nodoc:
 
         authorization = authorization_from(success, parameters, raw)
 
-        Response.new(success, raw['responsetext'], raw,
+        Response.new(
+          success,
+          raw['responsetext'],
+          raw,
           test: test?,
           authorization: authorization,
           avs_result: { code: raw['avsresponse'] },
-          cvv_result: raw['cvvresponse'])
+          cvv_result: raw['cvvresponse']
+        )
       end
 
       def build_request(action, parameters)

--- a/lib/active_merchant/billing/gateways/openpay.rb
+++ b/lib/active_merchant/billing/gateways/openpay.rb
@@ -201,11 +201,13 @@ module ActiveMerchant #:nodoc:
         response = http_request(method, resource, parameters, options)
         success = !error?(response)
 
-        Response.new(success,
+        Response.new(
+          success,
           (success ? response['error_code'] : response['description']),
           response,
           test: test?,
-          authorization: response['id'])
+          authorization: response['id']
+        )
       end
 
       def http_request(method, resource, parameters = {}, options = {})

--- a/lib/active_merchant/billing/gateways/opp.rb
+++ b/lib/active_merchant/billing/gateways/opp.rb
@@ -125,8 +125,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment, options = {})
         # debit
         options[:registrationId] = payment if payment.is_a?(String)
-        execute_dbpa(options[:risk_workflow] ? 'PA.CP' : 'DB',
-          money, payment, options)
+        execute_dbpa(options[:risk_workflow] ? 'PA.CP' : 'DB', money, payment, options)
       end
 
       def authorize(money, payment, options = {})

--- a/lib/active_merchant/billing/gateways/optimal_payment.rb
+++ b/lib/active_merchant/billing/gateways/optimal_payment.rb
@@ -121,11 +121,15 @@ module ActiveMerchant #:nodoc:
         txnRequest = escape_uri(xml)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, "txnMode=#{action}&txnRequest=#{txnRequest}"))
 
-        Response.new(successful?(response), message_from(response), hash_from_xml(response),
+        Response.new(
+          successful?(response),
+          message_from(response),
+          hash_from_xml(response),
           test: test?,
           authorization: authorization_from(response),
           avs_result: { code: avs_result_from(response) },
-          cvv_result: cvv_result_from(response))
+          cvv_result: cvv_result_from(response)
+        )
       end
 
       # The upstream is picky and so we can't use CGI.escape like we want to

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -886,13 +886,17 @@ module ActiveMerchant #:nodoc:
             request.call(remote_url(:secondary))
           end
 
-        Response.new(success?(response, message_type), message_from(response), response,
+        Response.new(
+          success?(response, message_type),
+          message_from(response),
+          response,
           {
             authorization: authorization_string(response[:tx_ref_num], response[:order_id]),
             test: self.test?,
             avs_result: OrbitalGateway::AVSResult.new(response[:avs_resp_code]),
             cvv_result: OrbitalGateway::CVVResult.new(response[:cvv2_resp_code])
-          })
+          }
+        )
       end
 
       def remote_url(url = :primary)

--- a/lib/active_merchant/billing/gateways/pac_net_raven.rb
+++ b/lib/active_merchant/billing/gateways/pac_net_raven.rb
@@ -121,7 +121,10 @@ module ActiveMerchant #:nodoc:
 
         test_mode = test? || message =~ /TESTMODE/
 
-        Response.new(success?(response), message, response,
+        Response.new(
+          success?(response),
+          message,
+          response,
           test: test_mode,
           authorization: response['TrackingNumber'],
           fraud_review: fraud_review?(response),
@@ -129,7 +132,8 @@ module ActiveMerchant #:nodoc:
             postal_match: AVS_POSTAL_CODES[response['AVSPostalResponseCode']],
             street_match: AVS_ADDRESS_CODES[response['AVSAddressResponseCode']]
           },
-          cvv_result: CVV2_CODES[response['CVV2ResponseCode']])
+          cvv_result: CVV2_CODES[response['CVV2ResponseCode']]
+        )
       end
 
       def url(action)

--- a/lib/active_merchant/billing/gateways/pay_gate_xml.rb
+++ b/lib/active_merchant/billing/gateways/pay_gate_xml.rb
@@ -264,9 +264,13 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, request, authorization = nil)
         response = parse(action, ssl_post(self.live_url, request))
-        Response.new(successful?(response), message_from(response), response,
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
           test: test?,
-          authorization: authorization || response[:tid])
+          authorization: authorization || response[:tid]
+        )
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/pay_hub.rb
+++ b/lib/active_merchant/billing/gateways/pay_hub.rb
@@ -182,14 +182,16 @@ module ActiveMerchant #:nodoc:
           response = json_error(raw_response)
         end
 
-        Response.new(success,
+        Response.new(
+          success,
           response_message(response),
           response,
           test: test?,
           avs_result: { code: response['AVS_RESULT_CODE'] },
           cvv_result: response['VERIFICATION_RESULT_CODE'],
           error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['RESPONSE_CODE']]),
-          authorization: response['TRANSACTION_ID'])
+          authorization: response['TRANSACTION_ID']
+        )
       end
 
       def response_error(raw_response)

--- a/lib/active_merchant/billing/gateways/pay_junction.rb
+++ b/lib/active_merchant/billing/gateways/pay_junction.rb
@@ -337,9 +337,13 @@ module ActiveMerchant #:nodoc:
 
         response = parse(ssl_post(url, post_data(action, parameters)))
 
-        Response.new(successful?(response), message_from(response), response,
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
           test: test?,
-          authorization: response[:transaction_id] || parameters[:transaction_id])
+          authorization: response[:transaction_id] || parameters[:transaction_id]
+        )
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/pay_secure.rb
+++ b/lib/active_merchant/billing/gateways/pay_secure.rb
@@ -68,9 +68,13 @@ module ActiveMerchant #:nodoc:
       def commit(action, money, parameters)
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
 
-        Response.new(successful?(response), message_from(response), response,
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
           test: test_response?(response),
-          authorization: authorization_from(response))
+          authorization: authorization_from(response)
+        )
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/payex.rb
+++ b/lib/active_merchant/billing/gateways/payex.rb
@@ -385,11 +385,13 @@ module ActiveMerchant #:nodoc:
           'Content-Length' => request.size.to_s
         }
         response = parse(ssl_post(url, request, headers))
-        Response.new(success?(response),
+        Response.new(
+          success?(response),
           message_from(response),
           response,
           test: test?,
-          authorization: build_authorization(response))
+          authorization: build_authorization(response)
+        )
       end
 
       def build_authorization(response)

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -306,9 +306,13 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url, request.to_s))
 
         # Return a response
-        PaymentExpressResponse.new(response[:success] == APPROVED, message_from(response), response,
+        PaymentExpressResponse.new(
+          response[:success] == APPROVED,
+          message_from(response),
+          response,
           test: response[:test_mode] == '1',
-          authorization: authorization_from(action, response))
+          authorization: authorization_from(action, response)
+        )
       end
 
       # Response XML documentation: http://www.paymentexpress.com/technical_resources/ecommerce_nonhosted/pxpost.html#XMLTxnOutput

--- a/lib/active_merchant/billing/gateways/payscout.rb
+++ b/lib/active_merchant/billing/gateways/payscout.rb
@@ -115,12 +115,16 @@ module ActiveMerchant #:nodoc:
 
         message = message_from(response)
         test_mode = (test? || message =~ /TESTMODE/)
-        Response.new(success?(response), message, response,
+        Response.new(
+          success?(response),
+          message,
+          response,
           test: test_mode,
           authorization: response['transactionid'],
           fraud_review: fraud_review?(response),
           avs_result: { code: response['avsresponse'] },
-          cvv_result: response['cvvresponse'])
+          cvv_result: response['cvvresponse']
+        )
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/paystation.rb
+++ b/lib/active_merchant/billing/gateways/paystation.rb
@@ -177,9 +177,13 @@ module ActiveMerchant #:nodoc:
         response = parse(data)
         message  = message_from(response)
 
-        PaystationResponse.new(success?(response), message, response,
+        PaystationResponse.new(
+          success?(response),
+          message,
+          response,
           test: (response[:tm]&.casecmp('t')&.zero?),
-          authorization: response[:paystation_transaction_id])
+          authorization: response[:paystation_transaction_id]
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/payway.rb
+++ b/lib/active_merchant/billing/gateways/payway.rb
@@ -192,9 +192,13 @@ module ActiveMerchant
 
         success = (params[:summary_code] ? (params[:summary_code] == '0') : (params[:response_code] == '00'))
 
-        Response.new(success, message, params,
+        Response.new(
+          success,
+          message,
+          params,
           test: (@options[:merchant].to_s == 'TEST'),
-          authorization: post[:order_number])
+          authorization: post[:order_number]
+        )
       rescue ActiveMerchant::ResponseError => e
         raise unless e.response.code == '403'
 

--- a/lib/active_merchant/billing/gateways/payway_dot_com.rb
+++ b/lib/active_merchant/billing/gateways/payway_dot_com.rb
@@ -48,7 +48,7 @@ module ActiveMerchant #:nodoc:
         'I5'  => 'M', #  +4 and Address Match
         'I6'  => 'W', #  +4 Match
         'I7'  => 'A', #  Address Match
-        'I8'  => 'C', #  No Match
+        'I8'  => 'C' #  No Match
       }
 
       PAYWAY_WS_SUCCESS = '5000'

--- a/lib/active_merchant/billing/gateways/plugnpay.rb
+++ b/lib/active_merchant/billing/gateways/plugnpay.rb
@@ -178,11 +178,15 @@ module ActiveMerchant
         success = SUCCESS_CODES.include?(response[:finalstatus])
         message = success ? 'Success' : message_from(response)
 
-        Response.new(success, message, response,
+        Response.new(
+          success,
+          message,
+          response,
           test: test?,
           authorization: response[:orderid],
           avs_result: { code: response[:avs_code] },
-          cvv_result: response[:cvvresp])
+          cvv_result: response[:cvvresp]
+        )
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/psigate.rb
+++ b/lib/active_merchant/billing/gateways/psigate.rb
@@ -102,11 +102,15 @@ module ActiveMerchant #:nodoc:
       def commit(money, creditcard, options = {})
         response = parse(ssl_post(url, post_data(money, creditcard, options)))
 
-        Response.new(successful?(response), message_from(response), response,
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
           test: test?,
           authorization: build_authorization(response),
           avs_result: { code: response[:avsresult] },
-          cvv_result: response[:cardidresult])
+          cvv_result: response[:cardidresult]
+        )
       end
 
       def url

--- a/lib/active_merchant/billing/gateways/psl_card.rb
+++ b/lib/active_merchant/billing/gateways/psl_card.rb
@@ -259,11 +259,15 @@ module ActiveMerchant
       def commit(request)
         response = parse(ssl_post(self.live_url, post_data(request)))
 
-        Response.new(response[:ResponseCode] == APPROVED, response[:Message], response,
+        Response.new(
+          response[:ResponseCode] == APPROVED,
+          response[:Message],
+          response,
           test: test?,
           authorization: response[:CrossReference],
           cvv_result: CVV_CODE[response[:AVSCV2Check]],
-          avs_result: { code: AVS_CODE[response[:AVSCV2Check]] })
+          avs_result: { code: AVS_CODE[response[:AVSCV2Check]] }
+        )
       end
 
       # Put the passed data into a format that can be submitted to PSL

--- a/lib/active_merchant/billing/gateways/qbms.rb
+++ b/lib/active_merchant/billing/gateways/qbms.rb
@@ -142,12 +142,16 @@ module ActiveMerchant #:nodoc:
         response = parse(type, data)
         message = (response[:status_message] || '').strip
 
-        Response.new(success?(response), message, response,
+        Response.new(
+          success?(response),
+          message,
+          response,
           test: test?,
           authorization: response[:credit_card_trans_id],
           fraud_review: fraud_review?(response),
           avs_result: { code: avs_result(response) },
-          cvv_result: cvv_result(response))
+          cvv_result: cvv_result(response)
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/quantum.rb
+++ b/lib/active_merchant/billing/gateways/quantum.rb
@@ -215,11 +215,15 @@ module ActiveMerchant #:nodoc:
           authorization = success ? authorization_for(response) : nil
         end
 
-        Response.new(success, message, response,
+        Response.new(
+          success,
+          message,
+          response,
           test: test?,
           authorization: authorization,
           avs_result: { code: response[:AVSResponseCode] },
-          cvv_result: response[:CVV2ResponseCode])
+          cvv_result: response[:CVV2ResponseCode]
+        )
       end
 
       # Parse the SOAP response

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -42,10 +42,10 @@ module ActiveMerchant #:nodoc:
         'PMT-5001' => STANDARD_ERROR_CODE[:card_declined],      # Merchant does not support given payment method
 
         # System Error
-        'PMT-6000' => STANDARD_ERROR_CODE[:processing_error], # A temporary Issue prevented this request from being processed.
+        'PMT-6000' => STANDARD_ERROR_CODE[:processing_error] # A temporary Issue prevented this request from being processed.
       }
 
-      FRAUD_WARNING_CODES = ['PMT-1000', 'PMT-1001', 'PMT-1002', 'PMT-1003']
+      FRAUD_WARNING_CODES = %w(PMT-1000 PMT-1001 PMT-1002 PMT-1003)
 
       def initialize(options = {})
         # Quickbooks is deprecating OAuth 1.0 on December 17, 2019.

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -153,9 +153,13 @@ module ActiveMerchant
           response = json_error(response)
         end
 
-        Response.new(success, message_from(success, response), response,
+        Response.new(
+          success,
+          message_from(success, response),
+          response,
           test: test?,
-          authorization: authorization_from(response))
+          authorization: authorization_from(response)
+        )
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
@@ -164,9 +164,13 @@ module ActiveMerchant #:nodoc:
       def commit(action, params)
         response = parse(ssl_post(self.live_url, post_data(action, params)))
 
-        Response.new(successful?(response), message_from(response), response,
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
           test: test?,
-          authorization: response[:transaction])
+          authorization: response[:transaction]
+        )
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/sage.rb
+++ b/lib/active_merchant/billing/gateways/sage.rb
@@ -260,11 +260,15 @@ module ActiveMerchant #:nodoc:
         url = url(params, source)
         response = parse(ssl_post(url, post_data(action, params)), source)
 
-        Response.new(success?(response), response[:message], response,
+        Response.new(
+          success?(response),
+          response[:message],
+          response,
           test: test?,
           authorization: authorization_from(response, source),
           avs_result: { code: response[:avs_result] },
-          cvv_result: response[:cvv_result])
+          cvv_result: response[:cvv_result]
+        )
       end
 
       def url(params, source)
@@ -380,8 +384,12 @@ module ActiveMerchant #:nodoc:
             message = success ? 'Succeeded' : 'Failed'
           end
 
-          Response.new(success, message, response,
-            authorization: response[:guid])
+          Response.new(
+            success,
+            message,
+            response,
+            authorization: response[:guid]
+          )
         end
 
         ENVELOPE_NAMESPACES = {

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -346,14 +346,18 @@ module ActiveMerchant #:nodoc:
       def commit(action, parameters)
         response = parse(ssl_post(url_for(action), post_data(action, parameters)))
 
-        Response.new(response['Status'] == APPROVED, message_from(response), response,
+        Response.new(
+          response['Status'] == APPROVED,
+          message_from(response),
+          response,
           test: test?,
           authorization: authorization_from(response, parameters, action),
           avs_result: {
             street_match: AVS_CODE[response['AddressResult']],
             postal_match: AVS_CODE[response['PostCodeResult']]
           },
-          cvv_result: CVV_CODE[response['CV2Result']])
+          cvv_result: CVV_CODE[response['CV2Result']]
+        )
       end
 
       def authorization_from(response, params, action)

--- a/lib/active_merchant/billing/gateways/sallie_mae.rb
+++ b/lib/active_merchant/billing/gateways/sallie_mae.rb
@@ -120,9 +120,13 @@ module ActiveMerchant #:nodoc:
         end
 
         response = parse(ssl_post(self.live_url, parameters.to_post_data) || '')
-        Response.new(successful?(response), message_from(response), response,
+        Response.new(
+          successful?(response),
+          message_from(response),
+          response,
           test: test?,
-          authorization: response['refcode'])
+          authorization: response['refcode']
+        )
       end
 
       def successful?(response)

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -79,11 +79,15 @@ module ActiveMerchant #:nodoc:
         data = ssl_post(url, xml, 'Content-Type' => 'text/xml')
         response = parse(data)
 
-        Response.new(success?(response), message_from(response), response,
+        Response.new(
+          success?(response),
+          message_from(response),
+          response,
           test: test?,
           authorization: build_authorization(response),
           avs_result: { code: response[:avs_result_code] },
-          cvv_result: response[:card_code_response_code])
+          cvv_result: response[:card_code_response_code]
+        )
       end
 
       def build_request(request)

--- a/lib/active_merchant/billing/gateways/secure_pay.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay.rb
@@ -56,12 +56,16 @@ module ActiveMerchant #:nodoc:
 
         message = message_from(response)
 
-        Response.new(success?(response), message, response,
+        Response.new(
+          success?(response),
+          message,
+          response,
           test: test?,
           authorization: response[:transaction_id],
           fraud_review: fraud_review?(response),
           avs_result: { code: response[:avs_result_code] },
-          cvv_result: response[:card_code])
+          cvv_result: response[:card_code]
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/secure_pay_au.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_au.rb
@@ -183,9 +183,13 @@ module ActiveMerchant #:nodoc:
       def commit(action, request)
         response = parse(ssl_post(test? ? self.test_url : self.live_url, build_request(action, request)))
 
-        Response.new(success?(response), message_from(response), response,
+        Response.new(
+          success?(response),
+          message_from(response),
+          response,
           test: test?,
-          authorization: authorization_from(response))
+          authorization: authorization_from(response)
+        )
       end
 
       def build_periodic_item(action, money, credit_card, options)
@@ -239,9 +243,13 @@ module ActiveMerchant #:nodoc:
         my_request = build_periodic_request(request)
         response = parse(ssl_post(test? ? self.test_periodic_url : self.live_periodic_url, my_request))
 
-        Response.new(success?(response), message_from(response), response,
+        Response.new(
+          success?(response),
+          message_from(response),
+          response,
           test: test?,
-          authorization: authorization_from(response))
+          authorization: authorization_from(response)
+        )
       end
 
       def success?(response)

--- a/lib/active_merchant/billing/gateways/secure_pay_tech.rb
+++ b/lib/active_merchant/billing/gateways/secure_pay_tech.rb
@@ -84,9 +84,13 @@ module ActiveMerchant #:nodoc:
       def commit(action, post)
         response = parse(ssl_post(self.live_url, post_data(action, post)))
 
-        Response.new(response[:result_code] == 1, message_from(response), response,
+        Response.new(
+          response[:result_code] == 1,
+          message_from(response),
+          response,
           test: test?,
-          authorization: response[:merchant_transaction_reference])
+          authorization: response[:merchant_transaction_reference]
+        )
       end
 
       def message_from(result)

--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -225,12 +225,14 @@ module ActiveMerchant #:nodoc:
         response = api_request(url, parameters, options, method)
         success = !response.key?('error')
 
-        Response.new(success,
+        Response.new(
+          success,
           (success ? 'Transaction approved' : response['error']['message']),
           response,
           test: test?,
           authorization: (success ? response['id'] : response['error']['charge']),
-          error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['error']['code']]))
+          error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['error']['code']])
+        )
       end
 
       def headers(options = {})

--- a/lib/active_merchant/billing/gateways/simetrik.rb
+++ b/lib/active_merchant/billing/gateways/simetrik.rb
@@ -280,12 +280,12 @@ module ActiveMerchant #:nodoc:
       def commit(action, parameters, url_params = {})
         begin
           response = JSON.parse ssl_post(url(action, url_params), post_data(parameters), authorized_headers())
-        rescue ResponseError => exception
-          case exception.response.code.to_i
+        rescue ResponseError => e
+          case e.response.code.to_i
           when 400...499
-            response = JSON.parse exception.response.body
+            response = JSON.parse e.response.body
           else
-            raise exception
+            raise e
           end
         end
 

--- a/lib/active_merchant/billing/gateways/skip_jack.rb
+++ b/lib/active_merchant/billing/gateways/skip_jack.rb
@@ -263,11 +263,15 @@ module ActiveMerchant #:nodoc:
         response = parse(ssl_post(url_for(action), post_data(action, money, parameters)), action)
 
         # Pass along the original transaction id in the case an update transaction
-        Response.new(response[:success], message_from(response, action), response,
+        Response.new(
+          response[:success],
+          message_from(response, action),
+          response,
           test: test?,
           authorization: response[:szTransactionFileName] || parameters[:szTransactionId],
           avs_result: { code: response[:szAVSResponseCode] },
-          cvv_result: response[:szCVV2ResponseCode])
+          cvv_result: response[:szCVV2ResponseCode]
+        )
       end
 
       def url_for(action)

--- a/lib/active_merchant/billing/gateways/smart_ps.rb
+++ b/lib/active_merchant/billing/gateways/smart_ps.rb
@@ -226,11 +226,15 @@ module ActiveMerchant #:nodoc:
       def commit(action, money, parameters)
         parameters[:amount] = localized_amount(money, parameters[:currency] || default_currency) if money
         response = parse(ssl_post(self.live_url, post_data(action, parameters)))
-        Response.new(response['response'] == '1', message_from(response), response,
+        Response.new(
+          response['response'] == '1',
+          message_from(response),
+          response,
           authorization: (response['transactionid'] || response['customer_vault_id']),
           test: test?,
           cvv_result: response['cvvresponse'],
-          avs_result: { code: response['avsresponse'] })
+          avs_result: { code: response['avsresponse'] }
+        )
       end
 
       def expdate(creditcard)

--- a/lib/active_merchant/billing/gateways/so_easy_pay.rb
+++ b/lib/active_merchant/billing/gateways/so_easy_pay.rb
@@ -161,11 +161,13 @@ module ActiveMerchant #:nodoc:
                    'Content-Type' => 'text/xml; charset=utf-8' }
         response_string = ssl_post(test? ? self.test_url : self.live_url, soap, headers)
         response = parse(response_string, soap_action)
-        return Response.new(response['errorcode'] == '000',
+        return Response.new(
+          response['errorcode'] == '000',
           response['errormessage'],
           response,
           test: test?,
-          authorization: response['transaction_id'])
+          authorization: response['transaction_id']
+        )
       end
 
       def build_soap(request)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -705,7 +705,8 @@ module ActiveMerchant #:nodoc:
         card = card_from_response(response)
         avs_code = AVS_CODE_TRANSLATOR["line1: #{card['address_line1_check']}, zip: #{card['address_zip_check']}"]
         cvc_code = CVC_CODE_TRANSLATOR[card['cvc_check']]
-        Response.new(success,
+        Response.new(
+          success,
           message_from(success, response),
           response,
           test: response_is_test?(response),
@@ -713,7 +714,8 @@ module ActiveMerchant #:nodoc:
           avs_result: { code: avs_code },
           cvv_result: cvc_code,
           emv_authorization: emv_authorization_from_response(response),
-          error_code: success ? nil : error_code_from(response))
+          error_code: success ? nil : error_code_from(response)
+        )
       end
 
       def key_valid?(options)

--- a/lib/active_merchant/billing/gateways/swipe_checkout.rb
+++ b/lib/active_merchant/billing/gateways/swipe_checkout.rb
@@ -104,12 +104,14 @@ module ActiveMerchant #:nodoc:
               result = response['data']['result']
               success = (result == 'accepted' || (test? && result == 'test-accepted'))
 
-              Response.new(success,
+              Response.new(
+                success,
                 success ?
                 TRANSACTION_APPROVED_MSG :
                 TRANSACTION_DECLINED_MSG,
                 response,
-                test: test?)
+                test: test?
+              )
             else
               build_error_response(message, response)
             end

--- a/lib/active_merchant/billing/gateways/trust_commerce.rb
+++ b/lib/active_merchant/billing/gateways/trust_commerce.rb
@@ -450,11 +450,15 @@ module ActiveMerchant #:nodoc:
         # to be considered successful, transaction status must be either "approved" or "accepted"
         success = SUCCESS_TYPES.include?(data['status'])
         message = message_from(data)
-        Response.new(success, message, data,
+        Response.new(
+          success,
+          message,
+          data,
           test: test?,
           authorization: authorization_from(action, data),
           cvv_result: data['cvv'],
-          avs_result: { code: data['avs'] })
+          avs_result: { code: data['avs'] }
+        )
       end
 
       def parse(body)

--- a/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_transaction.rb
@@ -329,12 +329,16 @@ module ActiveMerchant #:nodoc:
         approved = response[:status] == 'Approved'
         error_code = nil
         error_code = (STANDARD_ERROR_CODE_MAPPING[response[:error_code]] || STANDARD_ERROR_CODE[:processing_error]) unless approved
-        Response.new(approved, message_from(response), response,
+        Response.new(
+          approved,
+          message_from(response),
+          response,
           test: test?,
           authorization: authorization_from(action, response),
           cvv_result: response[:cvv2_result_code],
           avs_result: { code: response[:avs_result_code] },
-          error_code: error_code)
+          error_code: error_code
+        )
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/verifi.rb
+++ b/lib/active_merchant/billing/gateways/verifi.rb
@@ -194,11 +194,15 @@ module ActiveMerchant #:nodoc:
 
         response = parse(ssl_post(self.live_url, post_data(trx_type, post)))
 
-        Response.new(response[:response].to_i == SUCCESS, message_from(response), response,
+        Response.new(
+          response[:response].to_i == SUCCESS,
+          message_from(response),
+          response,
           test: test?,
           authorization: response[:transactionid],
           avs_result: { code: response[:avsresponse] },
-          cvv_result: response[:cvvresponse])
+          cvv_result: response[:cvvresponse]
+        )
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/viaklix.rb
+++ b/lib/active_merchant/billing/gateways/viaklix.rb
@@ -136,11 +136,15 @@ module ActiveMerchant #:nodoc:
 
         response = parse(ssl_post(test? ? self.test_url : self.live_url, post_data(parameters)))
 
-        Response.new(response['result'] == APPROVED, message_from(response), response,
+        Response.new(
+          response['result'] == APPROVED,
+          message_from(response),
+          response,
           test: @options[:test] || test?,
           authorization: authorization_from(response),
           avs_result: { code: response['avs_response'] },
-          cvv_result: response['cvv2_response'])
+          cvv_result: response['cvv2_response']
+        )
       end
 
       def authorization_from(response)

--- a/lib/active_merchant/billing/gateways/vpos.rb
+++ b/lib/active_merchant/billing/gateways/vpos.rb
@@ -158,10 +158,10 @@ module ActiveMerchant #:nodoc:
         url = build_request_url(action)
         begin
           response = parse(ssl_post(url, post_data(parameters)))
-        rescue ResponseError => response
+        rescue ResponseError => e
           # Errors are returned with helpful data,
           # but get filtered out by `ssl_post` because of their HTTP status.
-          response = parse(response.response.body)
+          response = parse(e.response.body)
         end
 
         Response.new(

--- a/lib/active_merchant/billing/gateways/wirecard.rb
+++ b/lib/active_merchant/billing/gateways/wirecard.rb
@@ -179,11 +179,15 @@ module ActiveMerchant #:nodoc:
         message = response[:Message]
         authorization = response[:GuWID]
 
-        Response.new(success, message, response,
+        Response.new(
+          success,
+          message,
+          response,
           test: test?,
           authorization: authorization,
           avs_result: { code: avs_code(response, options) },
-          cvv_result: response[:CVCResponseCode])
+          cvv_result: response[:CVCResponseCode]
+        )
       rescue ResponseError => e
         if e.response.code == '401'
           return Response.new(false, 'Invalid Login')
@@ -405,7 +409,7 @@ module ActiveMerchant #:nodoc:
         'N' => 'I', # CSC Match
         'U' => 'U', # Data Not Checked
         'Y' => 'D', # All Data Matched
-        'Z' => 'P', # CSC and Postcode Matched
+        'Z' => 'P' # CSC and Postcode Matched
       }
 
       # Amex have different AVS response codes to visa etc

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -38,14 +38,14 @@ module ActiveMerchant #:nodoc:
         'G' => 'C', # Address does not match, postcode not checked
         'H' => 'I', # Address and postcode not provided
         'I' => 'C', # Address not checked postcode does not match
-        'J' => 'C', # Address and postcode does not match
+        'J' => 'C' # Address and postcode does not match
       }
 
       CVC_CODE_MAP = {
         'A' => 'M', # CVV matches
         'B' => 'P', # Not provided
         'C' => 'P', # Not checked
-        'D' => 'N', # Does not match
+        'D' => 'N' # Does not match
       }
 
       def initialize(options = {})
@@ -832,7 +832,8 @@ module ActiveMerchant #:nodoc:
 
         # ensure cookie included on follow-up '3ds' and 'capture_request' calls, using the cookie saved from the preceding response
         # cookie should be present in options on the 3ds and capture calls, but also still saved in the instance var in case
-        cookie = options[:cookie] || @cookie || nil
+        cookie = defined?(@cookie) ? @cookie : nil
+        cookie = options[:cookie] || cookie
         headers['Cookie'] = cookie if cookie
 
         headers['Idempotency-Key'] = idempotency_key if idempotency_key

--- a/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_online_payments.rb
@@ -34,14 +34,16 @@ module ActiveMerchant #:nodoc:
         if authorization
           commit(:post, "orders/#{CGI.escape(authorization)}/capture", { 'captureAmount' => money }, options, 'capture')
         else
-          Response.new(false,
+          Response.new(
+            false,
             'FAILED',
             'FAILED',
             test: test?,
             authorization: false,
             avs_result: {},
             cvv_result: {},
-            error_code: false)
+            error_code: false
+          )
         end
       end
 
@@ -170,14 +172,16 @@ module ActiveMerchant #:nodoc:
           authorization = response['message']
         end
 
-        Response.new(success,
+        Response.new(
+          success,
           success ? 'SUCCESS' : response['message'],
           response,
           test: test?,
           authorization: authorization,
           avs_result: {},
           cvv_result: {},
-          error_code: success ? nil : response['customCode'])
+          error_code: success ? nil : response['customCode']
+        )
       end
 
       def test?

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = '1.133.0'
+  VERSION = '1.134.0'
 end

--- a/lib/support/ssl_verify.rb
+++ b/lib/support/ssl_verify.rb
@@ -80,9 +80,9 @@ class SSLVerify
     end
 
     return :success
-  rescue OpenSSL::SSL::SSLError => ex
-    return :fail, ex.inspect
-  rescue Net::HTTPBadResponse, Errno::ETIMEDOUT, EOFError, SocketError, Errno::ECONNREFUSED, Timeout::Error => ex
-    return :error, ex.inspect
+  rescue OpenSSL::SSL::SSLError => e
+    return :fail, e.inspect
+  rescue Net::HTTPBadResponse, Errno::ETIMEDOUT, EOFError, SocketError, Errno::ECONNREFUSED, Timeout::Error => e
+    return :error, e.inspect
   end
 end

--- a/lib/support/ssl_version.rb
+++ b/lib/support/ssl_version.rb
@@ -75,12 +75,12 @@ class SSLVersion
     return :success
   rescue Net::HTTPBadResponse
     return :success # version negotiation succeeded
-  rescue OpenSSL::SSL::SSLError => ex
-    return :fail, ex.inspect
-  rescue Interrupt => ex
+  rescue OpenSSL::SSL::SSLError => e
+    return :fail, e.inspect
+  rescue Interrupt => e
     print_summary
-    raise ex
-  rescue StandardError => ex
-    return :error, ex.inspect
+    raise e
+  rescue StandardError => e
+    return :error, e.inspect
   end
 end

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -12,67 +12,83 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
     @general_bank_account = check(name: 'A. Klaassen', account_number: '123456789', routing_number: 'NL13TEST0123456789')
 
-    @credit_card = credit_card('4111111111111111',
+    @credit_card = credit_card(
+      '4111111111111111',
       month: 3,
       year: 2030,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'visa')
+      brand: 'visa'
+    )
 
-    @avs_credit_card = credit_card('4400000000000008',
+    @avs_credit_card = credit_card(
+      '4400000000000008',
       month: 3,
       year: 2030,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'visa')
+      brand: 'visa'
+    )
 
-    @elo_credit_card = credit_card('5066 9911 1111 1118',
+    @elo_credit_card = credit_card(
+      '5066 9911 1111 1118',
       month: 3,
       year: 2030,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo')
+      brand: 'elo'
+    )
 
-    @three_ds_enrolled_card = credit_card('4917610000000000',
+    @three_ds_enrolled_card = credit_card(
+      '4917610000000000',
       month: 3,
       year: 2030,
       verification_value: '737',
-      brand: :visa)
+      brand: :visa
+    )
 
-    @cabal_credit_card = credit_card('6035 2277 1642 7021',
-      month: 3,
-      year: 2030,
-      first_name: 'John',
-      last_name: 'Smith',
-      verification_value: '737',
-      brand: 'cabal')
-
-    @invalid_cabal_credit_card = credit_card('6035 2200 0000 0006',
+    @cabal_credit_card = credit_card(
+      '6035 2277 1642 7021',
       month: 3,
       year: 2030,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'cabal')
+      brand: 'cabal'
+    )
 
-    @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
+    @invalid_cabal_credit_card = credit_card(
+      '6035 2200 0000 0006',
+      month: 3,
+      year: 2030,
+      first_name: 'John',
+      last_name: 'Smith',
+      verification_value: '737',
+      brand: 'cabal'
+    )
+
+    @unionpay_credit_card = credit_card(
+      '8171 9999 0000 0000 021',
       month: 10,
       year: 2030,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'unionpay')
+      brand: 'unionpay'
+    )
 
-    @invalid_unionpay_credit_card = credit_card('8171 9999 1234 0000 921',
+    @invalid_unionpay_credit_card = credit_card(
+      '8171 9999 1234 0000 921',
       month: 10,
       year: 2030,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'unionpay')
+      brand: 'unionpay'
+    )
 
     @declined_card = credit_card('4000300011112220')
 
@@ -148,44 +164,6 @@ class RemoteAdyenTest < Test::Unit::TestCase
     }
 
     @long_order_id = 'asdfjkl;asdfjkl;asdfj;aiwyutinvpoaieryutnmv;203987528752098375j3q-p489756ijmfpvbijpq348nmdf;vbjp3845'
-
-    @sub_seller_options = {
-      "subMerchant.numberOfSubSellers": '2',
-      "subMerchant.subSeller1.id": '111111111',
-      "subMerchant.subSeller1.name": 'testSub1',
-      "subMerchant.subSeller1.street": 'Street1',
-      "subMerchant.subSeller1.postalCode": '12242840',
-      "subMerchant.subSeller1.city": 'Sao jose dos campos',
-      "subMerchant.subSeller1.state": 'SP',
-      "subMerchant.subSeller1.country": 'BRA',
-      "subMerchant.subSeller1.taxId": '12312312340',
-      "subMerchant.subSeller1.mcc": '5691',
-      "subMerchant.subSeller1.debitSettlementBank": '1',
-      "subMerchant.subSeller1.debitSettlementAgency": '1',
-      "subMerchant.subSeller1.debitSettlementAccountType": '1',
-      "subMerchant.subSeller1.debitSettlementAccount": '1',
-      "subMerchant.subSeller1.creditSettlementBank": '1',
-      "subMerchant.subSeller1.creditSettlementAgency": '1',
-      "subMerchant.subSeller1.creditSettlementAccountType": '1',
-      "subMerchant.subSeller1.creditSettlementAccount": '1',
-      "subMerchant.subSeller2.id": '22222222',
-      "subMerchant.subSeller2.name": 'testSub2',
-      "subMerchant.subSeller2.street": 'Street2',
-      "subMerchant.subSeller2.postalCode": '12300000',
-      "subMerchant.subSeller2.city": 'Jacarei',
-      "subMerchant.subSeller2.state": 'SP',
-      "subMerchant.subSeller2.country": 'BRA',
-      "subMerchant.subSeller2.taxId": '12312312340',
-      "subMerchant.subSeller2.mcc": '5691',
-      "subMerchant.subSeller2.debitSettlementBank": '1',
-      "subMerchant.subSeller2.debitSettlementAgency": '1',
-      "subMerchant.subSeller2.debitSettlementAccountType": '1',
-      "subMerchant.subSeller2.debitSettlementAccount": '1',
-      "subMerchant.subSeller2.creditSettlementBank": '1',
-      "subMerchant.subSeller2.creditSettlementAgency": '1',
-      "subMerchant.subSeller2.creditSettlementAccountType": '1',
-      "subMerchant.subSeller2.creditSettlementAccount": '1'
-    }
   end
 
   def test_successful_authorize
@@ -343,13 +321,15 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
   # with rule set in merchant account to skip 3DS for cards of this brand
   def test_successful_authorize_with_3ds_dynamic_rule_broken
-    mastercard_threed = credit_card('5212345678901234',
+    mastercard_threed = credit_card(
+      '5212345678901234',
       month: 3,
       year: 2030,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'mastercard')
+      brand: 'mastercard'
+    )
     assert response = @gateway.authorize(@amount, mastercard_threed, @options.merge(threed_dynamic: true))
     assert response.test?
     refute response.authorization.blank?
@@ -1412,6 +1392,43 @@ class RemoteAdyenTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_sub_merchant_sub_seller_data
+    @sub_seller_options = {
+      "subMerchant.numberOfSubSellers": '2',
+      "subMerchant.subSeller1.id": '111111111',
+      "subMerchant.subSeller1.name": 'testSub1',
+      "subMerchant.subSeller1.street": 'Street1',
+      "subMerchant.subSeller1.postalCode": '12242840',
+      "subMerchant.subSeller1.city": 'Sao jose dos campos',
+      "subMerchant.subSeller1.state": 'SP',
+      "subMerchant.subSeller1.country": 'BRA',
+      "subMerchant.subSeller1.taxId": '12312312340',
+      "subMerchant.subSeller1.mcc": '5691',
+      "subMerchant.subSeller1.debitSettlementBank": '1',
+      "subMerchant.subSeller1.debitSettlementAgency": '1',
+      "subMerchant.subSeller1.debitSettlementAccountType": '1',
+      "subMerchant.subSeller1.debitSettlementAccount": '1',
+      "subMerchant.subSeller1.creditSettlementBank": '1',
+      "subMerchant.subSeller1.creditSettlementAgency": '1',
+      "subMerchant.subSeller1.creditSettlementAccountType": '1',
+      "subMerchant.subSeller1.creditSettlementAccount": '1',
+      "subMerchant.subSeller2.id": '22222222',
+      "subMerchant.subSeller2.name": 'testSub2',
+      "subMerchant.subSeller2.street": 'Street2',
+      "subMerchant.subSeller2.postalCode": '12300000',
+      "subMerchant.subSeller2.city": 'Jacarei',
+      "subMerchant.subSeller2.state": 'SP',
+      "subMerchant.subSeller2.country": 'BRA',
+      "subMerchant.subSeller2.taxId": '12312312340',
+      "subMerchant.subSeller2.mcc": '5691',
+      "subMerchant.subSeller2.debitSettlementBank": '1',
+      "subMerchant.subSeller2.debitSettlementAgency": '1',
+      "subMerchant.subSeller2.debitSettlementAccountType": '1',
+      "subMerchant.subSeller2.debitSettlementAccount": '1',
+      "subMerchant.subSeller2.creditSettlementBank": '1',
+      "subMerchant.subSeller2.creditSettlementAgency": '1',
+      "subMerchant.subSeller2.creditSettlementAccountType": '1',
+      "subMerchant.subSeller2.creditSettlementAccount": '1'
+    }
     assert response = @gateway.authorize(@amount, @avs_credit_card, @options.merge(sub_merchant_data: @sub_seller_options))
     assert response.test?
     refute response.authorization.blank?

--- a/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
+++ b/test/remote/gateways/remote_authorize_net_apple_pay_test.rb
@@ -82,9 +82,11 @@ class RemoteAuthorizeNetApplePayTest < Test::Unit::TestCase
       transaction_identifier: 'uniqueidentifier123'
     }.update(options)
 
-    ActiveMerchant::Billing::ApplePayPaymentToken.new(defaults[:payment_data],
+    ActiveMerchant::Billing::ApplePayPaymentToken.new(
+      defaults[:payment_data],
       payment_instrument_name: defaults[:payment_instrument_name],
       payment_network: defaults[:payment_network],
-      transaction_identifier: defaults[:transaction_identifier])
+      transaction_identifier: defaults[:transaction_identifier]
+    )
   end
 end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -458,8 +458,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_successful_verify_with_apple_pay
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: '111111111100cryptogram')
     response = @gateway.verify(credit_card, @options)
     assert_success response
     assert_equal 'This transaction has been approved', response.message
@@ -872,9 +871,11 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_and_capture_with_network_tokenization
-    credit_card = network_tokenization_credit_card('4000100011112224',
+    credit_card = network_tokenization_credit_card(
+      '4000100011112224',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil)
+      verification_value: nil
+    )
     auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
     assert_equal 'This transaction has been approved', auth.message
@@ -884,9 +885,11 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_successful_refund_with_network_tokenization
-    credit_card = network_tokenization_credit_card('4000100011112224',
+    credit_card = network_tokenization_credit_card(
+      '4000100011112224',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil)
+      verification_value: nil
+    )
 
     purchase = @gateway.purchase(@amount, credit_card, @options)
     assert_success purchase
@@ -899,9 +902,11 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_successful_credit_with_network_tokenization
-    credit_card = network_tokenization_credit_card('4000100011112224',
+    credit_card = network_tokenization_credit_card(
+      '4000100011112224',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      verification_value: nil)
+      verification_value: nil
+    )
 
     response = @gateway.credit(@amount, credit_card, @options)
     assert_success response
@@ -910,10 +915,12 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_network_tokenization_transcript_scrubbing
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
 
     transcript = capture_transcript(@gateway) do
       @gateway.authorize(@amount, credit_card, @options)

--- a/test/remote/gateways/remote_barclaycard_smartpay_test.rb
+++ b/test/remote/gateways/remote_barclaycard_smartpay_test.rb
@@ -100,10 +100,12 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
       }
     }
 
-    @avs_credit_card = credit_card('4400000000000008',
+    @avs_credit_card = credit_card(
+      '4400000000000008',
       month: 8,
       year: 2018,
-      verification_value: 737)
+      verification_value: 737
+    )
 
     @avs_address = @options.clone
     @avs_address.update(billing_address: {
@@ -158,25 +160,31 @@ class RemoteBarclaycardSmartpayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_unusual_address
-    response = @gateway.purchase(@amount,
+    response = @gateway.purchase(
+      @amount,
       @credit_card,
-      @options_with_alternate_address)
+      @options_with_alternate_address
+    )
     assert_success response
     assert_equal '[capture-received]', response.message
   end
 
   def test_successful_purchase_with_house_number_and_street
-    response = @gateway.purchase(@amount,
+    response = @gateway.purchase(
+      @amount,
       @credit_card,
-      @options.merge(street: 'Top Level Drive', house_number: '100'))
+      @options.merge(street: 'Top Level Drive', house_number: '100')
+    )
     assert_success response
     assert_equal '[capture-received]', response.message
   end
 
   def test_successful_purchase_with_no_address
-    response = @gateway.purchase(@amount,
+    response = @gateway.purchase(
+      @amount,
       @credit_card,
-      @options_with_no_address)
+      @options_with_no_address
+    )
     assert_success response
     assert_equal '[capture-received]', response.message
   end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -470,8 +470,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_email
-    assert response = @gateway.purchase(@amount, @credit_card,
-      email: 'customer@example.com')
+    assert response = @gateway.purchase(@amount, @credit_card, email: 'customer@example.com')
     assert_success response
     transaction = response.params['braintree_transaction']
     assert_equal 'customer@example.com', transaction['customer_details']['email']
@@ -570,9 +569,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_purchase_using_specified_payment_method_token
     assert response = @gateway.store(
-      credit_card('4111111111111111',
-        first_name: 'Old First', last_name: 'Old Last',
-        month: 9, year: 2012),
+      credit_card('4111111111111111', first_name: 'Old First', last_name: 'Old Last', month: 9, year: 2012),
       email: 'old@example.com',
       phone: '321-654-0987'
     )
@@ -604,9 +601,12 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       zip: '60103',
       country_name: 'Mexico'
     }
-    assert response = @gateway.purchase(@amount, @credit_card,
+    assert response = @gateway.purchase(
+      @amount,
+      @credit_card,
       billing_address: billing_address,
-      shipping_address: shipping_address)
+      shipping_address: shipping_address
+    )
     assert_success response
     transaction = response.params['braintree_transaction']
     assert_equal '1 E Main St', transaction['billing_details']['street_address']
@@ -627,15 +627,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_three_d_secure_pass_thru
     three_d_secure_params = { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id', cavv_algorithm: 'algorithm', directory_response_status: 'directory', authentication_response_status: 'auth' }
-    response = @gateway.purchase(@amount, @credit_card,
-      three_d_secure: three_d_secure_params)
+    response = @gateway.purchase(@amount, @credit_card, three_d_secure: three_d_secure_params)
     assert_success response
   end
 
   def test_successful_purchase_with_some_three_d_secure_pass_thru_fields
     three_d_secure_params = { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id' }
-    response = @gateway.purchase(@amount, @credit_card,
-      three_d_secure: three_d_secure_params)
+    response = @gateway.purchase(@amount, @credit_card, three_d_secure: three_d_secure_params)
     assert_success response
   end
 
@@ -669,10 +667,12 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_authorize_and_capture_with_apple_pay_card
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
@@ -683,13 +683,15 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_authorize_and_capture_with_android_pay_card
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
       year: '2024',
       source: :android_pay,
       transaction_id: '123456789',
-      eci: '05')
+      eci: '05'
+    )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
@@ -700,13 +702,15 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_authorize_and_capture_with_google_pay_card
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
       year: '2024',
       source: :google_pay,
       transaction_id: '123456789',
-      eci: '05')
+      eci: '05'
+    )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_success auth
@@ -817,9 +821,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_update
     assert response = @gateway.store(
-      credit_card('4111111111111111',
-        first_name: 'Old First', last_name: 'Old Last',
-        month: 9, year: 2012),
+      credit_card('4111111111111111', first_name: 'Old First', last_name: 'Old Last', month: 9, year: 2012),
       email: 'old@example.com',
       phone: '321-654-0987'
     )
@@ -838,9 +840,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
     assert response = @gateway.update(
       customer_vault_id,
-      credit_card('5105105105105100',
-        first_name: 'New First', last_name: 'New Last',
-        month: 10, year: 2014),
+      credit_card('5105105105105100', first_name: 'New First', last_name: 'New Last', month: 10, year: 2014),
       email: 'new@example.com',
       phone: '987-765-5432'
     )
@@ -946,25 +946,31 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_authorize_with_travel_data
-    assert auth = @gateway.authorize(@amount, @credit_card,
+    assert auth = @gateway.authorize(
+      @amount,
+      @credit_card,
       travel_data: {
         travel_package: 'flight',
         departure_date: '2050-07-22',
         lodging_check_in_date: '2050-07-22',
         lodging_check_out_date: '2050-07-25',
         lodging_name: 'Best Hotel Ever'
-      })
+      }
+    )
     assert_success auth
   end
 
   def test_authorize_with_lodging_data
-    assert auth = @gateway.authorize(@amount, @credit_card,
+    assert auth = @gateway.authorize(
+      @amount,
+      @credit_card,
       lodging_data: {
         folio_number: 'ABC123',
         check_in_date: '2050-12-22',
         check_out_date: '2050-12-25',
         room_rate: '80.00'
-      })
+      }
+    )
     assert_success auth
   end
 

--- a/test/remote/gateways/remote_card_stream_test.rb
+++ b/test/remote/gateways/remote_card_stream_test.rb
@@ -6,33 +6,43 @@ class RemoteCardStreamTest < Test::Unit::TestCase
 
     @gateway = CardStreamGateway.new(fixtures(:card_stream))
 
-    @amex = credit_card('374245455400001',
+    @amex = credit_card(
+      '374245455400001',
       month: '12',
       year: Time.now.year + 1,
       verification_value: '4887',
-      brand: :american_express)
+      brand: :american_express
+    )
 
-    @mastercard = credit_card('5301250070000191',
+    @mastercard = credit_card(
+      '5301250070000191',
       month: '12',
       year: Time.now.year + 1,
       verification_value: '419',
-      brand: :master)
+      brand: :master
+    )
 
-    @visacreditcard = credit_card('4929421234600821',
+    @visacreditcard = credit_card(
+      '4929421234600821',
       month: '12',
       year: Time.now.year + 1,
       verification_value: '356',
-      brand: :visa)
+      brand: :visa
+    )
 
-    @visadebitcard = credit_card('4539791001730106',
+    @visadebitcard = credit_card(
+      '4539791001730106',
       month: '12',
       year: Time.now.year + 1,
       verification_value: '289',
-      brand: :visa)
+      brand: :visa
+    )
 
-    @declined_card = credit_card('4000300011112220',
+    @declined_card = credit_card(
+      '4000300011112220',
       month: '9',
-      year: Time.now.year + 1)
+      year: Time.now.year + 1
+    )
 
     @amex_options = {
       billing_address: {
@@ -109,10 +119,12 @@ class RemoteCardStreamTest < Test::Unit::TestCase
       ip: '1.1.1.1'
     }
 
-    @three_ds_enrolled_card = credit_card('4012001037141112',
+    @three_ds_enrolled_card = credit_card(
+      '4012001037141112',
       month: '12',
       year: '2020',
-      brand: :visa)
+      brand: :visa
+    )
 
     @visacredit_three_ds_options = {
       threeds_required: true,

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -16,52 +16,64 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @threeds_card = credit_card('4485040371536584', verification_value: '100', month: '12', year: Time.now.year + 1)
     @mada_card = credit_card('5043000000000000', brand: 'mada')
 
-    @vts_network_token = network_tokenization_credit_card('4242424242424242',
+    @vts_network_token = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
-      month:              '10',
-      year:               Time.now.year + 1,
-      source:             :network_token,
-      brand:              'visa',
-      verification_value: nil)
+      month: '10',
+      year: Time.now.year + 1,
+      source: :network_token,
+      brand: 'visa',
+      verification_value: nil
+    )
 
-    @mdes_network_token = network_tokenization_credit_card('5436031030606378',
-      eci:                '02',
+    @mdes_network_token = network_tokenization_credit_card(
+      '5436031030606378',
+      eci: '02',
       payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
-      month:              '10',
-      year:               Time.now.year + 1,
-      source:             :network_token,
-      brand:              'master',
-      verification_value: nil)
+      month: '10',
+      year: Time.now.year + 1,
+      source: :network_token,
+      brand: 'master',
+      verification_value: nil
+    )
 
-    @google_pay_visa_cryptogram_3ds_network_token = network_tokenization_credit_card('4242424242424242',
-      eci:                '05',
+    @google_pay_visa_cryptogram_3ds_network_token = network_tokenization_credit_card(
+      '4242424242424242',
+      eci: '05',
       payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
-      month:              '10',
-      year:               Time.now.year + 1,
-      source:             :google_pay,
-      verification_value: nil)
+      month: '10',
+      year: Time.now.year + 1,
+      source: :google_pay,
+      verification_value: nil
+    )
 
-    @google_pay_master_cryptogram_3ds_network_token = network_tokenization_credit_card('5436031030606378',
+    @google_pay_master_cryptogram_3ds_network_token = network_tokenization_credit_card(
+      '5436031030606378',
       payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
-      month:              '10',
-      year:               Time.now.year + 1,
-      source:             :google_pay,
-      brand:              'master',
-      verification_value: nil)
+      month: '10',
+      year: Time.now.year + 1,
+      source: :google_pay,
+      brand: 'master',
+      verification_value: nil
+    )
 
-    @google_pay_pan_only_network_token = network_tokenization_credit_card('4242424242424242',
-      month:              '10',
-      year:               Time.now.year + 1,
-      source:             :google_pay,
-      verification_value: nil)
+    @google_pay_pan_only_network_token = network_tokenization_credit_card(
+      '4242424242424242',
+      month: '10',
+      year: Time.now.year + 1,
+      source:  :google_pay,
+      verification_value: nil
+    )
 
-    @apple_pay_network_token = network_tokenization_credit_card('4242424242424242',
-      eci:                '05',
+    @apple_pay_network_token = network_tokenization_credit_card(
+      '4242424242424242',
+      eci: '05',
       payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
-      month:              '10',
-      year:               Time.now.year + 1,
-      source:             :apple_pay,
-      verification_value: nil)
+      month: '10',
+      year: Time.now.year + 1,
+      source: :apple_pay,
+      verification_value: nil
+    )
 
     @options = {
       order_id: '1',

--- a/test/remote/gateways/remote_commerce_hub_test.rb
+++ b/test/remote/gateways/remote_commerce_hub_test.rb
@@ -10,27 +10,33 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
 
     @amount = 1204
     @credit_card = credit_card('4005550000000019', month: '02', year: '2035', verification_value: '123', first_name: 'John', last_name: 'Doe')
-    @google_pay = network_tokenization_credit_card('4005550000000019',
+    @google_pay = network_tokenization_credit_card(
+      '4005550000000019',
       brand: 'visa',
       eci: '05',
       month: '02',
       year: '2035',
       source: :google_pay,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
-    @apple_pay = network_tokenization_credit_card('4005550000000019',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+    @apple_pay = network_tokenization_credit_card(
+      '4005550000000019',
       brand: 'visa',
       eci: '05',
       month: '02',
       year: '2035',
       source: :apple_pay,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
-    @declined_apple_pay = network_tokenization_credit_card('4000300011112220',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+    @declined_apple_pay = network_tokenization_credit_card(
+      '4000300011112220',
       brand: 'visa',
       eci: '05',
       month: '02',
       year: '2035',
       source: :apple_pay,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
     @declined_card = credit_card('4000300011112220', month: '02', year: '2035', verification_value: '123')
     @master_card = credit_card('5454545454545454', brand: 'master')
     @options = {}

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -45,7 +45,8 @@ class RemoteCredoraxTest < Test::Unit::TestCase
       }
     }
 
-    @apple_pay_card = network_tokenization_credit_card('4176661000001015',
+    @apple_pay_card = network_tokenization_credit_card(
+      '4176661000001015',
       month: 10,
       year: Time.new.year + 2,
       first_name: 'John',
@@ -54,20 +55,25 @@ class RemoteCredoraxTest < Test::Unit::TestCase
       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
       eci: '07',
       transaction_id: 'abc123',
-      source: :apple_pay)
+      source: :apple_pay
+    )
 
-    @google_pay_card = network_tokenization_credit_card('4176661000001015',
+    @google_pay_card = network_tokenization_credit_card(
+      '4176661000001015',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
       year: Time.new.year + 2,
       source: :google_pay,
       transaction_id: '123456789',
-      eci: '07')
+      eci: '07'
+    )
 
-    @nt_credit_card = network_tokenization_credit_card('4176661000001015',
+    @nt_credit_card = network_tokenization_credit_card(
+      '4176661000001015',
       brand: 'visa',
       source: :network_token,
-      payment_cryptogram: 'AgAAAAAAosVKVV7FplLgQRYAAAA=')
+      payment_cryptogram: 'AgAAAAAAosVKVV7FplLgQRYAAAA='
+    )
   end
 
   def test_successful_purchase_with_apple_pay

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -8,10 +8,7 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     @bank_account = check(account_number: '4100', routing_number: '121042882')
     @declined_bank_account = check(account_number: '550111', routing_number: '121107882')
 
-    @visa_card = credit_card('4111111111111111',
-      verification_value: '987',
-      month: 12,
-      year: 2031)
+    @visa_card = credit_card('4111111111111111', verification_value: '987', month: 12, year: 2031)
 
     @master_card = credit_card('2222420000001113', brand: 'master')
     @discover_card = credit_card('6011111111111117', brand: 'discover')

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -10,37 +10,49 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
     @credit_card = credit_card('4111111111111111', verification_value: '987')
     @declined_card = credit_card('801111111111111')
-    @master_credit_card = credit_card('5555555555554444',
+    @master_credit_card = credit_card(
+      '5555555555554444',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :master)
+      brand: :master
+    )
     @pinless_debit_card = credit_card('4002269999999999')
-    @elo_credit_card = credit_card('5067310000000010',
+    @elo_credit_card = credit_card(
+      '5067310000000010',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :elo)
-    @three_ds_unenrolled_card = credit_card('4000000000000051',
+      brand: :elo
+    )
+    @three_ds_unenrolled_card = credit_card(
+      '4000000000000051',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :visa)
-    @three_ds_enrolled_card = credit_card('4000000000000002',
+      brand: :visa
+    )
+    @three_ds_enrolled_card = credit_card(
+      '4000000000000002',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :visa)
-    @three_ds_invalid_card = credit_card('4000000000000010',
+      brand: :visa
+    )
+    @three_ds_invalid_card = credit_card(
+      '4000000000000010',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :visa)
-    @three_ds_enrolled_mastercard = credit_card('5200000000001005',
+      brand: :visa
+    )
+    @three_ds_enrolled_mastercard = credit_card(
+      '5200000000001005',
       verification_value: '321',
       month: '12',
       year: (Time.now.year + 2).to_s,
-      brand: :master)
+      brand: :master
+    )
 
     @amount = 100
 
@@ -106,10 +118,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_network_tokenization_transcript_scrubbing
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
 
     transcript = capture_transcript(@gateway) do
       @gateway.authorize(@amount, credit_card, @options)
@@ -667,10 +681,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_network_tokenization_authorize_and_capture
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_successful_response(auth)
@@ -680,10 +696,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_network_tokenization_with_amex_cc_and_basic_cryptogram
-    credit_card = network_tokenization_credit_card('378282246310005',
+    credit_card = network_tokenization_credit_card(
+      '378282246310005',
       brand: 'american_express',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_successful_response(auth)
@@ -696,10 +714,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     # Generate a random 40 bytes binary amex cryptogram => Base64.encode64(Random.bytes(40))
     long_cryptogram = "NZwc40C4eTDWHVDXPekFaKkNYGk26w+GYDZmU50cATbjqOpNxR/eYA==\n"
 
-    credit_card = network_tokenization_credit_card('378282246310005',
+    credit_card = network_tokenization_credit_card(
+      '378282246310005',
       brand: 'american_express',
       eci: '05',
-      payment_cryptogram: long_cryptogram)
+      payment_cryptogram: long_cryptogram
+    )
 
     assert auth = @gateway.authorize(@amount, credit_card, @options)
     assert_successful_response(auth)
@@ -709,10 +729,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_purchase_with_network_tokenization_with_amex_cc
-    credit_card = network_tokenization_credit_card('378282246310005',
+    credit_card = network_tokenization_credit_card(
+      '378282246310005',
       brand: 'american_express',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
 
     assert auth = @gateway.purchase(@amount, credit_card, @options)
     assert_successful_response(auth)
@@ -910,8 +932,11 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @subscription_options)
     assert_successful_response(response)
 
-    assert response = @gateway.update(response.authorization, nil,
-      { order_id: generate_unique_id, setup_fee: 100, billing_address: address, email: 'someguy1232@fakeemail.net' })
+    assert response = @gateway.update(
+      response.authorization,
+      nil,
+      { order_id: generate_unique_id, setup_fee: 100, billing_address: address, email: 'someguy1232@fakeemail.net' }
+    )
 
     assert_successful_response(response)
   end

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -60,16 +60,14 @@ class RemoteDLocalTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_network_tokens
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
     response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_match 'The payment was paid', response.message
   end
 
   def test_successful_purchase_with_network_tokens_and_store_credential_type
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
     response = @gateway.purchase(@amount, credit_card, @options.merge!(stored_credential_type: 'SUBSCRIPTION'))
     assert_success response
     assert_match 'SUBSCRIPTION', response.params['card']['stored_credential_type']
@@ -78,8 +76,7 @@ class RemoteDLocalTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_network_tokens_and_store_credential_usage
     options = @options.merge!(stored_credential: stored_credential(:merchant, :recurring, ntid: 'abc123'))
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
     response = @gateway.purchase(@amount, credit_card, options)
     assert_success response
     assert_match 'USED', response.params['card']['stored_credential_usage']
@@ -209,8 +206,10 @@ class RemoteDLocalTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase_with_network_tokens
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA='
+    )
     response = @gateway.purchase(@amount, credit_card, @options.merge(description: '300'))
     assert_failure response
     assert_match 'The payment was rejected', response.message

--- a/test/remote/gateways/remote_element_test.rb
+++ b/test/remote/gateways/remote_element_test.rb
@@ -13,7 +13,8 @@ class RemoteElementTest < Test::Unit::TestCase
       description: 'Store Purchase'
     }
 
-    @google_pay_network_token = network_tokenization_credit_card('4444333322221111',
+    @google_pay_network_token = network_tokenization_credit_card(
+      '4444333322221111',
       month: '01',
       year: Time.new.year + 2,
       first_name: 'Jane',
@@ -22,9 +23,11 @@ class RemoteElementTest < Test::Unit::TestCase
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       eci: '05',
       transaction_id: '123456789',
-      source: :google_pay)
+      source: :google_pay
+    )
 
-    @apple_pay_network_token = network_tokenization_credit_card('4895370015293175',
+    @apple_pay_network_token = network_tokenization_credit_card(
+      '4895370015293175',
       month: '10',
       year: Time.new.year + 2,
       first_name: 'John',
@@ -33,7 +36,8 @@ class RemoteElementTest < Test::Unit::TestCase
       payment_cryptogram: 'CeABBJQ1AgAAAAAgJDUCAAAAAAA=',
       eci: '07',
       transaction_id: 'abc123',
-      source: :apple_pay)
+      source: :apple_pay
+    )
   end
 
   def test_successful_purchase

--- a/test/remote/gateways/remote_eway_rapid_test.rb
+++ b/test/remote/gateways/remote_eway_rapid_test.rb
@@ -112,7 +112,9 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
   end
 
   def test_fully_loaded_purchase
-    response = @gateway.purchase(@amount, @credit_card,
+    response = @gateway.purchase(
+      @amount,
+      @credit_card,
       redirect_url: 'http://awesomesauce.com',
       ip: '0.0.0.0',
       application_id: 'Woohoo',
@@ -148,7 +150,8 @@ class RemoteEwayRapidTest < Test::Unit::TestCase
         country:  'US',
         phone:    '1115555555',
         fax:      '1115556666'
-      })
+      }
+    )
     assert_success response
   end
 

--- a/test/remote/gateways/remote_eway_test.rb
+++ b/test/remote/gateways/remote_eway_test.rb
@@ -4,9 +4,7 @@ class EwayTest < Test::Unit::TestCase
   def setup
     @gateway = EwayGateway.new(fixtures(:eway))
     @credit_card_success = credit_card('4444333322221111')
-    @credit_card_fail = credit_card('1234567812345678',
-      month: Time.now.month,
-      year: Time.now.year - 1)
+    @credit_card_fail = credit_card('1234567812345678', month: Time.now.month, year: Time.now.year - 1)
 
     @params = {
       order_id: '1230123',

--- a/test/remote/gateways/remote_firstdata_e4_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_test.rb
@@ -26,9 +26,11 @@ class RemoteFirstdataE4Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_network_tokenization
-    @credit_card = network_tokenization_credit_card('4242424242424242',
+    @credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil)
+      verification_value: nil
+    )
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Transaction Normal - Approved', response.message

--- a/test/remote/gateways/remote_firstdata_e4_v27_test.rb
+++ b/test/remote/gateways/remote_firstdata_e4_v27_test.rb
@@ -27,9 +27,11 @@ class RemoteFirstdataE4V27Test < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_network_tokenization
-    @credit_card = network_tokenization_credit_card('4242424242424242',
+    @credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil)
+      verification_value: nil
+    )
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Transaction Normal - Approved', response.message

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -16,26 +16,32 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     @cabal_card = credit_card('6271701225979642', brand: 'cabal')
     @declined_card = credit_card('5424180279791732')
     @preprod_card = credit_card('4111111111111111')
-    @apple_pay = network_tokenization_credit_card('4567350000427977',
+    @apple_pay = network_tokenization_credit_card(
+      '4567350000427977',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
       year: Time.new.year + 2,
       first_name: 'John',
       last_name: 'Smith',
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
 
-    @google_pay = network_tokenization_credit_card('4567350000427977',
+    @google_pay = network_tokenization_credit_card(
+      '4567350000427977',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
       year: Time.new.year + 2,
       source: :google_pay,
       transaction_id: '123456789',
-      eci: '05')
+      eci: '05'
+    )
 
-    @google_pay_pan_only = credit_card('4567350000427977',
+    @google_pay_pan_only = credit_card(
+      '4567350000427977',
       month: '01',
-      year: Time.new.year + 2)
+      year: Time.new.year + 2
+    )
 
     @accepted_amount = 4005
     @rejected_amount = 2997

--- a/test/remote/gateways/remote_hps_test.rb
+++ b/test/remote/gateways/remote_hps_test.rb
@@ -359,11 +359,13 @@ class RemoteHpsTest < Test::Unit::TestCase
   end
 
   def test_transcript_scrubbing_with_cryptogram
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, credit_card, @options)
     end
@@ -384,126 +386,150 @@ class RemoteHpsTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_apple_pay_raw_cryptogram_with_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_purchase_with_apple_pay_raw_cryptogram_without_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_auth_with_apple_pay_raw_cryptogram_with_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_auth_with_apple_pay_raw_cryptogram_without_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_purchase_with_android_pay_raw_cryptogram_with_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_purchase_with_android_pay_raw_cryptogram_without_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_auth_with_android_pay_raw_cryptogram_with_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_auth_with_android_pay_raw_cryptogram_without_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_purchase_with_google_pay_raw_cryptogram_with_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_purchase_with_google_pay_raw_cryptogram_without_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_auth_with_google_pay_raw_cryptogram_with_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
   end
 
   def test_successful_auth_with_google_pay_raw_cryptogram_without_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message

--- a/test/remote/gateways/remote_linkpoint_test.rb
+++ b/test/remote/gateways/remote_linkpoint_test.rb
@@ -100,12 +100,15 @@ class LinkpointTest < Test::Unit::TestCase
   end
 
   def test_successful_recurring_payment
-    assert response = @gateway.recurring(2400, @credit_card,
+    assert response = @gateway.recurring(
+      2400,
+      @credit_card,
       order_id: generate_unique_id,
       installments: 12,
       startdate: 'immediate',
       periodicity: :monthly,
-      billing_address: address)
+      billing_address: address
+    )
 
     assert_success response
     assert_equal 'APPROVED', response.params['approved']

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -160,7 +160,9 @@ class RemoteLitleTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_authorization
-    assert response = @gateway.authorize(60060, @declined_card,
+    assert response = @gateway.authorize(
+      60060,
+      @declined_card,
       {
         order_id: '6',
         billing_address: {
@@ -171,7 +173,8 @@ class RemoteLitleTest < Test::Unit::TestCase
           zip: '03038',
           country: 'US'
         }
-      })
+      }
+    )
     assert_failure response
     assert_equal 'Insufficient Funds', response.message
   end

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -10,26 +10,31 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     @amount = 500
     @credit_card = credit_card('5031433215406351')
     @colombian_card = credit_card('4013540682746260')
-    @elo_credit_card = credit_card('5067268650517446',
+    @elo_credit_card = credit_card(
+      '5067268650517446',
       month: 10,
       year: exp_year,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '737')
-    @cabal_credit_card = credit_card('6035227716427021',
+      verification_value: '737'
+    )
+    @cabal_credit_card = credit_card(
+      '6035227716427021',
       month: 10,
       year: exp_year,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '737')
-    @naranja_credit_card = credit_card('5895627823453005',
+      verification_value: '737'
+    )
+    @naranja_credit_card = credit_card(
+      '5895627823453005',
       month: 10,
       year: exp_year,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '123')
-    @declined_card = credit_card('5031433215406351',
-      first_name: 'OTHE')
+      verification_value: '123'
+    )
+    @declined_card = credit_card('5031433215406351', first_name: 'OTHE')
     @options = {
       billing_address: address,
       shipping_address: address,

--- a/test/remote/gateways/remote_merchant_ware_version_four_test.rb
+++ b/test/remote/gateways/remote_merchant_ware_version_four_test.rb
@@ -69,9 +69,11 @@ class RemoteMerchantWareVersionFourTest < Test::Unit::TestCase
     assert_success purchase
     assert purchase.authorization
 
-    assert reference_purchase = @gateway.purchase(@amount,
+    assert reference_purchase = @gateway.purchase(
+      @amount,
       purchase.authorization,
-      @reference_purchase_options)
+      @reference_purchase_options
+    )
     assert_success reference_purchase
     assert_not_nil reference_purchase.authorization
   end

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -41,7 +41,9 @@ class MonerisRemoteTest < Test::Unit::TestCase
 
   def test_successful_cavv_purchase
     # See https://developer.moneris.com/livedemo/3ds2/cavv_purchase/tool/php
-    assert response = @gateway.purchase(@amount, @visa_credit_card_3ds,
+    assert response = @gateway.purchase(
+      @amount,
+      @visa_credit_card_3ds,
       @options.merge(
         three_d_secure: {
           version: '2',
@@ -50,7 +52,8 @@ class MonerisRemoteTest < Test::Unit::TestCase
           three_ds_server_trans_id: 'd0f461f8-960f-40c9-a323-4e43a4e16aaa',
           ds_transaction_id: '12345'
         }
-      ))
+      )
+    )
     assert_success response
     assert_equal 'Approved', response.message
     assert_false response.authorization.blank?
@@ -230,7 +233,9 @@ class MonerisRemoteTest < Test::Unit::TestCase
   def test_successful_cavv_authorization
     # see https://developer.moneris.com/livedemo/3ds2/cavv_preauth/tool/php
     # also see https://github.com/Moneris/eCommerce-Unified-API-PHP/blob/3cd3f0bd5a92432c1b4f9727d1ca6334786d9066/Examples/CA/TestCavvPreAuth.php
-    response = @gateway.authorize(@amount, @visa_credit_card_3ds,
+    response = @gateway.authorize(
+      @amount,
+      @visa_credit_card_3ds,
       @options.merge(
         three_d_secure: {
           version: '2',
@@ -239,7 +244,8 @@ class MonerisRemoteTest < Test::Unit::TestCase
           three_ds_server_trans_id: 'e11d4985-8d25-40ed-99d6-c3803fe5e68f',
           ds_transaction_id: '12345'
         }
-      ))
+      )
+    )
     assert_success response
     assert_equal 'Approved', response.message
     assert_false response.authorization.blank?
@@ -248,7 +254,9 @@ class MonerisRemoteTest < Test::Unit::TestCase
   def test_successful_cavv_authorization_and_capture
     # see https://developer.moneris.com/livedemo/3ds2/cavv_preauth/tool/php
     # also see https://github.com/Moneris/eCommerce-Unified-API-PHP/blob/3cd3f0bd5a92432c1b4f9727d1ca6334786d9066/Examples/CA/TestCavvPreAuth.php
-    response = @gateway.authorize(@amount, @visa_credit_card_3ds,
+    response = @gateway.authorize(
+      @amount,
+      @visa_credit_card_3ds,
       @options.merge(
         three_d_secure: {
           version: '2',
@@ -257,7 +265,8 @@ class MonerisRemoteTest < Test::Unit::TestCase
           three_ds_server_trans_id: 'e11d4985-8d25-40ed-99d6-c3803fe5e68f',
           ds_transaction_id: '12345'
         }
-      ))
+      )
+    )
     assert_success response
     assert_equal 'Approved', response.message
     assert_false response.authorization.blank?
@@ -270,7 +279,9 @@ class MonerisRemoteTest < Test::Unit::TestCase
     omit('There is no way to currently create a failed cavv authorization scenario')
     # see https://developer.moneris.com/livedemo/3ds2/cavv_preauth/tool/php
     # also see https://github.com/Moneris/eCommerce-Unified-API-PHP/blob/3cd3f0bd5a92432c1b4f9727d1ca6334786d9066/Examples/CA/TestCavvPreAuth.php
-    response = @gateway.authorize(@fail_amount, @visa_credit_card_3ds,
+    response = @gateway.authorize(
+      @fail_amount,
+      @visa_credit_card_3ds,
       @options.merge(
         three_d_secure: {
           version: '2',
@@ -279,7 +290,8 @@ class MonerisRemoteTest < Test::Unit::TestCase
           three_ds_server_trans_id: 'e11d4985-8d25-40ed-99d6-c3803fe5e68f',
           ds_transaction_id: '12345'
         }
-      ))
+      )
+    )
 
     assert_failure response
   end

--- a/test/remote/gateways/remote_net_registry_test.rb
+++ b/test/remote/gateways/remote_net_registry_test.rb
@@ -56,9 +56,7 @@ class NetRegistryTest < Test::Unit::TestCase
       assert_equal 'approved', response.params['status']
       assert_match(/\A\d{6}\z/, response.authorization)
 
-      response = @gateway.capture(@amount,
-        response.authorization,
-        credit_card: @valid_creditcard)
+      response = @gateway.capture(@amount, response.authorization, credit_card: @valid_creditcard)
       assert_success response
       assert_equal 'approved', response.params['status']
     end

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -10,13 +10,15 @@ class RemoteNmiTest < Test::Unit::TestCase
       routing_number: '123123123',
       account_number: '123123123'
     )
-    @apple_pay_card = network_tokenization_credit_card('4111111111111111',
+    @apple_pay_card = network_tokenization_credit_card(
+      '4111111111111111',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
       year: '2024',
       source: :apple_pay,
       eci: '5',
-      transaction_id: '123456789')
+      transaction_id: '123456789'
+    )
     @options = {
       order_id: generate_unique_id,
       billing_address: address,

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -195,11 +195,13 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_master_card_network_tokenization_credit_card
-    network_card = network_tokenization_credit_card('4788250000028291',
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
-      brand: 'master')
+      brand: 'master'
+    )
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -249,11 +251,13 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_american_express_network_tokenization_credit_card
-    network_card = network_tokenization_credit_card('4788250000028291',
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
-      brand: 'american_express')
+      brand: 'american_express'
+    )
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -261,11 +265,13 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_discover_network_tokenization_credit_card
-    network_card = network_tokenization_credit_card('4788250000028291',
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
-      brand: 'discover')
+      brand: 'discover'
+    )
     assert response = @gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -1226,11 +1232,13 @@ class TandemOrbitalTests < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_master_card_network_tokenization_credit_card
-    network_card = network_tokenization_credit_card('4788250000028291',
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
-      brand: 'master')
+      brand: 'master'
+    )
     assert response = @tandem_gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -1238,11 +1246,13 @@ class TandemOrbitalTests < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_american_express_network_tokenization_credit_card
-    network_card = network_tokenization_credit_card('4788250000028291',
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
-      brand: 'american_express')
+      brand: 'american_express'
+    )
     assert response = @tandem_gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
@@ -1250,11 +1260,13 @@ class TandemOrbitalTests < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_discover_network_tokenization_credit_card
-    network_card = network_tokenization_credit_card('4788250000028291',
+    network_card = network_tokenization_credit_card(
+      '4788250000028291',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       transaction_id: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: '111',
-      brand: 'discover')
+      brand: 'discover'
+    )
     assert response = @tandem_gateway.purchase(3000, network_card, @options)
     assert_success response
     assert_equal 'Approved', response.message

--- a/test/remote/gateways/remote_pay_junction_test.rb
+++ b/test/remote/gateways/remote_pay_junction_test.rb
@@ -71,8 +71,7 @@ class PayJunctionTest < Test::Unit::TestCase
     response = @gateway.capture(AMOUNT, auth.authorization, @options)
     assert_success response
     assert_equal 'capture', response.params['posture'], 'Should be a capture'
-    assert_equal auth.authorization, response.authorization,
-      'Should maintain transaction ID across request'
+    assert_equal auth.authorization, response.authorization, 'Should maintain transaction ID across request'
   end
 
   def test_successful_credit
@@ -93,8 +92,7 @@ class PayJunctionTest < Test::Unit::TestCase
     assert response = @gateway.void(purchase.authorization, order_id: order_id)
     assert_success response
     assert_equal 'void', response.params['posture'], 'Should be a capture'
-    assert_equal purchase.authorization, response.authorization,
-      'Should maintain transaction ID across request'
+    assert_equal purchase.authorization, response.authorization, 'Should maintain transaction ID across request'
   end
 
   def test_successful_instant_purchase
@@ -110,17 +108,19 @@ class PayJunctionTest < Test::Unit::TestCase
     assert_equal PayJunctionGateway::SUCCESS_MESSAGE, response.message
     assert_equal 'capture', response.params['posture'], 'Should be captured funds'
     assert_equal 'charge', response.params['transaction_action']
-    assert_not_equal purchase.authorization, response.authorization,
-      'Should have recieved new transaction ID'
+    assert_not_equal purchase.authorization, response.authorization, 'Should have recieved new transaction ID'
 
     assert_success response
   end
 
   def test_successful_recurring
-    assert response = @gateway.recurring(AMOUNT, @credit_card,
+    assert response = @gateway.recurring(
+      AMOUNT,
+      @credit_card,
       periodicity: :monthly,
       payments: 12,
-      order_id: generate_unique_id[0..15])
+      order_id: generate_unique_id[0..15]
+    )
 
     assert_equal PayJunctionGateway::SUCCESS_MESSAGE, response.message
     assert_equal 'charge', response.params['transaction_action']

--- a/test/remote/gateways/remote_payflow_test.rb
+++ b/test/remote/gateways/remote_payflow_test.rb
@@ -445,12 +445,15 @@ class RemotePayflowTest < Test::Unit::TestCase
 
   def test_recurring_with_initial_authorization
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(1000, @credit_card,
+      @gateway.recurring(
+        1000,
+        @credit_card,
         periodicity: :monthly,
         initial_transaction: {
           type: :purchase,
           amount: 500
-        })
+        }
+      )
     end
 
     assert_success response

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -8,13 +8,15 @@ class RemotePaymentezTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4111111111111111', verification_value: '666')
     @otp_card = credit_card('36417002140808', verification_value: '666')
-    @elo_credit_card = credit_card('6362970000457013',
+    @elo_credit_card = credit_card(
+      '6362970000457013',
       month: 10,
       year: 2022,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo')
+      brand: 'elo'
+    )
     @declined_card = credit_card('4242424242424242', verification_value: '666')
     @options = {
       billing_address: address,

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -232,9 +232,11 @@ class PaypalTest < Test::Unit::TestCase
     response = @gateway.purchase(900, @credit_card, @params)
     assert_success response
 
-    response = @gateway.transfer([@amount, 'joe@example.com'],
+    response = @gateway.transfer(
+      [@amount, 'joe@example.com'],
       [600, 'jane@example.com', { note: 'Thanks for taking care of that' }],
-      subject: 'Your money')
+      subject: 'Your money'
+    )
     assert_success response
   end
 

--- a/test/remote/gateways/remote_payway_test.rb
+++ b/test/remote/gateways/remote_payway_test.rb
@@ -8,37 +8,49 @@ class PaywayTest < Test::Unit::TestCase
 
     @gateway = ActiveMerchant::Billing::PaywayGateway.new(fixtures(:payway))
 
-    @visa = credit_card('4564710000000004',
+    @visa = credit_card(
+      '4564710000000004',
       month: 2,
       year: 2019,
-      verification_value: '847')
+      verification_value: '847'
+    )
 
-    @mastercard = credit_card('5163200000000008',
+    @mastercard = credit_card(
+      '5163200000000008',
       month: 8,
       year: 2020,
       verification_value: '070',
-      brand: 'master')
+      brand: 'master'
+    )
 
-    @expired = credit_card('4564710000000012',
+    @expired = credit_card(
+      '4564710000000012',
       month: 2,
       year: 2005,
-      verification_value: '963')
+      verification_value: '963'
+    )
 
-    @low = credit_card('4564710000000020',
+    @low = credit_card(
+      '4564710000000020',
       month: 5,
       year: 2020,
-      verification_value: '234')
+      verification_value: '234'
+    )
 
-    @stolen_mastercard = credit_card('5163200000000016',
+    @stolen_mastercard = credit_card(
+      '5163200000000016',
       month: 12,
       year: 2019,
       verification_value: '728',
-      brand: 'master')
+      brand: 'master'
+    )
 
-    @invalid = credit_card('4564720000000037',
+    @invalid = credit_card(
+      '4564720000000037',
       month: 9,
       year: 2019,
-      verification_value: '030')
+      verification_value: '030'
+    )
   end
 
   def test_successful_visa

--- a/test/remote/gateways/remote_psl_card_test.rb
+++ b/test/remote/gateways/remote_psl_card_test.rb
@@ -24,65 +24,55 @@ class RemotePslCardTest < Test::Unit::TestCase
   end
 
   def test_successful_visa_purchase
-    response = @gateway.purchase(@accept_amount, @visa,
-      billing_address: @visa_address)
+    response = @gateway.purchase(@accept_amount, @visa, billing_address: @visa_address)
     assert_success response
     assert response.test?
   end
 
   def test_successful_visa_debit_purchase
-    response = @gateway.purchase(@accept_amount, @visa_debit,
-      billing_address: @visa_debit_address)
+    response = @gateway.purchase(@accept_amount, @visa_debit, billing_address: @visa_debit_address)
     assert_success response
   end
 
   # Fix regression discovered in production
   def test_visa_debit_purchase_should_not_send_debit_info_if_present
     @visa_debit.start_month = '07'
-    response = @gateway.purchase(@accept_amount, @visa_debit,
-      billing_address: @visa_debit_address)
+    response = @gateway.purchase(@accept_amount, @visa_debit, billing_address: @visa_debit_address)
     assert_success response
   end
 
   def test_successful_visa_purchase_specifying_currency
-    response = @gateway.purchase(@accept_amount, @visa,
-      billing_address: @visa_address,
-      currency: 'GBP')
+    response = @gateway.purchase(@accept_amount, @visa, billing_address: @visa_address, currency: 'GBP')
     assert_success response
     assert response.test?
   end
 
   def test_successful_solo_purchase
-    response = @gateway.purchase(@accept_amount, @solo,
-      billing_address: @solo_address)
+    response = @gateway.purchase(@accept_amount, @solo, billing_address: @solo_address)
     assert_success response
     assert response.test?
   end
 
   def test_referred_purchase
-    response = @gateway.purchase(@referred_amount, @uk_maestro,
-      billing_address: @uk_maestro_address)
+    response = @gateway.purchase(@referred_amount, @uk_maestro, billing_address: @uk_maestro_address)
     assert_failure response
     assert response.test?
   end
 
   def test_declined_purchase
-    response = @gateway.purchase(@declined_amount, @uk_maestro,
-      billing_address: @uk_maestro_address)
+    response = @gateway.purchase(@declined_amount, @uk_maestro, billing_address: @uk_maestro_address)
     assert_failure response
     assert response.test?
   end
 
   def test_declined_keep_card_purchase
-    response = @gateway.purchase(@keep_card_amount, @uk_maestro,
-      billing_address: @uk_maestro_address)
+    response = @gateway.purchase(@keep_card_amount, @uk_maestro, billing_address: @uk_maestro_address)
     assert_failure response
     assert response.test?
   end
 
   def test_successful_authorization
-    response = @gateway.authorize(@accept_amount, @visa,
-      billing_address: @visa_address)
+    response = @gateway.authorize(@accept_amount, @visa, billing_address: @visa_address)
     assert_success response
     assert response.test?
   end
@@ -91,15 +81,13 @@ class RemotePslCardTest < Test::Unit::TestCase
     @gateway = PslCardGateway.new(
       login: ''
     )
-    response = @gateway.authorize(@accept_amount, @uk_maestro,
-      billing_address: @uk_maestro_address)
+    response = @gateway.authorize(@accept_amount, @uk_maestro, billing_address: @uk_maestro_address)
     assert_failure response
     assert response.test?
   end
 
   def test_successful_authorization_and_capture
-    authorization = @gateway.authorize(@accept_amount, @visa,
-      billing_address: @visa_address)
+    authorization = @gateway.authorize(@accept_amount, @visa, billing_address: @visa_address)
     assert_success authorization
     assert authorization.test?
 

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -18,17 +18,21 @@ class RemoteRealexTest < Test::Unit::TestCase
     @mastercard_referral_a = card_fixtures(:realex_mastercard_referral_a)
     @mastercard_coms_error = card_fixtures(:realex_mastercard_coms_error)
 
-    @apple_pay = network_tokenization_credit_card('4242424242424242',
+    @apple_pay = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
 
-    @declined_apple_pay = network_tokenization_credit_card('4000120000001154',
+    @declined_apple_pay = network_tokenization_credit_card(
+      '4000120000001154',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     @amount = 10000
   end
 
@@ -38,13 +42,16 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_purchase
     [@visa, @mastercard].each do |card|
-      response = @gateway.purchase(@amount, card,
+      response = @gateway.purchase(
+        @amount,
+        card,
         order_id: generate_unique_id,
         description: 'Test Realex Purchase',
         billing_address: {
           zip: '90210',
           country: 'US'
-        })
+        }
+      )
       assert_not_nil response
       assert_success response
       assert response.test?
@@ -58,9 +65,12 @@ class RemoteRealexTest < Test::Unit::TestCase
       login: 'invalid',
       password: 'invalid'
     )
-    response = gateway.purchase(@amount, @visa,
+    response = gateway.purchase(
+      @amount,
+      @visa,
       order_id: generate_unique_id,
-      description: 'Invalid login test')
+      description: 'Invalid login test'
+    )
 
     assert_not_nil response
     assert_failure response
@@ -70,9 +80,12 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_purchase_with_invalid_account
-    response = RealexGateway.new(fixtures(:realex_with_account).merge(account: 'invalid')).purchase(@amount, @visa,
+    response = RealexGateway.new(fixtures(:realex_with_account).merge(account: 'invalid')).purchase(
+      @amount,
+      @visa,
       order_id: generate_unique_id,
-      description: 'Test Realex purchase with invalid account')
+      description: 'Test Realex purchase with invalid account'
+    )
 
     assert_not_nil response
     assert_failure response
@@ -90,9 +103,12 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_purchase_declined
     [@visa_declined, @mastercard_declined].each do |card|
-      response = @gateway.purchase(@amount, card,
+      response = @gateway.purchase(
+        @amount,
+        card,
         order_id: generate_unique_id,
-        description: 'Test Realex purchase declined')
+        description: 'Test Realex purchase declined'
+      )
       assert_not_nil response
       assert_failure response
 
@@ -178,9 +194,12 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_purchase_referral_b
     [@visa_referral_b, @mastercard_referral_b].each do |card|
-      response = @gateway.purchase(@amount, card,
+      response = @gateway.purchase(
+        @amount,
+        card,
         order_id: generate_unique_id,
-        description: 'Test Realex Referral B')
+        description: 'Test Realex Referral B'
+      )
       assert_not_nil response
       assert_failure response
       assert response.test?
@@ -191,9 +210,12 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_purchase_referral_a
     [@visa_referral_a, @mastercard_referral_a].each do |card|
-      response = @gateway.purchase(@amount, card,
+      response = @gateway.purchase(
+        @amount,
+        card,
         order_id: generate_unique_id,
-        description: 'Test Realex Rqeferral A')
+        description: 'Test Realex Rqeferral A'
+      )
       assert_not_nil response
       assert_failure response
       assert_equal '103', response.params['result']
@@ -203,9 +225,12 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_realex_purchase_coms_error
     [@visa_coms_error, @mastercard_coms_error].each do |card|
-      response = @gateway.purchase(@amount, card,
+      response = @gateway.purchase(
+        @amount,
+        card,
         order_id: generate_unique_id,
-        description: 'Test Realex coms error')
+        description: 'Test Realex coms error'
+      )
       assert_not_nil response
       assert_failure response
 
@@ -217,9 +242,12 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_expiry_month_error
     @visa.month = 13
 
-    response = @gateway.purchase(@amount, @visa,
+    response = @gateway.purchase(
+      @amount,
+      @visa,
       order_id: generate_unique_id,
-      description: 'Test Realex expiry month error')
+      description: 'Test Realex expiry month error'
+    )
     assert_not_nil response
     assert_failure response
 
@@ -230,9 +258,12 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_expiry_year_error
     @visa.year = 2005
 
-    response = @gateway.purchase(@amount, @visa,
+    response = @gateway.purchase(
+      @amount,
+      @visa,
       order_id: generate_unique_id,
-      description: 'Test Realex expiry year error')
+      description: 'Test Realex expiry year error'
+    )
     assert_not_nil response
     assert_failure response
 
@@ -244,9 +275,12 @@ class RemoteRealexTest < Test::Unit::TestCase
     @visa.first_name = ''
     @visa.last_name = ''
 
-    response = @gateway.purchase(@amount, @visa,
+    response = @gateway.purchase(
+      @amount,
+      @visa,
       order_id: generate_unique_id,
-      description: 'test_chname_error')
+      description: 'test_chname_error'
+    )
     assert_not_nil response
     assert_failure response
 
@@ -257,32 +291,41 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_cvn
     @visa_cvn = @visa.clone
     @visa_cvn.verification_value = '111'
-    response = @gateway.purchase(@amount, @visa_cvn,
+    response = @gateway.purchase(
+      @amount,
+      @visa_cvn,
       order_id: generate_unique_id,
-      description: 'test_cvn')
+      description: 'test_cvn'
+    )
     assert_not_nil response
     assert_success response
     assert response.authorization.length > 0
   end
 
   def test_customer_number
-    response = @gateway.purchase(@amount, @visa,
+    response = @gateway.purchase(
+      @amount,
+      @visa,
       order_id: generate_unique_id,
       description: 'test_cust_num',
-      customer: 'my customer id')
+      customer: 'my customer id'
+    )
     assert_not_nil response
     assert_success response
     assert response.authorization.length > 0
   end
 
   def test_realex_authorize
-    response = @gateway.authorize(@amount, @visa,
+    response = @gateway.authorize(
+      @amount,
+      @visa,
       order_id: generate_unique_id,
       description: 'Test Realex Purchase',
       billing_address: {
         zip: '90210',
         country: 'US'
-      })
+      }
+    )
 
     assert_not_nil response
     assert_success response
@@ -294,13 +337,16 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_authorize_then_capture
     order_id = generate_unique_id
 
-    auth_response = @gateway.authorize(@amount, @visa,
+    auth_response = @gateway.authorize(
+      @amount,
+      @visa,
       order_id: order_id,
       description: 'Test Realex Purchase',
       billing_address: {
         zip: '90210',
         country: 'US'
-      })
+      }
+    )
     assert auth_response.test?
 
     capture_response = @gateway.capture(nil, auth_response.authorization)
@@ -315,13 +361,16 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_authorize_then_capture_with_extra_amount
     order_id = generate_unique_id
 
-    auth_response = @gateway.authorize(@amount * 115, @visa,
+    auth_response = @gateway.authorize(
+      @amount * 115,
+      @visa,
       order_id: order_id,
       description: 'Test Realex Purchase',
       billing_address: {
         zip: '90210',
         country: 'US'
-      })
+      }
+    )
     assert auth_response.test?
 
     capture_response = @gateway.capture(@amount, auth_response.authorization)
@@ -336,13 +385,16 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_then_void
     order_id = generate_unique_id
 
-    purchase_response = @gateway.purchase(@amount, @visa,
+    purchase_response = @gateway.purchase(
+      @amount,
+      @visa,
       order_id: order_id,
       description: 'Test Realex Purchase',
       billing_address: {
         zip: '90210',
         country: 'US'
-      })
+      }
+    )
     assert purchase_response.test?
 
     void_response = @gateway.void(purchase_response.authorization)
@@ -358,13 +410,16 @@ class RemoteRealexTest < Test::Unit::TestCase
 
     gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(rebate_secret: 'rebate'))
 
-    purchase_response = gateway_with_refund_password.purchase(@amount, @visa,
+    purchase_response = gateway_with_refund_password.purchase(
+      @amount,
+      @visa,
       order_id: order_id,
       description: 'Test Realex Purchase',
       billing_address: {
         zip: '90210',
         country: 'US'
-      })
+      }
+    )
     assert purchase_response.test?
 
     rebate_response = gateway_with_refund_password.refund(@amount, purchase_response.authorization)
@@ -376,9 +431,11 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_verify
-    response = @gateway.verify(@visa,
+    response = @gateway.verify(
+      @visa,
       order_id: generate_unique_id,
-      description: 'Test Realex verify')
+      description: 'Test Realex verify'
+    )
 
     assert_not_nil response
     assert_success response
@@ -388,9 +445,11 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_realex_verify_declined
-    response = @gateway.verify(@visa_declined,
+    response = @gateway.verify(
+      @visa_declined,
       order_id: generate_unique_id,
-      description: 'Test Realex verify declined')
+      description: 'Test Realex verify declined'
+    )
 
     assert_not_nil response
     assert_failure response
@@ -402,13 +461,16 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_successful_credit
     gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(refund_secret: 'refund'))
 
-    credit_response = gateway_with_refund_password.credit(@amount, @visa,
+    credit_response = gateway_with_refund_password.credit(
+      @amount,
+      @visa,
       order_id: generate_unique_id,
       description: 'Test Realex Credit',
       billing_address: {
         zip: '90210',
         country: 'US'
-      })
+      }
+    )
 
     assert_not_nil credit_response
     assert_success credit_response
@@ -417,13 +479,16 @@ class RemoteRealexTest < Test::Unit::TestCase
   end
 
   def test_failed_credit
-    credit_response = @gateway.credit(@amount, @visa,
+    credit_response = @gateway.credit(
+      @amount,
+      @visa,
       order_id: generate_unique_id,
       description: 'Test Realex Credit',
       billing_address: {
         zip: '90210',
         country: 'US'
-      })
+      }
+    )
 
     assert_not_nil credit_response
     assert_failure credit_response
@@ -433,13 +498,16 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_maps_avs_and_cvv_response_codes
     [@visa, @mastercard].each do |card|
-      response = @gateway.purchase(@amount, card,
+      response = @gateway.purchase(
+        @amount,
+        card,
         order_id: generate_unique_id,
         description: 'Test Realex Purchase',
         billing_address: {
           zip: '90210',
           country: 'US'
-        })
+        }
+      )
       assert_not_nil response
       assert_success response
       assert_equal 'M', response.avs_result['code']
@@ -449,13 +517,16 @@ class RemoteRealexTest < Test::Unit::TestCase
 
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
-      @gateway.purchase(@amount, @visa_declined,
+      @gateway.purchase(
+        @amount,
+        @visa_declined,
         order_id: generate_unique_id,
         description: 'Test Realex Purchase',
         billing_address: {
           zip: '90210',
           country: 'US'
-        })
+        }
+      )
     end
     clean_transcript = @gateway.scrub(transcript)
 

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -142,10 +142,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
 
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
-
-    assert refund = @gateway.refund(@amount, capture.authorization,
-      description: 'Crediting trx',
-      order_id: generate_unique_id)
+    assert refund = @gateway.refund(@amount, capture.authorization, description: 'Crediting trx', order_id: generate_unique_id)
     assert_success refund
   end
 
@@ -168,11 +165,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
   def test_successful_purchase_and_refund
     assert purchase = @gateway.purchase(@amount, @mastercard, @options)
     assert_success purchase
-
-    assert refund = @gateway.refund(@amount, purchase.authorization,
-      description: 'Crediting trx',
-      order_id: generate_unique_id)
-
+    assert refund = @gateway.refund(@amount, purchase.authorization, description: 'Crediting trx', order_id: generate_unique_id)
     assert_success refund
   end
 

--- a/test/remote/gateways/remote_sage_test.rb
+++ b/test/remote/gateways/remote_sage_test.rb
@@ -164,8 +164,7 @@ class RemoteSageTest < Test::Unit::TestCase
   def test_store_visa
     assert response = @gateway.store(@visa, @options)
     assert_success response
-    assert response.authorization,
-      'Store card authorization should not be nil'
+    assert response.authorization, 'Store card authorization should not be nil'
     assert_not_nil response.message
   end
 
@@ -176,15 +175,13 @@ class RemoteSageTest < Test::Unit::TestCase
   end
 
   def test_unstore_visa
-    assert auth = @gateway.store(@visa, @options).authorization,
-      'Unstore card authorization should not be nil'
+    assert auth = @gateway.store(@visa, @options).authorization, 'Unstore card authorization should not be nil'
     assert response = @gateway.unstore(auth, @options)
     assert_success response
   end
 
   def test_failed_unstore_visa
-    assert auth = @gateway.store(@visa, @options).authorization,
-      'Unstore card authorization should not be nil'
+    assert auth = @gateway.store(@visa, @options).authorization, 'Unstore card authorization should not be nil'
     assert response = @gateway.unstore(auth, @options)
     assert_success response
   end

--- a/test/remote/gateways/remote_secure_pay_test.rb
+++ b/test/remote/gateways/remote_secure_pay_test.rb
@@ -4,9 +4,7 @@ class RemoteSecurePayTest < Test::Unit::TestCase
   def setup
     @gateway = SecurePayGateway.new(fixtures(:secure_pay))
 
-    @credit_card = credit_card('4111111111111111',
-      month: '7',
-      year: '2014')
+    @credit_card = credit_card('4111111111111111', month: '7', year: '2014')
 
     @options = {
       order_id: generate_unique_id,

--- a/test/remote/gateways/remote_skipjack_test.rb
+++ b/test/remote/gateways/remote_skipjack_test.rb
@@ -6,8 +6,7 @@ class RemoteSkipJackTest < Test::Unit::TestCase
 
     @gateway = SkipJackGateway.new(fixtures(:skip_jack))
 
-    @credit_card = credit_card('4445999922225',
-      verification_value: '999')
+    @credit_card = credit_card('4445999922225', verification_value: '999')
 
     @amount = 100
 

--- a/test/remote/gateways/remote_stripe_android_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_android_pay_test.rb
@@ -15,11 +15,13 @@ class RemoteStripeAndroidPayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_android_pay_raw_cryptogram
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -30,11 +32,13 @@ class RemoteStripeAndroidPayTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_android_pay_raw_cryptogram
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']

--- a/test/remote/gateways/remote_stripe_apple_pay_test.rb
+++ b/test/remote/gateways/remote_stripe_apple_pay_test.rb
@@ -101,11 +101,13 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_apple_pay_raw_cryptogram_with_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -116,10 +118,12 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_apple_pay_raw_cryptogram_without_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -130,11 +134,13 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_apple_pay_raw_cryptogram_with_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']
@@ -145,10 +151,12 @@ class RemoteStripeApplePayTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_apple_pay_raw_cryptogram_without_eci
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'charge', response.params['object']

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -11,30 +11,42 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     @three_ds_moto_enabled = 'pm_card_authenticationRequiredOnSetup'
     @three_ds_authentication_required = 'pm_card_authenticationRequired'
     @three_ds_authentication_required_setup_for_off_session = 'pm_card_authenticationRequiredSetupForOffSession'
-    @three_ds_off_session_credit_card = credit_card('4000002500003155',
+    @three_ds_off_session_credit_card = credit_card(
+      '4000002500003155',
       verification_value: '737',
       month: 10,
-      year: 2028)
-    @three_ds_1_credit_card = credit_card('4000000000003063',
+      year: 2028
+    )
+    @three_ds_1_credit_card = credit_card(
+      '4000000000003063',
       verification_value: '737',
       month: 10,
-      year: 2028)
-    @three_ds_credit_card = credit_card('4000000000003220',
+      year: 2028
+    )
+    @three_ds_credit_card = credit_card(
+      '4000000000003220',
       verification_value: '737',
       month: 10,
-      year: 2028)
-    @three_ds_not_required_card = credit_card('4000000000003055',
+      year: 2028
+    )
+    @three_ds_not_required_card = credit_card(
+      '4000000000003055',
       verification_value: '737',
       month: 10,
-      year: 2028)
-    @three_ds_external_data_card = credit_card('4000002760003184',
+      year: 2028
+    )
+    @three_ds_external_data_card = credit_card(
+      '4000002760003184',
       verification_value: '737',
       month: 10,
-      year: 2031)
-    @visa_card = credit_card('4242424242424242',
+      year: 2031
+    )
+    @visa_card = credit_card(
+      '4242424242424242',
       verification_value: '737',
       month: 10,
-      year: 2028)
+      year: 2028
+    )
 
     @google_pay = network_tokenization_credit_card(
       '4242424242424242',
@@ -744,7 +756,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
         confirm: true,
         off_session: true,
         stored_credential: {
-          network_transaction_id: '1098510912210968', # TEST env seems happy with any value :/
+          network_transaction_id: '1098510912210968' # TEST env seems happy with any value :/
         }
       })
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -9,16 +9,20 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     @year = (Time.now.year + 2).to_s[-2..-1].to_i
     @credit_card = credit_card('4111111111111111')
     @amex_card = credit_card('3714 496353 98431')
-    @elo_credit_card = credit_card('4514 1600 0000 0008',
+    @elo_credit_card = credit_card(
+      '4514 1600 0000 0008',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo')
-    @credit_card_with_two_digits_year = credit_card('4111111111111111',
+      brand: 'elo'
+    )
+    @credit_card_with_two_digits_year = credit_card(
+      '4111111111111111',
       month: 10,
-      year: @year)
+      year: @year
+    )
     @cabal_card = credit_card('6035220000000006')
     @naranja_card = credit_card('5895620000000002')
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
@@ -27,14 +31,18 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     @threeDS2_card = credit_card('4111111111111111', first_name: nil, last_name: '3DS_V2_FRICTIONLESS_IDENTIFIED')
     @threeDS2_challenge_card = credit_card('4000000000001091', first_name: nil, last_name: 'challenge-me-plz')
     @threeDS_card_external_MPI = credit_card('4444333322221111', first_name: 'AA', last_name: 'BD')
-    @nt_credit_card = network_tokenization_credit_card('4895370015293175',
+    @nt_credit_card = network_tokenization_credit_card(
+      '4895370015293175',
       brand: 'visa',
       eci: '07',
       source: :network_token,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
-    @nt_credit_card_without_eci = network_tokenization_credit_card('4895370015293175',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+    @nt_credit_card_without_eci = network_tokenization_credit_card(
+      '4895370015293175',
       source: :network_token,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
 
     @options = {
       order_id: generate_unique_id,
@@ -131,7 +139,8 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         sub_tax_id: '987-65-4321'
       }
     }
-    @apple_pay_network_token = network_tokenization_credit_card('4895370015293175',
+    @apple_pay_network_token = network_tokenization_credit_card(
+      '4895370015293175',
       month: 10,
       year: Time.new.year + 2,
       first_name: 'John',
@@ -140,15 +149,18 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       payment_cryptogram: 'abc1234567890',
       eci: '07',
       transaction_id: 'abc123',
-      source: :apple_pay)
+      source: :apple_pay
+    )
 
-    @google_pay_network_token = network_tokenization_credit_card('4444333322221111',
+    @google_pay_network_token = network_tokenization_credit_card(
+      '4444333322221111',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
       year: Time.new.year + 2,
       source: :google_pay,
       transaction_id: '123456789',
-      eci: '05')
+      eci: '05'
+    )
   end
 
   def test_successful_purchase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -151,6 +151,7 @@ module ActiveMerchant
     end
 
     def credit_card(number = '4242424242424242', options = {})
+      number = number.is_a?(Integer) ? number.to_s : number
       defaults = {
         number: number,
         month: default_expiration_date.month,
@@ -213,10 +214,12 @@ module ActiveMerchant
         transaction_identifier: 'uniqueidentifier123'
       }.update(options)
 
-      ActiveMerchant::Billing::ApplePayPaymentToken.new(defaults[:payment_data],
+      ActiveMerchant::Billing::ApplePayPaymentToken.new(
+        defaults[:payment_data],
         payment_instrument_name: defaults[:payment_instrument_name],
         payment_network: defaults[:payment_network],
-        transaction_identifier: defaults[:transaction_identifier])
+        transaction_identifier: defaults[:transaction_identifier]
+      )
     end
 
     def address(options = {})
@@ -295,7 +298,7 @@ module ActiveMerchant
     def load_fixtures
       [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
         if File.exist?(file_name)
-          yaml_data = YAML.safe_load(File.read(file_name), [], [], true)
+          yaml_data = YAML.safe_load(File.read(file_name), aliases: true)
           credentials.merge!(symbolize_keys(yaml_data))
         end
         credentials

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -174,7 +174,7 @@ class CreditCardTest < Test::Unit::TestCase
   end
 
   def test_should_identify_wrong_card_brand
-    c = credit_card(brand: 'master')
+    c = credit_card('4779139500118580', brand: 'master')
     assert_not_valid c
   end
 

--- a/test/unit/fixtures_test.rb
+++ b/test/unit/fixtures_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class FixturesTest < Test::Unit::TestCase
   def test_sort
-    keys = YAML.safe_load(File.read(ActiveMerchant::Fixtures::DEFAULT_CREDENTIALS), [], [], true).keys
+    keys = YAML.safe_load(File.read(ActiveMerchant::Fixtures::DEFAULT_CREDENTIALS), aliases: true).keys
     assert_equal(
       keys,
       keys.sort

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -12,52 +12,64 @@ class AdyenTest < Test::Unit::TestCase
 
     @bank_account = check()
 
-    @credit_card = credit_card('4111111111111111',
+    @credit_card = credit_card(
+      '4111111111111111',
       month: 8,
       year: 2018,
       first_name: 'Test',
       last_name: 'Card',
       verification_value: '737',
-      brand: 'visa')
+      brand: 'visa'
+    )
 
-    @elo_credit_card = credit_card('5066 9911 1111 1118',
+    @elo_credit_card = credit_card(
+      '5066 9911 1111 1118',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo')
+      brand: 'elo'
+    )
 
-    @cabal_credit_card = credit_card('6035 2277 1642 7021',
+    @cabal_credit_card = credit_card(
+      '6035 2277 1642 7021',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'cabal')
+      brand: 'cabal'
+    )
 
-    @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
+    @unionpay_credit_card = credit_card(
+      '8171 9999 0000 0000 021',
       month: 10,
       year: 2030,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'unionpay')
+      brand: 'unionpay'
+    )
 
     @three_ds_enrolled_card = credit_card('4212345678901237', brand: :visa)
 
-    @apple_pay_card = network_tokenization_credit_card('4111111111111111',
+    @apple_pay_card = network_tokenization_credit_card(
+      '4111111111111111',
       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
       month: '08',
       year: '2018',
       source: :apple_pay,
-      verification_value: nil)
+      verification_value: nil
+    )
 
-    @nt_credit_card = network_tokenization_credit_card('4895370015293175',
+    @nt_credit_card = network_tokenization_credit_card(
+      '4895370015293175',
       brand: 'visa',
       eci: '07',
       source: :network_token,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
 
     @amount = 100
 

--- a/test/unit/gateways/authorize_net_arb_test.rb
+++ b/test/unit/gateways/authorize_net_arb_test.rb
@@ -18,7 +18,9 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
   def test_successful_recurring
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
 
-    response = @gateway.recurring(@amount, @credit_card,
+    response = @gateway.recurring(
+      @amount,
+      @credit_card,
       billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
       interval: {
         length: 10,
@@ -27,7 +29,8 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
       duration: {
         start_date: Time.now.strftime('%Y-%m-%d'),
         occurrences: 30
-      })
+      }
+    )
 
     assert_instance_of Response, response
     assert response.success?

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -1318,9 +1318,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_includes_shipping_name_when_different_from_billing_name
-    card = credit_card('4242424242424242',
-      first_name: 'billing',
-      last_name: 'name')
+    card = credit_card('4242424242424242', first_name: 'billing', last_name: 'name')
 
     options = {
       order_id: 'a' * 21,
@@ -1341,9 +1339,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_includes_shipping_name_when_passed_as_options
-    card = credit_card('4242424242424242',
-      first_name: 'billing',
-      last_name: 'name')
+    card = credit_card('4242424242424242', first_name: 'billing', last_name: 'name')
 
     shipping_address = address(first_name: 'shipping', last_name: 'lastname')
     shipping_address.delete(:name)
@@ -1366,9 +1362,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_truncation
-    card = credit_card('4242424242424242',
-      first_name: 'a' * 51,
-      last_name: 'a' * 51)
+    card = credit_card('4242424242424242', first_name: 'a' * 51, last_name: 'a' * 51)
 
     options = {
       order_id: 'a' * 21,
@@ -1440,8 +1434,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_successful_apple_pay_authorization_with_network_tokenization
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: '111111111100cryptogram')
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card)
@@ -1459,8 +1452,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_failed_apple_pay_authorization_with_network_tokenization_not_supported
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: '111111111100cryptogram')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: '111111111100cryptogram')
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card)

--- a/test/unit/gateways/banwire_test.rb
+++ b/test/unit/gateways/banwire_test.rb
@@ -9,10 +9,12 @@ class BanwireTest < Test::Unit::TestCase
       currency: 'MXN'
     )
 
-    @credit_card = credit_card('5204164299999999',
+    @credit_card = credit_card(
+      '5204164299999999',
       month: 11,
       year: 2012,
-      verification_value: '999')
+      verification_value: '999'
+    )
     @amount = 100
 
     @options = {
@@ -22,11 +24,13 @@ class BanwireTest < Test::Unit::TestCase
       description: 'Store purchase'
     }
 
-    @amex_credit_card = credit_card('375932134599999',
+    @amex_credit_card = credit_card(
+      '375932134599999',
       month: 3,
       year: 2017,
       first_name: 'Banwire',
-      last_name: 'Test Card')
+      last_name: 'Test Card'
+    )
     @amex_options = {
       order_id: '2',
       email: 'test@email.com',

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -152,9 +152,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_house_number_and_street
     response = stub_comms do
-      @gateway.authorize(@amount,
-        @credit_card,
-        @options_with_house_number_and_street)
+      @gateway.authorize(@amount, @credit_card, @options_with_house_number_and_street)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/billingAddress.street=Top\+Level\+Drive/, data)
       assert_match(/billingAddress.houseNumberOrName=1000/, data)
@@ -167,9 +165,7 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_shipping_house_number_and_street
     response = stub_comms do
-      @gateway.authorize(@amount,
-        @credit_card,
-        @options_with_shipping_house_number_and_shipping_street)
+      @gateway.authorize(@amount, @credit_card, @options_with_shipping_house_number_and_shipping_street)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/billingAddress.street=Top\+Level\+Drive/, data)
       assert_match(/billingAddress.houseNumberOrName=1000/, data)

--- a/test/unit/gateways/blue_pay_test.rb
+++ b/test/unit/gateways/blue_pay_test.rb
@@ -220,8 +220,7 @@ class BluePayTest < Test::Unit::TestCase
 
   def test_message_from
     assert_equal 'CVV does not match', @gateway.send(:parse, 'STATUS=2&CVV2=N&AVS=A&MESSAGE=FAILURE').message
-    assert_equal 'Street address matches, but postal code does not match.',
-      @gateway.send(:parse, 'STATUS=2&CVV2=M&AVS=A&MESSAGE=FAILURE').message
+    assert_equal 'Street address matches, but postal code does not match.', @gateway.send(:parse, 'STATUS=2&CVV2=M&AVS=A&MESSAGE=FAILURE').message
   end
 
   def test_passing_stored_credentials_data_for_mit_transaction
@@ -259,12 +258,15 @@ class BluePayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_recurring_response)
 
     response = assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-      @gateway.recurring(@amount, @credit_card,
+      @gateway.recurring(
+        @amount,
+        @credit_card,
         billing_address: address.merge(first_name: 'Jim', last_name: 'Smith'),
         rebill_start_date: '1 MONTH',
         rebill_expression: '14 DAYS',
         rebill_cycles: '24',
-        rebill_amount: @amount * 4)
+        rebill_amount: @amount * 4
+      )
     end
 
     assert_instance_of Response, response

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -945,14 +945,17 @@ class BraintreeBlueTest < Test::Unit::TestCase
         (params[:industry][:data][:lodging_name] == 'Best Hotel Ever')
     end.returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'),
+    @gateway.purchase(
+      100,
+      credit_card('41111111111111111111'),
       travel_data: {
         travel_package: 'flight',
         departure_date: '2050-07-22',
         lodging_check_in_date: '2050-07-22',
         lodging_check_out_date: '2050-07-25',
         lodging_name: 'Best Hotel Ever'
-      })
+      }
+    )
   end
 
   def test_successful_purchase_with_lodging_data
@@ -964,13 +967,16 @@ class BraintreeBlueTest < Test::Unit::TestCase
         (params[:industry][:data][:room_rate] == '80.00')
     end.returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'),
+    @gateway.purchase(
+      100,
+      credit_card('41111111111111111111'),
       lodging_data: {
         folio_number: 'ABC123',
         check_in_date: '2050-12-22',
         check_out_date: '2050-12-25',
         room_rate: '80.00'
-      })
+      }
+    )
   end
 
   def test_apple_pay_card
@@ -993,11 +999,13 @@ class BraintreeBlueTest < Test::Unit::TestCase
       ).
       returns(braintree_result(id: 'transaction_id'))
 
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram')
+      payment_cryptogram: '111111111100cryptogram'
+    )
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
@@ -1025,12 +1033,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
       ).
       returns(braintree_result(id: 'transaction_id'))
 
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       eci: '05',
       payment_cryptogram: '111111111100cryptogram',
       source: :android_pay,
-      transaction_id: '1234567890')
+      transaction_id: '1234567890'
+    )
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization
@@ -1058,12 +1068,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
       ).
       returns(braintree_result(id: 'transaction_id'))
 
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       eci: '05',
       payment_cryptogram: '111111111100cryptogram',
       source: :google_pay,
-      transaction_id: '1234567890')
+      transaction_id: '1234567890'
+    )
 
     response = @gateway.authorize(100, credit_card, test: true, order_id: '1')
     assert_equal 'transaction_id', response.authorization

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -9,11 +9,13 @@ class CardStreamTest < Test::Unit::TestCase
       shared_secret: 'secret'
     )
 
-    @visacreditcard = credit_card('4929421234600821',
+    @visacreditcard = credit_card(
+      '4929421234600821',
       month: '12',
       year: '2014',
       verification_value: '356',
-      brand: :visa)
+      brand: :visa
+    )
 
     @visacredit_options = {
       billing_address: {
@@ -51,15 +53,15 @@ class CardStreamTest < Test::Unit::TestCase
       dynamic_descriptor: 'product'
     }
 
-    @amex = credit_card('374245455400001',
+    @amex = credit_card(
+      '374245455400001',
       month: '12',
       year: 2014,
       verification_value: '4887',
-      brand: :american_express)
+      brand: :american_express
+    )
 
-    @declined_card = credit_card('4000300011112220',
-      month: '9',
-      year: '2014')
+    @declined_card = credit_card('4000300011112220', month: '9', year: '2014')
   end
 
   def test_successful_visacreditcard_authorization

--- a/test/unit/gateways/commerce_hub_test.rb
+++ b/test/unit/gateways/commerce_hub_test.rb
@@ -8,29 +8,35 @@ class CommerceHubTest < Test::Unit::TestCase
 
     @amount = 1204
     @credit_card = credit_card('4005550000000019', month: '02', year: '2035', verification_value: '123')
-    @google_pay = network_tokenization_credit_card('4005550000000019',
+    @google_pay = network_tokenization_credit_card(
+      '4005550000000019',
       brand: 'visa',
       eci: '05',
       month: '02',
       year: '2035',
       source: :google_pay,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      transaction_id: '13456789')
-    @apple_pay = network_tokenization_credit_card('4005550000000019',
+      transaction_id: '13456789'
+    )
+    @apple_pay = network_tokenization_credit_card(
+      '4005550000000019',
       brand: 'visa',
       eci: '05',
       month: '02',
       year: '2035',
       source: :apple_pay,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      transaction_id: '13456789')
-    @no_supported_source = network_tokenization_credit_card('4005550000000019',
+      transaction_id: '13456789'
+    )
+    @no_supported_source = network_tokenization_credit_card(
+      '4005550000000019',
       brand: 'visa',
       eci: '05',
       month: '02',
       year: '2035',
       source: :no_source,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
     @declined_card = credit_card('4000300011112220', month: '02', year: '2035', verification_value: '123')
     @options = {}
     @post = {}

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -43,13 +43,16 @@ class CredoraxTest < Test::Unit::TestCase
       }
     }
 
-    @nt_credit_card = network_tokenization_credit_card('4176661000001015',
+    @nt_credit_card = network_tokenization_credit_card(
+      '4176661000001015',
       brand: 'visa',
       eci: '07',
       source: :network_token,
-      payment_cryptogram: 'AgAAAAAAosVKVV7FplLgQRYAAAA=')
+      payment_cryptogram: 'AgAAAAAAosVKVV7FplLgQRYAAAA='
+    )
 
-    @apple_pay_card = network_tokenization_credit_card('4176661000001015',
+    @apple_pay_card = network_tokenization_credit_card(
+      '4176661000001015',
       month: 10,
       year: Time.new.year + 2,
       first_name: 'John',
@@ -58,7 +61,8 @@ class CredoraxTest < Test::Unit::TestCase
       payment_cryptogram: 'YwAAAAAABaYcCMX/OhNRQAAAAAA=',
       eci: '07',
       transaction_id: 'abc123',
-      source: :apple_pay)
+      source: :apple_pay
+    )
   end
 
   def test_supported_card_types

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -10,10 +10,12 @@ class CyberSourceRestTest < Test::Unit::TestCase
       private_key: "NYlM1sgultLjvgaraWvDCXykdz1buqOW8yXE3pMlmxQ=\n"
     )
     @bank_account = check(account_number: '4100', routing_number: '121042882')
-    @credit_card = credit_card('4111111111111111',
+    @credit_card = credit_card(
+      '4111111111111111',
       verification_value: '987',
       month: 12,
-      year: 2031)
+      year: 2031
+    )
     @apple_pay = network_tokenization_credit_card(
       '4111111111111111',
       payment_cryptogram: 'AceY+igABPs3jdwNaDg3MAACAAA=',

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -384,11 +384,13 @@ class CyberSourceTest < Test::Unit::TestCase
       true
     end.returns(successful_purchase_response)
 
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram')
+      payment_cryptogram: '111111111100cryptogram'
+    )
     options = @options.merge(ignore_avs: true)
     assert response = @gateway.purchase(@amount, credit_card, options)
     assert_success response
@@ -439,11 +441,13 @@ class CyberSourceTest < Test::Unit::TestCase
       true
     end.returns(successful_purchase_response)
 
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram')
+      payment_cryptogram: '111111111100cryptogram'
+    )
     options = @options.merge(ignore_cvv: true)
     assert response = @gateway.purchase(@amount, credit_card, options)
     assert_success response
@@ -880,11 +884,13 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_network_tokenization_for_visa
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram')
+      payment_cryptogram: '111111111100cryptogram'
+    )
 
     response = stub_comms do
       @gateway.authorize(@amount, credit_card, @options)
@@ -897,11 +903,13 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_network_tokenization_for_visa
-    credit_card = network_tokenization_credit_card('4111111111111111',
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
       brand: 'visa',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram')
+      payment_cryptogram: '111111111100cryptogram'
+    )
 
     response = stub_comms do
       @gateway.purchase(@amount, credit_card, @options)
@@ -920,11 +928,13 @@ class CyberSourceTest < Test::Unit::TestCase
       true
     end.returns(successful_purchase_response)
 
-    credit_card = network_tokenization_credit_card('5555555555554444',
+    credit_card = network_tokenization_credit_card(
+      '5555555555554444',
       brand: 'master',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram')
+      payment_cryptogram: '111111111100cryptogram'
+    )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
@@ -937,11 +947,13 @@ class CyberSourceTest < Test::Unit::TestCase
       true
     end.returns(successful_purchase_response)
 
-    credit_card = network_tokenization_credit_card('378282246310005',
+    credit_card = network_tokenization_credit_card(
+      '378282246310005',
       brand: 'american_express',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: Base64.encode64('111111111100cryptogram'))
+      payment_cryptogram: Base64.encode64('111111111100cryptogram')
+    )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
@@ -1508,9 +1520,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_able_to_properly_handle_40bytes_cryptogram
     long_cryptogram = "NZwc40C4eTDWHVDXPekFaKkNYGk26w+GYDZmU50cATbjqOpNxR/eYA==\n"
-    credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'american_express',
-      payment_cryptogram: long_cryptogram)
+    credit_card = network_tokenization_credit_card('4111111111111111', brand: 'american_express', payment_cryptogram: long_cryptogram)
 
     stub_comms do
       @gateway.authorize(@amount, credit_card, @options)
@@ -1524,9 +1534,7 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_able_to_properly_handle_20bytes_cryptogram
-    credit_card = network_tokenization_credit_card('4111111111111111',
-      brand: 'american_express',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+    credit_card = network_tokenization_credit_card('4111111111111111', brand: 'american_express', payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
 
     stub_comms do
       @gateway.authorize(@amount, credit_card, @options)
@@ -1539,9 +1547,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_raises_error_on_network_token_with_an_underlying_discover_card
     error = assert_raises ArgumentError do
-      credit_card = network_tokenization_credit_card('4111111111111111',
-        brand: 'discover',
-        payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      credit_card = network_tokenization_credit_card('4111111111111111', brand: 'discover', payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
 
       @gateway.authorize(100, credit_card, @options)
     end
@@ -1550,9 +1556,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_raises_error_on_network_token_with_an_underlying_apms
     error = assert_raises ArgumentError do
-      credit_card = network_tokenization_credit_card('4111111111111111',
-        brand: 'sodexo',
-        payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+      credit_card = network_tokenization_credit_card('4111111111111111', brand: 'sodexo', payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
 
       @gateway.authorize(100, credit_card, @options)
     end

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -65,8 +65,7 @@ class DLocalTest < Test::Unit::TestCase
   end
 
   def test_purchase_with_network_tokens
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
     stub_comms do
       @gateway.purchase(@amount, credit_card)
     end.check_request do |_endpoint, data, _headers|
@@ -77,8 +76,7 @@ class DLocalTest < Test::Unit::TestCase
 
   def test_purchase_with_network_tokens_and_store_credential_type_subscription
     options = @options.merge!(stored_credential: stored_credential(:merchant, :recurring, ntid: 'abc123'))
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
     stub_comms do
       @gateway.purchase(@amount, credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -90,8 +88,7 @@ class DLocalTest < Test::Unit::TestCase
 
   def test_purchase_with_network_tokens_and_store_credential_type_uneschedule
     options = @options.merge!(stored_credential: stored_credential(:merchant, :unscheduled, ntid: 'abc123'))
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
     stub_comms do
       @gateway.purchase(@amount, credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -103,8 +100,7 @@ class DLocalTest < Test::Unit::TestCase
 
   def test_purchase_with_network_tokens_and_store_credential_usage_first
     options = @options.merge!(stored_credential: stored_credential(:cardholder, :initial))
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
     stub_comms do
       @gateway.purchase(@amount, credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -116,8 +112,7 @@ class DLocalTest < Test::Unit::TestCase
 
   def test_purchase_with_network_tokens_and_store_credential_type_card_on_file_and_credential_usage_used
     options = @options.merge!(stored_credential: stored_credential(:cardholder, :unscheduled, ntid: 'abc123'))
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
     stub_comms do
       @gateway.purchase(@amount, credit_card, options)
     end.check_request do |_endpoint, data, _headers|
@@ -130,8 +125,7 @@ class DLocalTest < Test::Unit::TestCase
 
   def test_purchase_with_network_tokens_and_store_credential_usage
     options = @options.merge!(stored_credential: stored_credential(:cardholder, :recurring, ntid: 'abc123'))
-    credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
     stub_comms do
       @gateway.purchase(@amount, credit_card, options)
     end.check_request do |_endpoint, data, _headers|

--- a/test/unit/gateways/ebanx_test.rb
+++ b/test/unit/gateways/ebanx_test.rb
@@ -28,7 +28,7 @@ class EbanxTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_optional_processing_type_header
     response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@accepted_amount, @credit_card, @options.merge(processing_type: 'local'))
+      @gateway.purchase(@amount, @credit_card, @options.merge(processing_type: 'local'))
     end.check_request do |_method, _endpoint, _data, headers|
       assert_equal 'local', headers['x-ebanx-api-processing-type']
     end.respond_with(successful_purchase_response)

--- a/test/unit/gateways/epay_test.rb
+++ b/test/unit/gateways/epay_test.rb
@@ -26,8 +26,7 @@ class EpayTest < Test::Unit::TestCase
 
     assert response = @gateway.authorize(100, @credit_card)
     assert_failure response
-    assert_equal 'The payment was declined. Try again in a moment or try with another credit card.',
-      response.message
+    assert_equal 'The payment was declined. Try again in a moment or try with another credit card.', response.message
   end
 
   def test_successful_3ds_purchase
@@ -51,8 +50,7 @@ class EpayTest < Test::Unit::TestCase
 
     assert response = @gateway.authorize(100, @credit_card)
     assert_failure response
-    assert_equal 'The payment was declined of unknown reasons. For more information contact the bank. E.g. try with another credit card.<br />Denied - Call your bank for information',
-      response.message
+    assert_equal 'The payment was declined of unknown reasons. For more information contact the bank. E.g. try with another credit card.<br />Denied - Call your bank for information', response.message
   end
 
   def test_failed_response_on_purchase

--- a/test/unit/gateways/eway_rapid_test.rb
+++ b/test/unit/gateways/eway_rapid_test.rb
@@ -194,7 +194,9 @@ class EwayRapidTest < Test::Unit::TestCase
 
   def test_purchase_with_all_options
     response = stub_comms do
-      @gateway.purchase(200, @credit_card,
+      @gateway.purchase(
+        200,
+        @credit_card,
         transaction_type: 'CustomTransactionType',
         redirect_url: 'http://awesomesauce.com',
         ip: '0.0.0.0',
@@ -230,7 +232,8 @@ class EwayRapidTest < Test::Unit::TestCase
           country: 'US',
           phone: '1115555555',
           fax: '1115556666'
-        })
+        }
+      )
     end.check_request do |_endpoint, data, _headers|
       assert_match(%r{"TransactionType":"CustomTransactionType"}, data)
       assert_match(%r{"RedirectUrl":"http://awesomesauce.com"}, data)

--- a/test/unit/gateways/exact_test.rb
+++ b/test/unit/gateways/exact_test.rb
@@ -49,9 +49,10 @@ class ExactTest < Test::Unit::TestCase
   end
 
   def test_expdate
-    assert_equal('%02d%s' % [@credit_card.month,
-                             @credit_card.year.to_s[-2..-1]],
-      @gateway.send(:expdate, @credit_card))
+    assert_equal(
+      '%02d%s' % [@credit_card.month, @credit_card.year.to_s[-2..-1]],
+      @gateway.send(:expdate, @credit_card)
+    )
   end
 
   def test_soap_fault

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -63,8 +63,7 @@ class FirstdataE4Test < Test::Unit::TestCase
   def test_successful_purchase_with_specified_currency_and_token
     options_with_specified_currency = @options.merge({ currency: 'GBP' })
     @gateway.expects(:ssl_post).returns(successful_purchase_with_specified_currency_response)
-    assert response = @gateway.purchase(@amount, '8938737759041111;visa;Longbob;Longsen;9;2014',
-      options_with_specified_currency)
+    assert response = @gateway.purchase(@amount, '8938737759041111;visa;Longbob;Longsen;9;2014', options_with_specified_currency)
     assert_success response
     assert_equal 'GBP', response.params['currency']
   end
@@ -1049,7 +1048,7 @@ class FirstdataE4Test < Test::Unit::TestCase
         read: true
         socket:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def bad_credentials_response
@@ -1086,7 +1085,7 @@ class FirstdataE4Test < Test::Unit::TestCase
         http_version: '1.1'
         socket:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def successful_void_response

--- a/test/unit/gateways/firstdata_e4_v27_test.rb
+++ b/test/unit/gateways/firstdata_e4_v27_test.rb
@@ -1001,7 +1001,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
         read: true
         socket:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def bad_credentials_response
@@ -1038,7 +1038,7 @@ class FirstdataE4V27Test < Test::Unit::TestCase
         http_version: '1.1'
         socket:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def successful_void_response

--- a/test/unit/gateways/garanti_test.rb
+++ b/test/unit/gateways/garanti_test.rb
@@ -9,7 +9,7 @@ class GarantiTest < Test::Unit::TestCase
     Base.mode = :test
     @gateway = GarantiGateway.new(login: 'a', password: 'b', terminal_id: 'c', merchant_id: 'd')
 
-    @credit_card = credit_card(4242424242424242)
+    @credit_card = credit_card('4242424242424242')
     @amount = 1000 # 1000 cents, 10$
 
     @options = {

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -28,8 +28,7 @@ class GatewayTest < Test::Unit::TestCase
 
     assert_nothing_raised do
       Gateway.supported_countries = all_country_codes
-      assert Gateway.supported_countries == all_country_codes,
-        'List of supported countries not properly set'
+      assert Gateway.supported_countries == all_country_codes, 'List of supported countries not properly set'
     end
   end
 

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -9,26 +9,32 @@ class GlobalCollectTest < Test::Unit::TestCase
                                         secret_api_key: '109H/288H*50Y18W4/0G8571F245KA=')
 
     @credit_card = credit_card('4567350000427977')
-    @apple_pay_network_token = network_tokenization_credit_card('4444333322221111',
+    @apple_pay_network_token = network_tokenization_credit_card(
+      '4444333322221111',
       month: 10,
       year: 24,
       first_name: 'John',
       last_name: 'Smith',
       eci: '05',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      source: :apple_pay)
+      source: :apple_pay
+    )
 
-    @google_pay_network_token = network_tokenization_credit_card('4444333322221111',
+    @google_pay_network_token = network_tokenization_credit_card(
+      '4444333322221111',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
       year: Time.new.year + 2,
       source: :google_pay,
       transaction_id: '123456789',
-      eci: '05')
+      eci: '05'
+    )
 
-    @google_pay_pan_only = credit_card('4444333322221111',
+    @google_pay_pan_only = credit_card(
+      '4444333322221111',
       month: '01',
-      year: Time.new.year + 2)
+      year: Time.new.year + 2
+    )
 
     @declined_card = credit_card('5424180279791732')
     @accepted_amount = 4005

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -288,11 +288,13 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_purchase_with_apple_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -301,11 +303,13 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_purchase_with_apple_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -314,10 +318,12 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_purchase_with_apple_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -326,10 +332,12 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_purchase_with_apple_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -338,11 +346,13 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_auth_with_apple_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -351,11 +361,13 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_auth_with_apple_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -364,10 +376,12 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_auth_with_apple_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -376,10 +390,12 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_auth_with_apple_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :apple_pay)
+      source: :apple_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -388,11 +404,13 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_purchase_with_android_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -401,11 +419,13 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_purchase_with_android_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -414,10 +434,12 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_purchase_with_android_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -426,10 +448,12 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_purchase_with_android_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -438,11 +462,13 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_auth_with_android_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -451,11 +477,13 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_auth_with_android_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -464,10 +492,12 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_auth_with_android_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -476,10 +506,12 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_auth_with_android_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :android_pay)
+      source: :android_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -488,11 +520,13 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_purchase_with_google_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -501,11 +535,13 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_purchase_with_google_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -514,10 +550,12 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_purchase_with_google_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -526,10 +564,12 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_purchase_with_google_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(failed_charge_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -538,11 +578,13 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_auth_with_google_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -551,11 +593,13 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_auth_with_google_pay_raw_cryptogram_with_eci
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
       eci: '05',
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message
@@ -564,10 +608,12 @@ class HpsTest < Test::Unit::TestCase
   def test_successful_auth_with_google_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_success response
     assert_equal 'Success', response.message
@@ -576,10 +622,12 @@ class HpsTest < Test::Unit::TestCase
   def test_failed_auth_with_google_pay_raw_cryptogram_without_eci
     @gateway.expects(:ssl_post).returns(failed_authorize_response_decline)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       verification_value: nil,
-      source: :google_pay)
+      source: :google_pay
+    )
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_failure response
     assert_equal 'The card was declined.', response.message

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -6,24 +6,30 @@ class MercadoPagoTest < Test::Unit::TestCase
   def setup
     @gateway = MercadoPagoGateway.new(access_token: 'access_token')
     @credit_card = credit_card
-    @elo_credit_card = credit_card('5067268650517446',
+    @elo_credit_card = credit_card(
+      '5067268650517446',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '737')
-    @cabal_credit_card = credit_card('6035227716427021',
+      verification_value: '737'
+    )
+    @cabal_credit_card = credit_card(
+      '6035227716427021',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '737')
-    @naranja_credit_card = credit_card('5895627823453005',
+      verification_value: '737'
+    )
+    @naranja_credit_card = credit_card(
+      '5895627823453005',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '123')
+      verification_value: '123'
+    )
     @amount = 100
 
     @options = {

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -38,7 +38,9 @@ class MonerisTest < Test::Unit::TestCase
   def test_successful_mpi_cavv_purchase
     @gateway.expects(:ssl_post).returns(successful_cavv_purchase_response)
 
-    assert response = @gateway.purchase(100, @credit_card,
+    assert response = @gateway.purchase(
+      100,
+      @credit_card,
       @options.merge(
         three_d_secure: {
           version: '2',
@@ -47,7 +49,8 @@ class MonerisTest < Test::Unit::TestCase
           three_ds_server_trans_id: 'd0f461f8-960f-40c9-a323-4e43a4e16aaa',
           ds_transaction_id: '12345'
         }
-      ))
+      )
+    )
     assert_success response
     assert_equal '69785-0_98;a131684dbecc1d89d9927c539ed3791b', response.authorization
   end
@@ -55,7 +58,9 @@ class MonerisTest < Test::Unit::TestCase
   def test_failed_mpi_cavv_purchase
     @gateway.expects(:ssl_post).returns(failed_cavv_purchase_response)
 
-    assert response = @gateway.purchase(100, @credit_card,
+    assert response = @gateway.purchase(
+      100,
+      @credit_card,
       @options.merge(
         three_d_secure: {
           version: '2',
@@ -64,7 +69,8 @@ class MonerisTest < Test::Unit::TestCase
           three_ds_server_trans_id: 'd0f461f8-960f-40c9-a323-4e43a4e16aaa',
           ds_transaction_id: '12345'
         }
-      ))
+      )
+    )
     assert_failure response
     assert_equal '69785-0_98;a131684dbecc1d89d9927c539ed3791b', response.authorization
   end
@@ -128,9 +134,11 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_network_tokenization
     @gateway.expects(:ssl_post).returns(successful_purchase_network_tokenization)
-    @credit_card = network_tokenization_credit_card('4242424242424242',
+    @credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil)
+      verification_value: nil
+    )
     assert response = @gateway.purchase(100, @credit_card, @options)
     assert_success response
     assert_equal '101965-0_10;0bbb277b543a17b6781243889a689573', response.authorization
@@ -277,9 +285,11 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_network_tokenization
     @gateway.expects(:ssl_post).returns(successful_authorization_network_tokenization)
-    @credit_card = network_tokenization_credit_card('4242424242424242',
+    @credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
-      verification_value: nil)
+      verification_value: nil
+    )
     assert response = @gateway.authorize(100, @credit_card, @options)
     assert_success response
     assert_equal '109232-0_10;d88d9f5f3472898832c54d6b5572757e', response.authorization

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -588,8 +588,7 @@ class NmiTest < Test::Unit::TestCase
   end
 
   def test_supported_countries
-    assert_equal 1,
-      (['US'] | NmiGateway.supported_countries).size
+    assert_equal 1, (['US'] | NmiGateway.supported_countries).size
   end
 
   def test_supported_card_types
@@ -824,8 +823,7 @@ class NmiTest < Test::Unit::TestCase
       assert_match(/payment=creditcard/, data)
       assert_match(/ccnumber=#{@credit_card.number}/, data)
       assert_match(/cvv=#{@credit_card.verification_value}/, data)
-      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/,
-        data)
+      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/, data)
 
       test_level3_options(data) if options.any?
     end.respond_with(successful_validate_response)

--- a/test/unit/gateways/opp_test.rb
+++ b/test/unit/gateways/opp_test.rb
@@ -202,7 +202,8 @@ class OppTest < Test::Unit::TestCase
   end
 
   def successful_response(type, id)
-    OppMockResponse.new(200,
+    OppMockResponse.new(
+      200,
       JSON.generate({
         'id' => id,
         'paymentType' => type,
@@ -224,11 +225,13 @@ class OppTest < Test::Unit::TestCase
         'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
         'timestamp' => '2015-06-20 19:31:01+0000',
         'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
-      }))
+      })
+    )
   end
 
   def successful_store_response(id)
-    OppMockResponse.new(200,
+    OppMockResponse.new(
+      200,
       JSON.generate({
         'id' => id,
         'result' => {
@@ -245,11 +248,13 @@ class OppTest < Test::Unit::TestCase
         'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
         'timestamp' => '2015-06-20 19:31:01+0000',
         'ndc' => '8a8294174b7ecb28014b9699220015ca_4453edbc001f405da557c05cb3c3add9'
-      }))
+      })
+    )
   end
 
   def failed_response(type, id, code = '100.100.101')
-    OppMockResponse.new(400,
+    OppMockResponse.new(
+      400,
       JSON.generate({
         'id' => id,
         'paymentType' => type,
@@ -268,11 +273,13 @@ class OppTest < Test::Unit::TestCase
         'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
         'timestamp' => '2015-06-20 20:40:26+0000',
         'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
-      }))
+      })
+    )
   end
 
   def failed_store_response(id, code = '100.100.101')
-    OppMockResponse.new(400,
+    OppMockResponse.new(
+      400,
       JSON.generate({
         'id' => id,
         'result' => {
@@ -289,7 +296,8 @@ class OppTest < Test::Unit::TestCase
         'buildNumber' => '20150618-111601.r185004.opp-tags-20150618_stage',
         'timestamp' => '2015-06-20 20:40:26+0000',
         'ndc' => '8a8294174b7ecb28014b9699220015ca_5200332e7d664412a84ed5f4777b3c7d'
-      }))
+      })
+    )
   end
 
   class OppMockResponse

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -558,9 +558,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_truncates_name
-    card = credit_card('4242424242424242',
-      first_name: 'John',
-      last_name: 'Jacob Jingleheimer Smith-Jones')
+    card = credit_card('4242424242424242', first_name: 'John', last_name: 'Jacob Jingleheimer Smith-Jones')
 
     response = stub_comms do
       @gateway.purchase(50, card, order_id: 1, billing_address: address)
@@ -649,8 +647,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     response = stub_comms do
       assert_deprecation_warning do
-        @gateway.add_customer_profile(credit_card,
-          billing_address: address_with_invalid_chars)
+        @gateway.add_customer_profile(credit_card, billing_address: address_with_invalid_chars)
       end
     end.check_request do |_endpoint, data, _headers|
       assert_match(/456 Main Street</, data)
@@ -661,9 +658,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_truncates_by_byte_length
-    card = credit_card('4242424242424242',
-      first_name: 'John',
-      last_name: 'Jacob Jingleheimer Smith-Jones')
+    card = credit_card('4242424242424242', first_name: 'John', last_name: 'Jacob Jingleheimer Smith-Jones')
 
     long_address = address(
       address1: '456 Stréêt Name is Really Long',
@@ -699,8 +694,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
     response = stub_comms do
       assert_deprecation_warning do
-        @gateway.add_customer_profile(credit_card,
-          billing_address: long_address)
+        @gateway.add_customer_profile(credit_card, billing_address: long_address)
       end
     end.check_request do |_endpoint, data, _headers|
       assert_match(/456 Stréêt Name is Really Lo</, data)
@@ -777,9 +771,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       dest_country: 'US'
     )
 
-    card = credit_card('4242424242424242',
-      first_name: 'John',
-      last_name: 'Jacob Jingleheimer Smith-Jones')
+    card = credit_card('4242424242424242', first_name: 'John', last_name: 'Jacob Jingleheimer Smith-Jones')
 
     response = stub_comms do
       @gateway.purchase(50, card, order_id: 1, address: address)
@@ -817,9 +809,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_does_not_send_for_credit_card_with_no_address
-    card = credit_card('4242424242424242',
-      first_name: 'John',
-      last_name: 'Jacob Jingleheimer Smith-Jones')
+    card = credit_card('4242424242424242', first_name: 'John', last_name: 'Jacob Jingleheimer Smith-Jones')
 
     response = stub_comms do
       @gateway.purchase(50, card, order_id: 1, address: nil, billing_address: nil)
@@ -840,9 +830,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       country: 'US'
     )
 
-    card = credit_card('4242424242424242',
-      first_name: nil,
-      last_name: '')
+    card = credit_card('4242424242424242', first_name: nil, last_name: '')
 
     response = stub_comms do
       @gateway.purchase(50, card, order_id: 1, billing_address: billing_address)
@@ -863,9 +851,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       country: 'US'
     )
 
-    card = credit_card('4242424242424242',
-      first_name: nil,
-      last_name: nil)
+    card = credit_card('4242424242424242', first_name: nil, last_name: nil)
 
     response = stub_comms do
       @gateway.purchase(50, card, order_id: 1, billing_address: billing_address)
@@ -1091,13 +1077,15 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
         assert_deprecation_warning do
-          @gateway.add_customer_profile(credit_card,
+          @gateway.add_customer_profile(
+            credit_card,
             managed_billing: {
               start_date: '10-10-2014',
               end_date: '10-10-2015',
               max_dollar_value: 1500,
               max_transactions: 12
-            })
+            }
+          )
         end
       end
     end.check_request do |_endpoint, data, _headers|
@@ -1545,8 +1533,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = nil
 
     assert_deprecation_warning do
-      response = @gateway.add_customer_profile(credit_card,
-        billing_address: address)
+      response = @gateway.add_customer_profile(credit_card, billing_address: address)
     end
 
     assert_instance_of Response, response

--- a/test/unit/gateways/pac_net_raven_test.rb
+++ b/test/unit/gateways/pac_net_raven_test.rb
@@ -337,7 +337,8 @@ class PacNetRavenGatewayTest < Test::Unit::TestCase
     @gateway.stubs(request_id: 'wouykiikdvqbwwxueppby')
     @gateway.stubs(timestamp: '2013-10-08T14:31:54.Z')
 
-    assert_equal "PymtType=cc_preauth&RAPIVersion=2&UserName=user&Timestamp=2013-10-08T14%3A31%3A54.Z&RequestID=wouykiikdvqbwwxueppby&Signature=7794efc8c0d39f0983edc10f778e6143ba13531d&CardNumber=4242424242424242&Expiry=09#{@credit_card.year.to_s[-2..-1]}&CVV2=123&Currency=USD&BillingStreetAddressLineOne=Address+1&BillingStreetAddressLineFour=Address+2&BillingPostalCode=ZIP123",
+    assert_equal(
+      "PymtType=cc_preauth&RAPIVersion=2&UserName=user&Timestamp=2013-10-08T14%3A31%3A54.Z&RequestID=wouykiikdvqbwwxueppby&Signature=7794efc8c0d39f0983edc10f778e6143ba13531d&CardNumber=4242424242424242&Expiry=09#{@credit_card.year.to_s[-2..-1]}&CVV2=123&Currency=USD&BillingStreetAddressLineOne=Address+1&BillingStreetAddressLineFour=Address+2&BillingPostalCode=ZIP123",
       @gateway.send(:post_data, 'cc_preauth', {
         'CardNumber' => @credit_card.number,
         'Expiry' => @gateway.send(:expdate, @credit_card),
@@ -347,6 +348,7 @@ class PacNetRavenGatewayTest < Test::Unit::TestCase
         'BillingStreetAddressLineFour' => 'Address 2',
         'BillingPostalCode' => 'ZIP123'
       })
+    )
   end
 
   def test_signature_for_cc_preauth_action

--- a/test/unit/gateways/paybox_direct_test.rb
+++ b/test/unit/gateways/paybox_direct_test.rb
@@ -9,8 +9,7 @@ class PayboxDirectTest < Test::Unit::TestCase
       password: 'p'
     )
 
-    @credit_card = credit_card('1111222233334444',
-      brand: 'visa')
+    @credit_card = credit_card('1111222233334444', brand: 'visa')
     @amount = 100
 
     @options = {

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -843,7 +843,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def failed_purchase_response_for_insufficient_funds
@@ -928,7 +928,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def successful_void_response
@@ -973,7 +973,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def failed_capture_response
@@ -1013,7 +1013,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPBadRequest', 'ActiveMerchant::ResponseError'])
   end
 
   def invalid_token_response
@@ -1052,7 +1052,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def invalid_token_response_integration
@@ -1077,7 +1077,7 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPUnauthorized', 'ActiveMerchant::ResponseError'])
   end
 
   def bad_credentials_response
@@ -1102,6 +1102,6 @@ class PayeezyGateway < Test::Unit::TestCase
         body_exist: true
       message:
     RESPONSE
-    YAML.safe_load(yamlexcep, ['Net::HTTPForbidden', 'ActiveMerchant::ResponseError'])
+    YAML.safe_load(yamlexcep, permitted_classes: ['Net::HTTPForbidden', 'ActiveMerchant::ResponseError'])
   end
 end

--- a/test/unit/gateways/payflow_test.rb
+++ b/test/unit/gateways/payflow_test.rb
@@ -465,9 +465,12 @@ class PayflowTest < Test::Unit::TestCase
   def test_initial_recurring_transaction_missing_parameters
     assert_raises ArgumentError do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-        @gateway.recurring(@amount, @credit_card,
+        @gateway.recurring(
+          @amount,
+          @credit_card,
           periodicity: :monthly,
-          initial_transaction: {})
+          initial_transaction: {}
+        )
       end
     end
   end
@@ -475,9 +478,12 @@ class PayflowTest < Test::Unit::TestCase
   def test_initial_purchase_missing_amount
     assert_raises ArgumentError do
       assert_deprecation_warning(Gateway::RECURRING_DEPRECATION_MESSAGE) do
-        @gateway.recurring(@amount, @credit_card,
+        @gateway.recurring(
+          @amount,
+          @credit_card,
           periodicity: :monthly,
-          initial_transaction: { amount: :purchase })
+          initial_transaction: { amount: :purchase }
+        )
       end
     end
   end

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -6,13 +6,15 @@ class PaymentezTest < Test::Unit::TestCase
   def setup
     @gateway = PaymentezGateway.new(application_code: 'foo', app_key: 'bar')
     @credit_card = credit_card
-    @elo_credit_card = credit_card('6362970000457013',
+    @elo_credit_card = credit_card(
+      '6362970000457013',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo')
+      brand: 'elo'
+    )
     @amount = 100
 
     @options = {

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -190,10 +190,14 @@ class PaypalCommonApiTest < Test::Unit::TestCase
   end
 
   def test_build_reference_transaction_gets_ip
-    request = REXML::Document.new(@gateway.send(:build_reference_transaction_request,
-      100,
-      reference_id: 'id',
-      ip: '127.0.0.1'))
+    request = REXML::Document.new(
+      @gateway.send(
+        :build_reference_transaction_request,
+        100,
+        reference_id: 'id',
+        ip: '127.0.0.1'
+      )
+    )
     assert_equal '100', REXML::XPath.first(request, '//n2:PaymentDetails/n2:OrderTotal').text
     assert_equal 'id', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
     assert_equal '127.0.0.1', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:IPAddress').text

--- a/test/unit/gateways/paypal_digital_goods_test.rb
+++ b/test/unit/gateways/paypal_digital_goods_test.rb
@@ -34,60 +34,78 @@ class PaypalDigitalGoodsTest < Test::Unit::TestCase
 
   def test_setup_request_invalid_requests
     assert_raise ArgumentError do
-      @gateway.setup_purchase(100,
+      @gateway.setup_purchase(
+        100,
         ip: '127.0.0.1',
         description: 'Test Title',
         return_url: 'http://return.url',
-        cancel_return_url: 'http://cancel.url')
+        cancel_return_url: 'http://cancel.url'
+      )
     end
 
     assert_raise ArgumentError do
-      @gateway.setup_purchase(100,
+      @gateway.setup_purchase(
+        100,
         ip: '127.0.0.1',
         description: 'Test Title',
         return_url: 'http://return.url',
         cancel_return_url: 'http://cancel.url',
-        items: [])
+        items: []
+      )
     end
 
     assert_raise ArgumentError do
-      @gateway.setup_purchase(100,
+      @gateway.setup_purchase(
+        100,
         ip: '127.0.0.1',
         description: 'Test Title',
         return_url: 'http://return.url',
         cancel_return_url: 'http://cancel.url',
-        items: [Hash.new])
+        items: [Hash.new]
+      )
     end
 
     assert_raise ArgumentError do
-      @gateway.setup_purchase(100,
+      @gateway.setup_purchase(
+        100,
         ip: '127.0.0.1',
         description: 'Test Title',
         return_url: 'http://return.url',
         cancel_return_url: 'http://cancel.url',
-        items: [{ name: 'Charge',
-                  number: '1',
-                  quantity: '1',
-                  amount: 100,
-                  description: 'Description',
-                  category: 'Physical' }])
+        items: [
+          {
+            name: 'Charge',
+            number: '1',
+            quantity: '1',
+            amount: 100,
+            description: 'Description',
+            category: 'Physical'
+          }
+        ]
+      )
     end
   end
 
   def test_build_setup_request_valid
     @gateway.expects(:ssl_post).returns(successful_setup_response)
 
-    @gateway.setup_purchase(100,
+    @gateway.setup_purchase(
+      100,
       ip: '127.0.0.1',
       description: 'Test Title',
       return_url: 'http://return.url',
       cancel_return_url: 'http://cancel.url',
-      items: [{ name: 'Charge',
-                number: '1',
-                quantity: '1',
-                amount: 100,
-                description: 'Description',
-                category: 'Digital' }])
+      items: [
+        {
+          name: 'Charge',
+          number: '1',
+          quantity: '1',
+          amount: 100,
+          description: 'Description',
+          category: 'Digital'
+        }
+      ]
+    )
   end
 
   private

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -243,22 +243,28 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_flatrate_shipping_options_are_included_if_specified_in_build_setup_request
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 0,
-      {
-        currency: 'AUD',
-        shipping_options: [
-          {
-            default: true,
-            name: 'first one',
-            amount: 1000
-          },
-          {
-            default: false,
-            name: 'second one',
-            amount: 2000
-          }
-        ]
-      }))
+    xml = REXML::Document.new(
+      @gateway.send(
+        :build_setup_request,
+        'SetExpressCheckout',
+        0,
+        {
+          currency: 'AUD',
+          shipping_options: [
+            {
+              default: true,
+              name: 'first one',
+              amount: 1000
+            },
+            {
+              default: false,
+              name: 'second one',
+              amount: 2000
+            }
+          ]
+        }
+      )
+    )
 
     assert_equal 'true', REXML::XPath.first(xml, '//n2:FlatRateShippingOptions/n2:ShippingOptionIsDefault').text
     assert_equal 'first one', REXML::XPath.first(xml, '//n2:FlatRateShippingOptions/n2:ShippingOptionName').text
@@ -272,18 +278,24 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_address_is_included_if_specified
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'Sale', 0,
-      {
-        currency: 'GBP',
-        address: {
-          name: 'John Doe',
-          address1: '123 somewhere',
-          city: 'Townville',
-          country: 'Canada',
-          zip: 'k1l4p2',
-          phone: '1231231231'
+    xml = REXML::Document.new(
+      @gateway.send(
+        :build_setup_request,
+        'Sale',
+        0,
+        {
+          currency: 'GBP',
+          address: {
+            name: 'John Doe',
+            address1: '123 somewhere',
+            city: 'Townville',
+            country: 'Canada',
+            zip: 'k1l4p2',
+            phone: '1231231231'
+          }
         }
-      }))
+      )
+    )
 
     assert_equal 'John Doe', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:ShipToAddress/n2:Name').text
     assert_equal '123 somewhere', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:ShipToAddress/n2:Street1').text
@@ -312,30 +324,36 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_fractional_discounts_are_correctly_calculated_with_jpy_currency
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14250,
-      {
-        items: [
-          {
-            name: 'item one',
-            description: 'description',
-            amount: 15000,
-            number: 1,
-            quantity: 1
-          },
-          {
-            name: 'Discount',
-            description: 'Discount',
-            amount: -750,
-            number: 2,
-            quantity: 1
-          }
-        ],
-        subtotal: 14250,
-        currency: 'JPY',
-        shipping: 0,
-        handling: 0,
-        tax: 0
-      }))
+    xml = REXML::Document.new(
+      @gateway.send(
+        :build_setup_request,
+        'SetExpressCheckout',
+        14250,
+        {
+          items: [
+            {
+              name: 'item one',
+              description: 'description',
+              amount: 15000,
+              number: 1,
+              quantity: 1
+            },
+            {
+              name: 'Discount',
+              description: 'Discount',
+              amount: -750,
+              number: 2,
+              quantity: 1
+            }
+          ],
+          subtotal: 14250,
+          currency: 'JPY',
+          shipping: 0,
+          handling: 0,
+          tax: 0
+        }
+      )
+    )
 
     assert_equal '142', REXML::XPath.first(xml, '//n2:OrderTotal').text
     assert_equal '142', REXML::XPath.first(xml, '//n2:ItemTotal').text
@@ -345,30 +363,36 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_non_fractional_discounts_are_correctly_calculated_with_jpy_currency
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14300,
-      {
-        items: [
-          {
-            name: 'item one',
-            description: 'description',
-            amount: 15000,
-            number: 1,
-            quantity: 1
-          },
-          {
-            name: 'Discount',
-            description: 'Discount',
-            amount: -700,
-            number: 2,
-            quantity: 1
-          }
-        ],
-        subtotal: 14300,
-        currency: 'JPY',
-        shipping: 0,
-        handling: 0,
-        tax: 0
-      }))
+    xml = REXML::Document.new(
+      @gateway.send(
+        :build_setup_request,
+        'SetExpressCheckout',
+        14300,
+        {
+          items: [
+            {
+              name: 'item one',
+              description: 'description',
+              amount: 15000,
+              number: 1,
+              quantity: 1
+            },
+            {
+              name: 'Discount',
+              description: 'Discount',
+              amount: -700,
+              number: 2,
+              quantity: 1
+            }
+          ],
+          subtotal: 14300,
+          currency: 'JPY',
+          shipping: 0,
+          handling: 0,
+          tax: 0
+        }
+      )
+    )
 
     assert_equal '143', REXML::XPath.first(xml, '//n2:OrderTotal').text
     assert_equal '143', REXML::XPath.first(xml, '//n2:ItemTotal').text
@@ -378,30 +402,36 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_fractional_discounts_are_correctly_calculated_with_usd_currency
-    xml = REXML::Document.new(@gateway.send(:build_setup_request, 'SetExpressCheckout', 14250,
-      {
-        items: [
-          {
-            name: 'item one',
-            description: 'description',
-            amount: 15000,
-            number: 1,
-            quantity: 1
-          },
-          {
-            name: 'Discount',
-            description: 'Discount',
-            amount: -750,
-            number: 2,
-            quantity: 1
-          }
-        ],
-      subtotal: 14250,
-      currency: 'USD',
-      shipping: 0,
-      handling: 0,
-      tax: 0
-      }))
+    xml = REXML::Document.new(
+      @gateway.send(
+        :build_setup_request,
+        'SetExpressCheckout',
+        14250,
+        {
+          items: [
+            {
+              name: 'item one',
+              description: 'description',
+              amount: 15000,
+              number: 1,
+              quantity: 1
+            },
+            {
+              name: 'Discount',
+              description: 'Discount',
+              amount: -750,
+              number: 2,
+              quantity: 1
+            }
+          ],
+        subtotal: 14250,
+        currency: 'USD',
+        shipping: 0,
+        handling: 0,
+        tax: 0
+        }
+      )
+    )
 
     assert_equal '142.50', REXML::XPath.first(xml, '//n2:OrderTotal').text
     assert_equal '142.50', REXML::XPath.first(xml, '//n2:ItemTotal').text
@@ -454,25 +484,31 @@ class PaypalExpressTest < Test::Unit::TestCase
   end
 
   def test_items_are_included_if_specified_in_build_sale_or_authorization_request
-    xml = REXML::Document.new(@gateway.send(:build_sale_or_authorization_request, 'Sale', 100,
-      {
-        items: [
-          {
-            name: 'item one',
-            description: 'item one description',
-            amount: 10000,
-            number: 1,
-            quantity: 3
-          },
-          {
-            name: 'item two',
-            description: 'item two description',
-            amount: 20000,
-            number: 2,
-            quantity: 4
-          }
-        ]
-      }))
+    xml = REXML::Document.new(
+      @gateway.send(
+        :build_sale_or_authorization_request,
+        'Sale',
+        100,
+        {
+          items: [
+            {
+              name: 'item one',
+              description: 'item one description',
+              amount: 10000,
+              number: 1,
+              quantity: 3
+            },
+            {
+              name: 'item two',
+              description: 'item two description',
+              amount: 20000,
+              number: 2,
+              quantity: 4
+            }
+          ]
+        }
+      )
+    )
 
     assert_equal 'item one', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Name').text
     assert_equal 'item one description', REXML::XPath.first(xml, '//n2:PaymentDetails/n2:PaymentDetailsItem/n2:Description').text
@@ -548,15 +584,21 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_build_reference_transaction_test
     PaypalExpressGateway.application_id = 'ActiveMerchant_FOO'
-    xml = REXML::Document.new(@gateway.send(:build_reference_transaction_request, 'Sale', 2000,
-      {
-        reference_id: 'ref_id',
-        payment_type: 'Any',
-        invoice_id: 'invoice_id',
-        description: 'Description',
-        ip: '127.0.0.1',
-        merchant_session_id: 'example_merchant_session_id'
-      }))
+    xml = REXML::Document.new(
+      @gateway.send(
+        :build_reference_transaction_request,
+        'Sale',
+        2000,
+        {
+          reference_id: 'ref_id',
+          payment_type: 'Any',
+          invoice_id: 'invoice_id',
+          description: 'Description',
+          ip: '127.0.0.1',
+          merchant_session_id: 'example_merchant_session_id'
+        }
+      )
+    )
 
     assert_equal '124', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:Version').text
     assert_equal 'ref_id', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
@@ -572,14 +614,20 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_build_reference_transaction_without_merchant_session_test
     PaypalExpressGateway.application_id = 'ActiveMerchant_FOO'
-    xml = REXML::Document.new(@gateway.send(:build_reference_transaction_request, 'Sale', 2000,
-      {
-        reference_id: 'ref_id',
-        payment_type: 'Any',
-        invoice_id: 'invoice_id',
-        description: 'Description',
-        ip: '127.0.0.1'
-      }))
+    xml = REXML::Document.new(
+      @gateway.send(
+        :build_reference_transaction_request,
+        'Sale',
+        2000,
+        {
+          reference_id: 'ref_id',
+          payment_type: 'Any',
+          invoice_id: 'invoice_id',
+          description: 'Description',
+          ip: '127.0.0.1'
+        }
+      )
+    )
 
     assert_equal '124', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:Version').text
     assert_equal 'ref_id', REXML::XPath.first(xml, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
@@ -633,26 +681,20 @@ class PaypalExpressTest < Test::Unit::TestCase
 
   def test_error_code_for_single_error
     @gateway.expects(:ssl_post).returns(response_with_error)
-    response = @gateway.setup_authorization(100,
-      return_url: 'http://example.com',
-      cancel_return_url: 'http://example.com')
+    response = @gateway.setup_authorization(100, return_url: 'http://example.com', cancel_return_url: 'http://example.com')
     assert_equal '10736', response.params['error_codes']
   end
 
   def test_ensure_only_unique_error_codes
     @gateway.expects(:ssl_post).returns(response_with_duplicate_errors)
-    response = @gateway.setup_authorization(100,
-      return_url: 'http://example.com',
-      cancel_return_url: 'http://example.com')
+    response = @gateway.setup_authorization(100, return_url: 'http://example.com', cancel_return_url: 'http://example.com')
 
     assert_equal '10736', response.params['error_codes']
   end
 
   def test_error_codes_for_multiple_errors
     @gateway.expects(:ssl_post).returns(response_with_errors)
-    response = @gateway.setup_authorization(100,
-      return_url: 'http://example.com',
-      cancel_return_url: 'http://example.com')
+    response = @gateway.setup_authorization(100, return_url: 'http://example.com', cancel_return_url: 'http://example.com')
 
     assert_equal %w[10736 10002], response.params['error_codes'].split(',')
   end

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -260,21 +260,29 @@ class PaypalTest < Test::Unit::TestCase
   end
 
   def test_item_total_shipping_handling_and_tax_not_included_unless_all_are_present
-    xml = @gateway.send(:build_sale_or_authorization_request, 'Authorization', @amount, @credit_card,
+    xml = @gateway.send(
+      :build_sale_or_authorization_request,
+      'Authorization', @amount, @credit_card,
       tax: @amount,
       shipping: @amount,
-      handling: @amount)
+      handling: @amount
+    )
 
     doc = REXML::Document.new(xml)
     assert_nil REXML::XPath.first(doc, '//n2:PaymentDetails/n2:TaxTotal')
   end
 
   def test_item_total_shipping_handling_and_tax
-    xml = @gateway.send(:build_sale_or_authorization_request, 'Authorization', @amount, @credit_card,
+    xml = @gateway.send(
+      :build_sale_or_authorization_request,
+      'Authorization',
+      @amount,
+      @credit_card,
       tax: @amount,
       shipping: @amount,
       handling: @amount,
-      subtotal: 200)
+      subtotal: 200
+    )
 
     doc = REXML::Document.new(xml)
     assert_equal '1.00', REXML::XPath.first(doc, '//n2:PaymentDetails/n2:TaxTotal').text

--- a/test/unit/gateways/payway_test.rb
+++ b/test/unit/gateways/payway_test.rb
@@ -11,7 +11,7 @@ class PaywayTest < Test::Unit::TestCase
     @amount = 1000
 
     @credit_card = ActiveMerchant::Billing::CreditCard.new(
-      number: 4564710000000004,
+      number: '4564710000000004',
       month: 2,
       year: 2019,
       first_name: 'Bob',

--- a/test/unit/gateways/realex_test.rb
+++ b/test/unit/gateways/realex_test.rb
@@ -5,8 +5,7 @@ class RealexTest < Test::Unit::TestCase
 
   class ActiveMerchant::Billing::RealexGateway
     # For the purposes of testing, lets redefine some protected methods as public.
-    public :build_purchase_or_authorization_request, :build_refund_request, :build_void_request,
-      :build_capture_request, :build_verify_request, :build_credit_request
+    public :build_purchase_or_authorization_request, :build_refund_request, :build_void_request, :build_capture_request, :build_verify_request, :build_credit_request
   end
 
   def setup

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -316,9 +316,7 @@ class SagePayTest < Test::Unit::TestCase
     assert_success capture
 
     refund = stub_comms do
-      @gateway.refund(@amount, capture.authorization,
-        order_id: generate_unique_id,
-        description: 'Refund txn')
+      @gateway.refund(@amount, capture.authorization, order_id: generate_unique_id, description: 'Refund txn')
     end.respond_with(successful_refund_response)
     assert_success refund
   end

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -11,10 +11,12 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     @visa_token = 'pm_card_visa'
 
     @three_ds_authentication_required_setup_for_off_session = 'pm_card_authenticationRequiredSetupForOffSession'
-    @three_ds_off_session_credit_card = credit_card('4000002500003155',
+    @three_ds_off_session_credit_card = credit_card(
+      '4000002500003155',
       verification_value: '737',
       month: 10,
-      year: 2022)
+      year: 2022
+    )
 
     @amount = 2020
     @update_amount = 2050
@@ -426,7 +428,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
           confirm: true,
           off_session: true,
           stored_credential: {
-            network_transaction_id: network_transaction_id, # TEST env seems happy with any value :/
+            network_transaction_id: network_transaction_id # TEST env seems happy with any value :/
           }
         })
       end.check_request do |_method, _endpoint, data, _headers|
@@ -526,7 +528,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
   def test_purchase_with_shipping_carrier_and_tracking_number
     options = {
       currency: 'GBP',
-      customer: @customer,
       shipping_address: {
         name: 'John Adam',
         address1: 'block C'
@@ -534,6 +535,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       shipping_tracking_number: 'TXNABC123',
       shipping_carrier: 'FEDEX'
     }
+    options[:customer] = @customer if defined?(@customer)
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @visa_token, options)
     end.check_request do |_method, _endpoint, data, _headers|

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -966,10 +966,12 @@ class StripeTest < Test::Unit::TestCase
 
   def test_add_creditcard_pads_eci_value
     post = {}
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
-      eci: '7')
+      eci: '7'
+    )
 
     @gateway.send(:add_creditcard, post, credit_card, {})
 
@@ -1440,10 +1442,12 @@ class StripeTest < Test::Unit::TestCase
       true
     end.returns(successful_authorization_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
-      eci: '05')
+      eci: '05'
+    )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_instance_of Response, response
@@ -1460,11 +1464,13 @@ class StripeTest < Test::Unit::TestCase
       true
     end.returns(successful_authorization_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
     assert_instance_of Response, response
@@ -1481,10 +1487,12 @@ class StripeTest < Test::Unit::TestCase
       true
     end.returns(successful_authorization_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
-      eci: '05')
+      eci: '05'
+    )
 
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_instance_of Response, response
@@ -1501,11 +1509,13 @@ class StripeTest < Test::Unit::TestCase
       true
     end.returns(successful_authorization_response)
 
-    credit_card = network_tokenization_credit_card('4242424242424242',
+    credit_card = network_tokenization_credit_card(
+      '4242424242424242',
       payment_cryptogram: '111111111100cryptogram',
       verification_value: nil,
       eci: '05',
-      source: :android_pay)
+      source: :android_pay
+    )
 
     assert response = @gateway.purchase(@amount, credit_card, @options)
     assert_instance_of Response, response

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -12,27 +12,35 @@ class WorldpayTest < Test::Unit::TestCase
     @amount = 100
     @credit_card = credit_card('4242424242424242')
     @token = '|99411111780163871111|shopper|59424549c291397379f30c5c082dbed8'
-    @elo_credit_card = credit_card('4514 1600 0000 0008',
+    @elo_credit_card = credit_card(
+      '4514 1600 0000 0008',
       month: 10,
       year: 2020,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      brand: 'elo')
-    @nt_credit_card = network_tokenization_credit_card('4895370015293175',
+      brand: 'elo'
+    )
+    @nt_credit_card = network_tokenization_credit_card(
+      '4895370015293175',
       brand: 'visa',
       eci: 5,
       source: :network_token,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
-    @nt_credit_card_without_eci = network_tokenization_credit_card('4895370015293175',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+    @nt_credit_card_without_eci = network_tokenization_credit_card(
+      '4895370015293175',
       source: :network_token,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
-    @credit_card_with_two_digits_year = credit_card('4514 1600 0000 0008',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+    @credit_card_with_two_digits_year = credit_card(
+      '4514 1600 0000 0008',
       month: 10,
       year: 22,
       first_name: 'John',
       last_name: 'Smith',
-      verification_value: '737')
+      verification_value: '737'
+    )
     @sodexo_voucher = credit_card('6060704495764400', brand: 'sodexo')
     @options = { order_id: 1 }
     @store_options = {
@@ -47,21 +55,25 @@ class WorldpayTest < Test::Unit::TestCase
       }
     }
 
-    @apple_play_network_token = network_tokenization_credit_card('4895370015293175',
+    @apple_play_network_token = network_tokenization_credit_card(
+      '4895370015293175',
       month: 10,
       year: 24,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
-      source: :apple_pay)
+      source: :apple_pay
+    )
 
-    @google_pay_network_token = network_tokenization_credit_card('4444333322221111',
+    @google_pay_network_token = network_tokenization_credit_card(
+      '4444333322221111',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
       year: Time.new.year + 2,
       source: :google_pay,
       transaction_id: '123456789',
-      eci: '05')
+      eci: '05'
+    )
 
     @level_two_data = {
       level_2_data: {
@@ -664,9 +676,7 @@ class WorldpayTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       if /capture/.match?(data)
         t = Time.now
-        assert_tag_with_attributes 'date',
-          { 'dayOfMonth' => t.day.to_s, 'month' => t.month.to_s, 'year' => t.year.to_s },
-          data
+        assert_tag_with_attributes 'date', { 'dayOfMonth' => t.day.to_s, 'month' => t.month.to_s, 'year' => t.year.to_s }, data
       end
     end.respond_with(successful_inquiry_response, successful_capture_response)
   end
@@ -675,9 +685,7 @@ class WorldpayTest < Test::Unit::TestCase
     stub_comms do
       @gateway.authorize(100, @credit_card, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes 'amount',
-        { 'value' => '100', 'exponent' => '2', 'currencyCode' => 'GBP' },
-        data
+      assert_tag_with_attributes 'amount', { 'value' => '100', 'exponent' => '2', 'currencyCode' => 'GBP' }, data
     end.respond_with(successful_authorize_response)
   end
 
@@ -685,17 +693,13 @@ class WorldpayTest < Test::Unit::TestCase
     stub_comms do
       @gateway.authorize(10000, @credit_card, @options.merge(currency: :JPY))
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes 'amount',
-        { 'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY' },
-        data
+      assert_tag_with_attributes 'amount', { 'value' => '100', 'exponent' => '0', 'currencyCode' => 'JPY' }, data
     end.respond_with(successful_authorize_response)
 
     stub_comms do
       @gateway.authorize(10000, @credit_card, @options.merge(currency: :OMR))
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes 'amount',
-        { 'value' => '10000', 'exponent' => '3', 'currencyCode' => 'OMR' },
-        data
+      assert_tag_with_attributes 'amount', { 'value' => '10000', 'exponent' => '3', 'currencyCode' => 'OMR' }, data
     end.respond_with(successful_authorize_response)
   end
 


### PR DESCRIPTION
Updated required Ruby version to be 2.7 and Rubocop to 0.72.0.

All unit tests and rubocop:
5532 tests, 77501 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed