### PR TITLE
Redsys REST

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@
 * Worldpay: Update 3ds logic to accept df_reference_id directly [DustinHaefele] #4929
 * Orbital: Enable Third Party Vaulting [javierpedrozaing] #4928
 * Payeezy: Add the customer_ref and reference_3 fields [yunnydang] #4942
+* Redsys Rest: Add support for new gateway type Redsys Rest [aenand] #4951
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/redsys_rest.rb
+++ b/lib/active_merchant/billing/gateways/redsys_rest.rb
@@ -1,0 +1,433 @@
+# coding: utf-8
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # = Redsys Merchant Gateway
+    #
+    # Gateway support for the Spanish "Redsys" payment gateway system. This is
+    # used by many banks in Spain and is particularly well supported by
+    # Catalunya Caixa's ecommerce department.
+    #
+    # Redsys requires an order_id be provided with each transaction and it must
+    # follow a specific format. The rules are as follows:
+    #
+    #  * First 4 digits must be numerical
+    #  * Remaining 8 digits may be alphanumeric
+    #  * Max length: 12
+    #
+    #  If an invalid order_id is provided, we do our best to clean it up.
+    #
+    # Written by Piers Chambers (Varyonic.com)
+    #
+    # *** SHA256 Authentication Update ***
+    #
+    # Redsys has dropped support for the SHA1 authentication method.
+    # Developer documentation: https://pagosonline.redsys.es/desarrolladores.html
+    class RedsysRestGateway < Gateway
+      self.test_url = 'https://sis-t.redsys.es:25443/sis/rest/'
+      self.live_url = 'https://sis.redsys.es/sis/rest/'
+
+      self.supported_countries = ['ES']
+      self.default_currency    = 'EUR'
+      self.money_format        = :cents
+      # Not all card types may be activated by the bank!
+      self.supported_cardtypes = %i[visa master american_express jcb diners_club unionpay]
+      self.homepage_url        = 'http://www.redsys.es/'
+      self.display_name        = 'Redsys (REST)'
+
+      CURRENCY_CODES = {
+        'AED' => '784',
+        'ARS' => '32',
+        'AUD' => '36',
+        'BRL' => '986',
+        'BOB' => '68',
+        'CAD' => '124',
+        'CHF' => '756',
+        'CLP' => '152',
+        'CNY' => '156',
+        'COP' => '170',
+        'CRC' => '188',
+        'CZK' => '203',
+        'DKK' => '208',
+        'DOP' => '214',
+        'EUR' => '978',
+        'GBP' => '826',
+        'GTQ' => '320',
+        'HUF' => '348',
+        'IDR' => '360',
+        'INR' => '356',
+        'JPY' => '392',
+        'KRW' => '410',
+        'MYR' => '458',
+        'MXN' => '484',
+        'NOK' => '578',
+        'NZD' => '554',
+        'PEN' => '604',
+        'PLN' => '985',
+        'RUB' => '643',
+        'SAR' => '682',
+        'SEK' => '752',
+        'SGD' => '702',
+        'THB' => '764',
+        'TWD' => '901',
+        'USD' => '840',
+        'UYU' => '858'
+      }
+
+      # The set of supported transactions for this gateway.
+      # More operations are supported by the gateway itself, but
+      # are not supported in this library.
+      SUPPORTED_TRANSACTIONS = {
+        purchase:   '0',
+        authorize:  '1',
+        capture:    '2',
+        refund:     '3',
+        cancel:     '9'
+      }
+
+      # These are the text meanings sent back by the acquirer when
+      # a card has been rejected. Syntax or general request errors
+      # are not covered here.
+      RESPONSE_TEXTS = {
+        0 => 'Transaction Approved',
+        400 => 'Cancellation Accepted',
+        481 => 'Cancellation Accepted',
+        500 => 'Reconciliation Accepted',
+        900 => 'Refund / Confirmation approved',
+
+        101 => 'Card expired',
+        102 => 'Card blocked temporarily or under susciption of fraud',
+        104 => 'Transaction not permitted',
+        107 => 'Contact the card issuer',
+        109 => 'Invalid identification by merchant or POS terminal',
+        110 => 'Invalid amount',
+        114 => 'Card cannot be used to the requested transaction',
+        116 => 'Insufficient credit',
+        118 => 'Non-registered card',
+        125 => 'Card not effective',
+        129 => 'CVV2/CVC2 Error',
+        167 => 'Contact the card issuer: suspected fraud',
+        180 => 'Card out of service',
+        181 => 'Card with credit or debit restrictions',
+        182 => 'Card with credit or debit restrictions',
+        184 => 'Authentication error',
+        190 => 'Refusal with no specific reason',
+        191 => 'Expiry date incorrect',
+        195 => 'Requires SCA authentication',
+
+        201 => 'Card expired',
+        202 => 'Card blocked temporarily or under suspicion of fraud',
+        204 => 'Transaction not permitted',
+        207 => 'Contact the card issuer',
+        208 => 'Lost or stolen card',
+        209 => 'Lost or stolen card',
+        280 => 'CVV2/CVC2 Error',
+        290 => 'Declined with no specific reason',
+
+        480 => 'Original transaction not located, or time-out exceeded',
+        501 => 'Original transaction not located, or time-out exceeded',
+        502 => 'Original transaction not located, or time-out exceeded',
+        503 => 'Original transaction not located, or time-out exceeded',
+
+        904 => 'Merchant not registered at FUC',
+        909 => 'System error',
+        912 => 'Issuer not available',
+        913 => 'Duplicate transmission',
+        916 => 'Amount too low',
+        928 => 'Time-out exceeded',
+        940 => 'Transaction cancelled previously',
+        941 => 'Authorization operation already cancelled',
+        942 => 'Original authorization declined',
+        943 => 'Different details from origin transaction',
+        944 => 'Session error',
+        945 => 'Duplicate transmission',
+        946 => 'Cancellation of transaction while in progress',
+        947 => 'Duplicate tranmission while in progress',
+        949 => 'POS Inoperative',
+        950 => 'Refund not possible',
+        9064 => 'Card number incorrect',
+        9078 => 'No payment method available',
+        9093 => 'Non-existent card',
+        9218 => 'Recursive transaction in bad gateway',
+        9253 => 'Check-digit incorrect',
+        9256 => 'Preauth not allowed for merchant',
+        9257 => 'Preauth not allowed for card',
+        9261 => 'Operating limit exceeded',
+        9912 => 'Issuer not available',
+        9913 => 'Confirmation error',
+        9914 => 'KO Confirmation'
+      }
+
+      # Expected values as per documentation
+      THREE_DS_V2 = '2.1.0'
+
+      # Creates a new instance
+      #
+      # Redsys requires a login and secret_key, and optionally also accepts a
+      # non-default terminal.
+      #
+      # ==== Options
+      #
+      # * <tt>:login</tt> -- The Redsys Merchant ID (REQUIRED)
+      # * <tt>:secret_key</tt> -- The Redsys Secret Key. (REQUIRED)
+      # * <tt>:terminal</tt> -- The Redsys Terminal. Defaults to 1. (OPTIONAL)
+      # * <tt>:test</tt> -- +true+ or +false+. Defaults to +false+. (OPTIONAL)
+      def initialize(options = {})
+        requires!(options, :login, :secret_key)
+        options[:terminal] ||= 1
+        options[:signature_algorithm] = 'sha256'
+        super
+      end
+
+      def purchase(money, payment, options = {})
+        requires!(options, :order_id)
+
+        post = {}
+        add_action(post, :purchase, options)
+        add_amount(post, money, options)
+        add_order(post, options[:order_id])
+        add_payment(post, payment)
+        add_description(post, options)
+        add_direct_payment(post, options)
+        add_threeds(post, options)
+
+        commit(post, options)
+      end
+
+      def authorize(money, payment, options = {})
+        requires!(options, :order_id)
+
+        post = {}
+        add_action(post, :authorize, options)
+        add_amount(post, money, options)
+        add_order(post, options[:order_id])
+        add_payment(post, payment)
+        add_description(post, options)
+        add_direct_payment(post, options)
+        add_threeds(post, options)
+
+        commit(post, options)
+      end
+
+      def capture(money, authorization, options = {})
+        post = {}
+        add_action(post, :capture)
+        add_amount(post, money, options)
+        order_id, = split_authorization(authorization)
+        add_order(post, order_id)
+        add_description(post, options)
+
+        commit(post, options)
+      end
+
+      def void(authorization, options = {})
+        requires!(options, :order_id)
+
+        post = {}
+        add_action(post, :cancel)
+        order_id, amount, currency = split_authorization(authorization)
+        add_amount(post, amount, currency: currency)
+        add_order(post, order_id)
+        add_description(post, options)
+
+        commit(post, options)
+      end
+
+      def refund(money, authorization, options = {})
+        requires!(options, :order_id)
+
+        post = {}
+        add_action(post, :refund)
+        add_amount(post, money, options)
+        order_id, = split_authorization(authorization)
+        add_order(post, order_id)
+        add_description(post, options)
+
+        commit(post, options)
+      end
+
+      def verify(creditcard, options = {})
+        requires!(options, :order_id)
+
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, creditcard, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((PAN\"=>\")(\d+)), '\1[FILTERED]').
+          gsub(%r((CVV2\"=>\")(\d+)), '\1[FILTERED]')
+      end
+
+      private
+
+      def add_direct_payment(post, options)
+        # Direct payment skips 3DS authentication. We should only apply this if execute_threed is false
+        # or authentication data is not present. Authentication data support to be added in the future.
+        return if options[:execute_threed] || options[:authentication_data]
+
+        post[:DS_MERCHANT_DIRECTPAYMENT] = true
+      end
+
+      def add_threeds(post, options)
+        post[:DS_MERCHANT_EMV3DS] = { threeDSInfo: 'CardData' } if options[:execute_threed]
+      end
+
+      def add_action(post, action, options = {})
+        post[:DS_MERCHANT_TRANSACTIONTYPE] = transaction_code(action)
+      end
+
+      def add_amount(post, money, options)
+        post[:DS_MERCHANT_AMOUNT] = amount(money).to_s
+        post[:DS_MERCHANT_CURRENCY] = currency_code(options[:currency] || currency(money))
+      end
+
+      def add_description(post, options)
+        post[:DS_MERCHANT_PRODUCTDESCRIPTION] = CGI.escape(options[:description]) if options[:description]
+      end
+
+      def add_order(post, order_id)
+        post[:DS_MERCHANT_ORDER] = clean_order_id(order_id)
+      end
+
+      def add_payment(post, card)
+        name = [card.first_name, card.last_name].join(' ').slice(0, 60)
+        year = sprintf('%.4i', card.year)
+        month = sprintf('%.2i', card.month)
+        post['DS_MERCHANT_TITULAR'] = CGI.escape(name)
+        post['DS_MERCHANT_PAN'] = card.number
+        post['DS_MERCHANT_EXPIRYDATE'] = "#{year[2..3]}#{month}"
+        post['DS_MERCHANT_CVV2'] = card.verification_value
+      end
+
+      def determine_action(options)
+        # If execute_threed is true, we need to use iniciaPeticionREST to set up authentication
+        # Otherwise we are skipping 3DS or we should have 3DS authentication results
+        options[:execute_threed] ? 'iniciaPeticionREST' : 'trataPeticionREST'
+      end
+
+      def commit(post, options)
+        url = (test? ? test_url : live_url)
+        action = determine_action(options)
+        raw_response = parse(ssl_post(url + action, post_data(post, options)))
+        payload = raw_response['Ds_MerchantParameters']
+        return Response.new(false, "#{raw_response['errorCode']} ERROR") unless payload
+
+        response = JSON.parse(Base64.decode64(payload)).transform_keys!(&:downcase).with_indifferent_access
+        return Response.new(false, 'Unable to verify response') unless validate_signature(payload, raw_response['Ds_Signature'], response[:ds_order])
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?,
+          error_code: success_from(response) ? nil : response[:ds_response]
+        )
+      end
+
+      def post_data(post, options)
+        add_authentication(post, options)
+        merchant_parameters = JSON.generate(post)
+        encoded_parameters = Base64.strict_encode64(merchant_parameters)
+        post_data = PostData.new
+        post_data['Ds_SignatureVersion'] = 'HMAC_SHA256_V1'
+        post_data['Ds_MerchantParameters'] = encoded_parameters
+        post_data['Ds_Signature'] = sign_request(encoded_parameters, post[:DS_MERCHANT_ORDER])
+        post_data.to_post_data
+      end
+
+      def add_authentication(post, options)
+        post[:DS_MERCHANT_TERMINAL] = options[:terminal] || @options[:terminal]
+        post[:DS_MERCHANT_MERCHANTCODE] = @options[:login]
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def success_from(response)
+        # Need to get updated for 3DS support
+        if code = response[:ds_response]
+          (code.to_i < 100) || [400, 481, 500, 900].include?(code.to_i)
+        else
+          false
+        end
+      end
+
+      def message_from(response)
+        # Need to get updated for 3DS support
+        code = response[:ds_response]&.to_i
+        code = 0 if code < 100
+        RESPONSE_TEXTS[code] || 'Unknown code, please check in manual'
+      end
+
+      def validate_signature(data, signature, order_number)
+        key = encrypt(@options[:secret_key], order_number)
+        Base64.urlsafe_encode64(mac256(key, data)) == signature
+      end
+
+      def authorization_from(response)
+        # Need to get updated for 3DS support
+        [response[:ds_order], response[:ds_amount], response[:ds_currency]].join('|')
+      end
+
+      def split_authorization(authorization)
+        order_id, amount, currency = authorization.split('|')
+        [order_id, amount.to_i, currency]
+      end
+
+      def currency_code(currency)
+        return currency if currency =~ /^\d+$/
+        raise ArgumentError, "Unknown currency #{currency}" unless CURRENCY_CODES[currency]
+
+        CURRENCY_CODES[currency]
+      end
+
+      def transaction_code(type)
+        SUPPORTED_TRANSACTIONS[type]
+      end
+
+      def clean_order_id(order_id)
+        cleansed = order_id.gsub(/[^\da-zA-Z]/, '')
+        if /^\d{4}/.match?(cleansed)
+          cleansed[0..11]
+        else
+          '%04d' % [rand(0..9999)] + cleansed[0...8]
+        end
+      end
+
+      def sign_request(encoded_parameters, order_id)
+        raise(ArgumentError, 'missing order_id') unless order_id
+
+        key = encrypt(@options[:secret_key], order_id)
+        Base64.strict_encode64(mac256(key, encoded_parameters))
+      end
+
+      def encrypt(key, order_id)
+        block_length = 8
+        cipher = OpenSSL::Cipher.new('DES3')
+        cipher.encrypt
+
+        cipher.key = Base64.urlsafe_decode64(key)
+        # The OpenSSL default of an all-zeroes ("\\0") IV is used.
+        cipher.padding = 0
+
+        order_id += "\0" until order_id.bytesize % block_length == 0 # Pad with zeros
+
+        output = cipher.update(order_id) + cipher.final
+        output
+      end
+
+      def mac256(key, data)
+        OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key, data)
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1242,6 +1242,12 @@ redsys:
   login: MERCHANT CODE
   secret_key: SECRET KEY
 
+# https://pagosonline.redsys.es/entornosPruebas.html
+redsys_rest:
+  login: 999008881
+  secret_key: sq7HjrUOBfKmC576ILgskD5srU870gJ7
+  terminal: 001
+
 redsys_sha256:
   login: MERCHANT CODE
   secret_key: SECRET KEY

--- a/test/remote/gateways/remote_redsys_rest_test.rb
+++ b/test/remote/gateways/remote_redsys_rest_test.rb
@@ -1,0 +1,206 @@
+require 'test_helper'
+
+class RemoteRedsysRestTest < Test::Unit::TestCase
+  def setup
+    @gateway = RedsysRestGateway.new(fixtures(:redsys_rest))
+    @amount = 100
+    @credit_card = credit_card('4548812049400004')
+    @declined_card = credit_card
+    @threeds2_credit_card = credit_card('4918019199883839')
+
+    @threeds2_credit_card_frictionless = credit_card('4548814479727229')
+    @threeds2_credit_card_alt = credit_card('4548817212493017')
+    @options = {
+      order_id: generate_order_id
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction Approved', response.message
+  end
+
+  def test_purchase_with_invalid_order_id
+    response = @gateway.purchase(@amount, @credit_card, order_id: "a%4#{generate_order_id}")
+    assert_success response
+    assert_equal 'Transaction Approved', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Refusal with no specific reason', response.message
+  end
+
+  def test_purchase_and_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    refund = @gateway.refund(@amount, purchase.authorization, @options)
+    assert_success refund
+  end
+
+  def test_purchase_and_failed_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    refund = @gateway.refund(@amount + 100, purchase.authorization, @options)
+    assert_failure refund
+    assert_equal 'SIS0057 ERROR', refund.message
+  end
+
+  def test_failed_purchase_with_unsupported_currency
+    response = @gateway.purchase(600, @credit_card, @options.merge(currency: 'PEN'))
+    assert_failure response
+    assert_equal 'SIS0027 ERROR', response.message
+  end
+
+  def test_successful_authorize_and_capture
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+    assert_equal 'Transaction Approved', authorize.message
+    assert_not_nil authorize.authorization
+
+    capture = @gateway.capture(@amount, authorize.authorization, @options)
+    assert_success capture
+    assert_match(/Refund.*approved/, capture.message)
+  end
+
+  def test_successful_authorize_and_failed_capture
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+    assert_equal 'Transaction Approved', authorize.message
+    assert_not_nil authorize.authorization
+
+    capture = @gateway.capture(2 * @amount, authorize.authorization, @options)
+    assert_failure capture
+    assert_match(/SIS0062 ERROR/, capture.message)
+  end
+
+  def test_failed_authorize
+    response = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Refusal with no specific reason', response.message
+  end
+
+  def test_successful_void
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+
+    void = @gateway.void(authorize.authorization, @options)
+    assert_success void
+    assert_equal '100', void.params['ds_amount']
+    assert_equal 'Cancellation Accepted', void.message
+  end
+
+  def test_failed_void
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
+
+    authorization = "#{authorize.params[:ds_order]}|#{@amount}|203"
+    void = @gateway.void(authorization, @options)
+    assert_failure void
+    assert_equal 'SIS0027 ERROR', void.message
+  end
+
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card, @options)
+    assert_success response
+
+    assert_equal 'Transaction Approved', response.message
+    assert_success response.responses.last, 'The void should succeed'
+    assert_equal 'Cancellation Accepted', response.responses.last.message
+  end
+
+  def test_unsuccessful_verify
+    assert response = @gateway.verify(@declined_card, @options)
+    assert_failure response
+    assert_equal 'Refusal with no specific reason', response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@gateway.options[:secret_key], clean_transcript)
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+  end
+
+  def test_transcript_scrubbing_on_failed_transactions
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @declined_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@gateway.options[:secret_key], clean_transcript)
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+  end
+
+  def test_encrypt_handles_url_safe_character_in_secret_key_without_error
+    gateway = RedsysRestGateway.new({
+      login: '091952713',
+      secret_key: 'yG78qf-PkHyRzRiZGSTCJdO2TvjWgFa8'
+    })
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert response
+  end
+
+  # Pending 3DS support
+  # def test_successful_authorize_3ds_setup
+  #   options = @options.merge(execute_threed: true, terminal: 12)
+  #   response = @gateway.authorize(@amount, @credit_card, options)
+  #   assert_success response
+  #   assert response.params['ds_emv3ds']
+  #   assert_equal '2.2.0', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
+  #   assert_equal 'CardConfiguration', response.message
+  #   assert response.authorization
+  # end
+
+  # Pending 3DS support
+  # def test_successful_purchase_3ds
+  #   options = @options.merge(execute_threed: true)
+  #   response = @gateway.purchase(@amount, @threeds2_credit_card, options)
+  #   assert_success response
+  #   assert three_ds_data = JSON.parse(response.params['ds_emv3ds'])
+  #   assert_equal '2.1.0', three_ds_data['protocolVersion']
+  #   assert_equal 'https://sis-d.redsys.es/sis-simulador-web/threeDsMethod.jsp', three_ds_data['threeDSMethodURL']
+  #   assert_equal 'CardConfiguration', response.message
+  #   assert response.authorization
+  # end
+
+  # Pending 3DS support
+  # Requires account configuration to allow setting moto flag
+  # def test_purchase_with_moto_flag
+  #   response = @gateway.purchase(@amount, @credit_card, @options.merge(moto: true, metadata: { manual_entry: true }))
+  #   assert_equal 'SIS0488 ERROR', response.message
+  # end
+
+  # Pending 3DS support
+  # def test_successful_3ds_authorize_with_exemption
+  #   options = @options.merge(execute_threed: true, terminal: 12)
+  #   response = @gateway.authorize(@amount, @credit_card, options.merge(sca_exemption: 'LWV'))
+  #   assert_success response
+  #   assert response.params['ds_emv3ds']
+  #   assert_equal 'NO_3DS_v2', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
+  #   assert_equal 'CardConfiguration', response.message
+  # end
+
+  # Pending 3DS support
+  # def test_successful_3ds_purchase_with_exemption
+  #   options = @options.merge(execute_threed: true, terminal: 12)
+  #   response = @gateway.purchase(@amount, @credit_card, options.merge(sca_exemption: 'LWV'))
+  #   assert_success response
+  #   assert response.params['ds_emv3ds']
+  #   assert_equal 'NO_3DS_v2', JSON.parse(response.params['ds_emv3ds'])['protocolVersion']
+  #   assert_equal 'CardConfiguration', response.message
+  # end
+
+  private
+
+  def generate_order_id
+    (Time.now.to_f * 100).to_i.to_s
+  end
+end

--- a/test/unit/gateways/redsys_rest_test.rb
+++ b/test/unit/gateways/redsys_rest_test.rb
@@ -1,0 +1,269 @@
+require 'test_helper'
+
+class RedsysRestTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @credentials = {
+      login: '091952713',
+      secret_key: 'sq7HjrUOBfKmC576ILgskD5srU870gJ7',
+      terminal: '201'
+    }
+    @gateway = RedsysRestGateway.new(@credentials)
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1001',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    res = @gateway.purchase(123, credit_card, @options)
+    assert_success res
+    assert_equal 'Transaction Approved', res.message
+    assert_equal '164513224019|100|978', res.authorization
+    assert_equal '164513224019', res.params['ds_order']
+  end
+
+  def test_successful_purchase_requesting_credit_card_token
+    @gateway.expects(:ssl_post).returns(successful_purchase_response_with_credit_card_token)
+    res = @gateway.purchase(123, credit_card, @options)
+    assert_success res
+    assert_equal 'Transaction Approved', res.message
+    assert_equal '164522070945|100|978', res.authorization
+    assert_equal '164522070945', res.params['ds_order']
+    assert_equal '2202182245100', res.params['ds_merchant_cof_txnid']
+  end
+
+  def test_successful_purchase_with_stored_credentials
+    @gateway.expects(:ssl_post).returns(successful_purchase_initial_stored_credential_response)
+    initial_options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring'
+      }
+    )
+    initial_res = @gateway.purchase(123, credit_card, initial_options)
+    assert_success initial_res
+    assert_equal 'Transaction Approved', initial_res.message
+    assert_equal '2205022148020', initial_res.params['ds_merchant_cof_txnid']
+    network_transaction_id = initial_res.params['Ds_Merchant_Cof_Txnid']
+
+    @gateway.expects(:ssl_post).returns(successful_purchase_used_stored_credential_response)
+    used_options = {
+      order_id: '1002',
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled',
+        network_transaction_id: network_transaction_id
+      }
+    }
+    res = @gateway.purchase(123, credit_card, used_options)
+    assert_success res
+    assert_equal 'Transaction Approved', res.message
+    assert_equal '446527', res.params['ds_authorisationcode']
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+    res = @gateway.purchase(123, credit_card, @options)
+    assert_failure res
+    assert_equal 'Refusal with no specific reason', res.message
+    assert_equal '164513457405', res.params['ds_order']
+  end
+
+  def test_purchase_without_order_id
+    assert_raise ArgumentError do
+      @gateway.purchase(123, credit_card)
+    end
+  end
+
+  def test_error_purchase
+    @gateway.expects(:ssl_post).returns(error_purchase_response)
+    res = @gateway.purchase(123, credit_card, @options)
+    assert_failure res
+    assert_equal 'SIS0051 ERROR', res.message
+  end
+
+  def test_successful_authorize
+    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+    res = @gateway.authorize(123, credit_card, @options)
+    assert_success res
+    assert_equal 'Transaction Approved', res.message
+    assert_equal '165125433469|100|978', res.authorization
+    assert_equal '165125433469', res.params['ds_order']
+  end
+
+  def test_failed_authorize
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+    res = @gateway.authorize(123, credit_card, @options)
+    assert_failure res
+    assert_equal 'Refusal with no specific reason', res.message
+    assert_equal '165125669647', res.params['ds_order']
+  end
+
+  def test_successful_capture
+    @gateway.expects(:ssl_post).returns(successful_capture_response)
+    res = @gateway.capture(123, '165125709531|100|978', @options)
+    assert_success res
+    assert_equal 'Refund / Confirmation approved', res.message
+    assert_equal '165125709531|100|978', res.authorization
+    assert_equal '165125709531', res.params['ds_order']
+  end
+
+  def test_error_capture
+    @gateway.expects(:ssl_post).returns(error_capture_response)
+    res = @gateway.capture(123, '165125709531|100|978', @options)
+    assert_failure res
+    assert_equal 'SIS0062 ERROR', res.message
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    res = @gateway.refund(123, '165126074048|100|978', @options)
+    assert_success res
+    assert_equal 'Refund / Confirmation approved', res.message
+    assert_equal '165126074048|100|978', res.authorization
+    assert_equal '165126074048', res.params['ds_order']
+  end
+
+  def test_error_refund
+    @gateway.expects(:ssl_post).returns(error_refund_response)
+    res = @gateway.refund(123, '165126074048|100|978', @options)
+    assert_failure res
+    assert_equal 'SIS0057 ERROR', res.message
+  end
+
+  def test_successful_void
+    @gateway.expects(:ssl_post).returns(successful_void_response)
+    res = @gateway.void('165126313156|100|978', @options)
+    assert_success res
+    assert_equal 'Cancellation Accepted', res.message
+    assert_equal '165126313156|100|978', res.authorization
+    assert_equal '165126313156', res.params['ds_order']
+  end
+
+  def test_error_void
+    @gateway.expects(:ssl_post).returns(error_void_response)
+    res = @gateway.void('165126074048|100|978', @options)
+    assert_failure res
+    assert_equal 'SIS0222 ERROR', res.message
+  end
+
+  def test_successful_verify
+    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response).then.returns(successful_void_response)
+    response = @gateway.verify(credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_verify_with_failed_void
+    @gateway.expects(:ssl_post).times(2).returns(successful_authorize_response).then.returns(error_void_response)
+    response = @gateway.verify(credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction Approved', response.message
+  end
+
+  def test_unsuccessful_verify
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+    response = @gateway.verify(credit_card, @options)
+    assert_failure response
+    assert_equal 'Refusal with no specific reason', response.message
+  end
+
+  def test_unknown_currency
+    assert_raise ArgumentError do
+      @gateway.purchase(123, credit_card, @options.merge(currency: 'HUH WUT'))
+    end
+  end
+
+  def test_default_currency
+    assert_equal 'EUR', RedsysRestGateway.default_currency
+  end
+
+  def test_supported_countries
+    assert_equal ['ES'], RedsysRestGateway.supported_countries
+  end
+
+  def test_supported_cardtypes
+    assert_equal %i[visa master american_express jcb diners_club unionpay], RedsysRestGateway.supported_cardtypes
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    '
+      merchant_parameters: {"DS_MERCHANT_CURRENCY"=>"978", "DS_MERCHANT_AMOUNT"=>"100", "DS_MERCHANT_ORDER"=>"165126475243", "DS_MERCHANT_TRANSACTIONTYPE"=>"1", "DS_MERCHANT_PRODUCTDESCRIPTION"=>"", "DS_MERCHANT_TERMINAL"=>"3", "DS_MERCHANT_MERCHANTCODE"=>"327234688", "DS_MERCHANT_TITULAR"=>"Longbob Longsen", "DS_MERCHANT_PAN"=>"4242424242424242", "DS_MERCHANT_EXPIRYDATE"=>"2309", "DS_MERCHANT_CVV2"=>"123"}
+    '
+  end
+
+  def post_scrubbed
+    '
+      merchant_parameters: {"DS_MERCHANT_CURRENCY"=>"978", "DS_MERCHANT_AMOUNT"=>"100", "DS_MERCHANT_ORDER"=>"165126475243", "DS_MERCHANT_TRANSACTIONTYPE"=>"1", "DS_MERCHANT_PRODUCTDESCRIPTION"=>"", "DS_MERCHANT_TERMINAL"=>"3", "DS_MERCHANT_MERCHANTCODE"=>"327234688", "DS_MERCHANT_TITULAR"=>"Longbob Longsen", "DS_MERCHANT_PAN"=>"[FILTERED]", "DS_MERCHANT_EXPIRYDATE"=>"2309", "DS_MERCHANT_CVV2"=>"[FILTERED]"}
+    '
+  end
+
+  def successful_purchase_response
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY0NTEzMjI0MDE5IiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwMDAwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiI0ODgxODUiLCJEc19UcmFuc2FjdGlvblR5cGUiOiIwIiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI3MjQiLCJEc19DYXJkX0JyYW5kIjoiMSIsIkRzX1Byb2Nlc3NlZFBheU1ldGhvZCI6IjMiLCJEc19Db250cm9sXzE2NDUxMzIyNDE0NDkiOiIxNjQ1MTMyMjQxNDQ5In0=\",\"Ds_Signature\":\"63UXUOSVheJiBWxaWKih5yaVvfOSeOXAuoRUZyHBwJo=\"}]
+  end
+
+  def successful_purchase_response_with_credit_card_token
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY0NTIyMDcwOTQ1IiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwMDAwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiI0ODk5MTciLCJEc19UcmFuc2FjdGlvblR5cGUiOiIwIiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI3MjQiLCJEc19DYXJkX0JyYW5kIjoiMSIsIkRzX01lcmNoYW50X0NvZl9UeG5pZCI6IjIyMDIxODIyNDUxMDAiLCJEc19Qcm9jZXNzZWRQYXlNZXRob2QiOiIzIiwiRHNfQ29udHJvbF8xNjQ1MjIwNzEwNDcyIjoiMTY0NTIyMDcxMDQ3MiJ9\",\"Ds_Signature\":\"YV6W2Ym-p84q5246GK--hc-1L6Sz0tHOcMLYZtDIf-s=\"}]
+  end
+
+  def successful_purchase_initial_stored_credential_response
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY1MTUyMDg4MTM3IiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwMDAwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiI0NTk5MjIiLCJEc19UcmFuc2FjdGlvblR5cGUiOiIwIiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI3MjQiLCJEc19DYXJkX0JyYW5kIjoiMSIsIkRzX01lcmNoYW50X0NvZl9UeG5pZCI6IjIyMDUwMjIxNDgwMjAiLCJEc19Qcm9jZXNzZWRQYXlNZXRob2QiOiIzIiwiRHNfQ29udHJvbF8xNjUxNTIwODgyNDA5IjoiMTY1MTUyMDg4MjQwOSJ9\",\"Ds_Signature\":\"gIQ6ebPg-nXwCZ0Vld7LbSoKBXizlmaVe1djVDuVF4s=\"}]
+  end
+
+  def successful_purchase_used_stored_credential_response
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY1MTUyMDg4MjQ0IiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwMDAwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiI0NDY1MjciLCJEc19UcmFuc2FjdGlvblR5cGUiOiIwIiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI3MjQiLCJEc19DYXJkX0JyYW5kIjoiMSIsIkRzX1Byb2Nlc3NlZFBheU1ldGhvZCI6IjMiLCJEc19Db250cm9sXzE2NTE1MjA4ODMzMDMiOiIxNjUxNTIwODgzMzAzIn0=\",\"Ds_Signature\":\"BC3UB0Q0IgOyuXbEe8eJddK_H77XJv7d2MQr50d4v2o=\"}]
+  end
+
+  def failed_purchase_response
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY0NTEzNDU3NDA1IiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwMTkwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiIiLCJEc19UcmFuc2FjdGlvblR5cGUiOiIwIiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI4MjYiLCJEc19Qcm9jZXNzZWRQYXlNZXRob2QiOiIzIiwiRHNfQ29udHJvbF8xNjQ1MTM0NTc1MzU1IjoiMTY0NTEzNDU3NTM1NSJ9\",\"Ds_Signature\":\"zm3FCtPPhf5Do7FzlB4DbGDgkFcNFhXQCikc-batUW0=\"}]
+  end
+
+  def error_purchase_response
+    %[{\"errorCode\":\"SIS0051\"}]
+  end
+
+  def successful_authorize_response
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY1MTI1NDMzNDY5IiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwMDAwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiI0NTgyNjAiLCJEc19UcmFuc2FjdGlvblR5cGUiOiIxIiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI3MjQiLCJEc19DYXJkX0JyYW5kIjoiMSIsIkRzX1Byb2Nlc3NlZFBheU1ldGhvZCI6IjMiLCJEc19Db250cm9sXzE2NTEyNTQzMzYzMTEiOiIxNjUxMjU0MzM2MzExIn0=\",\"Ds_Signature\":\"8H7F04WLREFYi67DxusWJX12NZOrMrmtDOVWYA-604M=\"}]
+  end
+
+  def failed_authorize_response
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY1MTI1NjY5NjQ3IiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwMTkwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiIiLCJEc19UcmFuc2FjdGlvblR5cGUiOiIxIiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI4MjYiLCJEc19Qcm9jZXNzZWRQYXlNZXRob2QiOiIzIiwiRHNfQ29udHJvbF8xNjUxMjU2Njk4MDE0IjoiMTY1MTI1NjY5ODAxNCJ9\",\"Ds_Signature\":\"abBYZFLtYloFRQDTnMhXASMcS-4SLxEBNpTfBVCBtuc=\"}]
+  end
+
+  def successful_capture_response
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY1MTI1NzA5NTMxIiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwOTAwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiI0NDQ5NTIiLCJEc19UcmFuc2FjdGlvblR5cGUiOiIyIiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI3MjQiLCJEc19DYXJkX0JyYW5kIjoiMSIsIkRzX1Byb2Nlc3NlZFBheU1ldGhvZCI6IjMiLCJEc19Db250cm9sXzE2NTEyNTcwOTc5NjIiOiIxNjUxMjU3MDk3OTYyIn0=\",\"Ds_Signature\":\"9lKWSe94kdviKN_ApUV9nQAS6VQc7gPeARyhpbN3sXA=\"}]
+  end
+
+  def error_capture_response
+    %[{\"errorCode\":\"SIS0062\"}]
+  end
+
+  def successful_refund_response
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY1MTI2MDc0MDQ4IiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwOTAwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiI0NDQ5NjQiLCJEc19UcmFuc2FjdGlvblR5cGUiOiIzIiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI3MjQiLCJEc19DYXJkX0JyYW5kIjoiMSIsIkRzX1Byb2Nlc3NlZFBheU1ldGhvZCI6IjMiLCJEc19Db250cm9sXzE2NTEyNjA3NDM0NjAiOiIxNjUxMjYwNzQzNDYwIn0=\",\"Ds_Signature\":\"iGhvjtqbV-b3cvEoJxIwp3kE1b65onfZnF9Kb5JWWhw=\"}]
+  end
+
+  def error_refund_response
+    %[{\"errorCode\":\"SIS0057\"}]
+  end
+
+  def successful_void_response
+    %[{\"Ds_SignatureVersion\":\"HMAC_SHA256_V1\",\"Ds_MerchantParameters\":\"eyJEc19BbW91bnQiOiIxMDAiLCJEc19DdXJyZW5jeSI6Ijk3OCIsIkRzX09yZGVyIjoiMTY1MTI2MzEzMTU2IiwiRHNfTWVyY2hhbnRDb2RlIjoiMzI3MjM0Njg4IiwiRHNfVGVybWluYWwiOiIzIiwiRHNfUmVzcG9uc2UiOiIwNDAwIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiI0NTgzMDQiLCJEc19UcmFuc2FjdGlvblR5cGUiOiI5IiwiRHNfU2VjdXJlUGF5bWVudCI6IjAiLCJEc19MYW5ndWFnZSI6IjEiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19DYXJkX0NvdW50cnkiOiI3MjQiLCJEc19DYXJkX0JyYW5kIjoiMSIsIkRzX1Byb2Nlc3NlZFBheU1ldGhvZCI6IjMiLCJEc19Db250cm9sXzE2NTEyNjMxMzQzMzUiOiIxNjUxMjYzMTM0MzM1In0=\",\"Ds_Signature\":\"retARpDayWGhU-pa3OEBIT7b4iG91Mi98jHGB3EyD6c=\"}]
+  end
+
+  def error_void_response
+    %[{\"errorCode\":\"SIS0222\"}]
+  end
+end


### PR DESCRIPTION
ECS-3219

This ticket adds a new gateway that serves as an update over the legacy
Redsys integration by moving to the Redsys Rest integration. This commit
adds support for basic functionality including authorize, purchase, scrubbing,
and standardizes responses.

This commit does not include support for:
* Stored Credentials (Ticket not yet created to add this support)
* External 3DS Support (Ticket not yet created to add this support)
* Redsys 3DS Support (Ticket created to add this support)

Co-authored-by: Amit Enand <aenand@spreedly.com>
Co-authored-by: Piers Chambers <piers@varyonic.com>