### PR TITLE
Add 3DS global support to Commerce Hub gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,7 @@
 * Worldpay: Update stored credentials logic [DustinHaefele] #4950
 * Vantiv Express: New Xml gateway [DustinHaefele] #4956
 * Shift4 V2: Add unstore function [javierpedrozaing] #4953
+* CommerceHub: Add 3DS global support [sinourain] #4957
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -109,6 +109,23 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def add_three_d_secure(post, payment, options)
+        return unless three_d_secure = options[:three_d_secure]
+
+        post[:additionalData3DS] = {
+          dsTransactionId: three_d_secure[:ds_transaction_id],
+          authenticationStatus: three_d_secure[:authentication_response_status],
+          serviceProviderTransactionId: three_d_secure[:three_ds_server_trans_id],
+          acsTransactionId: three_d_secure[:acs_transaction_id],
+          mpiData: {
+            cavv: three_d_secure[:cavv],
+            eci: three_d_secure[:eci],
+            xid: three_d_secure[:xid]
+          }.compact,
+          versionData: { recommendedVersion: three_d_secure[:version] }
+        }.compact
+      end
+
       def add_transaction_interaction(post, options)
         post[:transactionInteraction] = {}
         post[:transactionInteraction][:origin] = options[:origin] || 'ECOM'
@@ -187,6 +204,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_purchase_and_auth_request(post, money, payment, options)
+        add_three_d_secure(post, payment, options)
         add_invoice(post, money, options)
         add_payment(post, payment, options)
         add_stored_credentials(post, options)

--- a/test/remote/gateways/remote_commerce_hub_test.rb
+++ b/test/remote/gateways/remote_commerce_hub_test.rb
@@ -40,9 +40,24 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
     @declined_card = credit_card('4000300011112220', month: '02', year: '2035', verification_value: '123')
     @master_card = credit_card('5454545454545454', brand: 'master')
     @options = {}
+    @three_d_secure = {
+      ds_transaction_id: '3543-b90d-d6dc1765c98',
+      authentication_response_status: 'A',
+      cavv: 'AAABCZIhcQAAAABZlyFxAAAAAAA',
+      eci: '05',
+      xid: '&x_MD5_Hash=abfaf1d1df004e3c27d5d2e05929b529&x_state=BC&x_reference_3=&x_auth_code=ET141870&x_fp_timestamp=1231877695',
+      version: '2.2.0'
+    }
   end
 
   def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_3ds_purchase
+    @options.merge!(three_d_secure: @three_d_secure)
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message


### PR DESCRIPTION
Description
-------------------------
Add 3DS global support to Commerce Hub gateway

Tickets for Spreedly reference
SER-922

Unit test
-------------------------
Finished in 23.891463 seconds.
5671 tests, 78366 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote test
-------------------------
237.37 tests/s, 3280.08 assertions/s

Rubocop
-------------------------
778 files inspected, no offenses detected