### PR TITLE
Rapyd: add force_3ds_secure flag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * Rapyd: Update recurrence_type field [yunnydang] #4922
 * Element: Add lodging fields [yunnydang] #4813
 * SafeCharge: Update sg_CreditType field on the credit method [yunnydang] #4918
+* Rapyd: add force_3ds_secure flag [Heavyblade] #4927
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -207,7 +207,7 @@ module ActiveMerchant #:nodoc:
 
       def add_3ds(post, payment, options)
         if options[:execute_threed] == true
-          post[:payment_method_options] = { '3d_required' => true }
+          post[:payment_method_options] = { '3d_required' => true } if options[:force_3d_secure].present?
         elsif three_d_secure = options[:three_d_secure]
           post[:payment_method_options] = {}
           post[:payment_method_options]['3d_required'] = three_d_secure[:required]

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -157,7 +157,7 @@ class RapydTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_successful_purchase_with_3ds_gateway_specific
+  def test_successful_purchase_with_3ds_global
     @options[:three_d_secure] = {
       required: true,
       version: '2.1.0'
@@ -170,6 +170,18 @@ class RapydTest < Test::Unit::TestCase
       assert_equal request['payment_method_options']['3d_version'], '2.1.0'
       assert request['complete_payment_url']
       assert request['error_payment_url']
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_successful_purchase_with_3ds_gateway_specific
+    @options.merge!(execute_threed: true, force_3d_secure: true)
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['payment_method_options']['3d_required'], true
+      assert_nil request['payment_method_options']['3d_version']
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
## Summary:

Introduces a change for 3ds transactions when dealing with 3DS gateway specific besides the standard fields a GSF needs to be sent in order to force the 3DS flow, this change is needed because the '3d_require' attribute works as a force flag, not like a feature flag.

[SER-889](https://spreedly.atlassian.net/browse/SER-889)

## Tests

### Remote Test:

Finished in 115.583277 seconds.
42 tests, 118 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.619% passed

*Note*: The failure test, fails becase is reference transaction related to a wallet.

### Unit Tests:

Finished in 42.100949 seconds.
5643 tests, 78206 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
773 files inspected, no offenses detected