### PR TITLE
Authorize.NET: Update network token method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,7 @@
 * SafeCharge: Update sg_CreditType field on the credit method [yunnydang] #4918
 * Rapyd: add force_3ds_secure flag [Heavyblade] #4927
 * Beanstream: add alternate option for passing phone number [jcreiff] #4923
+* AuthorizeNet: Update network token method [almalee24] #4852
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -69,7 +69,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_google_pay
     @payment_token.source = :google_pay
-    response = @gateway.purchase(@amount, @payment_token, @options)
+    response = @gateway.purchase(@amount, @payment_token, @options.merge(turn_on_nt_flow: true))
 
     assert_success response
     assert response.test?
@@ -78,6 +78,16 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_apple_pay
+    @payment_token.source = :apple_pay
+    response = @gateway.purchase(@amount, @payment_token, @options.merge(turn_on_nt_flow: true))
+
+    assert_success response
+    assert response.test?
+    assert_equal 'This transaction has been approved', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_apple_pay_without_turn_on_nt_flow_field
     @payment_token.source = :apple_pay
     response = @gateway.purchase(@amount, @payment_token, @options)
 
@@ -903,8 +913,8 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_credit_with_network_tokenization
     credit_card = network_tokenization_credit_card(
-      '4000100011112224',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      '5424000000000015',
+      payment_cryptogram: 'EjRWeJASNFZ4kBI0VniQEjRWeJA=',
       verification_value: nil
     )
 


### PR DESCRIPTION
Update network token payment method to clarify what is being sent.

Remote:
85 tests, 304 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
122 tests, 684 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed