### PR TITLE
CommerceHub: Update headers

### DIFF
--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -282,7 +282,7 @@ module ActiveMerchant #:nodoc:
         raw_signature = @options[:api_key] + client_request_id.to_s + time + request
         hmac = OpenSSL::HMAC.digest('sha256', @options[:api_secret], raw_signature)
         signature = Base64.strict_encode64(hmac.to_s).to_s
-
+        custom_headers = options.fetch(:headers_identifiers, {})
         {
           'Client-Request-Id' => client_request_id,
           'Api-Key' => @options[:api_key],
@@ -292,7 +292,7 @@ module ActiveMerchant #:nodoc:
           'Content-Type' => 'application/json',
           'Accept' => 'application/json',
           'Authorization' => signature
-        }
+        }.merge!(custom_headers)
       end
 
       def add_merchant_details(post)

--- a/test/unit/gateways/commerce_hub_test.rb
+++ b/test/unit/gateways/commerce_hub_test.rb
@@ -42,6 +42,30 @@ class CommerceHubTest < Test::Unit::TestCase
     @post = {}
   end
 
+  def test_successful_authorize_with_full_headers
+    @options.merge!(
+      headers_identifiers: {
+        'x-originator' => 'CommerceHub-Partners-Spreedly',
+        'user-agent' => 'CommerceHub-Partners-Spreedly-V1.00'
+      }
+    )
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, _data, headers|
+      assert_not_nil headers['Client-Request-Id']
+      assert_equal 'login', headers['Api-Key']
+      assert_not_nil headers['Timestamp']
+      assert_equal 'application/json', headers['Accept-Language']
+      assert_equal 'application/json', headers['Content-Type']
+      assert_equal 'application/json', headers['Accept']
+      assert_equal 'HMAC', headers['Auth-Token-Type']
+      assert_not_nil headers['Authorization']
+      assert_equal 'CommerceHub-Partners-Spreedly', headers['x-originator']
+      assert_equal 'CommerceHub-Partners-Spreedly-V1.00', headers['user-agent']
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_successful_purchase
     @options[:order_id] = 'abc123'
 


### PR DESCRIPTION
Description
-------------------------
This commit add new headers identifiers: 'x-originator', 'user-agent'. Additionally include a small test to verify the headers presence.

[SER-621](https://spreedly.atlassian.net/browse/SER-621)

Unit test
-------------------------
Finished in 0.033772 seconds.

25 tests, 175 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

740.26 tests/s, 5181.81 assertions/s

Remote test
-------------------------
Finished in 57.0542 seconds.

26 tests, 62 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 80.7692% passed

0.46 tests/s, 1.09 assertions/s

Rubocop
-------------------------
763 files inspected, no offenses detected