### PR TITLE
Ogone: Fix signature calulcation for blank fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -61,6 +61,7 @@
 * SumUp Gateway: Fix refund method [sinourain] #4924
 * Braintree: Add v2 stored credential option [aenand] #4937
 * Cybersource REST: Remove request-target parens [curiousepic] #4960
+* Ogone: Fix signature calulcation for blank fields [Heavyblade] #4963
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/ogone.rb
+++ b/lib/active_merchant/billing/gateways/ogone.rb
@@ -460,7 +460,7 @@ module ActiveMerchant #:nodoc:
             raise "Unknown signature algorithm #{algorithm}"
           end
 
-        filtered_params = signed_parameters.compact
+        filtered_params = signed_parameters.reject { |_k, v| v.nil? || v == '' }
         sha_encryptor.hexdigest(
           filtered_params.sort_by { |k, _v| k.upcase }.map { |k, v| "#{k.upcase}=#{v}#{secret}" }.join('')
         ).upcase

--- a/test/unit/gateways/ogone_test.rb
+++ b/test/unit/gateways/ogone_test.rb
@@ -453,6 +453,27 @@ class OgoneTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrub), post_scrub
   end
 
+  def test_signatire_calculation_with_with_space
+    payload = {
+      orderID: 'abc123',
+      currency: 'EUR',
+      amount: '100',
+      PM: 'CreditCard',
+      ACCEPTANCE: 'test123',
+      STATUS: '9',
+      CARDNO: 'XXXXXXXXXXXX3310',
+      ED: '1029',
+      DCC_INDICATOR: '0',
+      DCC_EXCHRATE: ''
+    }
+
+    signature_with = @gateway.send(:calculate_signature, payload, 'sha512', 'ABC123')
+    payload.delete(:DCC_EXCHRATE)
+    signature_without = @gateway.send(:calculate_signature, payload, 'sha512', 'ABC123')
+
+    assert_equal signature_without, signature_with
+  end
+
   private
 
   def string_to_digest


### PR DESCRIPTION
### Summary:
Add changes to deal with ogone signature when there are empty fields on the passed params

[SER-965](https://spreedly.atlassian.net/browse/SER-965)

## Tests

### Remote Test:
Finished in 135.715931 seconds.
33 tests, 138 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.9697% passed

### Unit Tests:
Finished in 38.938916 seconds.
5733 tests, 78693 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
784 files inspected, no offenses detected