### PR TITLE
Braintree: Add check for ACH on credit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Braintree: Additional tests for credit transactions [jcreiff] #4848
 * Rapyd: Change nesting of description, statement_descriptor, complete_payment_url, and error_payment_url [jcreiff] #4849
 * Rapyd: Add merchant_reference_id [jcreiff] #4858
+* Braintree: Return error for ACH on credit [jcreiff] #4859
 
 
 == Version 1.134.0 (July 25, 2023)

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -106,6 +106,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def credit(money, credit_card_or_vault_id, options = {})
+        return Response.new(false, DIRECT_BANK_ERROR) if credit_card_or_vault_id.is_a? Check
+
         create_transaction(:credit, money, credit_card_or_vault_id, options)
       end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1368,6 +1368,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'Direct bank account transactions are not supported. Bank accounts must be successfully stored before use.', response.message
   end
 
+  def test_returns_error_on_general_credit_when_passing_a_bank_account
+    bank_account = check({ account_number: '1000000002', routing_number: '011000015' })
+    response = @gateway.credit(100, bank_account, {})
+
+    assert_failure response
+    assert_equal 'Direct bank account transactions are not supported. Bank accounts must be successfully stored before use.', response.message
+  end
+
   def test_error_on_store_bank_account_without_a_mandate
     options = {
       billing_address: {


### PR DESCRIPTION
Return DIRECT_BANK_ERROR message if credit is attempted using a check

CER-790

LOCAL
5581 tests, 77777 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

763 files inspected, no offenses detected

UNIT
95 tests, 209 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
105 tests, 559 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed