### PR TITLE
Cybersource: Add merchant_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Braintree: Support third party Network Tokens [aenand] #4775
 * Kushki: Fix add amount default method for subtotalIva and subtotalIva0 [yunnydang] #4845
 * Rapyd: Add customer object to requests [aenand] #4838
+* CyberSource: Add merchant_id [almalee24] #4844
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -556,7 +556,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_merchant_data(xml, options)
-        xml.tag! 'merchantID', @options[:login]
+        xml.tag! 'merchantID', options[:merchant_id] || @options[:login]
         xml.tag! 'merchantReferenceCode', options[:order_id] || generate_unique_id
         xml.tag! 'clientLibrary', 'Ruby Active Merchant'
         xml.tag! 'clientLibraryVersion', VERSION

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -330,7 +330,7 @@ module ActiveMerchant #:nodoc:
         add_reconciliation_id(post, options)
         add_sec_code(post, options)
         add_invoice_number(post, options)
-        response = parse(ssl_post(url(action), post.to_json, auth_headers(action, post)))
+        response = parse(ssl_post(url(action), post.to_json, auth_headers(action, options, post)))
         Response.new(
           success_from(response),
           message_from(response),
@@ -396,14 +396,14 @@ module ActiveMerchant #:nodoc:
         Base64.strict_encode64(OpenSSL::HMAC.digest('sha256', decoded_key, payload))
       end
 
-      def auth_headers(action, post, http_method = 'post')
+      def auth_headers(action, options, post, http_method = 'post')
         digest = "SHA-256=#{Digest::SHA256.base64digest(post.to_json)}" if post.present?
         date = Time.now.httpdate
 
         {
           'Accept' => 'application/hal+json;charset=utf-8',
           'Content-Type' => 'application/json;charset=utf-8',
-          'V-C-Merchant-Id' => @options[:merchant_id],
+          'V-C-Merchant-Id' => options[:merchant_id] || @options[:merchant_id],
           'Date' => date,
           'Host' => host,
           'Signature' => get_http_signature(action, digest, http_method, date),

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -204,9 +204,10 @@ class CyberSourceRestTest < Test::Unit::TestCase
 
   def test_authorize_google_pay_master_card
     stub_comms do
-      @gateway.authorize(100, @google_pay_mc, @options)
-    end.check_request do |_endpoint, data, _headers|
+      @gateway.authorize(100, @google_pay_mc, @options.merge(merchant_id: 'MerchantId'))
+    end.check_request do |_endpoint, data, headers|
       request = JSON.parse(data)
+      assert_equal 'MerchantId', headers['V-C-Merchant-Id']
       assert_equal '002', request['paymentInformation']['tokenizedCard']['type']
       assert_equal '1', request['paymentInformation']['tokenizedCard']['transactionType']
       assert_nil request['paymentInformation']['tokenizedCard']['requestorId']

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -66,8 +66,9 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_other_tax_fields
     stub_comms do
-      @gateway.purchase(100, @credit_card, @options.merge(national_tax_indicator: 1, vat_tax_rate: 1.01))
+      @gateway.purchase(100, @credit_card, @options.merge!(national_tax_indicator: 1, vat_tax_rate: 1.01, merchant_id: 'MerchantId'))
     end.check_request do |_endpoint, data, _headers|
+      assert_match(/<merchantID>MerchantId<\/merchantID>/, data)
       assert_match(/<otherTax>\s+<vatTaxRate>1.01<\/vatTaxRate>\s+<nationalTaxIndicator>1<\/nationalTaxIndicator>\s+<\/otherTax>/m, data)
     end.respond_with(successful_purchase_response)
   end


### PR DESCRIPTION
Set the merchantId filed to options[:merchant_id] instead of @options[:login] if available.

Unit: 136 tests, 641 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed