### PR TITLE
Stripe PI: add the card brand field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -68,6 +68,7 @@
 * Litle: Update stored credentials [almalee24] #4903
 * WorldPay: Accept GooglePay pan only [almalee24] #4943
 * Braintree: Correct issue in v2 stored credentials [aenand] #4967
+* Stripe Payment Intents: Add the card brand field [yunnydang] #4964
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -44,6 +44,7 @@ module ActiveMerchant #:nodoc:
             add_fulfillment_date(post, options)
             request_three_d_secure(post, options)
             add_level_three(post, options)
+            add_card_brand(post, options)
             post[:expand] = ['charges.data.balance_transaction']
 
             CREATE_INTENT_ATTRIBUTES.each do |attribute|
@@ -140,6 +141,7 @@ module ActiveMerchant #:nodoc:
             add_return_url(post, options)
             add_fulfillment_date(post, options)
             request_three_d_secure(post, options)
+            add_card_brand(post, options)
             post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
             post[:usage] = options[:usage] if %w(on_session off_session).include?(options[:usage])
             post[:description] = options[:description] if options[:description]
@@ -321,6 +323,14 @@ module ActiveMerchant #:nodoc:
         super
 
         post[:metadata][:event_type] = options[:event_type] if options[:event_type]
+      end
+
+      def add_card_brand(post, options)
+        return unless options[:card_brand]
+
+        post[:payment_method_options] ||= {}
+        post[:payment_method_options][:card] ||= {}
+        post[:payment_method_options][:card][:network] = options[:card_brand] if options[:card_brand]
       end
 
       def add_level_three(post, options = {})

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -371,6 +371,16 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_create_intent_response)
   end
 
+  def test_successful_purchase_with_card_brand
+    @options[:card_brand] = 'cartes_bancaires'
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @visa_token, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match('payment_method_options[card][network]=cartes_bancaires', data)
+    end.respond_with(successful_create_intent_response)
+  end
+
   def test_succesful_purchase_with_stored_credentials_without_sending_ntid
     [@three_ds_off_session_credit_card, @three_ds_authentication_required_setup_for_off_session].each do |card_to_use|
       network_transaction_id = '1098510912210968'


### PR DESCRIPTION
This will add the card brand field for the payment and setup intents

Local:
5733 tests, 78645 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
99.6686% passed

Unit
58 tests, 302 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
95 tests, 448 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed