### PR TITLE
Checkout: Add support for `sender`, `destination` and `instruction` o…

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -57,12 +57,13 @@ module ActiveMerchant #:nodoc:
 
       def credit(amount, payment, options = {})
         post = {}
-        post[:instruction] = {}
-        post[:instruction][:funds_transfer_type] = options[:funds_transfer_type] || 'FD'
         add_processing_channel(post, options)
         add_invoice(post, amount, options)
         add_payment_method(post, payment, options, :destination)
         add_source(post, options)
+        add_instruction_data(post, options)
+        add_payout_sender_data(post, options)
+        add_payout_destination_data(post, options)
 
         commit(:credit, post, options)
       end
@@ -173,6 +174,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment_method(post, payment_method, options, key = :source)
+        # the key = :destination when this method is called in def credit
         post[key] = {}
         case payment_method
         when NetworkTokenizationCreditCard
@@ -190,13 +192,23 @@ module ActiveMerchant #:nodoc:
           post[key][:type] = 'card'
           post[key][:name] = payment_method.name
           post[key][:number] = payment_method.number
-          post[key][:cvv] = payment_method.verification_value
+          post[key][:cvv] = payment_method.verification_value unless options[:funds_transfer_type]
           post[key][:stored] = 'true' if options[:card_on_file] == true
+
+          # because of the way the key = is implemented in the method signature, some of the destination
+          # data will be added here, some in the destination specific method below.
+          # at first i was going to move this, but since this data is coming from the payment method
+          # i think it makes sense to leave it
           if options[:account_holder_type]
             post[key][:account_holder] = {}
             post[key][:account_holder][:type] = options[:account_holder_type]
-            post[key][:account_holder][:first_name] = payment_method.first_name if payment_method.first_name
-            post[key][:account_holder][:last_name] = payment_method.last_name if payment_method.last_name
+
+            if options[:account_holder_type] == 'corporate' || options[:account_holder_type] == 'government'
+              post[key][:account_holder][:company_name] = payment_method.name if payment_method.respond_to?(:name)
+            else
+              post[key][:account_holder][:first_name] = payment_method.first_name if payment_method.first_name
+              post[key][:account_holder][:last_name] = payment_method.last_name if payment_method.last_name
+            end
           else
             post[key][:first_name] = payment_method.first_name if payment_method.first_name
             post[key][:last_name] = payment_method.last_name if payment_method.last_name
@@ -319,6 +331,81 @@ module ActiveMerchant #:nodoc:
 
       def add_processing_channel(post, options)
         post[:processing_channel_id] = options[:processing_channel_id] if options[:processing_channel_id]
+      end
+
+      def add_instruction_data(post, options)
+        post[:instruction] = {}
+        post[:instruction][:funds_transfer_type] = options[:funds_transfer_type] || 'FD'
+        post[:instruction][:purpose] = options[:instruction_purpose] if options[:instruction_purpose]
+      end
+
+      def add_payout_sender_data(post, options)
+        return unless options[:payout] == true
+
+        post[:sender] = {
+          # options for type are individual, corporate, or government
+          type: options[:sender][:type],
+          # first and last name required if sent by type: individual
+          first_name: options[:sender][:first_name],
+          middle_name: options[:sender][:middle_name],
+          last_name: options[:sender][:last_name],
+          # company name required if sent by type: corporate or government
+          company_name: options[:sender][:company_name],
+          # these are required fields for payout, may not work if address is blank or different than cardholder(option for sender to be a company or government).
+          # may need to still include in GSF hash.
+
+          address: {
+            address_line1: options.dig(:sender, :address, :address1),
+            address_line2: options.dig(:sender, :address, :address2),
+            city: options.dig(:sender, :address, :city),
+            state: options.dig(:sender, :address, :state),
+            country: options.dig(:sender, :address, :country),
+            zip: options.dig(:sender, :address, :zip)
+          }.compact,
+          reference: options[:sender][:reference],
+          reference_type: options[:sender][:reference_type],
+          source_of_funds: options[:sender][:source_of_funds],
+          # identification object is conditional. required when card metadata issuer_country = AR, BR, CO, or PR
+          # checkout docs say PR (Peru), but PR is puerto rico and PE is Peru so yikes
+          identification: {
+            type: options.dig(:sender, :identification, :type),
+            number: options.dig(:sender, :identification, :number),
+            issuing_country: options.dig(:sender, :identification, :issuing_country),
+            date_of_expiry: options.dig(:sender, :identification, :date_of_expiry)
+          }.compact,
+          date_of_birth: options[:sender][:date_of_birth],
+          country_of_birth: options[:sender][:country_of_birth],
+          nationality: options[:sender][:nationality]
+        }.compact
+      end
+
+      def add_payout_destination_data(post, options)
+        return unless options[:payout] == true
+
+        post[:destination] ||= {}
+        post[:destination][:account_holder] ||= {}
+        post[:destination][:account_holder][:email] = options[:destination][:account_holder][:email] if options[:destination][:account_holder][:email]
+        post[:destination][:account_holder][:date_of_birth] = options[:destination][:account_holder][:date_of_birth] if options[:destination][:account_holder][:date_of_birth]
+        post[:destination][:account_holder][:country_of_birth] = options[:destination][:account_holder][:country_of_birth] if options[:destination][:account_holder][:country_of_birth]
+        # below fields only required during a card to card payout
+        post[:destination][:account_holder][:phone] = {}
+        post[:destination][:account_holder][:phone][:country_code] = options.dig(:destination, :account_holder, :phone, :country_code) if options.dig(:destination, :account_holder, :phone, :country_code)
+        post[:destination][:account_holder][:phone][:number] = options.dig(:destination, :account_holder, :phone, :number) if options.dig(:destination, :account_holder, :phone, :number)
+
+        post[:destination][:account_holder][:identification] = {}
+        post[:destination][:account_holder][:identification][:type] = options.dig(:destination, :account_holder, :identification, :type) if options.dig(:destination, :account_holder, :identification, :type)
+        post[:destination][:account_holder][:identification][:number] = options.dig(:destination, :account_holder, :identification, :number) if options.dig(:destination, :account_holder, :identification, :number)
+        post[:destination][:account_holder][:identification][:issuing_country] = options.dig(:destination, :account_holder, :identification, :issuing_country) if options.dig(:destination, :account_holder, :identification, :issuing_country)
+        post[:destination][:account_holder][:identification][:date_of_expiry] = options.dig(:destination, :account_holder, :identification, :date_of_expiry) if options.dig(:destination, :account_holder, :identification, :date_of_expiry)
+
+        address = options[:billing_address] || options[:address] # destination address will come from the tokenized card billing address
+        post[:destination][:account_holder][:billing_address] = {}
+        post[:destination][:account_holder][:billing_address][:address_line1] = address[:address1] unless address[:address1].blank?
+        post[:destination][:account_holder][:billing_address][:address_line2] = address[:address2] unless address[:address2].blank?
+        post[:destination][:account_holder][:billing_address][:city] = address[:city] unless address[:city].blank?
+        post[:destination][:account_holder][:billing_address][:state] = address[:state] unless address[:state].blank?
+        post[:destination][:account_holder][:billing_address][:country] = address[:country] unless address[:country].blank?
+        post[:destination][:account_holder][:billing_address][:zip] = address[:zip] unless address[:zip].blank?
       end
 
       def add_marketplace_data(post, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -116,6 +116,48 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
       phone_country_code: '1',
       phone: '9108675309'
     )
