### PR TITLE
Adyen: Add mcc field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@
 * Adding Oauth Response for access tokens [almalee24] #4907
 * GlobalCollect: Added support for 3DS exemption request field [almalee24] #4917
 * NMI: Update supported countries list [jcreiff] #4931
+* Adyen: Add mcc field [jcreiff] #4926
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -255,6 +255,7 @@ module ActiveMerchant #:nodoc:
         post[:shopperIP] = options[:shopper_ip] || options[:ip] if options[:shopper_ip] || options[:ip]
         post[:shopperStatement] = options[:shopper_statement] if options[:shopper_statement]
         post[:store] = options[:store] if options[:store]
+        post[:mcc] = options[:mcc] if options[:mcc]
 
         add_shopper_data(post, payment, options)
         add_additional_data(post, payment, options)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1485,6 +1485,20 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_sending_mcc_on_authorize
+    options = {
+      reference: '345123',
+      email: 'john.smith@test.com',
+      ip: '77.110.174.153',
+      shopper_reference: 'John Smith',
+      order_id: '123',
+      mcc: '5411'
+    }
+    response = @gateway.authorize(@amount, @credit_card, options)
+    assert_failure response
+    assert_equal 'Could not find an acquirer account for the provided currency (USD).', response.message
+  end
+
   def test_successful_authorize_with_level_2_data
     level_2_data = {
       total_tax_amount: '160',

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -1473,9 +1473,10 @@ class AdyenTest < Test::Unit::TestCase
 
   def test_additional_extra_data
     response = stub_comms do
-      @gateway.authorize(@amount, @credit_card, @options.merge(store: 'test store'))
+      @gateway.authorize(@amount, @credit_card, @options.merge(store: 'test store', mcc: '1234'))
     end.check_request do |_endpoint, data, _headers|
       assert_equal JSON.parse(data)['store'], 'test store'
+      assert_equal JSON.parse(data)['mcc'], '1234'
     end.respond_with(successful_authorize_response)
     assert_success response
   end


### PR DESCRIPTION
LOCAL
5643 tests, 78207 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

773 files inspected, no offenses detected

UNIT
113 tests, 596 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

REMOTE
139 tests, 459 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.0863% passed