### PR TITLE
Rapyd: Add customer object and fix tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Paysafe: Truncate address fields [jcreiff] #4841
 * Braintree: Support third party Network Tokens [aenand] #4775
 * Kushki: Fix add amount default method for subtotalIva and subtotalIva0 [yunnydang] #4845
+* Rapyd: Add customer object to requests [aenand] #4838
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -41,13 +41,6 @@ class RapydTest < Test::Unit::TestCase
     @ewallet_id = 'ewallet_1a867a32b47158b30a8c17d42f12f3f1'
 
     @address_object = address(line_1: '123 State Street', line_2: 'Apt. 34', phone_number: '12125559999')
-
-    @customer_object = {
-      name: 'John Doe',
-      phone_number: '1234567890',
-      email: 'est@example.com',
-      addresses: [@address_object]
-    }
   end
 
   def test_successful_purchase
@@ -227,14 +220,13 @@ class RapydTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_customer_object
     stub_comms(@gateway, :ssl_request) do
-      @options[:customer] = @customer_object
       @options[:pm_type] = 'us_debit_mastercard_card'
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
       assert_match(/"name":"Jim Reynolds"/, data)
       assert_match(/"email":"test@example.com"/, data)
       assert_match(/"phone_number":"5555555555"/, data)
-      assert_match(/"address1":"456 My Street","address2":"Apt 1","company":"Widgets Inc","city":"Ottawa","state":"ON","zip":"K1C2N6","country":"CA"/, data)
+      assert_match(/"customer":/, data)
     end
   end
 


### PR DESCRIPTION
The Rapyd gateway requires the Customer object on multiple payment types now and is optional on all. This commit adds teh customer subhash to requests and updates the remote tests to pass

Remote:
32 tests, 76 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 78.125% passed