### PR TITLE
Close stale issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'To provide a cleaner slate for the maintenance of the library, this PR/Issue is being labeled stale after 60 days without activity. It will be closed in 14 days unless you comment with an update regarding its applicability to the current build. Thank you!'
+          stale-pr-message: 'To provide a cleaner slate for the maintenance of the library, this PR/Issue is being labeled stale after 60 days without activity. It will be closed in 14 days unless you comment with an update regarding its applicability to the current build. Thank you!'
+          days-before-close: 14
+          exempt-draft-pr: true
+          debug-only: true


### PR DESCRIPTION
The ActiveMerchant repository often has old issues and PRs that have gone stale. This makes it hard
to keep track of new requests. This commit adds the `stale` Github Action to ActiveMerchant.

If an issue or PR goes more than 60 days without activity it will apply the `stale` label. Any issue or PR with a `stale` label for more than 7 days will be closed. Draft PRs are exempt from this. 

Docs: https://github.com/marketplace/actions/close-stale-issues