### PR TITLE
Ecs 3181 stripe pi checks

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -786,9 +786,9 @@ module ActiveMerchant #:nodoc:
         payment.respond_to?(:read_method) && payment.read_method == 'contact_quickchip'
       end
 
-      def card_from_response(response) 
+      def card_from_response(response)
         # StripePI puts the AVS and CVC check significantly deeper into the response object
-        response['card'] || response['active_card'] || response['source'] || response.dig('charges','data',0,'payment_method_details','card','checks') || {}
+        response['card'] || response['active_card'] || response['source'] || response.dig('charges', 'data', 0, 'payment_method_details', 'card', 'checks') || {}
       end
 
       def emv_authorization_from_response(response)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -18,7 +18,7 @@ module ActiveMerchant #:nodoc:
         'line1: unchecked, zip: unchecked' => 'I'
       }
 
-      # TODO: Lookup codes, figure out if I need ot add `null` values, and what they map to. May be in StripePaymentIntents Docs
+      #  TODO: Lookup codes, figure out if I need ot add `null` values, and what they map to. May be in StripePaymentIntents Docs
       CVC_CODE_TRANSLATOR = {
         'pass' => 'M',
         'fail' => 'N',

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -7,6 +7,7 @@ module ActiveMerchant #:nodoc:
     class StripeGateway < Gateway
       self.live_url = 'https://api.stripe.com/v1/'
 
+      # TODO: Lookup the codes, figure out if I need to add `null` values, and what they map to. May be in StripePaymentIntents Docs
       AVS_CODE_TRANSLATOR = {
         'line1: pass, zip: pass' => 'Y',
         'line1: pass, zip: fail' => 'A',
@@ -17,6 +18,7 @@ module ActiveMerchant #:nodoc:
         'line1: unchecked, zip: unchecked' => 'I'
       }
 
+      # TODO: Lookup codes, figure out if I need ot add `null` values, and what they map to. May be in StripePaymentIntents Docs
       CVC_CODE_TRANSLATOR = {
         'pass' => 'M',
         'fail' => 'N',
@@ -703,7 +705,7 @@ module ActiveMerchant #:nodoc:
         success = success_from(response, options)
 
         card = card_from_response(response)
-        avs_code = AVS_CODE_TRANSLATOR["line1: #{card['address_line1_check']}, zip: #{card['address_zip_check']}"]
+        avs_code = AVS_CODE_TRANSLATOR["line1: #{card['address_line1_check']}, zip: #{card['address_zip_check'] || card['address_postal_code_check']}"]
         cvc_code = CVC_CODE_TRANSLATOR[card['cvc_check']]
         Response.new(
           success,
@@ -785,7 +787,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def card_from_response(response)
-        response['card'] || response['active_card'] || response['source'] || {}
+        response['card'] || response['active_card'] || response['source'] || response['checks'] || {}
       end
 
       def emv_authorization_from_response(response)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1498,7 +1498,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
   def test_succeeded_cvc_check
     options = {}
     assert purchase = @gateway.purchase(@amount, @visa_card, options)
-    
+
     assert_equal 'succeeded', purchase.params['status']
     assert_equal 'M', purchase.cvv_result.dig('code')
     assert_equal 'CVV matches', purchase.cvv_result.dig('message')


### PR DESCRIPTION
This adds the ability for StripePI to get the same AVS checks that come with Stripe.