### PR TITLE
SumUp - Void and partial refund calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Ogone: Add gateway specific 3ds option with default options mapping [jherreraa] #4894
 * Rapyd: Add recurrence_type field [yunnydang] #4912
 * Revert "Adyen: Update MIT flagging for NT" [almalee24] #4914
+* SumUp: Void and partial refund calls [sinourain] #4891
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827


### PR DESCRIPTION
Description
-------------------------
Add Void and Refund calls to SumUp Gateway adapter with the basic information needed

This are the relevant links to review the initial implementation:

- [Deactivate a checkout](https://developer.sumup.com/docs/api/deactivate-a-checkout/)
- [Make a refund](https://developer.sumup.com/docs/online-payments/guides/refund/)

Tickets for Spreedly reference
SER-713

Unit test
-------------------------
Finished in 31.708763 seconds.
5609 tests, 78038 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

Remote test
-------------------------
100% passed
176.89 tests/s, 2461.09 assertions/s

Rubocop
-------------------------
Running RuboCop...
Inspecting 769 files
769 files inspected, no offenses detected