### PR TITLE
IPG: Refactor Credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,7 +17,7 @@
 * Rapyd: Add merchant_reference_id [jcreiff] #4858
 * Braintree: Return error for ACH on credit [jcreiff] #4859
 * Rapyd: Update handling of ewallet and billing address phone [jcreiff] #4863
-
+* IPG: Change credentials inputs to use a combined store and user ID string as the user ID input [kylene-spreedly] #4854
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/lib/active_merchant/billing/gateways/ipg.rb
+++ b/lib/active_merchant/billing/gateways/ipg.rb
@@ -18,8 +18,8 @@ module ActiveMerchant #:nodoc:
       ACTION_REQUEST_ITEMS = %w(vault unstore)
 
       def initialize(options = {})
-        requires!(options, :store_id, :user_id, :password, :pem, :pem_password)
-        @credentials = options
+        requires!(options, :user_id, :password, :pem, :pem_password)
+        @credentials = options.merge(store_and_user_id_from(options[:user_id]))
         @hosted_data_id = nil
         super
       end
@@ -393,6 +393,11 @@ module ActiveMerchant #:nodoc:
           reply["#{parent}#{node.name}".to_sym] ||= node.text
         end
         return reply
+      end
+
+      def store_and_user_id_from(user_id)
+        split_credentials = user_id.split('._.')
+        { store_id: split_credentials[0].sub(/^WS/, ''), user_id: split_credentials[1] }
       end
 
       def message_from(response)

--- a/test/unit/gateways/ipg_test.rb
+++ b/test/unit/gateways/ipg_test.rb
@@ -332,6 +332,38 @@ class IpgTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_store_and_user_id_from_with_complete_credentials
+    test_combined_user_id = 'WS5921102002._.1'
+    split_credentials = @gateway.send(:store_and_user_id_from, test_combined_user_id)
+
+    assert_equal '5921102002', split_credentials[:store_id]
+    assert_equal '1', split_credentials[:user_id]
+  end
+
+  def test_store_and_user_id_from_missing_store_id_prefix
+    test_combined_user_id = '5921102002._.1'
+    split_credentials = @gateway.send(:store_and_user_id_from, test_combined_user_id)
+
+    assert_equal '5921102002', split_credentials[:store_id]
+    assert_equal '1', split_credentials[:user_id]
+  end
+
+  def test_store_and_user_id_misplaced_store_id_prefix
+    test_combined_user_id = '5921102002WS._.1'
+    split_credentials = @gateway.send(:store_and_user_id_from, test_combined_user_id)
+
+    assert_equal '5921102002WS', split_credentials[:store_id]
+    assert_equal '1', split_credentials[:user_id]
+  end
+
+  def test_store_and_user_id_from_missing_delimiter
+    test_combined_user_id = 'WS59211020021'
+    split_credentials = @gateway.send(:store_and_user_id_from, test_combined_user_id)
+
+    assert_equal '59211020021', split_credentials[:store_id]
+    assert_equal nil, split_credentials[:user_id]
+  end
+
   def test_message_from_just_with_transaction_result
     am_response = { TransactionResult: 'success !' }
     assert_equal 'success !', @gateway.send(:message_from, am_response)


### PR DESCRIPTION
Refactor IPG credentials to accept a combined user ID/store ID string since this is what is provided to IPG merchants as their user ID.

ECS-2839

Unit: 31 tests, 135 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications, 100% passed

Remote: 18 tests, 42 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications, 66.6667% passed