### PR TITLE
Worldpay: Update 3ds logic to accept df_reference_id directly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@
 * Cecabank: Add 3DS Global to Cecabank REST JSON gateway [sinourain] #4940
 * Cecabank: Add scrub implementation [sinourain] #4945
 * GlobalCollect: Fix bug in success_from logic [DustinHaefele] #4939
+* Worldpay: Update 3ds logic to accept df_reference_id directly [DustinHaefele] #4929
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -443,7 +443,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_additional_3ds_data(xml, options)
-        additional_data = { 'dfReferenceId' => options[:session_id] }
+        additional_data = { 'dfReferenceId' => options[:df_reference_id] }
         additional_data['challengeWindowSize'] = options[:browser_size] if options[:browser_size]
 
         xml.additional3DSData additional_data

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -455,9 +455,8 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     )
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert first_message.test?
+    assert first_message.success?
     refute first_message.authorization.blank?
-    refute first_message.params['issuer_url'].blank?
-    refute first_message.params['pa_request'].blank?
     refute first_message.params['cookie'].blank?
     refute first_message.params['session_id'].blank?
   end
@@ -483,8 +482,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @threeDS2_challenge_card, options)
     assert response.test?
     refute response.authorization.blank?
-    refute response.params['issuer_url'].blank?
-    refute response.params['pa_request'].blank?
+    assert response.success?
     refute response.params['cookie'].blank?
     refute response.params['session_id'].blank?
   end
@@ -570,8 +568,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert first_message.test?
     refute first_message.authorization.blank?
-    refute first_message.params['issuer_url'].blank?
-    refute first_message.params['pa_request'].blank?
+    assert first_message.success?
     refute first_message.params['cookie'].blank?
     refute first_message.params['session_id'].blank?
   end
@@ -592,8 +589,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert first_message = @gateway.authorize(@amount, @threeDS_card, options)
     assert first_message.test?
     refute first_message.authorization.blank?
-    refute first_message.params['issuer_url'].blank?
-    refute first_message.params['pa_request'].blank?
+    assert first_message.success?
     refute first_message.params['cookie'].blank?
     refute first_message.params['session_id'].blank?
   end
@@ -869,7 +865,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
   def test_failed_fast_fund_credit_on_cft_gateway
     options = @options.merge({ fast_fund_credit: true })
-    refused_card = credit_card('4917300800000000', name: 'REFUSED') # 'magic' value for testing failures, provided by Worldpay
+    refused_card = credit_card('4444333322221111', name: 'REFUSED') # 'magic' value for testing failures, provided by Worldpay
 
     credit = @cftgateway.credit(@amount, refused_card, options)
     assert_failure credit

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1097,9 +1097,11 @@ class WorldpayTest < Test::Unit::TestCase
   def test_3ds_additional_information
     browser_size = '390x400'
     session_id = '0215ui8ib1'
+    df_reference_id = '1326vj9jc2'
 
     options = @options.merge(
       session_id: session_id,
+      df_reference_id: df_reference_id,
       browser_size: browser_size,
       execute_threed: true,
       three_ds_version: '2.0.1'
@@ -1108,7 +1110,7 @@ class WorldpayTest < Test::Unit::TestCase
     stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_tag_with_attributes 'additional3DSData', { 'dfReferenceId' => session_id, 'challengeWindowSize' => browser_size }, data
+      assert_tag_with_attributes 'additional3DSData', { 'dfReferenceId' => df_reference_id, 'challengeWindowSize' => browser_size }, data
     end.respond_with(successful_authorize_response)
   end
 


### PR DESCRIPTION
unit tests:
-------------------------------------------------------------------------------------------------------------------------
113 tests, 645 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
--------------------------------------------------------------------------------------------------------------------------426.14 tests/s, 2432.37 assertions/s

remote tests:
--------------------------------------------------------------------------------------------------------------------------
100 tests, 412 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
--------------------------------------------------------------------------------------------------------------------------

ticket for spreedly tracking: ECS-3125