### PR TITLE
Nuvie/SafeCharge: Add unreferenced refund field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Kushki: Add Brazil as supported country [almalee24] #4829
 * Adyen: Add additional data for airline and lodging [javierpedrozaing] #4815
 * MIT: Changed how the payload was sent to the gateway [alejandrofloresm] #4655
+* SafeCharge: Add unreferenced_refund field [yunnydang] #4831
 
 == Version 1.131.0 (June 21, 2023)
 * Redsys: Add supported countries [jcreiff] #4811

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -73,10 +73,10 @@ module ActiveMerchant #:nodoc:
         add_transaction_data('Credit', post, money, options.merge!({ currency: original_currency }))
         post[:sg_CreditType] = 2
         post[:sg_AuthCode] = auth
-        post[:sg_TransactionID] = transaction_id
         post[:sg_CCToken] = token
         post[:sg_ExpMonth] = exp_month
         post[:sg_ExpYear] = exp_year
+        post[:sg_TransactionID] = transaction_id unless options[:unreferenced_refund]
 
         commit(post)
       end

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -256,6 +256,18 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     assert_equal 'Transaction must contain a Card/Token/Account', response.message
   end
 
+  def test_successful_unreferenced_refund
+    option = {
+      unreferenced_refund: true
+    }
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, option)
+    assert_success refund
+    assert_equal 'Success', refund.message
+  end
+
   def test_successful_credit
     response = @gateway.credit(@amount, credit_card('4444436501403986'), @options)
     assert_success response

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -203,6 +203,26 @@ class SafeChargeTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_unreferenced_refund
+    refund = stub_comms do
+      @gateway.refund(@amount, 'auth|transaction_id|token|month|year|amount|currency', @options.merge(unreferenced_refund: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal(data.split('&').include?('sg_TransactionID=transaction_id'), false)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
+  def test_successful_refund_without_unreferenced_refund
+    refund = stub_comms do
+      @gateway.refund(@amount, 'auth|transaction_id|token|month|year|amount|currency', @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal(data.split('&').include?('sg_TransactionID=transaction_id'), true)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
   def test_failed_refund
     @gateway.expects(:ssl_post).returns(failed_refund_response)
 


### PR DESCRIPTION
Note: 
I didn't include a unit test because this fields purpose is to exclude sending the sg_TransactionID and not meant to return anything. 

Local:
5545 tests, 77509 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6573% passed

Unit:
25 tests, 144 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
32 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed