### PR TITLE
Rapyd: fixing issue with json encoding and signatures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * CyberSource (SOAP): Added support for 3DS exemption request fields [BritneyS] #4881
 * StripePI: Adding network tokenization fields to Stripe PaymentIntents [BritneyS] #4867
 * Shift4: Fixing currency bug [Heavyblade] #4887
+* Rapyd: fixing issue with json encoding and signatures [Heavyblade] #4892
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -302,8 +302,19 @@ module ActiveMerchant #:nodoc:
         )
       end
 
+      # We need to revert the work of ActiveSupport JSON encoder to prevent discrepancies
+      # Between the signature and the actual request body
+      def revert_json_html_encoding!(string)
+        {
+          '\\u003e' => '>',
+          '\\u003c' => '<',
+          '\\u0026' => '&'
+        }.each { |k, v| string.gsub! k, v }
+      end
+
       def api_request(method, url, rel_path, params)
         params == {} ? body = '' : body = params.to_json
+        revert_json_html_encoding!(body) if defined?(ActiveSupport::JSON::Encoding) && ActiveSupport::JSON::Encoding.escape_html_entities_in_json
         parse(ssl_request(method, url, body, headers(rel_path, body)))
       end
 

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -368,12 +368,16 @@ class RemoteRapydTest < Test::Unit::TestCase
   end
 
   def test_successful_authorize_with_execute_threed
+    ActiveSupport::JSON::Encoding.escape_html_entities_in_json = true
+    @options[:complete_payment_url] = 'http://www.google.com?param1=1&param2=2'
     options = @options.merge(pm_type: 'gb_visa_card', execute_threed: true)
     response = @gateway.authorize(105000, @credit_card, options)
     assert_success response
     assert_equal 'ACT', response.params['data']['status']
     assert_equal '3d_verification', response.params['data']['payment_method_data']['next_action']
     assert response.params['data']['redirect_url']
+  ensure
+    ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
   end
 
   def test_successful_purchase_without_cvv


### PR DESCRIPTION
## Summary:

Fixes a bug for Rapyd where the signature doesn't match the actual body and happens as a consequence of how ActiveSupport encodes some URL parameters.

[ActiveSupport](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/json/encoding.rb#L46)

[SER-813](https://spreedly.atlassian.net/browse/SER-813)


Note: 
A failing test happens due to a reference that needs to be updated every time.

## Tests

###  Remote Test:
Finished in 108.783668 seconds.
38 tests, 110 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.3684% passed

###  Unit Tests:
Finished in 37.178252 seconds.
5604 tests, 78022 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

###  RuboCop:
766 files inspected, no offenses detected



