### PR TITLE
Orbital: Enable Third Party Vaulting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,7 @@
 * Cecabank: Add scrub implementation [sinourain] #4945
 * GlobalCollect: Fix bug in success_from logic [DustinHaefele] #4939
 * Worldpay: Update 3ds logic to accept df_reference_id directly [DustinHaefele] #4929
+* Orbital: Enable Third Party Vaulting [javierpedrozaing] #4928
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -727,6 +727,11 @@ orbital_tandem_gateway:
   password: PASSWORD
   merchant_id: MERCHANTID
 
+orbital_tpv_gateway:
+  login: LOGIN
+  password: PASSWORD
+  merchant_id: MERCHANTID
+
 # Working credentials, no need to replace
 pagarme:
     api_key: 'ak_test_e1QGU2gL98MDCHZxHLJ9sofPUFJ7tH'


### PR DESCRIPTION
Description
-------------------------
[SER-782](https://spreedly.atlassian.net/browse/SER-782)

This commit enable third party vaulting for Orbital in this case Orbital needs a flag to enable the store process and it doesn't support unstore function.

Orbital does not have a store and unstore endpoint. We are enabling the store process through a Spreedly store endpoint, but behind the scenes, we are performing a $0 authorization and sending the tokenTxType."

Unit test
-------------------------
Finished in 1.849371 seconds.

147 tests, 831 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

79.49 tests/s, 449.34 assertions/s

Remote test
-------------------------
Finished in 101.551157 seconds.

126 tests, 509 assertions, 9 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.8571% passed

1.24 tests/s, 5.01 assertions/s

Rubocop
-------------------------
773 files inspected, no offenses detected