### PR TITLE
Rapyd: Update cvv behavior

### DIFF
--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -169,7 +169,7 @@ module ActiveMerchant #:nodoc:
         pm_fields[:expiration_month] = payment.month.to_s
         pm_fields[:expiration_year] = payment.year.to_s
         pm_fields[:name] = "#{payment.first_name} #{payment.last_name}"
-        pm_fields[:cvv] = payment.verification_value.to_s
+        pm_fields[:cvv] = payment.verification_value.to_s if payment.verification_value.present?
 
         add_stored_credential(post, options)
       end
@@ -197,15 +197,17 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_3ds(post, payment, options)
-        return unless three_d_secure = options[:three_d_secure]
-
-        post[:payment_method_options] = {}
-        post[:payment_method_options]['3d_required'] = three_d_secure[:required]
-        post[:payment_method_options]['3d_version'] = three_d_secure[:version]
-        post[:payment_method_options][:cavv] = three_d_secure[:cavv]
-        post[:payment_method_options][:eci] = three_d_secure[:eci]
-        post[:payment_method_options][:xid] = three_d_secure[:xid]
-        post[:payment_method_options][:ds_trans_id] = three_d_secure[:ds_transaction_id]
+        if options[:execute_threed] == true
+          post[:payment_method_options] = { '3d_required' => true }
+        elsif three_d_secure = options[:three_d_secure]
+          post[:payment_method_options] = {}
+          post[:payment_method_options]['3d_required'] = three_d_secure[:required]
+          post[:payment_method_options]['3d_version'] = three_d_secure[:version]
+          post[:payment_method_options][:cavv] = three_d_secure[:cavv]
+          post[:payment_method_options][:eci] = three_d_secure[:eci]
+          post[:payment_method_options][:xid] = three_d_secure[:xid]
+          post[:payment_method_options][:ds_trans_id] = three_d_secure[:ds_transaction_id]
+        end
       end
 
       def add_metadata(post, options)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -366,4 +366,21 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert_equal 'not_applicable', response.params['data']['payment_method_data']['next_action']
     assert_equal '', response.params['data']['redirect_url']
   end
+
+  def test_successful_authorize_with_execute_threed
+    options = @options.merge(pm_type: 'gb_visa_card', execute_threed: true)
+    response = @gateway.authorize(105000, @credit_card, options)
+    assert_success response
+    assert_equal 'ACT', response.params['data']['status']
+    assert_equal '3d_verification', response.params['data']['payment_method_data']['next_action']
+    assert response.params['data']['redirect_url']
+  end
+
+  def test_successful_purchase_without_cvv
+    options = @options.merge({ pm_type: 'gb_visa_card', stored_credential: { network_transaction_id: rand.to_s[2..11] } })
+    @credit_card.verification_value = nil
+    response = @gateway.purchase(100, @credit_card, options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
 end

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -55,6 +55,17 @@ class RapydTest < Test::Unit::TestCase
     assert_equal 'payment_716ce0efc63aa8d91579e873d29d9d5e', response.authorization.split('|')[0]
   end
 
+  def test_successful_purchase_without_cvv
+    @credit_card.verification_value = nil
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"number":"4242424242424242","expiration_month":"9","expiration_year":"2024","name":"Longbob Longsen/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+    assert_equal 'payment_716ce0efc63aa8d91579e873d29d9d5e', response.authorization.split('|')[0]
+  end
+
   def test_successful_purchase_with_ach
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @check, @options.merge(billing_address: address(name: 'Joe John-ston')))


### PR DESCRIPTION
Description
-------------------------
[SER-808](https://spreedly.atlassian.net/browse/SER-808)

This commit validate if the cvv in order to don't allow send empty values to Rapyd.
This commit also include a small update for the previos work made for [3ds Gateway Specific](https://github.com/activemerchant/active_merchant/pull/4876)

Unit test
-------------------------
Finished in 0.183111 seconds.

29 tests, 148 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notificationsomissions, 0 notifications 100% passed

158.37 tests/s, 808.25 assertions/s

Remote test
-------------------------
Finished in 113.329864 seconds.

34 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.0588% passed

0.30 tests/s, 0.86 assertions/s

Rubocop
-------------------------
763 files inspected, no offenses detected