### PR TITLE
Consider already captured transactions in Paypal as successful

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -40,6 +40,7 @@ module ActiveMerchant #:nodoc:
       SUCCESS_CODES = [ 'Success', 'SuccessWithWarning' ]
 
       FRAUD_REVIEW_CODE = "11610"
+      ALREADY_AUTHORIZED_CODE = "10602"
 
       STANDARD_ERROR_CODE_MAPPING = {
         '15005' => :card_declined,
@@ -695,10 +696,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def successful?(response)
-        SUCCESS_CODES.include?(response[:ack])
+        SUCCESS_CODES.include?(response[:ack]) || response[:error_codes] == ALREADY_AUTHORIZED_CODE
       end
 
       def message_from(response)
+        if response[:error_codes] == ALREADY_AUTHORIZED_CODE
+          return "#{response[:message]} | status overridden to success due to error code #{ALREADY_AUTHORIZED_CODE} " \
+                    "(transaction already captured)"
+        end
         response[:message] || response[:ack]
       end
 

--- a/test/unit/gateways/paypal/paypal_common_api_test.rb
+++ b/test/unit/gateways/paypal/paypal_common_api_test.rb
@@ -202,4 +202,15 @@ class PaypalCommonApiTest < Test::Unit::TestCase
     assert_equal 'id', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:ReferenceID').text
     assert_equal '127.0.0.1', REXML::XPath.first(request, '//DoReferenceTransactionReq/DoReferenceTransactionRequest/n2:DoReferenceTransactionRequestDetails/n2:IPAddress').text
   end
+
+  def test_successful_with_paypal_already_authorized_error_code
+    response = { error_codes: "10602" }
+    assert_true @gateway.send(:successful?, response)
+  end
+
+  def test_message_from_with_paypal_already_authorized_error_code
+    response = { error_codes: "10602", message: "test message" }
+    assert_equal "test message | status overridden to success due to error code 10602 (transaction already captured)",
+      @gateway.send(:message_from, response)
+  end
 end


### PR DESCRIPTION
When Paypal responds with an [error code](https://developer.paypal.com/api/nvp-soap/errors) `10602` it means that the transaction is already captured on their side, which is not an error per se.
To reflect that we are doing an override of the status, we have improved the message with that information.

To run tests:
`bundle exec rake test:units TEST=test/unit/gateways/paypal/paypal_common_api_test.rb`