+    @payout_options = @options.merge(
+      source_type: 'currency_account',
+      source_id: 'ca_spwmped4qmqenai7hcghquqle4',
+      funds_transfer_type: 'FD',
+      instruction_purpose: 'leisure',
+      destination: {
+        account_holder: {
+          phone: {
+            number: '9108675309',
+            country_code: '1'
+          },
+          identification: {
+            type: 'passport',
+            number: '12345788848438'
+          }
+        }
+      },
+      currency: 'GBP',
+      sender: {
+        type: 'individual',
+        first_name: 'Jane',
+        middle_name: 'Middle',
+        last_name: 'Doe',
+        address: {
+          address1: '123 Main St',
+          address2: 'Apt G',
+          city: 'Narnia',
+          state: 'ME',
+          zip: '12345',
+          country: 'US'
+        },
+        reference: '012345',
+        reference_type: 'other',
+        source_of_funds: 'debit',
+          identification: {
+            type: 'passport',
+            number: 'ABC123',
+            issuing_country: 'US',
+            date_of_expiry: '2027-07-07'
+          }
+      }
+    )
   end
 
   def test_transcript_scrubbing
@@ -632,6 +674,29 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @credit_card.first_name = 'John'
     @credit_card.last_name = 'Doe'
     response = @gateway_oauth.credit(@amount, @credit_card, @options.merge({ source_type: 'currency_account', source_id: 'ca_spwmped4qmqenai7hcghquqle4', account_holder_type: 'individual' }))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_money_transfer_payout_via_credit_individual_account_holder_type
+    @credit_card.first_name = 'John'
+    @credit_card.last_name = 'Doe'
+    response = @gateway_oauth.credit(@amount, @credit_card, @payout_options.merge(account_holder_type: 'individual', payout: true))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_money_transfer_payout_via_credit_corporate_account_holder_type
+    @credit_card.name = 'ACME, Inc.'
+    response = @gateway_oauth.credit(@amount, @credit_card, @payout_options.merge(account_holder_type: 'corporate'))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_money_transfer_payout_reverts_to_credit_if_payout_sent_as_nil
+    @credit_card.first_name = 'John'
+    @credit_card.last_name = 'Doe'
+    response = @gateway_oauth.credit(@amount, @credit_card, @payout_options.merge({ account_holder_type: 'individual', payout: nil }))
     assert_success response
     assert_equal 'Succeeded', response.message
   end


### PR DESCRIPTION
…bjects

CER-757

These changes will enhance functionality for Credits/Payouts. The fields that are added with this logic are all opt-in, no existing logic has been changed.

There are several fields that should be added conditionally, for this it would be best to reference the [Checkout docs](https://api-reference.checkout.com/#operation/requestAPaymentOrPayout).

Remote Tests:
95 tests, 231 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit Tests:
60 tests, 360 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Local Tests:
5551 tests, 77653 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed