### PR TITLE
Braintree: Add sca_exemption

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * IPG: Change credentials inputs to use a combined store and user ID string as the user ID input [kylene-spreedly] #4854
 * Braintree Blue: Update the credit card details transaction hash [yunnydang] #4865
 * VisaNet Peru: Update generate_purchase_number_stamp [almalee24] #4855
+* Braintree: Add sca_exemption [almalee24] #4864
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -678,6 +678,8 @@ module ActiveMerchant #:nodoc:
 
         add_3ds_info(parameters, options[:three_d_secure])
 
+        parameters[:sca_exemption] = options[:three_ds_exemption_type] if options[:three_ds_exemption_type]
+
         if options[:payment_method_nonce].is_a?(String)
           parameters.delete(:customer)
           parameters[:payment_method_nonce] = options[:payment_method_nonce]

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -638,9 +638,12 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'Mexico', transaction['shipping_details']['country_name']
   end
 
-  def test_successful_purchase_with_three_d_secure_pass_thru
-    three_d_secure_params = { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id', cavv_algorithm: 'algorithm', directory_response_status: 'directory', authentication_response_status: 'auth' }
-    response = @gateway.purchase(@amount, @credit_card, three_d_secure: three_d_secure_params)
+  def test_successful_purchase_with_three_d_secure_pass_thru_and_sca_exemption
+    options = {
+      three_ds_exemption_type: 'low_value',
+      three_d_secure: { version: '2.0', cavv: 'cavv', eci: '02', ds_transaction_id: 'trans_id', cavv_algorithm: 'algorithm', directory_response_status: 'directory', authentication_response_status: 'auth' }
+    }
+    response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response
   end
 


### PR DESCRIPTION
To specifiy the SCA exemption that a trasaction will be claming.

Remote:
105 tests, 559 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
94 tests, 207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed