### PR TITLE
Authorize.NET: Specially designate update excludeFromAccountUpdater

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -742,6 +742,7 @@ module ActiveMerchant #:nodoc:
       end
 
       # :customer_type => 'individual or business', # Optional
+      # :exclude_from_account_updater => 'true or false', # Optional
       # :bill_to => @address,
       # :payment => @payment
       def add_payment_profile(xml, payment_profile)
@@ -764,6 +765,9 @@ module ActiveMerchant #:nodoc:
             xml.tag!('taxId', payment_profile[:payment]) if payment_profile[:payment].has_key?(:tax_id)
           end
         end
+
+        # https://support.authorize.net/knowledgebase/Knowledgearticle/?code=000001022#SelectProfiles
+        xml.tag!('excludeFromAccountUpdater', payment_profile[:exclude_from_account_updater].to_s) if payment_profile.key?(:exclude_from_account_updater)
 
         xml.tag!('customerPaymentProfileId', payment_profile[:customer_payment_profile_id]) if payment_profile[:customer_payment_profile_id]
       end

--- a/test/remote/gateways/remote_authorize_net_cim_test.rb
+++ b/test/remote/gateways/remote_authorize_net_cim_test.rb
@@ -464,6 +464,23 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
 
     # Show that the billing address on the payment profile was updated
     assert_equal 'Frank', response.params['payment_profile']['bill_to']['first_name'], 'The billing address should contain the first name we passed in: Frank'
+
+    # Specially designate update excludeFromAccountUpdater
+    # https://support.authorize.net/knowledgebase/Knowledgearticle/?code=000001022#SelectProfiles
+    # Because the response does not return information about exclude_from_account_updater,
+    # we can only test the response success.
+    assert response = @gateway.update_customer_payment_profile(
+      customer_profile_id: @customer_profile_id,
+      payment_profile: {
+        exclude_from_account_updater: [true, false].sample,
+        customer_payment_profile_id: customer_payment_profile_id,
+        payment: {
+          credit_card: masked_credit_card
+        }
+      }
+    )
+    assert response.test?
+    assert_success response
   end
 
   def test_successful_update_customer_payment_profile_request_with_credit_card_last_four

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -413,7 +413,10 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
       customer_profile_id: @customer_profile_id,
       payment_profile: {
         customer_payment_profile_id: @customer_payment_profile_id,
-        customer_type: 'business'
+        customer_type: 'business',
+        # Specially designate update excludeFromAccountUpdater
+        # https://support.authorize.net/knowledgebase/Knowledgearticle/?code=000001022#SelectProfiles
+        exclude_from_account_updater: [true, false].sample
       }
     )
     assert_instance_of Response, response


### PR DESCRIPTION
Specially designate update excludeFromAccountUpdater
https://support.authorize.net/knowledgebase/Knowledgearticle/?code=000001022#SelectProfiles

Unit:
113 tests, 595 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote: `test/remote/gateways/remote_authorize_net_cim_test.rb`
26 tests, 373 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed