### PR TITLE
Adyen: Support raw refusal reason

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 
 == HEAD
 * PaymentExpress: Correct endpoints [steveh] #4827
+* Adyen: Add option to elect which error message [aenand] #4843
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -354,6 +354,15 @@ class AdyenTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failed_authorise_mastercard_raw_error_message
+    @gateway.expects(:ssl_post).returns(failed_authorize_mastercard_response)
+
+    response = @gateway.send(:commit, 'authorise', {}, { raw_error_message: true })
+
+    assert_equal 'Refused | 01: Refer to card issuer', response.message
+    assert_failure response
+  end
+
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
     response = @gateway.capture(@amount, '7914775043909934')


### PR DESCRIPTION
ECS-3082

A change was made two months ago to provide the MerchantAdviceCode as the error message if available before falling back to the refusalReasonRaw value. Some merchants do not want this change in messaging so this gives them a way to elect which error message they want

Test Summary
Remote:
11 failing tests on master
134 tests, 447 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 91.791% passed