### PR TITLE
Rapyd: Enable new auth mode payment_redirect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -69,6 +69,7 @@
 * WorldPay: Accept GooglePay pan only [almalee24] #4943
 * Braintree: Correct issue in v2 stored credentials [aenand] #4967
 * Stripe Payment Intents: Add the card brand field [yunnydang] #4964
+* Rapyd: Enable new auth mode payment_redirect [javierpedrozaing] #4970
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827


### PR DESCRIPTION
Description
-------------------------
[SER-970](https://spreedly.atlassian.net/browse/SER-974)

This commit enable a new mode of authentication for Rapyd. 
This new mode only apply for create payments

Unit test
-------------------------
Finished in 0.189728 seconds.

41 tests, 188 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

100% passed

216.10 tests/s, 990.89 assertions/s

Remote test
-------------------------
Finished in 208.640892 seconds.

47 tests, 123 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 87.234% passed

0.23 tests/s, 0.59 assertions/s

Rubocop
-------------------------
784 files inspected, no offenses detected