### PR TITLE
Paysafe: Truncate address fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * PaymentExpress: Correct endpoints [steveh] #4827
 * Adyen: Add option to elect which error message [aenand] #4843
 * Reach: Update list of supported countries [jcreiff] #4842
+* Paysafe: Truncate address fields [jcreiff] #4841
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -124,12 +124,13 @@ module ActiveMerchant #:nodoc:
         return unless address = options[:billing_address] || options[:address]
 
         post[:billingDetails] = {}
-        post[:billingDetails][:street] = address[:address1]
-        post[:billingDetails][:city] = address[:city]
-        post[:billingDetails][:state] = address[:state]
+        post[:billingDetails][:street] = truncate(address[:address1], 50)
+        post[:billingDetails][:street2] = truncate(address[:address2], 50)
+        post[:billingDetails][:city] = truncate(address[:city], 40)
+        post[:billingDetails][:state] = truncate(address[:state], 40)
         post[:billingDetails][:country] = address[:country]
-        post[:billingDetails][:zip] = address[:zip]
-        post[:billingDetails][:phone] = address[:phone]
+        post[:billingDetails][:zip] = truncate(address[:zip], 10)
+        post[:billingDetails][:phone] = truncate(address[:phone], 40)
       end
 
       # The add_address_for_vaulting method is applicable to the store method, as the APIs address
@@ -138,12 +139,12 @@ module ActiveMerchant #:nodoc:
         return unless address = options[:billing_address] || options[:address]
 
         post[:card][:billingAddress] = {}
-        post[:card][:billingAddress][:street] = address[:address1]
-        post[:card][:billingAddress][:street2] = address[:address2]
-        post[:card][:billingAddress][:city] = address[:city]
-        post[:card][:billingAddress][:zip] = address[:zip]
+        post[:card][:billingAddress][:street] = truncate(address[:address1], 50)
+        post[:card][:billingAddress][:street2] = truncate(address[:address2], 50)
+        post[:card][:billingAddress][:city] = truncate(address[:city], 40)
+        post[:card][:billingAddress][:zip] = truncate(address[:zip], 10)
         post[:card][:billingAddress][:country] = address[:country]
-        post[:card][:billingAddress][:state] = address[:state] if address[:state]
+        post[:card][:billingAddress][:state] = truncate(address[:state], 40) if address[:state]
       end
 
       # This data is specific to creating a profile at the gateway's vault level

--- a/test/remote/gateways/remote_paysafe_test.rb
+++ b/test/remote/gateways/remote_paysafe_test.rb
@@ -148,6 +148,20 @@ class RemotePaysafeTest < Test::Unit::TestCase
     assert_equal 'F', response.params['airlineTravelDetails']['tripLegs']['leg2']['serviceClass']
   end
 
+  def test_successful_purchase_with_truncated_address
+    options = {
+      billing_address: {
+        address1: "This is an extremely long address, it is unreasonably long and we can't allow it.",
+        address2: "This is an extremely long address2, it is unreasonably long and we can't allow it.",
+        city: 'Lake Chargoggagoggmanchauggagoggchaubunagungamaugg',
+        state: 'NC',
+        zip: '27701'
+      }
+    }
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+  end
+
   def test_successful_purchase_with_token
     response = @gateway.purchase(200, @pm_token, @options)
     assert_success response


### PR DESCRIPTION
Limits the length of address fields, according to Paysafe docs

LOCAL
5560 tests, 77697 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

760 files inspected, no offenses detected

UNIT
19 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
34 tests, 83 assertions, 8 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
76.4706% passed

CER-746