### PR TITLE
Adding Oauth Response for access tokens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,6 +41,7 @@
 * Rapyd: add force_3ds_secure flag [Heavyblade] #4927
 * Beanstream: add alternate option for passing phone number [jcreiff] #4923
 * AuthorizeNet: Update network token method [almalee24] #4852
+* Adding Oauth Response for access tokens [almalee24] #4907
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -32,7 +32,7 @@ module ActiveMerchant #:nodoc:
         @client_id = options[:client_id]
         @client_api_key = options[:client_api_key]
         super
-        @access_token = setup_access_token
+        @access_token = options[:access_token] || setup_access_token
       end
 
       def purchase(money, card, options = {})
@@ -133,8 +133,20 @@ module ActiveMerchant #:nodoc:
           'x-client-id' => @client_id,
           'x-api-key' => @client_api_key
         }
-        response = ssl_post(build_request_url(:login), nil, token_headers)
-        JSON.parse(response)['token']
+
+        begin
+          raw_response = ssl_post(build_request_url(:login), nil, token_headers)
+        rescue ResponseError => e
+          raise OAuthResponseError.new(e)
+        else
+          response = JSON.parse(raw_response)
+          if (token = response['token'])
+            token
+          else
+            oauth_response = Response.new(false, response['message'])
+            raise OAuthResponseError.new(oauth_response)
+          end
+        end
       end
 
       def build_request_url(action, id = nil)

--- a/lib/active_merchant/billing/gateways/alelo.rb
+++ b/lib/active_merchant/billing/gateways/alelo.rb
@@ -110,8 +110,18 @@ module ActiveMerchant #:nodoc:
           'Content-Type' => 'application/x-www-form-urlencoded'
         }
 
-        parsed = parse(ssl_post(url('captura-oauth-provider/oauth/token'), post_data(params), headers))
-        Response.new(true, parsed[:access_token], parsed)
+        begin
+          raw_response = ssl_post(url('captura-oauth-provider/oauth/token'), post_data(params), headers)
+        rescue ResponseError => e
+          raise OAuthResponseError.new(e)
+        else
+          response = parse(raw_response)
+          if (access_token = response[:access_token])
+            Response.new(true, access_token, response)
+          else
+            raise OAuthResponseError.new(response)
+          end
+        end
       end
 
       def remote_encryption_key(access_token)
@@ -144,9 +154,11 @@ module ActiveMerchant #:nodoc:
           access_token: access_token,
           multiresp: multiresp.responses.present? ? multiresp : nil
         }
+      rescue ActiveMerchant::OAuthResponseError => e
+        raise e
       rescue ResponseError => e
         # retry to generate a new access_token when the provided one is expired
-        raise e unless try_again && %w(401 404).include?(e.response.code) && @options[:access_token].present?
+        raise e unless retry?(try_again, e, :access_token)
 
         @options.delete(:access_token)
         @options.delete(:encryption_key)
@@ -206,15 +218,21 @@ module ActiveMerchant #:nodoc:
         multiresp.process { resp }
 
         multiresp
+      rescue ActiveMerchant::OAuthResponseError => e
+        raise OAuthResponseError.new(e)
       rescue ActiveMerchant::ResponseError => e
         # Retry on a possible expired encryption key
-        if try_again && %w(401 404).include?(e.response.code) && @options[:encryption_key].present?
+        if retry?(try_again, e, :encryption_key)
           @options.delete(:encryption_key)
           commit(action, body, options, false)
         else
           res = parse(e.response.body)
           Response.new(false, res[:messageUser] || res[:error], res, test: test?)
         end
+      end
+
+      def retry?(try_again, error, key)
+        try_again && %w(401 404).include?(error.response.code) && @options[key].present?
       end
 
       def success_from(action, response)

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -18,13 +18,13 @@ module ActiveMerchant #:nodoc:
 
       def initialize(options = {})
         @options = options
-        @access_token = nil
+        @access_token = options[:access_token] || nil
 
         if options.has_key?(:secret_key)
           requires!(options, :secret_key)
         else
           requires!(options, :client_id, :client_secret)
-          @access_token = setup_access_token
+          @access_token ||= setup_access_token
         end
 
         super
