### PR TITLE
Adyen: Fix bug for shopperEmail

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * CheckoutV2: Update stored credentials [almalee24] #4901
 * Revert "Adding Oauth Response for access tokens" [almalee24] #4906
 * Braintree: Create credit card nonce [gasb150] #4897
+* Adyen: Fix shopperEmail bug [almalee24] #4904
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -105,6 +105,7 @@ module ActiveMerchant #:nodoc:
           add_fraud_offset(post, options)
           add_fund_source(post, options)
           add_recurring_contract(post, options)
+          add_shopper_data(post, payment, options)
 
           if (address = options[:billing_address] || options[:address]) && address[:country]
             add_billing_address(post, address)
@@ -255,6 +256,7 @@ module ActiveMerchant #:nodoc:
         post[:shopperStatement] = options[:shopper_statement] if options[:shopper_statement]
         post[:store] = options[:store] if options[:store]
 
+        add_shopper_data(post, payment, options)
         add_additional_data(post, payment, options)
         add_risk_data(post, options)
         add_shopper_reference(post, options)
@@ -553,7 +555,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_bank_account(post, bank_account, options, action)
-        add_shopper_data(post, bank_account, options)
         bank = {
           bankAccountNumber: bank_account.account_number,
           ownerName: bank_account.name,
@@ -567,7 +568,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_card(post, credit_card)
-        add_shopper_data(post, credit_card, options)
         card = {
           expiryMonth: credit_card.month,
           expiryYear: credit_card.year,
@@ -583,9 +583,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_shopper_data(post, payment, options)
-        post[:shopperName] = {}
-        post[:shopperName][:firstName] = payment.first_name
-        post[:shopperName][:lastName] = payment.last_name
+        if payment && !payment.is_a?(String)
+          post[:shopperName] = {}
+          post[:shopperName][:firstName] = payment.first_name
+          post[:shopperName][:lastName] = payment.last_name
+        end
+
         post[:shopperEmail] = options[:email] if options[:email]
         post[:shopperEmail] = options[:shopper_email] if options[:shopper_email]
       end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -184,6 +184,7 @@ class AdyenTest < Test::Unit::TestCase
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge({ recurring_contract_type: 'ONECLICK' }))
     end.check_request do |_endpoint, data, _headers|
+      assert_equal 'john.smith@test.com', JSON.parse(data)['shopperEmail']
       assert_equal 'ONECLICK', JSON.parse(data)['recurring']['contract']
     end.respond_with(successful_authorize_response)
   end


### PR DESCRIPTION
Move add_shopper_data back to add_extra_data to ensure that shopperEmail is being sent in all transaction types.

Unit:
112 tests, 589 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
137 tests, 455 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 91.9708% passed