### PR TITLE
Rapyd: send customer object on us payment types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@
 * Rapyd: Add recurrence_type field [yunnydang] #4912
 * Revert "Adyen: Update MIT flagging for NT" [almalee24] #4914
 * SumUp: Void and partial refund calls [sinourain] #4891
+* Rapyd: send customer object on us payment types [Heavyblade] #4919
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827


### PR DESCRIPTION
## Summary:

Introduces a change for authorize/purchase transactions to only include the custome_object for us payment types.

[SER-885](https://spreedly.atlassian.net/browse/SER-885)

## Tests

### Remote Test:
Finished in 138.6279 seconds.
42 tests, 118 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.619% passed

*Note*: The failure test, fails because is a reference transaction related to a wallet.

### Unit Tests:
Finished in 42.121938 seconds.
5643 tests, 78206 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
773 files inspected, no offenses detected