@@ -428,8 +428,19 @@ module ActiveMerchant #:nodoc:
 
       def setup_access_token
         request = 'grant_type=client_credentials'
-        response = parse(ssl_post(access_token_url, request, access_token_header))
-        response['access_token']
+        begin
+          raw_response = ssl_post(access_token_url, request, access_token_header)
+        rescue ResponseError => e
+          raise OAuthResponseError.new(e)
+        else
+          response = parse(raw_response)
+
+          if (access_token = response['access_token'])
+            access_token
+          else
+            raise OAuthResponseError.new(response)
+          end
+        end
       end
 
       def commit(action, post, options, authorization = nil, method = :post)

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -305,12 +305,17 @@ module ActiveMerchant #:nodoc:
           'Authorization'     => "Basic #{basic_auth}"
         }
 
-        response = ssl_post(REFRESH_URI, data, headers)
-        json_response = JSON.parse(response)
+        begin
+          response = ssl_post(REFRESH_URI, data, headers)
+        rescue ResponseError => e
+          raise OAuthResponseError.new(e)
+        else
+          json_response = JSON.parse(response)
 
-        @options[:access_token] = json_response['access_token'] if json_response['access_token']
-        @options[:refresh_token] = json_response['refresh_token'] if json_response['refresh_token']
-        response
+          @options[:access_token] = json_response['access_token'] if json_response['access_token']
+          @options[:refresh_token] = json_response['refresh_token'] if json_response['refresh_token']
+          response
+        end
       end
 
       def cvv_code_from(response)
@@ -358,6 +363,10 @@ module ActiveMerchant #:nodoc:
         rescue JSON::ParserError
           raise response_error
         end
+
+        error_code = JSON.parse(response_error.response.body)['code']
+        raise OAuthResponseError.new(response_error, error_code) if error_code == 'AuthenticationFailed'
+
         response_error.response.body
       end
 

--- a/lib/active_merchant/billing/gateways/simetrik.rb
+++ b/lib/active_merchant/billing/gateways/simetrik.rb
@@ -44,7 +44,7 @@ module ActiveMerchant #:nodoc:
       def initialize(options = {})
         requires!(options, :client_id, :client_secret)
         super
-        @access_token = {}
+        @access_token = options[:access_token] || {}
         sign_access_token()
       end
 
@@ -356,12 +356,18 @@ module ActiveMerchant #:nodoc:
         login_info[:client_secret] = @options[:client_secret]
         login_info[:audience] = test? ? test_audience : live_audience
         login_info[:grant_type] = 'client_credentials'
-        response = parse(ssl_post(auth_url(), login_info.to_json, {
-          'content-Type' => 'application/json'
-        }))
 
-        @access_token[:access_token] = response['access_token']
-        @access_token[:expires_at] = Time.new.to_i + response['expires_in']
+        begin
+          raw_response = ssl_post(auth_url(), login_info.to_json, {
+            'content-Type' => 'application/json'
+          })
+        rescue ResponseError => e
+          raise OAuthResponseError.new(e)
+        else
+          response = parse(raw_response)
+          @access_token[:access_token] = response['access_token']
+          @access_token[:expires_at] = Time.new.to_i + response['expires_in']
+        end
       end
     end
   end

--- a/lib/active_merchant/errors.rb
+++ b/lib/active_merchant/errors.rb
@@ -23,6 +23,18 @@ module ActiveMerchant #:nodoc:
     end
 
     def to_s
+      if response.kind_of?(String)
+        if response.start_with?('Failed')
+          return response
+        else
+          return "Failed with #{response}"
+        end
+      end
+
+      if response.respond_to?(:message)
+        return response.message if response.message.start_with?('Failed')
+      end
+
       "Failed with #{response.code if response.respond_to?(:code)} #{response.message if response.respond_to?(:message)}"
     end
   end

--- a/test/remote/gateways/remote_airwallex_test.rb
+++ b/test/remote/gateways/remote_airwallex_test.rb
@@ -14,6 +14,13 @@ class RemoteAirwallexTest < Test::Unit::TestCase
     @stored_credential_mit_options = { initial_transaction: false, initiator: 'merchant', reason_type: 'recurring' }
   end
 
