### PR TITLE
Rapyd: Fix cvv validation

### DIFF
--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -169,12 +169,8 @@ module ActiveMerchant #:nodoc:
         pm_fields[:expiration_month] = payment.month.to_s
         pm_fields[:expiration_year] = payment.year.to_s
         pm_fields[:name] = "#{payment.first_name} #{payment.last_name}"
-        pm_fields[:cvv] = payment.verification_value.to_s unless send_cvv_value?(payment, options) || valid_network_transaction_id?(options)
+        pm_fields[:cvv] = payment.verification_value.to_s unless valid_network_transaction_id?(options) || payment.verification_value.blank?
         add_stored_credential(post, options)
-      end
-
-      def send_cvv_value?(payment, options)
-        return (payment.verification_value.nil? || payment.verification_value&.empty?)
       end
 
       def send_customer_object?(options)
@@ -182,8 +178,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def valid_network_transaction_id?(options)
-        network_transaction_id = options[:network_tansaction_id] || options.dig(:stored_credential_options, :network_transaction_id)
-        return false if network_transaction_id.nil? || network_transaction_id.empty?
+        network_transaction_id = options[:network_tansaction_id] || options.dig(:stored_credential_options, :network_transaction_id) || options.dig(:stored_credential, :network_transaction_id)
+        return network_transaction_id.present?
       end
 
       def add_ach(post, payment, options)

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -169,16 +169,21 @@ module ActiveMerchant #:nodoc:
         pm_fields[:expiration_month] = payment.month.to_s
         pm_fields[:expiration_year] = payment.year.to_s
         pm_fields[:name] = "#{payment.first_name} #{payment.last_name}"
-        pm_fields[:cvv] = payment.verification_value.to_s unless send_cvv_value?(payment, options)
+        pm_fields[:cvv] = payment.verification_value.to_s unless send_cvv_value?(payment, options) || valid_network_transaction_id?(options)
         add_stored_credential(post, options)
       end
 
       def send_cvv_value?(payment, options)
-        (payment.verification_value.nil? || payment.verification_value&.empty?) && (options[:stored_credential] && options[:stored_credential][:reason_type] == 'recurring')
+        return (payment.verification_value.nil? || payment.verification_value&.empty?)
       end
 
       def send_customer_object?(options)
         options[:stored_credential] && options[:stored_credential][:reason_type] == 'recurring'
+      end
+
+      def valid_network_transaction_id?(options)
+        network_transaction_id = options[:network_tansaction_id] || options.dig(:stored_credential_options, :network_transaction_id)
+        return false if network_transaction_id.nil? || network_transaction_id.empty?
       end
 
       def add_ach(post, payment, options)

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -174,7 +174,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def send_cvv_value?(payment, options)
-        payment.verification_value.nil? || payment.verification_value&.empty? || (options[:stored_credential] && options[:stored_credential][:reason_type] == 'recurring')
+        (payment.verification_value.nil? || payment.verification_value&.empty?) && (options[:stored_credential] && options[:stored_credential][:reason_type] == 'recurring')
       end
 
       def send_customer_object?(options)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -400,4 +400,10 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'SUCCESS', response.message
   end
+
+  def test_successful_purchase_nil_network_transaction_id
+    response = @gateway.purchase(15000, @credit_card, @stored_credential_options.merge(network_transaction_id: nil, initiation_type: 'customer_present'))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
 end

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -407,7 +407,7 @@ class RapydTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_equal request['payment_method']['fields']['cvv'], '123'
+      assert_nil request['payment_method']['fields']['cvv']
     end
   end
 

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -384,7 +384,7 @@ class RapydTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_equal request['payment_method']['fields']['cvv'], ''
+      assert_nil request['payment_method']['fields']['cvv']
     end
   end
 
@@ -394,7 +394,7 @@ class RapydTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_equal request['payment_method']['fields']['cvv'], ''
+      assert_nil request['payment_method']['fields']['cvv']
     end
   end
 

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -384,7 +384,7 @@ class RapydTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_nil request['payment_method']['fields']['cvv']
+      assert_equal request['payment_method']['fields']['cvv'], ''
     end
   end
 
@@ -394,7 +394,7 @@ class RapydTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_nil request['payment_method']['fields']['cvv']
+      assert_equal request['payment_method']['fields']['cvv'], ''
     end
   end
 
@@ -407,7 +407,7 @@ class RapydTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_nil request['payment_method']['fields']['cvv']
+      assert_equal request['payment_method']['fields']['cvv'], '123'
     end
   end
 


### PR DESCRIPTION
Description
-------------------------
This is a super small commit to update the validations to not send cvv value

Unit test
-------------------------
Finished in 0.132965 seconds.

34 tests, 163 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

100% passed

Remote test
-------------------------
Finished in 79.856446 seconds.

40 tests, 115 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

97.5% passed

Rubocop
-------------------------

766 files inspected, no offenses detected