### PR TITLE
Stripe PI: Gate sending NTID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 == HEAD
 * Paysafe: Map order_id to merchantRefNum [jcreiff] #4839
+* Stripe PI: Gate sending NTID [almalee24] #4828
 
 == Version 1.133.0 (July 20, 2023)
 * CyberSource: remove credentials from tests [bbraschi] #4836


### PR DESCRIPTION
Don't send NTID in add_stored_credential if
post[:payment_method_options][:card][:stored_credential_transaction_type] = 'setup_on_session' and setup_future_usage=off_session.