+  def test_failed_access_token
+    assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway = AirwallexGateway.new({ client_id: 'YOUR_CLIENT_ID', client_api_key: 'YOUR_API_KEY' })
+      gateway.send :setup_access_token
+    end
+  end
+
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/remote/gateways/remote_alelo_test.rb
+++ b/test/remote/gateways/remote_alelo_test.rb
@@ -26,7 +26,7 @@ class RemoteAleloTest < Test::Unit::TestCase
   end
 
   def test_failure_access_token_with_invalid_keys
-    error = assert_raises(ActiveMerchant::ResponseError) do
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
       gateway = AleloGateway.new({ client_id: 'abc123', client_secret: 'abc456' })
       gateway.send :fetch_access_token
     end
@@ -145,9 +145,11 @@ class RemoteAleloTest < Test::Unit::TestCase
   def test_invalid_login
     gateway = AleloGateway.new(client_id: 'asdfghj', client_secret: '1234rtytre')
 
-    response = gateway.purchase(@amount, @credit_card, @options)
-    assert_failure response
-    assert_match %r{invalid_client}, response.message
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway.purchase(@amount, @credit_card, @options)
+    end
+
+    assert_match(/401/, error.message)
   end
 
   def test_transcript_scrubbing

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -160,6 +160,22 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     )
   end
 
+  def test_failed_access_token
+    assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway = CheckoutV2Gateway.new({ client_id: 'YOUR_CLIENT_ID', client_secret: 'YOUR_CLIENT_SECRET' })
+      gateway.send :setup_access_token
+    end
+  end
+
+  def test_failed_purchase_with_failed_access_token
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway = CheckoutV2Gateway.new({ client_id: 'YOUR_CLIENT_ID', client_secret: 'YOUR_CLIENT_SECRET' })
+      gateway.purchase(@amount, @credit_card, @options)
+    end
+
+    assert_equal error.message, 'Failed with 400 Bad Request'
+  end
+
   def test_transcript_scrubbing
     declined_card = credit_card('4000300011112220', verification_value: '423')
     transcript = capture_transcript(@gateway) do

--- a/test/remote/gateways/remote_pay_trace_test.rb
+++ b/test/remote/gateways/remote_pay_trace_test.rb
@@ -39,6 +39,23 @@ class RemotePayTraceTest < Test::Unit::TestCase
     assert_not_nil response['access_token']
   end
 
+  def test_failed_access_token
+    assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway = PayTraceGateway.new(username: 'username', password: 'password', integrator_id: 'uniqueintegrator')
+      gateway.send :acquire_access_token
+    end
+  end
+
+  def test_failed_purchase_with_failed_access_token
+    gateway = PayTraceGateway.new(username: 'username', password: 'password', integrator_id: 'uniqueintegrator')
+
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway.purchase(1000, @credit_card, @options)
+    end
+
+    assert_equal error.message, 'Failed with The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+  end
+
   def test_successful_purchase
     response = @gateway.purchase(1000, @credit_card, @options)
     assert_success response

--- a/test/remote/gateways/remote_quickbooks_test.rb
+++ b/test/remote/gateways/remote_quickbooks_test.rb
@@ -18,6 +18,23 @@ class RemoteTest < Test::Unit::TestCase
     }
   end
 
+  def test_failed_access_token
+    assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway = QuickbooksGateway.new({ client_id: 'YOUR_CLIENT_ID', client_secret: 'YOUR_CLIENT_SECRET', refresh_token: 'YOUR_REFRESH_TOKEN', access_token: 'YOUR_ACCESS_TOKEN' })
+      gateway.send :refresh_access_token
+    end
+  end
+
+  def test_failed_purchase_with_failed_access_token
+    gateway = QuickbooksGateway.new({ client_id: 'YOUR_CLIENT_ID', client_secret: 'YOUR_CLIENT_SECRET', refresh_token: 'YOUR_REFRESH_TOKEN', access_token: 'YOUR_ACCESS_TOKEN' })
+
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway.purchase(@amount, @credit_card, @options)
+    end
+
+    assert_equal error.message, 'Failed with 401 Unauthorized'
+  end
+
   def test_successful_purchase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/remote/gateways/remote_simetrik_test.rb
+++ b/test/remote/gateways/remote_simetrik_test.rb
@@ -78,6 +78,22 @@ class RemoteSimetrikTest < Test::Unit::TestCase
     }
   end
 
