### PR TITLE
WorldPay: Accept GooglePay pan only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,7 @@
 * SafeCharge: Support tokens [almalee24] #4948
 * Redsys: Update to $0 verify [almalee24] #4944
 * Litle: Update stored credentials [almalee24] #4903
+* WorldPay: Accept GooglePay pan only [almalee24] #4943
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -197,6 +197,30 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_authorize_with_google_pay_pan_only
+    response = @gateway.authorize(@amount, @credit_card, @options.merge!(wallet_type: :google_pay))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_purchase_with_google_pay_pan_only
+    assert auth = @gateway.purchase(@amount, @credit_card, @options.merge!(wallet_type: :google_pay))
+    assert_success auth
+    assert_equal 'SUCCESS', auth.message
+    assert auth.authorization
+  end
+
+  def test_successful_authorize_with_void_google_pay_pan_only
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge!(wallet_type: :google_pay))
+    assert_success auth
+    assert_equal 'authorize', auth.params['action']
+    assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge(authorization_validated: true))
+    assert_success capture
+    assert void = @gateway.void(auth.authorization, @options.merge(authorization_validated: true))
+    assert_success void
+  end
+
   def test_successful_authorize_without_card_holder_name_apple_pay
     @apple_pay_network_token.first_name = ''
     @apple_pay_network_token.last_name = ''

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1463,6 +1463,14 @@ class WorldpayTest < Test::Unit::TestCase
     end
   end
 
+  def test_network_token_type_assignation_when_google_pay_pan_only
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge!(wallet_type: :google_pay))
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      assert_match %r(<EMVCO_TOKEN-SSL type="GOOGLEPAY">), data
+    end
+  end
+
   def test_order_id_crop_and_clean
     @options[:order_id] = "abc1234 abc1234 'abc1234' <abc1234> \"abc1234\" | abc1234 abc1234 abc1234 abc1234 abc1234"
     response = stub_comms do


### PR DESCRIPTION
Update payment_details and add_network_tokenization_card to accept GooglePay payment methods that are pan only.

Remote:
103 tests, 416 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 93.2039% passed

Unit:
114 tests, 648 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed