### PR TITLE
Decidir: Add support for network tokens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * XpayGateway: Initial setup [javierpedrozaing] #4889
 * Rapyd: Add validation to not send cvv and network_reference_id [javierpedrozaing] #4895
 * Ebanx: Add Ecuador and Bolivia as supported countries [almalee24] #4893
+* Decidir: Add support for network tokens [almalee24] #4870
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -30,6 +30,16 @@ class RemoteDecidirTest < Test::Unit::TestCase
         amount: 1500
       }
     ]
+    @network_token = network_tokenization_credit_card(
+      '4012001037141112',
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: '000203016912340000000FA08400317500000000',
+      name: 'Tesest payway'
+    )
+
+    @failed_message = ['PEDIR AUTORIZACION | request_authorization_card', 'COMERCIO INVALIDO | invalid_card']
+    @failed_code = ['1, call_issuer', '3, config_error']
   end
 
   def test_successful_purchase
@@ -48,6 +58,22 @@ class RemoteDecidirTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_amex
     response = @gateway_for_purchase.purchase(@amount, @amex_credit_card, @options)
+    assert_success response
+    assert_equal 'approved', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_network_token
+    options = {
+      card_holder_door_number: 1234,
+      card_holder_birthday: '200988',
+      card_holder_identification_type: 'DNI',
+      card_holder_identification_number: '44444444',
+      order_id: SecureRandom.uuid,
+      last_4: @credit_card.last_digits
+    }
+    response = @gateway_for_purchase.purchase(500, @network_token, options)
+
     assert_success response
     assert_equal 'approved', response.message
     assert response.authorization
@@ -169,9 +195,14 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_purchase
     response = @gateway_for_purchase.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'COMERCIO INVALIDO | invalid_card', response.message
-    assert_equal '3, config_error', response.error_code
-    assert_match Gateway::STANDARD_ERROR_CODE[:config_error], response.error_code
+    assert_equal @failed_message.include?(response.message), true
+    assert_equal @failed_code.include?(response.error_code), true
+
+    if response.error_code.start_with?('1')
+      assert_match Gateway::STANDARD_ERROR_CODE[:call_issuer], response.error_code
+    else
+      assert_match Gateway::STANDARD_ERROR_CODE[:config_error], response.error_code
+    end
   end
 
   def test_failed_purchase_with_invalid_field
@@ -196,8 +227,13 @@ class RemoteDecidirTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway_for_auth.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'PEDIR AUTORIZACION | request_authorization_card', response.message
-    assert_match '1, call_issuer', response.error_code
+    assert_equal @failed_message.include?(response.message), true
+    assert_equal @failed_code.include?(response.error_code), true
+    if response.error_code.start_with?('1')
+      assert_match Gateway::STANDARD_ERROR_CODE[:call_issuer], response.error_code
+    else
+      assert_match Gateway::STANDARD_ERROR_CODE[:config_error], response.error_code
+    end
   end
 
   def test_failed_partial_capture

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -38,6 +38,13 @@ class DecidirTest < Test::Unit::TestCase
         amount: 1500
       }
     ]
+
+    @network_token = network_tokenization_credit_card(
+      '4012001037141112',
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: '000203016912340000000FA08400317500000000'
+    )
   end
 
   def test_successful_purchase
@@ -378,6 +385,22 @@ class DecidirTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_network_token_payment_method
+    options = {
+      card_holder_name: 'Tesest payway',
+      card_holder_door_number: 1234,
+      card_holder_birthday: '200988',
+      card_holder_identification_type: 'DNI',
+      card_holder_identification_number: '44444444',
+      last_4: @credit_card.last_digits
+    }
+    @gateway_for_auth.expects(:ssl_request).returns(successful_network_token_response)
+    response = @gateway_for_auth.authorize(100, @network_token, options)
+
+    assert_success response
+    assert_equal 49120515, response.authorization
+  end
+
   def test_scrub
     assert @gateway_for_purchase.supports_scrubbing?
     assert_equal @gateway_for_purchase.scrub(pre_scrubbed), post_scrubbed
@@ -546,6 +569,59 @@ class DecidirTest < Test::Unit::TestCase
   def failed_authorize_response
     %(
       {"id":7719358,"site_transaction_id":"ff1c12c1-fb6d-4c1a-bc20-2e77d4322c61","payment_method_id":1,"card_brand":"Visa","amount":100,"currency":"ars","status":"rejected","status_details":{"ticket":"8189","card_authorization_code":"","address_validation_code":null,"error":{"type":"invalid_number","reason":{"id":14,"description":"TARJETA INVALIDA","additional_description":""}}},"date":"2019-06-21T18:07Z","customer":null,"bin":"400030","installments":1,"first_installment_expiration_date":null,"payment_type":"single","sub_payments":[],"site_id":"99999997","fraud_detection":null,"aggregate_data":null,"establishment_name":null,"spv":null,"confirmed":null,"pan":"11b076fbc8fa6a55783b2f5d03f6938d8a","customer_token":null,"card_data":"/tokens/7719358"}
+    )
+  end
+
+  def successful_network_token_response
+    %(
+      {"id": 49120515,
+      "site_transaction_id": "Tx1673372774",
+      "payment_method_id": 1,
+      "card_brand": "Visa",
+      "amount": 1200,
+      "currency": "ars",
+      "status": "approved",
+      "status_details": {
+          "ticket": "88",
+          "card_authorization_code": "B45857",
+          "address_validation_code": "VTE2222",
+          "error": null
+      },
+      "date": "2023-01-10T14:46Z",
+      "customer": null,
+      "bin": "450799",
+      "installments": 1,
+      "first_installment_expiration_date": null,
+      "payment_type": "single",
+      "sub_payments": [],
+      "site_id": "09001000",
+      "fraud_detection": null,
+      "aggregate_data": {
+          "indicator": "1",
+          "identification_number": "30598910045",
+          "bill_to_pay": "Payway_Test",
+          "bill_to_refund": "Payway_Test",
+          "merchant_name": "PAYWAY",
+          "street": "Lavarden",
+          "number": "247",
+          "postal_code": "C1437FBE",
+          "category": "05044",
+          "channel": "005",
+          "geographic_code": "C1437",
+          "city": "Buenos Aires",
+          "merchant_id": "id_Aggregator",
+          "province": "Buenos Aires",
+          "country": "Argentina",
+          "merchant_email": "qa@test.com",
+          "merchant_phone": "+541135211111"
+      },
+      "establishment_name": null,
+      "spv":null,
+      "confirmed":null,
+      "bread":null,
+      "customer_token":null,
+      "card_data":"/tokens/49120515",
+      "token":"b7b6ca89-ed81-44e0-9d1f-3b3cf443cd74"}
     )
   end
 


### PR DESCRIPTION
This PR adds support for network tokens to the Decidir gateway.