+  def test_failed_access_token
+    assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway = SimetrikGateway.new({ client_id: 'YOUR_CLIENT_ID', client_secret: 'YOUR_API_KEY', audience: 'audience_url' })
+      gateway.send :fetch_access_token
+    end
+  end
+
+  def test_failed_authorize_with_failed_access_token
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      gateway = SimetrikGateway.new({ client_id: 'YOUR_CLIENT_ID', client_secret: 'YOUR_API_KEY', audience: 'audience_url' })
+      gateway.authorize(@amount, @credit_card, @authorize_options_success)
+    end
+
+    assert_equal error.message, 'Failed with 401 Unauthorized'
+  end
+
   def test_success_authorize
     response = @gateway.authorize(@amount, @credit_card, @authorize_options_success)
     assert_success response

--- a/test/unit/gateways/airwallex_test.rb
+++ b/test/unit/gateways/airwallex_test.rb
@@ -1,20 +1,10 @@
 require 'test_helper'
 
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
-    class AirwallexGateway
-      def setup_access_token
-        '12345678'
-      end
-    end
-  end
-end
-
 class AirwallexTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = AirwallexGateway.new(client_id: 'login', client_api_key: 'password')
+    @gateway = AirwallexGateway.new(client_id: 'login', client_api_key: 'password', access_token: '12345678')
     @credit_card = credit_card
     @declined_card = credit_card('2223 0000 1018 1375')
     @amount = 100
@@ -26,6 +16,15 @@ class AirwallexTest < Test::Unit::TestCase
 
     @stored_credential_cit_options = { initial_transaction: true, initiator: 'cardholder', reason_type: 'recurring', network_transaction_id: nil }
     @stored_credential_mit_options = { initial_transaction: false, initiator: 'merchant', reason_type: 'recurring' }
+  end
+
+  def test_setup_access_token_should_rise_an_exception_under_unauthorized
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      @gateway.expects(:ssl_post).returns({ code: 'invalid_argument', message: "Failed to convert 'YOUR_CLIENT_ID' to UUID", source: '' }.to_json)
+      @gateway.send(:setup_access_token)
+    end
+
+    assert_match(/Failed to convert 'YOUR_CLIENT_ID' to UUID/, error.message)
   end
 
   def test_gateway_has_access_token

--- a/test/unit/gateways/alelo_test.rb
+++ b/test/unit/gateways/alelo_test.rb
@@ -19,6 +19,15 @@ class AleloTest < Test::Unit::TestCase
     }
   end
 
+  def test_fetch_access_token_should_rise_an_exception_under_unauthorized
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      @gateway .expects(:raw_ssl_request).returns(Net::HTTPBadRequest.new(1.0, 401, 'Unauthorized'))
+      @gateway .send(:fetch_access_token)
+    end
+
+    assert_match(/Failed with 401 Unauthorized/, error.message)
+  end
+
   def test_required_client_id_and_client_secret
     error = assert_raises ArgumentError do
       AleloGateway.new

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -1,15 +1,5 @@
 require 'test_helper'
 
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
-    class CheckoutV2Gateway
-      def setup_access_token
-        '12345678'
-      end
-    end
-  end
-end
-
 class CheckoutV2Test < Test::Unit::TestCase
   include CommStub
 
@@ -17,7 +7,7 @@ class CheckoutV2Test < Test::Unit::TestCase
     @gateway = CheckoutV2Gateway.new(
       secret_key: '1111111111111'
     )
