### PR TITLE
GlobalCollect: Add support for 3DS exemptions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@
 * Beanstream: add alternate option for passing phone number [jcreiff] #4923
 * AuthorizeNet: Update network token method [almalee24] #4852
 * Adding Oauth Response for access tokens [almalee24] #4907
+* GlobalCollect: Added support for 3DS exemption request field [almalee24] #4917
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -40,6 +40,7 @@ module ActiveMerchant #:nodoc:
         add_creator_info(post, options)
         add_fraud_fields(post, options)
         add_external_cardholder_authentication_data(post, options)
+        add_threeds_exemption_data(post, options)
         commit(:post, :authorize, post, options: options)
       end
 
@@ -404,6 +405,12 @@ module ActiveMerchant #:nodoc:
         post['cardPaymentMethodSpecificInput']['threeDSecure']['exemptionRequest'] = threeds_2_options[:exemption_request]
         post['cardPaymentMethodSpecificInput']['threeDSecure']['secureCorporatePayment'] = threeds_2_options[:secure_corporate_payment]
         post['cardPaymentMethodSpecificInput']['threeDSecure']['externalCardholderAuthenticationData'] = authentication_data unless authentication_data.empty?
+      end
+
+      def add_threeds_exemption_data(post, options)
+        return unless options[:three_ds_exemption_type]
+
+        post['cardPaymentMethodSpecificInput']['transactionChannel'] = 'MOTO' if options[:three_ds_exemption_type] == 'moto'
       end
 
       def add_number_of_installments(post, options)

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -196,6 +196,13 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
   end
 
+  def test_successful_authorize_with_moto_exemption
+    options = @options.merge(three_ds_exemption_type: 'moto')
+
+    response = @gateway.authorize(@amount, @credit_card, options)
+    assert_success response
+  end
+
   def test_successful_authorize_via_normalized_3ds2_fields
     options = @options.merge(
       three_d_secure: {

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -433,6 +433,16 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_authorize_with_3ds_exemption
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@accepted_amount, @credit_card, { three_ds_exemption_type: 'moto' })
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"transactionChannel\":\"MOTO\"/, data)
+    end.respond_with(successful_authorize_with_3ds2_data_response)
+
+    assert_success response
+  end
+
   def test_truncates_first_name_to_15_chars
     credit_card = credit_card('4567350000427977', { first_name: 'thisisaverylongfirstname' })
 


### PR DESCRIPTION
Remote
53 tests, 121 assertions, 10 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications 79.2453% passed

Unit
46 tests, 234 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed