### PR TITLE
Kushki: Fixing issue with 3DS info on visa cc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * Braintree: Create credit card nonce [gasb150] #4897
 * Adyen: Fix shopperEmail bug [almalee24] #4904
 * Add Cabal card bin ranges [yunnydang] #4908
+* Kushki: Fixing issue with 3DS info on visa cc [heavyblade] #4899
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -230,7 +230,7 @@ module ActiveMerchant #:nodoc:
         elsif payment_method.brand == 'visa'
           post[:threeDomainSecure][:acceptRisk] = three_d_secure[:eci] == '07'
           post[:threeDomainSecure][:cavv] = three_d_secure[:cavv]
-          post[:threeDomainSecure][:xid] = three_d_secure[:xid]
+          post[:threeDomainSecure][:xid] = three_d_secure[:xid] if three_d_secure[:xid].present?
         else
           raise ArgumentError.new 'Kushki supports 3ds2 authentication for only Visa and Mastercard brands.'
         end

--- a/test/remote/gateways/remote_kushki_test.rb
+++ b/test/remote/gateways/remote_kushki_test.rb
@@ -195,6 +195,21 @@ class RemoteKushkiTest < Test::Unit::TestCase
     assert_match %r(^\d+$), response.authorization
   end
 
+  def test_successful_3ds2_authorize_with_visa_card_with_optional_xid
+    options = {
+      currency: 'PEN',
+      three_d_secure: {
+        version: '2.2.0',
+        cavv: 'AAABBoVBaZKAR3BkdkFpELpWIiE=',
+        eci: '07'
+      }
+    }
+    response = @gateway.authorize(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_match %r(^\d+$), response.authorization
+  end
+
   def test_successful_3ds2_authorize_with_master_card
     options = {
       currency: 'PEN',


### PR DESCRIPTION
## Summary:
Fixes a bug for Kushki that fails transactions when 3DS info is passed for VISA Credit Cards.

[SER-830](https://spreedly.atlassian.net/browse/SER-830)

## Tests

### Remote Test:
Finished in 87.534566 seconds.
24 tests, 71 assertions, 0 failures, 0 errors,
0 pendings, 0 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 37.30761 seconds.
5624 tests, 78070 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
772 files inspected, no offenses detected