### PR TITLE
Payeezy: Add customer_ref and reference_3 fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,7 @@
 * GlobalCollect: Fix bug in success_from logic [DustinHaefele] #4939
 * Worldpay: Update 3ds logic to accept df_reference_id directly [DustinHaefele] #4929
 * Orbital: Enable Third Party Vaulting [javierpedrozaing] #4928
+* Payeezy: Add the customer_ref and reference_3 fields [yunnydang] #4942
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -35,6 +35,8 @@ module ActiveMerchant
 
         add_invoice(params, options)
         add_reversal_id(params, options)
+        add_customer_ref(params, options)
+        add_reference_3(params, options)
         add_payment_method(params, payment_method, options)
         add_address(params, options)
         add_amount(params, amount, options)
@@ -51,6 +53,8 @@ module ActiveMerchant
 
         add_invoice(params, options)
         add_reversal_id(params, options)
+        add_customer_ref(params, options)
+        add_reference_3(params, options)
         add_payment_method(params, payment_method, options)
         add_address(params, options)
         add_amount(params, amount, options)
@@ -168,6 +172,14 @@ module ActiveMerchant
 
       def add_reversal_id(params, options)
         params[:reversal_id] = options[:reversal_id] if options[:reversal_id]
+      end
+
+      def add_customer_ref(params, options)
+        params[:customer_ref] = options[:customer_ref] if options[:customer_ref]
+      end
+
+      def add_reference_3(params, options)
+        params[:reference_3] = options[:reference_3] if options[:reference_3]
       end
 
       def amount_from_authorization(authorization)

--- a/test/remote/gateways/remote_payeezy_test.rb
+++ b/test/remote/gateways/remote_payeezy_test.rb
@@ -122,6 +122,26 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_and_authorize_with_reference_3
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(reference_3: '123345'))
+    assert_match(/Transaction Normal/, response.message)
+    assert_success response
+
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(reference_3: '123345'))
+    assert_match(/Transaction Normal/, auth.message)
+    assert_success auth
+  end
+
+  def test_successful_purchase_and_authorize_with_customer_ref_top_level
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(customer_ref: 'abcde'))
+    assert_match(/Transaction Normal/, response.message)
+    assert_success response
+
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(customer_ref: 'abcde'))
+    assert_match(/Transaction Normal/, auth.message)
+    assert_success auth
+  end
+
   def test_successful_purchase_with_customer_ref
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(level2: { customer_ref: 'An important customer' }))
     assert_match(/Transaction Normal/, response.message)
@@ -441,7 +461,7 @@ class RemotePayeezyTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_match(/Server Error/, response.message) # 42 is 'unable to send trans'
     assert_failure response
-    assert_equal '500', response.error_code
+    assert_equal '500 INTERNAL_SERVER_ERROR', response.error_code
   end
 
   def test_transcript_scrubbing_store

--- a/test/unit/gateways/payeezy_test.rb
+++ b/test/unit/gateways/payeezy_test.rb
@@ -221,6 +221,28 @@ class PayeezyGateway < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_customer_ref_top_level
+    options = @options.merge(customer_ref: 'abcde')
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/"customer_ref":"abcde"/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_successful_purchase_with_reference_3
+    options = @options.merge(reference_3: '12345')
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/"reference_3":"12345"/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_stored_credentials
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(@options_stored_credentials))


### PR DESCRIPTION
This adds the customer_ref (top level) field and the reference_3 field.

Local:
5654 tests, 78215 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.664% passed

Unit:
51 tests, 235 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
52 tests, 213 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed