### PR TITLE
VisaNet Peru: Update generate_purchase_number_stamp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Rapyd: Update handling of ewallet and billing address phone [jcreiff] #4863
 * IPG: Change credentials inputs to use a combined store and user ID string as the user ID input [kylene-spreedly] #4854
 * Braintree Blue: Update the credit card details transaction hash [yunnydang] #4865
+* VisaNet Peru: Update generate_purchase_number_stamp [almalee24] #4855
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :test, :remote_test do
   gem 'jose', '~> 1.1.3'
   gem 'jwe'
   gem 'mechanize'
+  gem 'timecop'
 end

--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -143,7 +143,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def generate_purchase_number_stamp
-        Time.now.to_f.to_s.delete('.')[1..10] + rand(99).to_s
+        rand(('9' * 12).to_i).to_s.center(12, rand(9).to_s)
       end
 
       def commit(action, params, options = {})


### PR DESCRIPTION
Update generate_purchase_number_stamp to always produce unique 12-digit alphanumberic value even if multiple transactions occur at the same time.

Unit:
16 tests, 100 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed