### PR TITLE
Add payment_data to network_tokenization_credit_card

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -105,6 +105,7 @@
 * Cecabank: Fix gateway scrub method [sinourain] #5009
 * Pin: Add the platform_adjustment field [yunnydang] #5011
 * Priority: Allow gateway fields to be available on capture [yunnydang] #5010
+* Add payment_data to NetworkTokenizationCreditCard [almalee24] #4888
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/network_tokenization_credit_card.rb
+++ b/lib/active_merchant/billing/network_tokenization_credit_card.rb
@@ -14,7 +14,7 @@ module ActiveMerchant #:nodoc:
       self.require_verification_value = false
       self.require_name = false
 
-      attr_accessor :payment_cryptogram, :eci, :transaction_id, :metadata
+      attr_accessor :payment_cryptogram, :eci, :transaction_id, :metadata, :payment_data
       attr_writer :source
 
       SOURCES = %i(apple_pay android_pay google_pay network_token)

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -100,7 +100,7 @@ class PinTest < Test::Unit::TestCase
     post = {}
     @gateway.send(:add_platform_adjustment, post, @options.merge(options_with_platform_adjustment))
     assert_equal 30, post[:platform_adjustment][:amount]
-    assert_equal 'AUD', post[:platform_adjustment][:currency]    
+    assert_equal 'AUD', post[:platform_adjustment][:currency]
   end
 
   def test_unsuccessful_request

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -264,7 +264,7 @@ class Shift4Test < Test::Unit::TestCase
   def test_failed_authorize_with_host_response
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card)
-    end.respond_with(failed_authorize_with_hostResponse_response)
+    end.respond_with(failed_authorize_with_host_response)
 
     assert_failure response
     assert_equal 'CVV value N not accepted.', response.message

--- a/test/unit/network_tokenization_credit_card_test.rb
+++ b/test/unit/network_tokenization_credit_card_test.rb
@@ -6,7 +6,15 @@ class NetworkTokenizationCreditCardTest < Test::Unit::TestCase
       number: '4242424242424242', brand: 'visa',
       month: default_expiration_date.month, year: default_expiration_date.year,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=', eci: '05',
-      metadata: { device_manufacturer_id: '1324' }
+      metadata: { device_manufacturer_id: '1324' },
+      payment_data: {
+        'version': 'EC_v1',
+        'data': 'QlzLxRFnNP9/GTaMhBwgmZ2ywntbr9iOcBY4TjPZyNrnCwsJd2cq61bDQjo3agVU0LuEot2VIHHocVrp5jdy0FkxdFhGd+j7hPvutFYGwZPcuuBgROb0beA1wfGDi09I+OWL+8x5+8QPl+y8EAGJdWHXr4CuL7hEj4CjtUhfj5GYLMceUcvwgGaWY7WzqnEO9UwUowlDP9C3cD21cW8osn/IKROTInGcZB0mzM5bVHM73NSFiFepNL6rQtomp034C+p9mikB4nc+vR49oVop0Pf+uO7YVq7cIWrrpgMG7ussnc3u4bmr3JhCNtKZzRQ2MqTxKv/CfDq099JQIvTj8hbqswv1t+yQ5ZhJ3m4bcPwrcyIVej5J241R7dNPu9xVjM6LSOX9KeGZQGud',
+        'signature': 'MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZKYr/0F+3ZD3VNoo6+8ZyBXkK3ifiY95tZn5jVQQ2PnenC/gIwMi3VRCGwowV3bF3zODuQZ/0XfCwhbZZPxnJpghJvVPh6fRuZy5sJiSFhBpkPCZIdAAAxggFfMIIBWwIBATCBhjB6MS4wLAYDVQQDDCVBcHBsZSBBcHBsaWNhdGlvbiBJbnRlZ3JhdGlvbiBDQSAtIEczMSYwJAYDVQQLDB1BcHBsZSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMCCCRD8qgGnfV3MA0GCWCGSAFlAwQCAQUAoGkwGAYkiG3j7AAAAAAAA',
+        'header': {
+          'ephemeralPublicKey': 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQwjaSlnZ3EXpwKfWAd2e1VnbS6vmioMyF6bNcq/Qd65NLQsjrPatzHWbJzG7v5vJtAyrf6WhoNx3C1VchQxYuw==', 'transactionId': 'e220cc1504ec15835a375e9e8659e27dcbc1abe1f959a179d8308dd8211c9371", "publicKeyHash": "/4UKqrtx7AmlRvLatYt9LDt64IYo+G9eaqqS6LFOAdI='
+        }
+      }
     )
     @tokenized_apple_pay_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
       source: :apple_pay


### PR DESCRIPTION
Some gateways required use to send the encrypted payment_data for ApplePay and GooglePay instead of the decrypted data.

Unit:
4 tests, 13 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed