### PR TITLE
Rapyd: Add merchant_reference_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 * Deepstack: Add Deepstack Gateway [khoinguyendeepstack] #4830
 * Braintree: Additional tests for credit transactions [jcreiff] #4848
 * Rapyd: Change nesting of description, statement_descriptor, complete_payment_url, and error_payment_url [jcreiff] #4849
+* Rapyd: Add merchant_reference_id [jcreiff] #4858
 
 
 == Version 1.134.0 (July 25, 2023)

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -127,6 +127,7 @@ module ActiveMerchant #:nodoc:
       def add_invoice(post, money, options)
         post[:amount] = money.zero? ? 0 : amount(money).to_f.to_s
         post[:currency] = (options[:currency] || currency(money))
+        post[:merchant_reference_id] = options[:merchant_reference_id] || options[:order_id]
       end
 
       def add_payment(post, payment, options)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -16,7 +16,8 @@ class RemoteRapydTest < Test::Unit::TestCase
       description: 'Describe this transaction',
       statement_descriptor: 'Statement Descriptor',
       email: 'test@example.com',
-      billing_address: address(name: 'Jim Reynolds')
+      billing_address: address(name: 'Jim Reynolds'),
+      order_id: '987654321'
     }
     @ach_options = {
       pm_type: 'us_ach_bank',

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -18,7 +18,8 @@ class RapydTest < Test::Unit::TestCase
       description: 'Describe this transaction',
       statement_descriptor: 'Statement Descriptor',
       email: 'test@example.com',
-      billing_address: address(name: 'Jim Reynolds')
+      billing_address: address(name: 'Jim Reynolds'),
+      order_id: '987654321'
     }
 
     @metadata = {
@@ -87,6 +88,21 @@ class RapydTest < Test::Unit::TestCase
       assert_match(/"error_payment_url":"www.google.com"/, data)
       assert_match(/"description":"Describe this transaction"/, data)
       assert_match(/"statement_descriptor":"Statement Descriptor"/, data)
+      assert_match(/"merchant_reference_id":"987654321"/, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+  end
+
+  def test_successful_purchase_with_explicit_merchant_reference_id
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({ merchant_reference_id: '99988877776' }))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"complete_payment_url":"www.google.com"/, data)
+      assert_match(/"error_payment_url":"www.google.com"/, data)
+      assert_match(/"description":"Describe this transaction"/, data)
+      assert_match(/"statement_descriptor":"Statement Descriptor"/, data)
+      assert_match(/"merchant_reference_id":"99988877776"/, data)
     end.respond_with(successful_authorize_response)
 
     assert_success response


### PR DESCRIPTION
This maps order_id to the merchant_reference_id field at Rapyd

CER-831

LOCAL
5580 tests, 77776 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

763 files inspected, no offenses detected

UNIT
24 tests, 120 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
31 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed