### PR TITLE
CYBS: Recurring NT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * IPG: Change credentials inputs to use a combined store and user ID string as the user ID input [kylene-spreedly] #4854
 * Braintree Blue: Update the credit card details transaction hash [yunnydang] #4865
 * VisaNet Peru: Update generate_purchase_number_stamp [almalee24] #4855
+* Cybersource: Support recurring transactions for NT [aenand] #4840
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -740,6 +740,38 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(auth)
   end
 
+  def test_purchase_with_apple_pay_network_tokenization_visa_subsequent_auth
+    credit_card = network_tokenization_credit_card('4111111111111111',
+                                                   brand: 'visa',
+                                                   eci: '05',
+                                                   source: :apple_pay,
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+    @options[:stored_credential] = {
+      initiator: 'merchant',
+      reason_type: 'unscheduled',
+      network_transaction_id: '016150703802094'
+    }
+
+    assert auth = @gateway.purchase(@amount, credit_card, @options)
+    assert_successful_response(auth)
+  end
+
+  def test_purchase_with_apple_pay_network_tokenization_mastercard_subsequent_auth
+    credit_card = network_tokenization_credit_card('5555555555554444',
+                                                   brand: 'master',
+                                                   eci: '05',
+                                                   source: :apple_pay,
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+    @options[:stored_credential] = {
+      initiator: 'merchant',
+      reason_type: 'unscheduled',
+      network_transaction_id: '0602MCC603474'
+    }
+
+    assert auth = @gateway.purchase(@amount, credit_card, @options)
+    assert_successful_response(auth)
+  end
+
   def test_successful_authorize_with_mdd_fields
     (1..20).each { |e| @options["mdd_field_#{e}".to_sym] = "value #{e}" }
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -478,6 +478,53 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_network_token_purchase_subsequent_auth_visa
+    @gateway.expects(:ssl_post).with do |_host, request_body|
+      assert_not_match %r'<cavv>', request_body
+      assert_not_match %r'<xid>', request_body
+      assert_match %r'<commerceIndicator>internet</commerceIndicator>', request_body
+      true
+    end.returns(successful_purchase_response)
+
+    credit_card = network_tokenization_credit_card('4111111111111111',
+                                                   brand: 'visa',
+                                                   transaction_id: '123',
+                                                   eci: '05',
+                                                   payment_cryptogram: '111111111100cryptogram')
+    options = @options.merge({
+      stored_credential: {
+        initiator: 'merchant',
+        reason_type: 'unscheduled',
+        network_transaction_id: '016150703802094'
+      }
+    })
+    assert response = @gateway.purchase(@amount, credit_card, options)
+    assert_success response
+  end
+
+  def test_successful_network_token_purchase_subsequent_auth_mastercard
+    @gateway.expects(:ssl_post).with do |_host, request_body|
+      assert_not_match %r'<authenticationData>', request_body
+      assert_match %r'<commerceIndicator>internet</commerceIndicator>', request_body
+      true
+    end.returns(successful_purchase_response)
+
+    credit_card = network_tokenization_credit_card('5555555555554444',
+                                                   brand: 'master',
+                                                   transaction_id: '123',
+                                                   eci: '05',
+                                                   payment_cryptogram: '111111111100cryptogram')
+    options = @options.merge({
+      stored_credential: {
+        initiator: 'merchant',
+        reason_type: 'unscheduled',
+        network_transaction_id: '016150703802094'
+      }
+    })
+    assert response = @gateway.purchase(@amount, credit_card, options)
+    assert_success response
+  end
+
   def test_successful_reference_purchase
     @gateway.stubs(:ssl_post).returns(successful_create_subscription_response, successful_purchase_response)
 


### PR DESCRIPTION
Cybersource's legacy gateway supports recurring transactions for Network Tokens. The way
to accomplish this is to not send the `cryptogram` since that is one time use and mark the
`commerce_indicator` as `internet`.

Remote:
123 tests, 619 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.935% passed
5 tests failing on master