### PR TITLE
Adyen: Add `address_override` optional field to swap address1 and address2

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -108,7 +108,7 @@ module ActiveMerchant #:nodoc:
           add_shopper_data(post, payment, options)
 
           if (address = options[:billing_address] || options[:address]) && address[:country]
-            add_billing_address(post, address)
+            add_billing_address(post, options, address)
           end
 
           post[:dateOfBirth] = options[:date_of_birth] if options[:date_of_birth]
@@ -493,8 +493,8 @@ module ActiveMerchant #:nodoc:
       def add_address(post, options)
         if address = options[:shipping_address]
           post[:deliveryAddress] = {}
-          post[:deliveryAddress][:street] = address[:address1] || 'NA'
-          post[:deliveryAddress][:houseNumberOrName] = address[:address2] || 'NA'
+          post[:deliveryAddress][:street] = options[:address_override] == true ? address[:address2] : address[:address1] || 'NA'
+          post[:deliveryAddress][:houseNumberOrName] = options[:address_override] == true ? address[:address1] : address[:address2] || 'NA'
           post[:deliveryAddress][:postalCode] = address[:zip] if address[:zip]
           post[:deliveryAddress][:city] = address[:city] || 'NA'
           post[:deliveryAddress][:stateOrProvince] = get_state(address)
@@ -503,14 +503,14 @@ module ActiveMerchant #:nodoc:
         return unless post[:bankAccount]&.kind_of?(Hash) || post[:card]&.kind_of?(Hash)
 
         if (address = options[:billing_address] || options[:address]) && address[:country]
-          add_billing_address(post, address)
+          add_billing_address(post, options, address)
         end
       end
 
-      def add_billing_address(post, address)
+      def add_billing_address(post, options, address)
         post[:billingAddress] = {}
-        post[:billingAddress][:street] = address[:address1] || 'NA'
-        post[:billingAddress][:houseNumberOrName] = address[:address2] || 'NA'
+        post[:billingAddress][:street] = options[:address_override] == true ? address[:address2] : address[:address1] || 'NA'
+        post[:billingAddress][:houseNumberOrName] = options[:address_override] == true ? address[:address1] : address[:address2] || 'NA'
         post[:billingAddress][:postalCode] = address[:zip] if address[:zip]
         post[:billingAddress][:city] = address[:city] || 'NA'
         post[:billingAddress][:stateOrProvince] = get_state(address)
@@ -738,7 +738,7 @@ module ActiveMerchant #:nodoc:
         end
 
         if (address = fund_source[:billing_address])
-          add_billing_address(post[:fundSource], address)
+          add_billing_address(post[:fundSource], options, address)
         end
       end
 

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1675,6 +1675,20 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_authorize_with_address_override
+    address = {
+      address1: 'Bag End',
+      address2: '123 Hobbiton Way',
+      city: 'Hobbiton',
+      state: 'Derbyshire',
+      country: 'GB',
+      zip: 'DE45 1PP'
+    }
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(billing_address: address, address_override: true))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
   private
 
   def stored_credential_options(*args, ntid: nil)

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -1061,6 +1061,16 @@ class AdyenTest < Test::Unit::TestCase
     assert_equal @options[:shipping_address][:country], post[:deliveryAddress][:country]
   end
 
+  def test_address_override_that_will_swap_housenumberorname_and_street
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(address_override: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/"houseNumberOrName":"456 My Street"/, data)
+      assert_match(/"street":"Apt 1"/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_successful_auth_phone
     options = @options.merge(billing_address: { phone: 1234567890 })
     response = stub_comms do


### PR DESCRIPTION
CER-777

Adyen address fields are more European centric: `houseNumberOrName` and `street`.

`address1` is currently mapped to `street` and `address2` is currently mapped to `houseNumberOrName` which causes AVS errors for users. This may be worth making a permanent change and removing the override in the future.

Remote Tests:
138 tests, 457 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.029% passed
*11 failures are also failing on master

Unit Tests:
113 tests, 595 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Local Tests:
5634 tests, 78165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed