### PR TITLE
VisaNet Peru: Pass the purchaseNumber in response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,7 +53,7 @@
 * Orbital: Enable Third Party Vaulting [javierpedrozaing] #4928
 * Payeezy: Add the customer_ref and reference_3 fields [yunnydang] #4942
 * Redsys Rest: Add support for new gateway type Redsys Rest [aenand] #4951
-* CyberSource: surface the reconciliationID2 field [yunnydang] #4934
+* CyberSource: Surface the reconciliationID2 field [yunnydang] #4934
 * Worldpay: Update stored credentials logic [DustinHaefele] #4950
 * Vantiv Express: New Xml gateway [DustinHaefele] #4956
 * Shift4 V2: Add unstore function [javierpedrozaing] #4953
@@ -62,6 +62,7 @@
 * Braintree: Add v2 stored credential option [aenand] #4937
 * Cybersource REST: Remove request-target parens [curiousepic] #4960
 * Ogone: Fix signature calulcation for blank fields [Heavyblade] #4963
+* VisaNet Peru: Add purchaseNumber to response object [yunnydang] #4961
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -148,7 +148,7 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, params, options = {})
         raw_response = ssl_request(method(action), url(action, params, options), params.to_json, headers)
-        response = parse(raw_response)
+        response = parse(raw_response).merge('purchaseNumber' => params[:purchaseNumber])
       rescue ResponseError => e
         raw_response = e.response.body
         response_error(raw_response, options, action)

--- a/test/unit/gateways/visanet_peru_test.rb
+++ b/test/unit/gateways/visanet_peru_test.rb
@@ -21,10 +21,11 @@ class VisanetPeruTest < Test::Unit::TestCase
   def test_successful_purchase
     @gateway.expects(:ssl_request).with(:post, any_parameters).returns(successful_authorize_response)
     @gateway.expects(:ssl_request).with(:put, any_parameters).returns(successful_capture_response)
-
     response = @gateway.purchase(@amount, @credit_card, @options)
+
     assert_success response
     assert_equal 'OK', response.message
+    assert_not_nil response.params['purchaseNumber']
 
     assert_match %r([0-9]{9}|$), response.authorization
     assert_equal 'de9dc65c094fb4f1defddc562731af81', response.params['externalTransactionId']


### PR DESCRIPTION
This passes along the generated purchaseNumber in the response as Visanet peru does not echo this back to us.

Note: remote test for this gateway are un-available due to outdated credentials and issues with receiving new ones.

Local:
5732 tests, 78643 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6685% passed

Unit:
16 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed