### PR TITLE
PaymentExpress: correct endpoints

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* PaymentExpress: Correct endpoints [steveh] #4827
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -20,8 +20,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'https://www.windcave.com/'
       self.display_name = 'Windcave (formerly PaymentExpress)'
 
-      self.live_url = 'https://sec.paymentexpress.com/pxpost.aspx'
-      self.test_url = 'https://uat.paymentexpress.com/pxpost.aspx'
+      self.live_url = 'https://sec.windcave.com/pxpost.aspx'
+      self.test_url = 'https://uat.windcave.com/pxpost.aspx'
 
       APPROVED = '1'
 


### PR DESCRIPTION
Now that Payment Express has renamed to Windcave, the old endpoints no longer work.

Test Summary
Local: 5543 tests, 77553 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Unit: 37 tests, 263 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Remote: 17 tests, 79 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed