### PR TITLE
Cybersource REST: Remove request-target parens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,7 @@
 * CommerceHub: Add 3DS global support [sinourain] #4957
 * SumUp Gateway: Fix refund method [sinourain] #4924
 * Braintree: Add v2 stored credential option [aenand] #4937
+* Cybersource REST: Remove request-target parens [curiousepic] #4960
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -378,7 +378,7 @@ module ActiveMerchant #:nodoc:
         string_to_sign = {
           host: host,
           date: gmtdatetime,
-          "(request-target)": "#{http_method} /pts/v2/#{resource}",
+          "request-target": "#{http_method} /pts/v2/#{resource}",
           digest: digest,
           "v-c-merchant-id": @options[:merchant_id]
         }.map { |k, v| "#{k}: #{v}" }.join("\n").force_encoding(Encoding::UTF_8)
@@ -386,7 +386,7 @@ module ActiveMerchant #:nodoc:
         {
           keyid: @options[:public_key],
           algorithm: 'HmacSHA256',
-          headers: "host date (request-target)#{digest.present? ? ' digest' : ''} v-c-merchant-id",
+          headers: "host date request-target#{digest.present? ? ' digest' : ''} v-c-merchant-id",
           signature: sign_payload(string_to_sign)
         }.map { |k, v| %{#{k}="#{v}"} }.join(', ')
       end

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -98,7 +98,7 @@ class CyberSourceRestTest < Test::Unit::TestCase
 
     assert_equal 'def345', parsed['keyid']
     assert_equal 'HmacSHA256', parsed['algorithm']
-    assert_equal 'host date (request-target) digest v-c-merchant-id', parsed['headers']
+    assert_equal 'host date request-target digest v-c-merchant-id', parsed['headers']
     assert_equal %w[algorithm headers keyid signature], signature.split(', ').map { |v| v.split('=').first }.sort
   end
 
@@ -106,7 +106,7 @@ class CyberSourceRestTest < Test::Unit::TestCase
     signature = @gateway.send :get_http_signature, @resource, nil, 'get', @gmt_time
 
     parsed = parse_signature(signature)
-    assert_equal 'host date (request-target) v-c-merchant-id', parsed['headers']
+    assert_equal 'host date request-target v-c-merchant-id', parsed['headers']
   end
 
   def test_scrub


### PR DESCRIPTION
Cybersource has updated their API to allow the Signature's request-target header to no longer be enclosed in parentheses, ahead of instating this as a requirement on January 22 2024:
https://community.developer.cybersource.com/t5/cybersource-Developer-Blog/REST-API-Http-Signature-Authentication-Critical-Security-Update/ba-p/87319

ECS-3236

Remote:
47 tests, 157 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
47 tests, 157 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed