### PR TITLE
CyberSource: include `networkTokenCryptogram` in `ccAuthService` for MC

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Kushki: Add Brazil as supported country [almalee24] #4829
 * Adyen: Add additional data for airline and lodging [javierpedrozaing] #4815
 * MIT: Changed how the payload was sent to the gateway [alejandrofloresm] #4655
+* CyberSource: include `networkTokenCryptogram` in `ccAuthService` [bbraschi]
 
 == Version 1.131.0 (June 21, 2023)
 * Redsys: Add supported countries [jcreiff] #4811

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -813,6 +813,7 @@ module ActiveMerchant #:nodoc:
             xml.tag!('collectionIndicator', DEFAULT_COLLECTION_INDICATOR)
           end
           xml.tag! 'ccAuthService', { 'run' => 'true' } do
+            xml.tag!('networkTokenCryptogram', payment_method.payment_cryptogram) if payment_method.payment_cryptogram
             xml.tag!('commerceIndicator', ECI_BRAND_MAPPING[brand])
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
           end

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -884,7 +884,7 @@ class CyberSourceTest < Test::Unit::TestCase
   def test_successful_auth_with_network_tokenization_for_mastercard
     @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_xml_valid_to_xsd(request_body)
-      assert_match %r'<ucaf>\n  <authenticationData>111111111100cryptogram</authenticationData>\n  <collectionIndicator>2</collectionIndicator>\n</ucaf>\n<ccAuthService run=\"true\">\n  <commerceIndicator>spa</commerceIndicator>\n</ccAuthService>\n<businessRules>\n</businessRules>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
+      assert_match %r'<ucaf>\n  <authenticationData>111111111100cryptogram</authenticationData>\n  <collectionIndicator>2</collectionIndicator>\n</ucaf>\n<ccAuthService run=\"true\">\n  <networkTokenCryptogram>111111111100cryptogram</networkTokenCryptogram>\n  <commerceIndicator>spa</commerceIndicator>\n</ccAuthService>\n<businessRules>\n</businessRules>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
       true
     end.returns(successful_purchase_response)
 


### PR DESCRIPTION
See
- https://developer.cybersource.com/docs/cybs/en-us/payments/developer/cielo/so/payments/payments-processing-basic-intro/pnt-auth-intro.html

Schema:
- https://developer.cybersource.com/library/documentation/dev_guides/Simple_Order_API_Clients/html/Topics/Using_XML1.htm
- https://ics2ws.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.211.xsd