### PR TITLE
Braintree: Add new stored credential method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,6 +59,7 @@
 * Shift4 V2: Add unstore function [javierpedrozaing] #4953
 * CommerceHub: Add 3DS global support [sinourain] #4957
 * SumUp Gateway: Fix refund method [sinourain] #4924
+* Braintree: Add v2 stored credential option [aenand] #4937
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -827,15 +827,39 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_stored_credential_data(parameters, credit_card_or_vault_id, options)
+        # Braintree has informed us that the stored_credential mapping may be incorrect
+        # In order to prevent possible breaking changes we will only apply the new logic if
+        # specifically requested. This will be the default behavior in a future release.
         return unless (stored_credential = options[:stored_credential])
 
-        parameters[:external_vault] = {}
-        if stored_credential[:initial_transaction]
-          parameters[:external_vault][:status] = 'will_vault'
+        add_external_vault(parameters, stored_credential)
+
+        if options[:stored_credentials_v2]
+          stored_credentials_v2(parameters, stored_credential)
         else
-          parameters[:external_vault][:status] = 'vaulted'
-          parameters[:external_vault][:previous_network_transaction_id] = stored_credential[:network_transaction_id]
+          stored_credentials_v1(parameters, stored_credential)
         end
+      end
+
+      def stored_credentials_v2(parameters, stored_credential)
+        # Differences between v1 and v2 are
+        # initial_transaction + recurring/installment should be labeled {{reason_type}}_first
+        # unscheduled in AM should map to '' at BT because unscheduled here means not on a fixed timeline or fixed amount
+        case stored_credential[:reason_type]
+        when 'recurring', 'installment'
+          if stored_credential[:initial_transaction]
+            parameters[:transaction_source] = "#{stored_credential[:reason_type]}_first"
+          else
+            parameters[:transaction_source] = stored_credential[:reason_type]
+          end
+        when 'recurring_first', 'moto'
+          parameters[:transaction_source] = stored_credential[:reason_type]
+        else
+          parameters[:transaction_source] = ''
+        end
+      end
+
+      def stored_credentials_v1(parameters, stored_credential)
         if stored_credential[:initiator] == 'merchant'
           if stored_credential[:reason_type] == 'installment'
             parameters[:transaction_source] = 'recurring'
@@ -846,6 +870,16 @@ module ActiveMerchant #:nodoc:
           parameters[:transaction_source] = stored_credential[:reason_type]
         else
           parameters[:transaction_source] = ''
+        end
+      end
+
+      def add_external_vault(parameters, stored_credential)
+        parameters[:external_vault] = {}
+        if stored_credential[:initial_transaction]
+          parameters[:external_vault][:status] = 'will_vault'
+        else
+          parameters[:external_vault][:status] = 'vaulted'
+          parameters[:external_vault][:previous_network_transaction_id] = stored_credential[:network_transaction_id]
         end
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1014,6 +1014,43 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert !gateway.verify_credentials
   end
 
+  def test_successful_recurring_first_stored_credential_v2
+    creds_options = stored_credential_options(:cardholder, :recurring, :initial)
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options, stored_credentials_v2: true))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_not_nil response.params['braintree_transaction']['network_transaction_id']
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
+  def test_successful_follow_on_recurring_first_cit_stored_credential_v2
+    creds_options = stored_credential_options(:cardholder, :recurring, id: '020190722142652')
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options, stored_credentials_v2: true))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_not_nil response.params['braintree_transaction']['network_transaction_id']
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
+  def test_successful_follow_on_recurring_first_mit_stored_credential_v2
+    creds_options = stored_credential_options(:merchant, :recurring, id: '020190722142652')
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options, stored_credentials_v2: true))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_not_nil response.params['braintree_transaction']['network_transaction_id']
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+  end
+
+  def test_successful_one_time_mit_stored_credential_v2
+    creds_options = stored_credential_options(:merchant, id: '020190722142652')
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options, stored_credentials_v2: true))
+
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'submitted_for_settlement', response.params['braintree_transaction']['status']
+    assert_not_nil response.params['braintree_transaction']['network_transaction_id']
+  end
+
   def test_successful_merchant_purchase_initial
     creds_options = stored_credential_options(:merchant, :recurring, :initial)
     response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1351,6 +1351,21 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: { initiator: 'merchant', reason_type: 'recurring_first', initial_transaction: true } })
   end
 
+  def test_stored_credential_v2_recurring_first_cit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'will_vault'
+          },
+          transaction_source: 'recurring_first'
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: { initiator: 'merchant', reason_type: 'recurring_first', initial_transaction: true } })
+  end
+
   def test_stored_credential_moto_cit_initial
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
@@ -1364,6 +1379,84 @@ class BraintreeBlueTest < Test::Unit::TestCase
     ).returns(braintree_result)
 
     @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: { initiator: 'merchant', reason_type: 'moto', initial_transaction: true } })
+  end
+
+  def test_stored_credential_v2_recurring_first
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'will_vault'
+          },
+          transaction_source: 'recurring_first'
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:cardholder, :recurring, :initial) })
+  end
+
+  def test_stored_credential_v2_follow_on_recurring_first
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '123ABC'
+          },
+          transaction_source: 'recurring'
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:merchant, :recurring, id: '123ABC') })
+  end
+
+  def test_stored_credential_v2_installment_first
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'will_vault'
+          },
+          transaction_source: 'installment_first'
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:cardholder, :installment, :initial) })
+  end
+
+  def test_stored_credential_v2_follow_on_installment_first
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '123ABC'
+          },
+          transaction_source: 'installment'
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:merchant, :installment, id: '123ABC') })
+  end
+
+  def test_stored_credential_v2_merchant_one_time
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '123ABC'
+          },
+          transaction_source: ''
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:merchant, id: '123ABC') })
   end
 
   def test_raises_exeption_when_adding_bank_account_to_customer_without_billing_address


### PR DESCRIPTION
ECS-3194

Braintree has informed us we are not handling stored credentials appropriately in certain cases. This commit adds a new method to handle this new behavior in a controlled manner.

The changes are that if it's the initial_transaction & recurring it is to be marked as `recurring_first`.

If there are any reason_types unrecognized we will mark transaction_source as nil

Test Summary
Remote:
111 tests, 585 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed