### PR TITLE
Rapyd: update force_3d_secure GSF behavior

### DIFF
--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -207,7 +207,7 @@ module ActiveMerchant #:nodoc:
 
       def add_3ds(post, payment, options)
         if options[:execute_threed] == true
-          post[:payment_method_options] = { '3d_required' => true } if options[:force_3d_secure].present?
+          post[:payment_method_options] = { '3d_required' => true } if options[:force_3d_secure].to_s == 'true'
         elsif three_d_secure = options[:three_d_secure]
           post[:payment_method_options] = {}
           post[:payment_method_options]['3d_required'] = three_d_secure[:required]

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -185,6 +185,22 @@ class RapydTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_does_not_send_3ds_version_if_not_required
+    false_values = [false, nil, 'false', '']
+    @options[:execute_threed] = true
+
+    false_values.each do |value|
+      @options[:force_3d_secure] = value
+
+      stub_comms(@gateway, :ssl_request) do
+        @gateway.purchase(@amount, @credit_card, @options)
+      end.check_request do |_method, _endpoint, data, _headers|
+        request = JSON.parse(data)
+        assert_nil request['payment_method_options']
+      end.respond_with(successful_purchase_response)
+    end
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_request).returns(failed_purchase_response)
 


### PR DESCRIPTION
### Summary:

Add changes to be more strict on how the `force_3d_secure` is considered true.

[SER-968](https://spreedly.atlassian.net/browse/SER-968)

## Tests

### Remote Test:
Finished in 239.011074 seconds.
42 tests, 118 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.619% passed

*Note:* The reason for the failing test is aun outdated wallet reference.

### Unit Tests:
Finished in 38.879517 seconds.
5670 tests, 78363 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

## RuboCop:
778 files inspected, no offenses detected