### PR TITLE
SecurionPay:  Enable securionPay API to be used as shift4_v2

### DIFF
--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1286,6 +1286,9 @@ shift4:
   client_guid: YOUR_CLIENT_ID
   auth_token: YOUR_AUTH_TOKEN
 
+shift4_v2:
+  secret_key: pr_test_tXHm9qV9qV9bjIRHcQr9PLPa
+
 # Working credentials, no need to replace
 simetrik:
   client_id: 'wNhJBdrKDk3vTmkQMAWi5zWN7y21adO3'


### PR DESCRIPTION
Description
-------------------------
[SER-653](https://spreedly.atlassian.net/browse/SER-653)
[SER-654](https://spreedly.atlassian.net/browse/SER-654)
[SER-655](https://spreedly.atlassian.net/browse/SER-655)
[SER-661](https://spreedly.atlassian.net/browse/SER-661)
[SER-662](https://spreedly.atlassian.net/browse/SER-662)
[SER-663](https://spreedly.atlassian.net/browse/SER-663)

Shift4 purchased Securion Pay and is now using their API, that's why
this commit enables the basic operations with securionPay to be used as shift4_v2

**Note:** WIP, eventually we'll add stored credentials.

Unit test
-------------------------
Finished in 0.150258 seconds.

34 tests, 191 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

226.28 tests/s, 1271.15 assertions/s

Remote test
-------------------------
Finished in 28.137188 seconds.

30 tests, 103 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

1.07 tests/s, 3.66 assertions/s

Rubocop
-------------------------
760 files inspected, no offenses detected