### PR TITLE
Rapyd: Update handling of `ewallet` and billing address phone

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Rapyd: Change nesting of description, statement_descriptor, complete_payment_url, and error_payment_url [jcreiff] #4849
 * Rapyd: Add merchant_reference_id [jcreiff] #4858
 * Braintree: Return error for ACH on credit [jcreiff] #4859
+* Rapyd: Update handling of ewallet and billing address phone [jcreiff] #4863
 
 
 == Version 1.134.0 (July 25, 2023)

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -201,7 +201,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_ewallet(post, options)
-        post[:ewallet_id] = options[:ewallet_id] if options[:ewallet_id]
+        post[:ewallet] = options[:ewallet_id] if options[:ewallet_id]
       end
 
       def add_payment_fields(post, options)
@@ -221,7 +221,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(post, payment, options, action = '')
-        post[:phone_number] = options.dig(:billing_address, :phone) .gsub(/\D/, '') unless options[:billing_address].nil?
+        phone_number = options.dig(:billing_address, :phone) || options.dig(:billing_address, :phone_number)
+        post[:phone_number] = phone_number.gsub(/\D/, '') unless phone_number.nil?
         post[:email] = options[:email]
         return if payment.is_a?(String)
         return add_customer_id(post, options) if options[:customer_id]
@@ -236,9 +237,10 @@ module ActiveMerchant #:nodoc:
       def customer_fields(payment, options)
         return if options[:customer_id]
 
+        customer_address = address(options)
         customer_data = {}
         customer_data[:name] = "#{payment.first_name} #{payment.last_name}" unless payment.is_a?(String)
-        customer_data[:addresses] = [address(options)]
+        customer_data[:addresses] = [customer_address] if customer_address
         customer_data
       end
 

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -100,6 +100,18 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_purchase_with_no_address
+    credit_card = credit_card('4111111111111111', month: '12', year: '2035', verification_value: '345')
+
+    options = @options.dup
+    options[:billing_address] = nil
+    options[:pm_type] = 'gb_mastercard_card'
+
+    response = @gateway.purchase(@amount, credit_card, options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_successful_purchase_using_ach
     response = @gateway.purchase(100000, @check, @ach_options)
     assert_success response
@@ -108,7 +120,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_options
-    options = @options.merge(metadata: @metadata, ewallet_id: 'ewallet_1a867a32b47158b30a8c17d42f12f3f1')
+    options = @options.merge(metadata: @metadata, ewallet_id: 'ewallet_897aca846f002686e14677541f78a0f4')
     response = @gateway.purchase(100000, @credit_card, options)
     assert_success response
     assert_equal 'SUCCESS', response.message

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -246,6 +246,22 @@ class RapydTest < Test::Unit::TestCase
     end
   end
 
+  def test_successful_purchase_with_billing_address_phone_variations
+    stub_comms(@gateway, :ssl_request) do
+      @options[:pm_type] = 'us_debit_mastercard_card'
+      @gateway.purchase(@amount, @credit_card, { billing_address: { phone_number: '919.123.1234' } })
+    end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
+      assert_match(/"phone_number":"9191231234"/, data)
+    end
+
+    stub_comms(@gateway, :ssl_request) do
+      @options[:pm_type] = 'us_debit_mastercard_card'
+      @gateway.purchase(@amount, @credit_card, { billing_address: { phone: '919.123.1234' } })
+    end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
+      assert_match(/"phone_number":"9191231234"/, data)
+    end
+  end
+
   def test_successful_store_with_customer_object
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.store(@credit_card, @options)


### PR DESCRIPTION
Changes `ewallet_id` to `ewallet` to match [Rapyd's specifications](https://docs.rapyd.net/en/create-payment.html) 
Adds handling for alternate method of passing `phone_number` in the `billing_address` object

CER-843, CER-844

LOCAL
5581 tests, 77780 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

763 files inspected, no offenses detected

UNIT
25 tests, 124 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
31 tests, 89 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed