### PR TITLE
Braintree Blue: Update the credit card details transaction hash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * Braintree: Return error for ACH on credit [jcreiff] #4859
 * Rapyd: Update handling of ewallet and billing address phone [jcreiff] #4863
 * IPG: Change credentials inputs to use a combined store and user ID string as the user ID input [kylene-spreedly] #4854
+* Braintree Blue: Update the credit card details transaction hash [yunnydang] #4865
 
 == Version 1.134.0 (July 25, 2023)
 * Update required Ruby version [almalee24] #4823

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -601,7 +601,10 @@ module ActiveMerchant #:nodoc:
           'bin'                 => transaction.credit_card_details.bin,
           'last_4'              => transaction.credit_card_details.last_4,
           'card_type'           => transaction.credit_card_details.card_type,
-          'token'               => transaction.credit_card_details.token
+          'token'               => transaction.credit_card_details.token,
+          'debit'               => transaction.credit_card_details.debit,
+          'prepaid'             => transaction.credit_card_details.prepaid,
+          'issuing_bank'        => transaction.credit_card_details.issuing_bank
         }
 
         if transaction.risk_data

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1226,6 +1226,15 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_not_nil response.params['braintree_transaction']['processor_authorization_code']
   end
 
+  def test_successful_purchase_with_with_prepaid_debit_issuing_bank
+    assert response = @gateway.purchase(@amount, @credit_card)
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['prepaid']
+    assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['debit']
+    assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['issuing_bank']
+  end
+
   def test_unsucessful_purchase_using_a_bank_account_token_not_verified
     bank_account = check({ account_number: '1000000002', routing_number: '011000015' })
     response = @gateway.store(bank_account, @options.merge(@check_required_options))


### PR DESCRIPTION
This is to allow AM to include the prepaid, debit, and issuing bank fields on the credit card details object for transactions.

Local:
5582 tests, 77736 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6596% passed

Unit:
95 tests, 209 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
106 tests, 515 assertions, 4 failures, 4 errors, 0 pendings, 0 omissions, 0 notifications
92.4528% passed (the ones that failed are authentication errors)