-    @gateway_oauth = CheckoutV2Gateway.new({ client_id: 'abcd', client_secret: '1234' })
+    @gateway_oauth = CheckoutV2Gateway.new({ client_id: 'abcd', client_secret: '1234', access_token: '12345678' })
     @gateway_api = CheckoutV2Gateway.new({
       secret_key: '1111111111111',
       public_key: '2222222222222'
@@ -25,6 +15,15 @@ class CheckoutV2Test < Test::Unit::TestCase
     @credit_card = credit_card
     @amount = 100
     @token = '2MPedsuenG2o8yFfrsdOBWmOuEf'
+  end
+
+  def test_setup_access_token_should_rise_an_exception_under_bad_request
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      @gateway.expects(:raw_ssl_request).returns(Net::HTTPBadRequest.new(1.0, 400, 'Bad Request'))
+      @gateway.send(:setup_access_token)
+    end
+
+    assert_match(/Failed with 400 Bad Request/, error.message)
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/pay_trace_test.rb
+++ b/test/unit/gateways/pay_trace_test.rb
@@ -1,20 +1,10 @@
 require 'test_helper'
 
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
-    class PayTraceGateway < Gateway
-      def acquire_access_token
-        @options[:access_token] = SecureRandom.hex(16)
-      end
-    end
-  end
-end
-
 class PayTraceTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    @gateway = PayTraceGateway.new(username: 'username', password: 'password', integrator_id: 'uniqueintegrator')
+    @gateway = PayTraceGateway.new(username: 'username', password: 'password', integrator_id: 'uniqueintegrator', access_token: SecureRandom.hex(16))
     @credit_card = credit_card
     @echeck = check(account_number: '123456', routing_number: '325070760')
     @amount = 100
@@ -22,6 +12,19 @@ class PayTraceTest < Test::Unit::TestCase
     @options = {
       billing_address: address
     }
+  end
+
+  def test_setup_access_token_should_rise_an_exception_under_bad_request
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      access_token_response = {
+        error: 'invalid_grant',
+        error_description: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+      }.to_json
+      @gateway.expects(:ssl_post).returns(access_token_response)
+      @gateway.send(:acquire_access_token)
+    end
+
+    assert_match(/Failed with  The provided authorization grant is invalid/, error.message)
   end
 
   def test_successful_purchase

--- a/test/unit/gateways/quickbooks_test.rb
+++ b/test/unit/gateways/quickbooks_test.rb
@@ -32,6 +32,15 @@ class QuickBooksTest < Test::Unit::TestCase
     @authorization_no_request_id = 'ECZ7U0SO423E'
   end
 
+  def test_refresh_access_token_should_rise_an_exception_under_unauthorized
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      @oauth_2_gateway .expects(:raw_ssl_request).returns(Net::HTTPBadRequest.new(1.0, 401, 'Unauthorized'))
+      @oauth_2_gateway .send(:refresh_access_token)
+    end
+
+    assert_match(/Failed with 401 Unauthorized/, error.message)
+  end
+
   def test_successful_purchase
     [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
       gateway.expects(:ssl_post).returns(successful_purchase_response)

--- a/test/unit/gateways/simetrik_test.rb
+++ b/test/unit/gateways/simetrik_test.rb
@@ -1,15 +1,5 @@
 require 'test_helper'
 
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
-    class SimetrikGateway < Gateway
-      def fetch_access_token
-        @access_token[:access_token] = SecureRandom.hex(16)
-      end
-    end
-  end
-end
-
 class SimetrikTest < Test::Unit::TestCase
   def setup
     @token_acquirer = 'ea890fd1-49f3-4a34-a150-192bf9a59205'
@@ -17,7 +7,8 @@ class SimetrikTest < Test::Unit::TestCase
     @gateway = SimetrikGateway.new(
       client_id: 'client_id',
       client_secret: 'client_secret_key',
-      audience: 'audience_url'
+      audience: 'audience_url',
+      access_token: { expires_at: Time.new.to_i }
     )
     @credit_card = CreditCard.new(
       first_name: 'sergiod',
@@ -168,6 +159,15 @@ class SimetrikTest < Test::Unit::TestCase
     assert_equal response.avs_result['code'], 'G'
     assert_equal response.cvv_result['code'], 'P'
     assert response.test?
+  end
+
+  def test_fetch_access_token_should_rise_an_exception_under_bad_request
+    error = assert_raises(ActiveMerchant::OAuthResponseError) do
+      @gateway.expects(:raw_ssl_request).returns(Net::HTTPBadRequest.new(1.0, 401, 'Unauthorized'))
+      @gateway.send(:fetch_access_token)
+    end
+
+    assert_match(/Failed with 401 Unauthorized/, error.message)
   end
 
   def test_success_purchase_with_shipping_address


### PR DESCRIPTION
Add new OAuth Response error handling to PayTrace, Quickbooks, Simetrik, Alelo, CheckoutV2 and Airwallex.