### PR TITLE
CyberSource: include `paymentSolution` for ApplePay and GooglePay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Adyen: Add additional data for airline and lodging [javierpedrozaing] #4815
 * MIT: Changed how the payload was sent to the gateway [alejandrofloresm] #4655
 * SafeCharge: Add unreferenced_refund field [yunnydang] #4831
+* CyberSource: include `paymentSolution` for ApplePay and GooglePay [bbraschi] #4835
 
 == Version 1.131.0 (June 21, 2023)
 * Redsys: Add supported countries [jcreiff] #4811

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -132,6 +132,11 @@ module ActiveMerchant #:nodoc:
         r703: 'Export hostname_country/ip_country match'
       }
 
+      @@payment_solution = {
+        apple_pay: '001',
+        google_pay: '012'
+      }
+
       # These are the options that can be used when creating a new CyberSource
       # Gateway object.
       #
@@ -322,6 +327,7 @@ module ActiveMerchant #:nodoc:
         add_airline_data(xml, options)
         add_sales_slip_number(xml, options)
         add_payment_network_token(xml) if network_tokenization?(creditcard_or_reference)
+        add_payment_solution(xml, creditcard_or_reference.source) if network_tokenization?(creditcard_or_reference)
         add_tax_management_indicator(xml, options)
         add_stored_credential_subsequent_auth(xml, options)
         add_issuer_additional_data(xml, options)
@@ -393,6 +399,7 @@ module ActiveMerchant #:nodoc:
           add_airline_data(xml, options)
           add_sales_slip_number(xml, options)
           add_payment_network_token(xml) if network_tokenization?(payment_method_or_reference)
+          add_payment_solution(xml, payment_method_or_reference.source) if network_tokenization?(payment_method_or_reference)
           add_tax_management_indicator(xml, options)
           add_stored_credential_subsequent_auth(xml, options)
           add_issuer_additional_data(xml, options)
@@ -668,6 +675,12 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'enabled', options[:decision_manager_enabled] if options[:decision_manager_enabled]
           xml.tag! 'profile', options[:decision_manager_profile] if options[:decision_manager_profile]
         end
+      end
+
+      def add_payment_solution(xml, source)
+        return unless (payment_solution = @@payment_solution[source])
+
+        xml.tag! 'paymentSolution', payment_solution
       end
 
       def add_issuer_additional_data(xml, options)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -214,6 +214,22 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_purchase_with_apple_pay_includes_payment_solution_001
+    stub_comms do
+      @gateway.purchase(100, network_tokenization_credit_card('4242424242424242', source: :apple_pay))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<paymentSolution>001<\/paymentSolution>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_purchase_with_google_pay_includes_payment_solution_012
+    stub_comms do
+      @gateway.purchase(100, network_tokenization_credit_card('4242424242424242', source: :google_pay))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<paymentSolution>012<\/paymentSolution>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_purchase_includes_tax_management_indicator
     stub_comms do
       @gateway.purchase(100, @credit_card, tax_management_indicator: 3)
@@ -277,6 +293,22 @@ class CyberSourceTest < Test::Unit::TestCase
       @gateway.authorize(100, @credit_card, customer_id: '5afefb801188d70023b7debb')
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<customerID>5afefb801188d70023b7debb<\/customerID>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_authorize_with_apple_pay_includes_payment_solution_001
+    stub_comms do
+      @gateway.authorize(100, network_tokenization_credit_card('4242424242424242', source: :apple_pay))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<paymentSolution>001<\/paymentSolution>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_authorize_with_google_pay_includes_payment_solution_012
+    stub_comms do
+      @gateway.authorize(100, network_tokenization_credit_card('4242424242424242', source: :google_pay))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<paymentSolution>012<\/paymentSolution>/, data)
     end.respond_with(successful_authorization_response)
   end
 


### PR DESCRIPTION
This PR adds `paymentSolution` to the purchase and authorization request when the payment is using network tokenization with Apple Pay and Google Pay, as per 
- https://developer.cybersource.com/content/dam/docs/cybs/en-us/apple-pay/developer/fdiglobal/rest/applepay.pdf
- https://developer.cybersource.com/content/dam/docs/cybs/en-us/google-pay/developer/fdiglobal/rest/googlepay.pdf

Schema:
- https://developer.cybersource.com/library/documentation/dev_guides/Simple_Order_API_Clients/html/Topics/Using_XML1.htm
- https://ics2ws.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.211.xsd

#### Unit tests
```
bundle exec rake test:units TEST=test/unit/gateways/cyber_source_test.rb

136 tests, 640 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

#### Remote tests
Same outcome on `master` and on the PR's branch
```
bundle exec rake test:remote TEST=test/remote/gateways/remote_cyber_source_test.rb

121 tests, 506 assertions, 36 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
70.2479% passed
```
