### PR TITLE
CyberSource (SOAP): Added support for 3DS exemption request fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Rapyd: Add network_reference_id, initiation_type, and update stored credential method [yunnydang] #4877
 * Adyen: Add the store field [yunnydang] #4878
 * Stripe Payment Intents: Expand balance txns for regular transactions [yunnydang] #4882
+* CyberSource (SOAP): Added support for 3DS exemption request fields [BritneyS] #4881
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -33,6 +33,15 @@ module ActiveMerchant #:nodoc:
         discover: 'pb',
         diners_club: 'pb'
       }.freeze
+      THREEDS_EXEMPTIONS = {
+        authentication_outage: 'authenticationOutageExemptionIndicator',
+        corporate_card: 'secureCorporatePaymentIndicator',
+        delegated_authentication: 'delegatedAuthenticationExemptionIndicator',
+        low_risk: 'riskAnalysisExemptionIndicator',
+        low_value: 'lowValueExemptionIndicator',
+        stored_credential: 'stored_credential',
+        trusted_merchant: 'trustedMerchantExemptionIndicator'
+      }
       DEFAULT_COLLECTION_INDICATOR = 2
 
       self.supported_cardtypes = %i[visa master american_express discover diners_club jcb dankort maestro elo]
@@ -736,6 +745,7 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'ccAuthService', { 'run' => 'true' } do
             if options[:three_d_secure]
               add_normalized_threeds_2_data(xml, payment_method, options)
+              add_threeds_exemption_data(xml, options) if options[:three_ds_exemption_type]
             else
               indicator = options[:commerce_indicator] || stored_credential_commerce_indicator(options)
               xml.tag!('commerceIndicator', indicator) if indicator
@@ -743,6 +753,17 @@ module ActiveMerchant #:nodoc:
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
             xml.tag!('mobileRemotePaymentType', options[:mobile_remote_payment_type]) if options[:mobile_remote_payment_type]
           end
+        end
+      end
+
+      def add_threeds_exemption_data(xml, options)
+        return unless options[:three_ds_exemption_type]
+
+        exemption = options[:three_ds_exemption_type].to_sym
+
+        case exemption
+        when :authentication_outage, :corporate_card, :delegated_authentication, :low_risk, :low_value, :trusted_merchant
+          xml.tag!(THREEDS_EXEMPTIONS[exemption], '1')
         end
       end
 
@@ -1014,7 +1035,7 @@ module ActiveMerchant #:nodoc:
 
         stored_credential_subsequent_auth_first = 'true' if options.dig(:stored_credential, :initial_transaction)
         stored_credential_transaction_id = options.dig(:stored_credential, :network_transaction_id) if options.dig(:stored_credential, :initiator) == 'merchant'
-        stored_credential_subsequent_auth_stored_cred = 'true' if options.dig(:stored_credential, :initiator) == 'cardholder' && !options.dig(:stored_credential, :initial_transaction) || options.dig(:stored_credential, :initiator) == 'merchant' && options.dig(:stored_credential, :reason_type) == 'unscheduled'
+        stored_credential_subsequent_auth_stored_cred = 'true' if subsequent_cardholder_initiated_transaction?(options) || unscheduled_merchant_initiated_transaction?(options) || threeds_stored_credential_exemption?(options)
 
         override_subsequent_auth_first = options.dig(:stored_credential_overrides, :subsequent_auth_first)
         override_subsequent_auth_transaction_id = options.dig(:stored_credential_overrides, :subsequent_auth_transaction_id)
@@ -1023,6 +1044,18 @@ module ActiveMerchant #:nodoc:
         xml.subsequentAuthFirst override_subsequent_auth_first.nil? ? stored_credential_subsequent_auth_first : override_subsequent_auth_first
         xml.subsequentAuthTransactionID override_subsequent_auth_transaction_id.nil? ? stored_credential_transaction_id : override_subsequent_auth_transaction_id
         xml.subsequentAuthStoredCredential override_subsequent_auth_stored_cred.nil? ? stored_credential_subsequent_auth_stored_cred : override_subsequent_auth_stored_cred
+      end
+
+      def subsequent_cardholder_initiated_transaction?(options)
+        options.dig(:stored_credential, :initiator) == 'cardholder' && !options.dig(:stored_credential, :initial_transaction)
+      end
+
+      def unscheduled_merchant_initiated_transaction?(options)
+        options.dig(:stored_credential, :initiator) == 'merchant' && options.dig(:stored_credential, :reason_type) == 'unscheduled'
+      end
+
+      def threeds_stored_credential_exemption?(options)
+        options[:three_ds_exemption_type] == THREEDS_EXEMPTIONS[:stored_credential]
       end
 
       def add_partner_solution_id(xml)

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -1190,6 +1190,72 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
   end
 
+  def test_successful_authorize_with_3ds_exemption
+    @options[:three_d_secure] = {
+      version: '2.0',
+      eci: '05',
+      cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
+      xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC'
+    }
+
+    assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge(three_ds_exemption_type: 'moto'))
+    assert_successful_response(response)
+  end
+
+  def test_successful_purchase_with_3ds_exemption
+    @options[:three_d_secure] = {
+      version: '2.0',
+      eci: '05',
+      cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
+      xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC'
+    }
+
+    assert response = @gateway.purchase(@amount, @three_ds_enrolled_card, @options.merge(three_ds_exemption_type: 'moto'))
+    assert_successful_response(response)
+  end
+
+  def test_successful_recurring_cof_authorize_with_3ds_exemption
+    @options[:stored_credential] = {
+      initiator: 'merchant',
+      reason_type: 'recurring',
+      initial_transaction: false,
+      network_transaction_id: ''
+    }
+
+    @options[:three_d_secure] = {
+      version: '2.0',
+      eci: '05',
+      cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
+      xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC'
+    }
+
+    assert response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge(three_ds_exemption_type: CyberSourceGateway::THREEDS_EXEMPTIONS[:stored_credential]))
+    assert_successful_response(response)
+  end
+
+  def test_successful_recurring_cof_purchase_with_3ds_exemption
+    @options[:stored_credential] = {
+      initiator: 'merchant',
+      reason_type: 'recurring',
+      initial_transaction: false,
+      network_transaction_id: ''
+    }
+
+    @options[:three_d_secure] = {
+      version: '2.0',
+      eci: '05',
+      cavv: 'jJ81HADVRtXfCBATEp01CJUAAAA=',
+      xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC'
+    }
+
+    assert response = @gateway.purchase(@amount, @three_ds_enrolled_card, @options.merge(three_ds_exemption_type: CyberSourceGateway::THREEDS_EXEMPTIONS[:stored_credential]))
+    assert_successful_response(response)
+  end
+
   def test_invalid_field
     @options = @options.merge({
       address: {


### PR DESCRIPTION
CyberSource (SOAP): Added support for 3DS exemption request fields

Test Summary
Local: 5591 tests, 77934 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Unit at test/unit/gateways/cyber_source_test.rb: 138 tests, 762 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Remote at test/remote/gateways/remote_cyber_source_test.rb: 125 tests, 627 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96% passed (same as `master`)