### PR TITLE
Rapyd: Add recurrence_type field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@
 * Adyen: Add MIT flagging for Network Tokens [aenand] #4905
 * Moneris: Update sca actions [almalee24] #4902
 * Ogone: Add gateway specific 3ds option with default options mapping [jherreraa] #4894
+* Rapyd: Add recurrence_type field [yunnydang] #4912
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -104,6 +104,7 @@ module ActiveMerchant #:nodoc:
         add_3ds(post, payment, options)
         add_address(post, payment, options)
         add_metadata(post, options)
+        add_recurrence_type(post, options)
         add_ewallet(post, options)
         add_payment_fields(post, options)
         add_payment_urls(post, options)
@@ -157,6 +158,10 @@ module ActiveMerchant #:nodoc:
 
         initiation_type = options[:initiation_type] || options[:stored_credential][:reason_type]
         post[:initiation_type] = initiation_type if initiation_type
+      end
+
+      def add_recurrence_type(post, options)
+        post[:recurrence_type] = options[:recurrence_type] if options[:recurrence_type]
       end
 
       def add_creditcard(post, payment, options)

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -113,6 +113,12 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert_equal 'customer_present', response.params['data']['initiation_type']
   end
 
+  def test_successful_purchase_with_reccurence_type
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(recurrence_type: 'recurring'))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_successful_purchase_with_address
     billing_address = address(name: 'Henry Winkler', address1: '123 Happy Days Lane')
 

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -146,6 +146,17 @@ class RapydTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_success_purchase_with_recurrence_type
+    @options[:recurrence_type] = 'recurring'
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['recurrence_type'], @options[:recurrence_type]
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_purchase_with_3ds_gateway_specific
     @options[:three_d_secure] = {
       required: true,


### PR DESCRIPTION
Added the recurrence_type field

Local:
5636 tests, 78128 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6629% passed

Unit:
35 tests, 166 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
42 tests, 119 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed