### PR TITLE
Beanstream: add alternate option for passing phone number

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@
 * Element: Add lodging fields [yunnydang] #4813
 * SafeCharge: Update sg_CreditType field on the credit method [yunnydang] #4918
 * Rapyd: add force_3ds_secure flag [Heavyblade] #4927
+* Beanstream: add alternate option for passing phone number [jcreiff] #4923
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
+++ b/lib/active_merchant/billing/gateways/beanstream/beanstream_core.rb
@@ -228,7 +228,7 @@ module ActiveMerchant #:nodoc:
 
         if billing_address = options[:billing_address] || options[:address]
           post[:ordName]          = billing_address[:name]
-          post[:ordPhoneNumber]   = billing_address[:phone]
+          post[:ordPhoneNumber]   = billing_address[:phone] || billing_address[:phone_number]
           post[:ordAddress1]      = billing_address[:address1]
           post[:ordAddress2]      = billing_address[:address2]
           post[:ordCity]          = billing_address[:city]

--- a/test/unit/gateways/beanstream_test.rb
+++ b/test/unit/gateways/beanstream_test.rb
@@ -302,6 +302,19 @@ class BeanstreamTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_sends_alternate_phone_number_value
+    @options[:billing_address][:phone] = nil
+    @options[:billing_address][:phone_number] = '9191234567'
+
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/ordPhoneNumber=9191234567/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_transcript_scrubbing
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end


### PR DESCRIPTION
LOCAL
5639 tests, 78187 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

773 files inspected, no offenses detected

UNIT
24 tests, 112 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE 
45 tests, 201 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
*Tests also fail on master branch