### PR TITLE
Cecabank: Fix exemption_type when it is blank and update the error code for some tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -70,6 +70,7 @@
 * Braintree: Correct issue in v2 stored credentials [aenand] #4967
 * Stripe Payment Intents: Add the card brand field [yunnydang] #4964
 * Rapyd: Enable new auth mode payment_redirect [javierpedrozaing] #4970
+* Cecabank: Fix exemption_type when it is blank and update the error code for some tests [sinourain] #4968
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/test/remote/gateways/remote_cecabank_rest_json_test.rb
+++ b/test/remote/gateways/remote_cecabank_rest_json_test.rb
@@ -33,7 +33,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
     assert_match '106900640', response.message
-    assert_match '1-190', response.error_code
+    assert_match '190', response.error_code
   end
 
   def test_successful_capture
@@ -61,7 +61,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
     assert_match '106900640', response.message
-    assert_match '1-190', response.error_code
+    assert_match '190', response.error_code
   end
 
   def test_successful_refund
@@ -155,6 +155,11 @@ class RemoteCecabankTest < Test::Unit::TestCase
   end
 
   private
+
+  def get_response_params(transcript)
+    response = JSON.parse(transcript.gsub(%r(\\\")i, "'").scan(/{[^>]*}/).first.gsub("'", '"'))
+    JSON.parse(Base64.decode64(response['parametros']))
+  end
 
   def three_d_secure
     {


### PR DESCRIPTION
Cecabank: Fix exemption_type when it is blank and update the error code for some tests

Summary:
------------------------------
Fix `exemption_type` when it is blank
Add `exemption_type` tests to increase the coverage
Update the error code for some tests
Replace `ssl_request` to `ssl_post` in the `commit` method

For Spreedly reference:
[SER-1009](https://spreedly.atlassian.net/browse/SER-1009)

Remote Test:
------------------------------
Finished in 63.024038 seconds.
19 tests, 65 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
0.30 tests/s, 1.03 assertions/s

Unit Tests:
------------------------------
Finished in 31.381399 seconds.
5739 tests, 78700 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

RuboCop:
------------------------------
784 files inspected, no offenses detected

182.88 tests/s, 2507.86 assertions/s