### PR TITLE
SafeCharge (Nuvei): Fix the credit method for sg_CreditType field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * SecurionPay/Shift4_v2: authorization from [gasb150] #4913
 * Rapyd: Update recurrence_type field [yunnydang] #4922
 * Element: Add lodging fields [yunnydang] #4813
+* SafeCharge: Update sg_CreditType field on the credit method [yunnydang] #4918
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -88,7 +88,7 @@ module ActiveMerchant #:nodoc:
         add_transaction_data('Credit', post, money, options)
         add_customer_details(post, payment, options)
 
-        post[:sg_CreditType] = 1
+        options[:unreferenced_refund].to_s == 'true' ? post[:sg_CreditType] = 2 : post[:sg_CreditType] = 1
 
         commit(post)
       end

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -268,6 +268,16 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     assert_equal 'Success', refund.message
   end
 
+  def test_successful_unreferenced_refund_with_credit
+    option = {
+      unreferenced_refund: true
+    }
+
+    assert general_credit = @gateway.credit(@amount, @credit_card, option)
+    assert_success general_credit
+    assert_equal 'Success', general_credit.message
+  end
+
   def test_successful_credit
     response = @gateway.credit(@amount, credit_card('4444436501403986'), @options)
     assert_success response

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -223,6 +223,26 @@ class SafeChargeTest < Test::Unit::TestCase
     assert_success refund
   end
 
+  def test_successful_credit_with_unreferenced_refund
+    credit = stub_comms do
+      @gateway.credit(@amount, @credit_card, @options.merge(unreferenced_refund: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal(data.split('&').include?('sg_CreditType=2'), true)
+    end.respond_with(successful_credit_response)
+
+    assert_success credit
+  end
+
+  def test_successful_credit_without_unreferenced_refund
+    credit = stub_comms do
+      @gateway.credit(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal(data.split('&').include?('sg_CreditType=1'), true)
+    end.respond_with(successful_credit_response)
+
+    assert_success credit
+  end
+
   def test_failed_refund
     @gateway.expects(:ssl_post).returns(failed_refund_response)
 


### PR DESCRIPTION
This is to essentially do an override on the sg_CreditType field to send a 2 if unreferenced_refund field is sent as true.

Local:
5636 tests, 78102 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6629% passed

Unit:
29 tests, 160 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
33 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed