### PR TITLE
Kushki: Add Brazil as supported country

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * CheckoutV2: Parse the AVS and CVV checks more often [aenand] #4822
 * NMI: Add shipping_firstname, shipping_lastname, shipping_email, and surcharge fields [jcreiff] #4825
 * Borgun: Update authorization_from & message_from [almalee24] #4826
+* Kushki: Add Brazil as supported country [almalee24] #4829
 
 == Version 1.131.0 (June 21, 2023)
 * Redsys: Add supported countries [jcreiff] #4811

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -7,7 +7,7 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://api-uat.kushkipagos.com/'
       self.live_url = 'https://api.kushkipagos.com/'
 
-      self.supported_countries = %w[CL CO EC MX PE]
+      self.supported_countries = %w[BR CL CO EC MX PE]
       self.default_currency = 'USD'
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master american_express discover diners_club alia]

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -15,6 +15,13 @@ class RemoteKushkiTest < Test::Unit::TestCase
     assert_match %r(^\d+$), response.authorization
   end
 
+  def test_successful_purchase_brazil
+    response = @gateway.purchase(@amount, @credit_card, { currency: 'BRL' })
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_match %r(^\d+$), response.authorization
+  end
+
   def test_successful_purchase_with_options
     options = {
       currency: 'USD',
@@ -137,8 +144,14 @@ class RemoteKushkiTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize
-    # Kushki only allows preauthorization for PEN, CLP, and UF.
     response = @gateway.authorize(@amount, @credit_card, { currency: 'PEN' })
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_match %r(^\d+$), response.authorization
+  end
+
+  def test_successful_authorize_brazil
+    response = @gateway.authorize(@amount, @credit_card, { currency: 'BRL' })
     assert_success response
     assert_equal 'Succeeded', response.message
     assert_match %r(^\d+$), response.authorization


### PR DESCRIPTION
Unit
17 tests, 109 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote
18 tests, 57 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed