### PR TITLE
GlobalCollect: Fix bug in success_from logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@
 * Cecabank: Add new Cecabank gateway to use the JSON REST API [sinourain] #4920
 * Cecabank: Add 3DS Global to Cecabank REST JSON gateway [sinourain] #4940
 * Cecabank: Add scrub implementation [sinourain] #4945
+* GlobalCollect: Fix bug in success_from logic [DustinHaefele] #4939
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -522,8 +522,6 @@ module ActiveMerchant #:nodoc:
       def success_from(action, response)
         return false if response['errorId'] || response['error_message']
 
-        return %w(CAPTURED CAPTURE_REQUESTED).include?(response.dig('payment', 'status')) if response.dig('payment', 'paymentOutput', 'paymentMethod') == 'mobile'
-
         case action
         when :authorize
           response.dig('payment', 'statusOutput', 'isAuthorized')

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -105,6 +105,32 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
   end
 
+  def test_successful_authorize_with_apple_pay
+    options = @preprod_options.merge(requires_approval: false, currency: 'USD')
+    response = @gateway_preprod.authorize(4500, @apple_pay, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
+  end
+
+  def test_successful_purchase_with_apple_pay_ogone_direct
+    options = @preprod_options.merge(requires_approval: false, currency: 'USD')
+    response = @gateway_direct.purchase(100, @apple_pay, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 'PENDING_CAPTURE', response.params['payment']['status']
+  end
+
+  def test_successful_authorize_and_capture_with_apple_pay_ogone_direct
+    options = @preprod_options.merge(requires_approval: false, currency: 'USD')
+    auth = @gateway_direct.authorize(100, @apple_pay, options)
+    assert_success auth
+
+    assert capture = @gateway_direct.capture(@amount, auth.authorization, @options)
+    assert_success capture
+    assert_equal 'Succeeded', capture.message
+  end
+
   def test_successful_purchase_with_google_pay
     options = @preprod_options.merge(requires_approval: false)
     response = @gateway_preprod.purchase(4500, @google_pay, options)


### PR DESCRIPTION
Some apple_pay transactions that were through global collect direct (ogone) were being marked as failed despite success. The response from direct was slightly different than the standard global collect so the logic wasn't seeing them as successful.

Spreedly reference ticket: ECS-3197
remote tests:
54 tests, 141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

unit tests:
45 tests, 230 assertions, 0 failures, 0 errors, 0 pending, 0 omissions, 0 notifications 100% passed
1497.80 tests/s, 7655.44 assertions/s