### PR TITLE
Rapyd: Add fields and update stored credential method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * TNS: Use the specified order_id in request if available [yunnydang] #4880
 * Cybersource: Support recurring apple pay [aenand] #4874
 * Verve BIN ranges and add card type to Rapyd gateway [jherreraa] #4875
+* Rapyd: Add network_reference_id, initiation_type, and update stored credential method [yunnydang] #4877
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -141,10 +141,22 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_stored_credential(post, options)
-        return unless stored_credential = options[:stored_credential]
+        add_network_reference_id(post, options)
+        add_initiation_type(post, options)
+      end
 
-        post[:payment_method][:fields][:network_reference_id] = stored_credential[:network_transaction_id] if stored_credential[:network_transaction_id]
-        post[:initiation_type] = stored_credential[:reason_type] if stored_credential[:reason_type]
+      def add_network_reference_id(post, options)
+        return unless options[:stored_credential] || options[:network_transaction_id]
+
+        network_transaction_id = options[:network_transaction_id] || options[:stored_credential][:network_transaction_id]
+        post[:payment_method][:fields][:network_reference_id] = network_transaction_id if network_transaction_id
+      end
+
+      def add_initiation_type(post, options)
+        return unless options[:stored_credential] || options[:initiation_type]
+
+        initiation_type = options[:initiation_type] || options[:stored_credential][:reason_type]
+        post[:initiation_type] = initiation_type if initiation_type
       end
 
       def add_creditcard(post, payment, options)

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -122,6 +122,19 @@ class RapydTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_network_transaction_id_and_initiation_type_fields
+    @options[:network_transaction_id] = '54321'
+    @options[:initiation_type] = 'customer_present'
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['payment_method']['fields']['network_reference_id'], @options[:network_transaction_id]
+      assert_equal request['initiation_type'], @options[:initiation_type]
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_purchase_with_3ds_gateway_specific
     @options[:three_d_secure] = {
       required: true,


### PR DESCRIPTION
This change is allow users to manage NTID themselves by adding an option for them to pass in the fields network_reference_id and initiation_type directly.

Local:
5588 tests, 77761 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications 99.66% passed

Unit:
27 tests, 137 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
34 tests, 95 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed