### PR TITLE
SecurionPay/Shift4_v2: authorization from.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@
 * Revert "Adyen: Update MIT flagging for NT" [almalee24] #4914
 * SumUp: Void and partial refund calls [sinourain] #4891
 * Rapyd: send customer object on us payment types [Heavyblade] #4919
+* SecurionPay/Shift4_v2: authorization from [gasb150] #4913
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -239,7 +239,7 @@ module ActiveMerchant #:nodoc:
         if action == 'customers' && success?(response) && response['cards'].present?
           response['cards'].first['id']
         else
-          success?(response) ? response['id'] : response['error']['charge']
+          success?(response) ? response['id'] : (response.dig('error', 'charge') || response.dig('error', 'chargeId'))
         end
       end
 

--- a/test/remote/gateways/remote_securion_pay_test.rb
+++ b/test/remote/gateways/remote_securion_pay_test.rb
@@ -107,6 +107,9 @@ class RemoteSecurionPayTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
+    assert_match CHARGE_ID_REGEX, response.authorization
+    assert_equal response.authorization, response.params['error']['chargeId']
+    assert_equal response.message, 'The card was declined.'
   end
 
   def test_failed_capture

--- a/test/remote/gateways/remote_shift4_v2_test.rb
+++ b/test/remote/gateways/remote_shift4_v2_test.rb
@@ -77,4 +77,12 @@ class RemoteShift4V2Test < RemoteSecurionPayTest
     assert_equal 'merchant_initiated', response.params['type']
     assert_match CHARGE_ID_REGEX, response.authorization
   end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_match CHARGE_ID_REGEX, response.authorization
+    assert_equal response.authorization, response.params['error']['chargeId']
+    assert_equal response.message, 'The card was declined.'
+  end
 end

--- a/test/unit/gateways/securion_pay_test.rb
+++ b/test/unit/gateways/securion_pay_test.rb
@@ -262,7 +262,7 @@ class SecurionPayTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
-    assert_nil response.authorization
+    assert_equal 'char_mApucpvVbCJgo7x09Je4n9gC', response.authorization
     assert response.test?
   end
 


### PR DESCRIPTION
Modift the authorization_from when is a unsuccesful transaction, to get the value from chargeId key.