### PR TITLE
Rapyd: fix the recurrence_type field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@
 * SumUp: Void and partial refund calls [sinourain] #4891
 * Rapyd: send customer object on us payment types [Heavyblade] #4919
 * SecurionPay/Shift4_v2: authorization from [gasb150] #4913
+* Rapyd: Update recurrence_type field [yunnydang] #4922
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -104,7 +104,6 @@ module ActiveMerchant #:nodoc:
         add_3ds(post, payment, options)
         add_address(post, payment, options)
         add_metadata(post, options)
-        add_recurrence_type(post, options)
         add_ewallet(post, options)
         add_payment_fields(post, options)
         add_payment_urls(post, options)
@@ -160,10 +159,6 @@ module ActiveMerchant #:nodoc:
         post[:initiation_type] = initiation_type if initiation_type
       end
 
-      def add_recurrence_type(post, options)
-        post[:recurrence_type] = options[:recurrence_type] if options[:recurrence_type]
-      end
-
       def add_creditcard(post, payment, options)
         post[:payment_method] = {}
         post[:payment_method][:fields] = {}
@@ -175,6 +170,7 @@ module ActiveMerchant #:nodoc:
         pm_fields[:expiration_year] = payment.year.to_s
         pm_fields[:name] = "#{payment.first_name} #{payment.last_name}"
         pm_fields[:cvv] = payment.verification_value.to_s unless valid_network_transaction_id?(options) || payment.verification_value.blank?
+        pm_fields[:recurrence_type] = options[:recurrence_type] if options[:recurrence_type]
         add_stored_credential(post, options)
       end
 

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -114,6 +114,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_reccurence_type
+    @options[:pm_type] = 'gb_visa_mo_card'
     response = @gateway.purchase(@amount, @credit_card, @options.merge(recurrence_type: 'recurring'))
     assert_success response
     assert_equal 'SUCCESS', response.message

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -153,7 +153,7 @@ class RapydTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_method, _endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_equal request['recurrence_type'], @options[:recurrence_type]
+      assert_equal request['payment_method']['fields']['recurrence_type'], @options[:recurrence_type]
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
This change is to properly nest the recurrence_type field. 

Local:
5638 tests, 78133 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.663% passed

Unit:
35 tests, 166 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
41 tests, 117 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed