### PR TITLE
Braintree: return global_id in response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rubocop', '~> 0.72.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 4.12.0'
+  gem 'braintree', '>= 4.14.0'
   gem 'jose', '~> 1.1.3'
   gem 'jwe'
   gem 'mechanize'

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -618,6 +618,14 @@ module ActiveMerchant #:nodoc:
           risk_data = nil
         end
 
+        if transaction.payment_receipt
+          payment_receipt = {
+            'global_id' => transaction.payment_receipt.global_id
+          }
+        else
+          payment_receipt = nil
+        end
+
         {
           'order_id'                     => transaction.order_id,
           'amount'                       => transaction.amount.to_s,
@@ -632,7 +640,8 @@ module ActiveMerchant #:nodoc:
           'network_transaction_id'       => transaction.network_transaction_id || nil,
           'processor_response_code'      => response_code_from_result(result),
           'processor_authorization_code' => transaction.processor_authorization_code,
-          'recurring'                    => transaction.recurring
+          'recurring'                    => transaction.recurring,
+          'payment_receipt'              => payment_receipt
         }
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1238,6 +1238,13 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['issuing_bank']
   end
 
+  def test_successful_purchase_with_global_id
+    assert response = @gateway.purchase(@amount, @credit_card)
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_not_nil response.params['braintree_transaction']['payment_receipt']['global_id']
+  end
+
   def test_unsucessful_purchase_using_a_bank_account_token_not_verified
     bank_account = check({ account_number: '1000000002', routing_number: '011000015' })
     response = @gateway.store(bank_account, @options.merge(@check_required_options))


### PR DESCRIPTION
CER-868

This field needs to be added to the transaction_hash method to be returned in the response. The Braintree gem required an update to make the `payment_receipt` object available

I did not include a unit test because I'm trying to get something returned in the response and according to the [Braintree docs](https://developer.paypal.com/braintree/docs/reference/response/transaction/ruby#global_id), it does not appear that anything should be passed in the request to trigger this coming back. 

Remote
107 tests, 212 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
31.7757% passed

Unit
95 tests, 110 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
41.0526% passed

Local
5599 tests, 77770 assertions, 0 failures, 56 errors, 0 pendings, 0 omissions, 0 notifications
98.9998% passed