### PR TITLE
Quickbooks: Remove OAuth from commit method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@
 * GlobalCollect: Added support for 3DS exemption request field [almalee24] #4917
 * NMI: Update supported countries list [jcreiff] #4931
 * Adyen: Add mcc field [jcreiff] #4926
+* Quickbooks: Remove raise OAuth from extract_response_body_or_raise [almalee24] #4935
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -364,9 +364,6 @@ module ActiveMerchant #:nodoc:
           raise response_error
         end
 
-        error_code = JSON.parse(response_error.response.body)['code']
-        raise OAuthResponseError.new(response_error, error_code) if error_code == 'AuthenticationFailed'
-
         response_error.response.body
       end
 


### PR DESCRIPTION
The OAuth response in commit is preventing the transaction from being retried if they failed with AuthenticationFailed because of invalid credentials or expired access tokens.