### PR TITLE
Braintree stored creds v2: update unschedule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,7 @@
 * Redsys: Update to $0 verify [almalee24] #4944
 * Litle: Update stored credentials [almalee24] #4903
 * WorldPay: Accept GooglePay pan only [almalee24] #4943
+* Braintree: Correct issue in v2 stored credentials [aenand] #4967
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -854,6 +854,8 @@ module ActiveMerchant #:nodoc:
           end
         when 'recurring_first', 'moto'
           parameters[:transaction_source] = stored_credential[:reason_type]
+        when 'unscheduled'
+          parameters[:transaction_source] = stored_credential[:initiator] == 'merchant' ? stored_credential[:reason_type] : ''
         else
           parameters[:transaction_source] = ''
         end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1443,20 +1443,34 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:merchant, :installment, id: '123ABC') })
   end
 
-  def test_stored_credential_v2_merchant_one_time
+  def test_stored_credential_v2_unscheduled_cit_initial
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(
         {
           external_vault: {
-            status: 'vaulted',
-            previous_network_transaction_id: '123ABC'
+            status: 'will_vault'
           },
           transaction_source: ''
         }
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:merchant, id: '123ABC') })
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:cardholder, :unscheduled, :initial) })
+  end
+
+  def test_stored_credential_v2_unscheduled_mit_initial
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'will_vault'
+          },
+          transaction_source: 'unscheduled'
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:merchant, :unscheduled, :initial) })
   end
 
   def test_raises_exeption_when_adding_bank_account_to_customer_without_billing_address


### PR DESCRIPTION
Ensure that MIT unscheduled transactions get mapped to unscheduled at Braintree

Remote:
111 tests, 585 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed