### PR TITLE
Realex: updated and separate live and test gateway URLs

### DIFF
--- a/lib/active_merchant/billing/gateways/realex.rb
+++ b/lib/active_merchant/billing/gateways/realex.rb
@@ -19,7 +19,9 @@ module ActiveMerchant
     # so if validation fails you can not correct and resend using the
     # same order id
     class RealexGateway < Gateway
-      self.live_url = self.test_url = 'https://epage.payandshop.com/epage-remote.cgi'
+      # See https://developer.globalpay.com/api/getting-started for API URLs
+      self.live_url = 'https://api.realexpayments.com/epage-remote.cgi'
+      self.test_url = 'https://api.sandbox.realexpayments.com/epage-remote.cgi'
 
       CARD_MAPPING = {
         'master'            => 'MC',
@@ -101,7 +103,7 @@ module ActiveMerchant
       private
 
       def commit(request)
-        response = parse(ssl_post(self.live_url, request))
+        response = parse(ssl_post(test? ? self.test_url : self.live_url, request))
 
         Response.new(
           (response[:result] == '00'),


### PR DESCRIPTION
Realex changed their domain names for their API quite some time ago, and while the old one still works for the live gateway, they also now have a separate test gateway, which we discovered by our tests suddenly breaking. After speaking with their support, and testing this fix in our own app, this seems to fix the issue. 