### PR TITLE
Paysafe: Map order_id to merchantRefNum

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Paysafe: Map order_id to merchantRefNum [jcreiff] #4839
 
 == Version 1.133.0 (July 20, 2023)
 * CyberSource: remove credentials from tests [bbraschi] #4836

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -401,7 +401,7 @@ module ActiveMerchant #:nodoc:
       def post_data(parameters = {}, options = {})
         return unless parameters.present?
 
-        parameters[:merchantRefNum] = options[:merchant_ref_num] || SecureRandom.hex(16).to_s
+        parameters[:merchantRefNum] = options[:merchant_ref_num] || options[:order_id] || SecureRandom.hex(16).to_s
 
         parameters.to_json
       end

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -243,6 +243,26 @@ class PaysafeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_merchant_ref_num_and_order_id
+    options = @options.merge({ order_id: '12345678' })
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"merchantRefNum":"12345678"/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    options = @options.merge({ order_id: '12345678', merchant_ref_num: '87654321' })
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"merchantRefNum":"87654321"/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
If options[:merchant_ref_num] is not supplied, options[:order_id] will be used as the fallback value

CER-683

LOCAL
5559 tests, 77691 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

760 files inspected, no offenses detected

UNIT
18 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

REMOTE
33 tests, 82 assertions, 8 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 75.7576% passed

Note: the failing tests also occur on the master branch and seem to be related to assertions that involve a token stored at the gateway that is now linked to a card with an invalid expiration date