### PR TITLE
Rapyd: Change nesting of description, statement_descriptor, complete_…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * Global Collect: Add agent numeric code and house number field [yunnydang] #4847
 * Deepstack: Add Deepstack Gateway [khoinguyendeepstack] #4830
 * Braintree: Additional tests for credit transactions [jcreiff] #4848
+* Rapyd: Change nesting of description, statement_descriptor, complete_payment_url, and error_payment_url [jcreiff] #4849
 
 
 == Version 1.134.0 (July 25, 2023)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -225,8 +225,9 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert store.params.dig('data', 'default_payment_method')
 
     # 3DS authorization is required on storing a payment method for future transactions
-    # purchase = @gateway.purchase(100, store.authorization, @options.merge(customer_id: customer_id))
-    # assert_sucess purchase
+    # This test verifies that the card id and customer id are sent with the purchase
+    purchase = @gateway.purchase(100, store.authorization, @options)
+    assert_match(/The request tried to use a card ID, but the cardholder has not completed the 3DS verification process./, purchase.message)
   end
 
   def test_successful_store_and_unstore


### PR DESCRIPTION
…payment_url, and error_payment_url

According to [Rapyd docs](https://docs.rapyd.net/build-with-rapyd/reference/payment#create-payment), `description` and `statement_descriptor` should be at the top level of the request body.

When storing a payment method at Rapyd, the `complete_payment_url` and `error_payment_url` are nested in the `payment_method` object. (See [Rapyd docs](https://docs.rapyd.net/build-with-rapyd/reference/customer#create-customer) for "Create customer with payment method".) On other operations, these fields appear at the top level of the request.

CER-768

LOCAL
5564 tests, 77726 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

760 files inspected, no offenses detected

UNIT
23 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
31 tests, 88 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed