### PR TITLE
Kushki: Add support for Partial Refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -48,8 +48,9 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:ticketNumber] = authorization
         add_full_response(post, options)
+        add_invoice(action, post, amount, options)
 
-        commit(action, post)
+        commit(action, post, options)
       end
 
       def void(authorization, options = {})
@@ -185,7 +186,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_full_response(post, options)
-        post[:fullResponse] = options[:full_response].to_s.casecmp('true').zero? if options[:full_response]
+        # this is the only currently accepted value for this field, previously it was 'true'
+        post[:fullResponse] = 'v2' unless options[:full_response] == 'false' || options[:full_response].blank?
       end
 
       def add_metadata(post, options)
@@ -245,10 +247,10 @@ module ActiveMerchant #:nodoc:
         'capture' => 'capture'
       }
 
-      def commit(action, params)
+      def commit(action, params, options = {})
         response =
           begin
-            parse(ssl_invoke(action, params))
+            parse(ssl_invoke(action, params, options))
           rescue ResponseError => e
             parse(e.response.body)
           end
@@ -265,9 +267,11 @@ module ActiveMerchant #:nodoc:
         )
       end
 
-      def ssl_invoke(action, params)
+      def ssl_invoke(action, params, options)
         if %w[void refund].include?(action)
-          ssl_request(:delete, url(action, params), nil, headers(action))
+          # removes ticketNumber from request for partial refunds because gateway will reject if included in request body
+          data = options[:partial_refund] == true ? post_data(params.except(:ticketNumber)) : nil
+          ssl_request(:delete, url(action, params), data, headers(action))
         else
           ssl_post(url(action, params), post_data(params), headers(action))
         end


### PR DESCRIPTION
This updates the logic to allow a request body to be sent as part of a refund request. Kushki uses the DELETE http method for refunds and voids, which meant that they were truly reference transactions only without a request body. The ssl_invoke method needed to be updated to allow for this, and still be able to send the ticketNumber through in post to be captured and added to the url.

This also updates several remote tests that had `PEN` currency to use credentials that are tied to Peru so they will pass.

Unit Tests:
18 tests, 117 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests:
25 tests, 74 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96% passed
*There are 3 tests failing due to credentials issues. Kushki has credentials tied to certain countries and we are trying to get that fixed

Local Tests:
5651 tests, 78252 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed