### PR TITLE
Orbital:  Remove needless GSF for TPV

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -74,6 +74,7 @@
 * RedsysRest: Update to $0 verify [almalee24] #4973
 * CommerceHub: Add credit transaction [sinourain] #4965
 * PayTrace: Send CSC value on gateway request. [DustinHaefele] #4974
+* Orbital: Remove needless GSF for TPV [javierpedrozaing] #4959
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -565,15 +565,16 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_safetech_token_data(xml, payment_source, options)
+        payment_source_token = split_authorization(payment_source).values_at(2).first
         xml.tag! :CardBrand, options[:card_brand]
-        xml.tag! :AccountNum, payment_source
+        xml.tag! :AccountNum, payment_source_token
       end
 
       #=====PAYMENT SOURCE FIELDS=====
 
       # Payment can be done through either Credit Card or Electronic Check
       def add_payment_source(xml, payment_source, options = {})
-        add_safetech_token_data(xml, payment_source, options) if options[:token_txn_type] == USE_TOKEN
+        add_safetech_token_data(xml, payment_source, options) if payment_source.is_a?(String)
         payment_source.is_a?(Check) ? add_echeck(xml, payment_source, options) : add_credit_card(xml, payment_source, options)
       end
 
@@ -901,7 +902,7 @@ module ActiveMerchant #:nodoc:
             request.call(remote_url(:secondary))
           end
 
-        authorization = order.include?('<TokenTxnType>GT</TokenTxnType>') ? response[:safetech_token] : authorization_string(response[:tx_ref_num], response[:order_id])
+        authorization = authorization_string(response[:tx_ref_num], response[:order_id], response[:safetech_token], response[:card_brand])
 
         Response.new(
           success?(response, message_type),

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -123,7 +123,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert response = @gateway.purchase(50, credit_card, order_id: '1')
     assert_instance_of Response, response
     assert_success response
-    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
+    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1;VI', response.authorization
   end
 
   def test_successful_purchase_with_echeck
@@ -133,7 +133,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_equal 'Approved', response.message
     assert_success response
-    assert_equal '5F8E8BEE7299FD339A38F70CFF6E5D010EF55498;9baedc697f2cf06457de78', response.authorization
+    assert_equal '5F8E8BEE7299FD339A38F70CFF6E5D010EF55498;9baedc697f2cf06457de78;EC', response.authorization
   end
 
   def test_successful_purchase_with_commercial_echeck
@@ -163,7 +163,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_match 'APPROVAL', response.message
     assert_equal 'Approved and Completed', response.params['status_msg']
-    assert_equal '5F8ED3D950A43BD63369845D5385B6354C3654B4;2930847bc732eb4e8102cf', response.authorization
+    assert_equal '5F8ED3D950A43BD63369845D5385B6354C3654B4;2930847bc732eb4e8102cf;EC', response.authorization
   end
 
   def test_successful_force_capture_with_echeck_prenote
@@ -173,7 +173,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_match 'APPROVAL', response.message
     assert_equal 'Approved and Completed', response.params['status_msg']
-    assert_equal '5F8ED3D950A43BD63369845D5385B6354C3654B4;2930847bc732eb4e8102cf', response.authorization
+    assert_equal '5F8ED3D950A43BD63369845D5385B6354C3654B4;2930847bc732eb4e8102cf;EC', response.authorization
   end
 
   def test_failed_force_capture_with_echeck_prenote
@@ -509,9 +509,9 @@ class OrbitalGatewayTest < Test::Unit::TestCase
 
   def test_order_id_format_for_capture
     response = stub_comms do
-      @gateway.capture(101, '4A5398CF9B87744GG84A1D30F2F2321C66249416;1001.1', order_id: '#1001.1')
+      @gateway.capture(101, '4A5398CF9B87744GG84A1D30F2F2321C66249416;1;VI001.1;VI', order_id: '#1001.1')
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<OrderID>1001-1<\/OrderID>/, data)
+      assert_match(/<OrderID>1<\/OrderID>/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
   end
@@ -524,7 +524,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     )
 
     response = stub_comms(gateway) do
-      gateway.capture(101, '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', @options)
+      gateway.capture(101, '4A5398CF9B87744GG84A1D30F2F2321C66249416;1;VI', @options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<MerchantID>700000123456<\/MerchantID>/, data)
     end.respond_with(successful_purchase_response)
@@ -1056,11 +1056,10 @@ class OrbitalGatewayTest < Test::Unit::TestCase
   end
 
   def test_successful_payment_request_with_token_stored
-    options = @options.merge(card_brand: 'MC', token_txn_type: 'UT')
     stub_comms do
-      @gateway.purchase(50, '2521002395820006', options)
+      @gateway.purchase(50, '4A5398CF9B87744GG84A1D30F2F2321C66249416;1;2521002395820006;VI', @options.merge(card_brand: 'VI'))
     end.check_request(skip_response: true) do |_endpoint, data, _headers|
-      assert_match %{<CardBrand>MC</CardBrand>}, data
+      assert_match %{<CardBrand>VI</CardBrand>}, data
       assert_match %{<AccountNum>2521002395820006</AccountNum>}, data
     end
   end
@@ -1242,7 +1241,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     assert_instance_of Response, response
     assert_equal 'Approved', response.message
     assert_success response
-    assert_equal '5F8E8D2B077217F3EF1ACD3B61610E4CD12954A3;2', response.authorization
+    assert_equal '5F8E8D2B077217F3EF1ACD3B61610E4CD12954A3;2;EC', response.authorization
   end
 
   def test_failed_authorize_with_echeck
@@ -1586,7 +1585,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       @gateway.verify(credit_card, @options)
     end.respond_with(successful_purchase_response, successful_purchase_response)
     assert_success response
-    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
+    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1;VI', response.authorization
     assert_equal 'Approved', response.message
   end
 
@@ -1614,7 +1613,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_purchase_response)
     assert_success response
-    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
+    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1;VI', response.authorization
     assert_equal 'Approved', response.message
   end
 
@@ -1633,7 +1632,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_purchase_response, successful_void_response)
     assert_success response
-    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
+    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1;VI', response.authorization
     assert_equal 'Approved', response.message
   end
 
@@ -1643,7 +1642,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       @gateway.verify(credit_card, @options)
     end.respond_with(successful_purchase_response, failed_purchase_response)
     assert_success response
-    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
+    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1;VI', response.authorization
     assert_equal 'Approved', response.message
   end
 
@@ -1652,7 +1651,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       @gateway.verify(credit_card, @options)
     end.respond_with(successful_purchase_response, failed_purchase_response)
     assert_success response
-    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1', response.authorization
+    assert_equal '4A5398CF9B87744GG84A1D30F2F2321C66249416;1;VI', response.authorization
     assert_equal 'Approved', response.message
   end
 


### PR DESCRIPTION
Description
-------------------------
[SER-969](https://spreedly.atlassian.net/browse/SER-969) 
[SER-970](https://spreedly.atlassian.net/browse/SER-970) 
[SER-971](https://spreedly.atlassian.net/browse/SER-971)

This commit remove a couple of needless GSF during a TPV flow we hard-coded the values required for token_tx_type and card_brand instead of sending these as GSF

Unit test
-------------------------
Finished in 1.903239 seconds.

148 tests, 839 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

77.76 tests/s, 440.83 assertions/s

Remote test
-------------------------
Finished in 118.453815 seconds.

133 tests, 526 assertions, 13 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 90.2256% passed

1.12 tests/s, 4.44 assertions/s

Rubocop
-------------------------
781 files inspected, no offenses detected