### PR TITLE
CYBS: Recurring Apple Pay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 == HEAD
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860
 * TNS: Use the specified order_id in request if available [yunnydang] #4880
+* Cybersource: Support recurring apple pay [aenand] #4874
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -807,26 +807,35 @@ module ActiveMerchant #:nodoc:
         payment_method.is_a?(NetworkTokenizationCreditCard)
       end
 
+      def subsequent_nt_apple_pay_auth(source, options)
+        return unless options[:stored_credential] || options[:stored_credential_overrides]
+        return unless @@payment_solution[source]
+
+        options.dig(:stored_credential_overrides, :subsequent_auth) || options.dig(:stored_credential, :initiator) == 'merchant'
+      end
+
       def add_auth_network_tokenization(xml, payment_method, options)
         return unless network_tokenization?(payment_method)
+
+        commerce_indicator = 'internet' if subsequent_nt_apple_pay_auth(payment_method.source, options)
 
         brand = card_brand(payment_method).to_sym
 
         case brand
         when :visa
           xml.tag! 'ccAuthService', { 'run' => 'true' } do
-            xml.tag!('cavv', payment_method.payment_cryptogram)
-            xml.tag!('commerceIndicator', ECI_BRAND_MAPPING[brand])
-            xml.tag!('xid', payment_method.payment_cryptogram)
+            xml.tag!('cavv', payment_method.payment_cryptogram) unless commerce_indicator
+            xml.commerceIndicator commerce_indicator.nil? ? ECI_BRAND_MAPPING[brand] : commerce_indicator
+            xml.tag!('xid', payment_method.payment_cryptogram) unless commerce_indicator
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
           end
         when :master
           xml.tag! 'ucaf' do
-            xml.tag!('authenticationData', payment_method.payment_cryptogram)
+            xml.tag!('authenticationData', payment_method.payment_cryptogram) unless commerce_indicator
             xml.tag!('collectionIndicator', DEFAULT_COLLECTION_INDICATOR)
           end
           xml.tag! 'ccAuthService', { 'run' => 'true' } do
-            xml.tag!('commerceIndicator', ECI_BRAND_MAPPING[brand])
+            xml.commerceIndicator commerce_indicator.nil? ? ECI_BRAND_MAPPING[brand] : commerce_indicator
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
           end
         when :american_express


### PR DESCRIPTION
Cybersource's legacy gateway supports recurring transactions for Network Tokens. The way to accomplish this is to not send the `cryptogram` since that is one time use and mark the `commerce_indicator` as `internet`.

Remote:
123 tests, 619 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95.935% passed
5 tests failing on master