### PR TITLE
Shift4_v2: Inherit securionPay API to enable Shift4v2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -223,16 +223,28 @@ module ActiveMerchant #:nodoc:
         end
 
         response = api_request(url, parameters, options, method)
-        success = !response.key?('error')
+        success = success?(response)
 
         Response.new(
           success,
           (success ? 'Transaction approved' : response['error']['message']),
           response,
           test: test?,
-          authorization: (success ? response['id'] : response['error']['charge']),
+          authorization: authorization_from(url, response),
           error_code: (success ? nil : STANDARD_ERROR_CODE_MAPPING[response['error']['code']])
         )
+      end
+
+      def authorization_from(action, response)
+        if action == 'customers' && success?(response) && response['cards'].present?
+          response['cards'].first['id']
+        else
+          success?(response) ? response['id'] : response['error']['charge']
+        end
+      end
+
+      def success?(response)
+        !response.key?('error')
       end
 
       def headers(options = {})
@@ -289,8 +301,8 @@ module ActiveMerchant #:nodoc:
         response
       end
 
-      def json_error(raw_response)
-        msg = 'Invalid response received from the SecurionPay API.'
+      def json_error(raw_response, gateway_name = 'SecurionPay')
+        msg = "Invalid response received from the #{gateway_name} API."
         msg += "  (The raw response returned by the API was #{raw_response.inspect})"
         {
           'error' => {

--- a/lib/active_merchant/billing/gateways/shift4_v2.rb
+++ b/lib/active_merchant/billing/gateways/shift4_v2.rb
@@ -1,0 +1,53 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class Shift4V2Gateway < SecurionPayGateway
+      # same endpont for testing
+      self.live_url = 'https://api.shift4.com/'
+      self.display_name = 'Shift4'
+      self.homepage_url = 'https://dev.shift4.com/us/'
+
+      def credit(money, payment, options = {})
+        post = create_post_for_auth_or_purchase(money, payment, options)
+        commit('credits', post, options)
+      end
+
+      def create_post_for_auth_or_purchase(money, payment, options)
+        super.tap do |post|
+          add_stored_credentials(post, options)
+        end
+      end
+
+      def add_stored_credentials(post, options)
+        return unless options[:stored_credential].present?
+
+        initiator = options.dig(:stored_credential, :initiator)
+        reason_type = options.dig(:stored_credential, :reason_type)
+
+        post_type = {
+          %w[cardholder recurring] => 'first_recurring',
+          %w[merchant recurring] => 'subsequent_recurring',
+          %w[cardholder unscheduled] => 'customer_initiated',
+          %w[merchant installment] => 'merchant_initiated'
+        }[[initiator, reason_type]]
+        post[:type] = post_type if post_type
+      end
+
+      def headers(options = {})
+        super.tap do |headers|
+          headers['User-Agent'] = "Shift4/v2 ActiveMerchantBindings/#{ActiveMerchant::VERSION}"
+        end
+      end
+
+      def scrub(transcript)
+        super.
+          gsub(%r((card\[expMonth\]=)\d+), '\1[FILTERED]').
+          gsub(%r((card\[expYear\]=)\d+), '\1[FILTERED]').
+          gsub(%r((card\[cardholderName\]=)\w+[^ ]\w+), '\1[FILTERED]')
+      end
+
+      def json_error(raw_response)
+        super(raw_response, 'Shift4 V2')
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1291,6 +1291,9 @@ shift4:
   client_guid: YOUR_CLIENT_ID
   auth_token: YOUR_AUTH_TOKEN
 
+shift4_v2:
+  secret_key: pr_test_xxxxxxxxx
+
 # Working credentials, no need to replace
 simetrik:
   client_id: 'wNhJBdrKDk3vTmkQMAWi5zWN7y21adO3'

--- a/test/remote/gateways/remote_securion_pay_test.rb
+++ b/test/remote/gateways/remote_securion_pay_test.rb
@@ -20,15 +20,28 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
     }
   end
 
-  def test_successful_store
+  def test_successful_store_and_purchase
     response = @gateway.store(@credit_card, @options)
     assert_success response
-    assert_match %r(^cust_\w+$), response.authorization
     assert_equal 'customer', response.params['objectType']
     assert_match %r(^card_\w+$), response.params['cards'][0]['id']
     assert_equal 'card', response.params['cards'][0]['objectType']
 
-    @options[:customer_id] = response.authorization
+    @options[:customer_id] = response.params['cards'][0]['customerId']
+
+    response = @gateway.purchase(@amount, response.authorization, @options)
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal 'customer', response.params['objectType']
+    assert_match %r(^card_\w+$), response.params['cards'][0]['id']
+    assert_equal 'card', response.params['cards'][0]['objectType']
+
+    @options[:customer_id] = response.params['cards'][0]['customerId']
     response = @gateway.store(@new_credit_card, @options)
     assert_success response
     assert_match %r(^card_\w+$), response.params['card']['id']
@@ -42,11 +55,6 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
     assert_equal '424242', response.params['cards'][1]['first6']
     assert_equal '4242', response.params['cards'][1]['last4']
   end
-
-  # def test_dump_transcript
-  #   skip("Transcript scrubbing for this gateway has been tested.")
-  #   dump_transcript_and_fail(@gateway, @amount, @credit_card, @options)
-  # end
 
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
@@ -81,7 +89,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_match %r{The card was declined for other reason.}, response.message
+    assert_match %r{The card was declined}, response.message
     assert_match Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
   end
 
@@ -104,7 +112,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
   def test_failed_capture
     response = @gateway.capture(@amount, 'invalid_authorization_token')
     assert_failure response
-    assert_match %r{Requested Charge does not exist}, response.message
+    assert_match %r{Charge 'invalid_authorization_token' does not exist}, response.message
   end
 
   def test_successful_full_refund
@@ -116,7 +124,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
     assert_success refund
 
     assert refund.params['refunded']
-    assert_equal 0, refund.params['amount']
+    assert_equal 2000, refund.params['refunds'].first['amount']
     assert_equal 1, refund.params['refunds'].size
     assert_equal @amount, refund.params['refunds'].map { |r| r['amount'] }.sum
 
@@ -130,6 +138,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
 
     first_refund = @gateway.refund(@refund_amount, purchase.authorization)
     assert_success first_refund
+    assert_equal @refund_amount, first_refund.params['refunds'].first['amount']
 
     second_refund = @gateway.refund(@refund_amount, purchase.authorization)
     assert_success second_refund
@@ -143,7 +152,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
   def test_unsuccessful_authorize_refund
     response = @gateway.refund(@amount, 'invalid_authorization_token')
     assert_failure response
-    assert_match %r{Requested Charge does not exist}, response.message
+    assert_match %r{Charge 'invalid_authorization_token' does not exist}, response.message
   end
 
   def test_unsuccessful_refund
@@ -173,7 +182,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void('invalid_authorization_token', @options)
     assert_failure response
-    assert_match %r{Requested Charge does not exist}, response.message
+    assert_match %r{Charge 'invalid_authorization_token' does not exist}, response.message
   end
 
   def test_successful_verify
@@ -185,7 +194,7 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_match %r{The card was declined for other reason.}, response.message
+    assert_match %r{The card was declined}, response.message
     assert_match Gateway::STANDARD_ERROR_CODE[:card_declined], response.primary_response.error_code
   end
 

--- a/test/remote/gateways/remote_shift4_v2_test.rb
+++ b/test/remote/gateways/remote_shift4_v2_test.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+require_relative 'remote_securion_pay_test'
+
+class RemoteShift4V2Test < RemoteSecurionPayTest
+  def setup
+    super
+    @gateway = Shift4V2Gateway.new(fixtures(:shift4_v2))
+  end
+
+  def test_successful_purchase_third_party_token
+    auth = @gateway.store(@credit_card, @options)
+    token = auth.params['defaultCardId']
+    customer_id = auth.params['id']
+    response = @gateway.purchase(@amount, token, @options.merge!(customer_id: customer_id))
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+    assert_equal 'foo@example.com', response.params['metadata']['email']
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  def test_unsuccessful_purchase_third_party_token
+    auth = @gateway.store(@credit_card, @options)
+    customer_id = auth.params['id']
+    response = @gateway.purchase(@amount, @invalid_token, @options.merge!(customer_id: customer_id))
+    assert_failure response
+    assert_equal "Token 'tok_invalid' does not exist", response.message
+  end
+
+  def test_successful_stored_credentials_first_recurring
+    stored_credentials = {
+      initiator: 'cardholder',
+      reason_type: 'recurring'
+    }
+    @options.merge!(stored_credential: stored_credentials)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+    assert_equal 'first_recurring', response.params['type']
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  def test_successful_stored_credentials_subsequent_recurring
+    stored_credentials = {
+      initiator: 'merchant',
+      reason_type: 'recurring'
+    }
+    @options.merge!(stored_credential: stored_credentials)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+    assert_equal 'subsequent_recurring', response.params['type']
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  def test_successful_stored_credentials_customer_initiated
+    stored_credentials = {
+      initiator: 'cardholder',
+      reason_type: 'unscheduled'
+    }
+    @options.merge!(stored_credential: stored_credentials)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+    assert_equal 'customer_initiated', response.params['type']
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+
+  def test_successful_stored_credentials_merchant_initiated
+    stored_credentials = {
+      initiator: 'merchant',
+      reason_type: 'installment'
+    }
+    @options.merge!(stored_credential: stored_credentials)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+    assert_equal 'merchant_initiated', response.params['type']
+    assert_match CHARGE_ID_REGEX, response.authorization
+  end
+end

--- a/test/unit/gateways/securion_pay_test.rb
+++ b/test/unit/gateways/securion_pay_test.rb
@@ -36,7 +36,6 @@ class SecurionPayTest < Test::Unit::TestCase
 
     response = @gateway.store(@credit_card, @options)
     assert_success response
-    assert_match %r(^cust_\w+$), response.authorization
     assert_equal 'customer', response.params['objectType']
     assert_match %r(^card_\w+$), response.params['cards'][0]['id']
     assert_equal 'card', response.params['cards'][0]['objectType']
@@ -44,7 +43,8 @@ class SecurionPayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
     @gateway.expects(:ssl_post).returns(successful_void_response)
 
-    @options[:customer_id] = response.authorization
+    @options[:customer_id] = response.params['cards'][0]['customerId']
+
     response = @gateway.store(@new_credit_card, @options)
     assert_success response
     assert_match %r(^card_\w+$), response.params['card']['id']

--- a/test/unit/gateways/shift4_v2_test.rb
+++ b/test/unit/gateways/shift4_v2_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+require_relative 'securion_pay_test'
+
+class Shift4V2Test < SecurionPayTest
+  include CommStub
+
+  def setup
+    super
+    @gateway = Shift4V2Gateway.new(
+      secret_key: 'pr_test_random_key'
+    )
+  end
+
+  def test_invalid_raw_response
+    @gateway.expects(:ssl_request).returns(invalid_json_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match(/^Invalid response received from the Shift4 V2 API/, response.message)
+  end
+
+  def test_ensure_does_not_respond_to_credit; end
+
+  private
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      opening connection to api.shift4.com:443...
+      opened
+      starting SSL for api.shift4.com:443...
+      SSL established
+      <- "POST /charges HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic cHJfdGVzdF9xWk40VlZJS0N5U2ZDZVhDQm9ITzlEQmU6\r\nUser-Agent: SecurionPay/v1 ActiveMerchantBindings/1.47.0\r\nAccept-Encoding: gzip;q=0,deflate;q=0.6\r\nAccept: */*\r\nConnection: close\r\nHost: api.shift4.com\r\nContent-Length: 214\r\n\r\n"
+      <- "amount=2000&currency=usd&card[number]=4242424242424242&card[expMonth]=9&card[expYear]=2016&card[cvc]=123&card[cardholderName]=Longbob+Longsen&description=ActiveMerchant+test+charge&metadata[email]=foo%40example.com"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: cloudflare-nginx\r\n"
+      -> "Date: Fri, 12 Jun 2015 21:36:39 GMT\r\n"
+      -> "Content-Type: application/json;charset=UTF-8\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "Set-Cookie: __cfduid=d5da73266c61acce6307176d45e2672b41434144998; expires=Sat, 11-Jun-16 21:36:38 GMT; path=/; domain=.securionpay.com; HttpOnly\r\n"
+      -> "CF-RAY: 1f58b1414ca00af6-WAW\r\n"
+      -> "\r\n"
+      -> "1f4\r\n"
+      reading 500 bytes...
+      -> "{\"id\":\"char_TOnen0ZcDMYzECNS4fItK9P4\",\"created\":1434144998,\"objectType\":\"charge\",\"amount\":2000,\"currency\":\"USD\",\"description\":\"ActiveMerchant test charge\",\"card\":{\"id\":\"card_yJ4JNcp6P4sG8UrtZ62VWb5e\",\"created\":1434144998,\"objectType\":\"card\",\"first6\":\"424242\",\"last4\":\"4242\",\"fingerprint\":\"ecAKhFD1dmDAMKD9\",\"expMonth\":\"9\",\"expYear\":\"2016\",\"cardholderName\":\"Longbob Longsen\",\"brand\":\"Visa\",\"type\":\"Credit Card\"},\"captured\":true,\"refunded\":false,\"disputed\":false,\"metadata\":{\"email\":\"foo@example.com\"}}"
+      read 500 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      opening connection to api.shift4.com:443...
+      opened
+      starting SSL for api.shift4.com:443...
+      SSL established
+      <- "POST /charges HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAuthorization: Basic [FILTERED]\r\nUser-Agent: SecurionPay/v1 ActiveMerchantBindings/1.47.0\r\nAccept-Encoding: gzip;q=0,deflate;q=0.6\r\nAccept: */*\r\nConnection: close\r\nHost: api.shift4.com\r\nContent-Length: 214\r\n\r\n"
+      <- "amount=2000&currency=usd&card[number]=[FILTERED]&card[expMonth]=[FILTERED]&card[expYear]=[FILTERED]&card[cvc]=[FILTERED]&card[cardholderName]=[FILTERED]&description=ActiveMerchant+test+charge&metadata[email]=foo%40example.com"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Server: cloudflare-nginx\r\n"
+      -> "Date: Fri, 12 Jun 2015 21:36:39 GMT\r\n"
+      -> "Content-Type: application/json;charset=UTF-8\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "Set-Cookie: __cfduid=d5da73266c61acce6307176d45e2672b41434144998; expires=Sat, 11-Jun-16 21:36:38 GMT; path=/; domain=.securionpay.com; HttpOnly\r\n"
+      -> "CF-RAY: 1f58b1414ca00af6-WAW\r\n"
+      -> "\r\n"
+      -> "1f4\r\n"
+      reading 500 bytes...
+      -> "{\"id\":\"char_TOnen0ZcDMYzECNS4fItK9P4\",\"created\":1434144998,\"objectType\":\"charge\",\"amount\":2000,\"currency\":\"USD\",\"description\":\"ActiveMerchant test charge\",\"card\":{\"id\":\"card_yJ4JNcp6P4sG8UrtZ62VWb5e\",\"created\":1434144998,\"objectType\":\"card\",\"first6\":\"424242\",\"last4\":\"4242\",\"fingerprint\":\"ecAKhFD1dmDAMKD9\",\"expMonth\":\"9\",\"expYear\":\"2016\",\"cardholderName\":\"Longbob Longsen\",\"brand\":\"Visa\",\"type\":\"Credit Card\"},\"captured\":true,\"refunded\":false,\"disputed\":false,\"metadata\":{\"email\":\"foo@example.com\"}}"
+      read 500 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    POST_SCRUBBED
+  end
+end


### PR DESCRIPTION
[SER-653](https://spreedly.atlassian.net/browse/SER-653)
[SER-654](https://spreedly.atlassian.net/browse/SER-654)
[SER-655](https://spreedly.atlassian.net/browse/SER-655)
[SER-661](https://spreedly.atlassian.net/browse/SER-661)
[SER-662](https://spreedly.atlassian.net/browse/SER-662)
[SER-663](https://spreedly.atlassian.net/browse/SER-663)
    
Shift4 purchased Securion Pay and is now using their API, that's why
this commit enables a new shift4_v2 gateway
    
WIP: Pending to include general credit support

**Unit test**
------------------------------------
Finished in 0.150258 seconds.
34 tests, 191 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
226.28 tests/s, 1271.15 assertions/s

**Remote test**
------------------------------------
Finished in 27.855679 seconds.
33 tests, 116 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

**Rubocop**
------------------------------------
760 files inspected, no offenses detected