### PR TITLE
Rapyd: Add validation to not send cvv and network_reference_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * Rapyd: fixing issue with json encoding and signatures [Heavyblade] #4892
 * SumUp: Setup, Scrub and Purchase build [sinourain] #4890
 * XpayGateway: Initial setup [javierpedrozaing] #4889
+* Rapyd: Add validation to not send cvv and network_reference_id [javierpedrozaing] #4895
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -381,9 +381,22 @@ class RemoteRapydTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_without_cvv
-    options = @options.merge({ pm_type: 'gb_visa_card', stored_credential: { network_transaction_id: rand.to_s[2..11] } })
+    options = @options.merge({ pm_type: 'gb_visa_card', network_transaction_id: rand.to_s[2..11] })
     @credit_card.verification_value = nil
     response = @gateway.purchase(100, @credit_card, options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_recurring_transaction_without_cvv
+    @credit_card.verification_value = nil
+    response = @gateway.purchase(15000, @credit_card, @stored_credential_options.merge(stored_credential: { network_transaction_id: rand.to_s[2..11], reason_type: 'recurring' }))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_purchase_empty_network_transaction_id
+    response = @gateway.purchase(15000, @credit_card, @stored_credential_options.merge(network_transaction_id: '', initiation_type: 'customer_present'))
     assert_success response
     assert_equal 'SUCCESS', response.message
   end


### PR DESCRIPTION
Description
-------------------------

[SER-826](https://spreedly.atlassian.net/browse/SER-826)

This commit add some validations to not send the `cvv` and `network_reference_id` on recurring transactions if it does not exist

Unit test
-------------------------
Finished in 0.132965 seconds.

34 tests, 163 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

100% passed

Remote test
-------------------------
Finished in 79.856446 seconds.

40 tests, 115 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

97.5% passed

Rubocop
-------------------------
766 files inspected, no offenses detected