### PR TITLE
Adyen: Provide ZZ as default country code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -75,6 +75,7 @@
 * CommerceHub: Add credit transaction [sinourain] #4965
 * PayTrace: Send CSC value on gateway request. [DustinHaefele] #4974
 * Orbital: Remove needless GSF for TPV [javierpedrozaing] #4959
+* Adyen: Provide ZZ as default country code [jcreiff] #4971
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -499,7 +499,7 @@ module ActiveMerchant #:nodoc:
           post[:deliveryAddress][:postalCode] = address[:zip] if address[:zip]
           post[:deliveryAddress][:city] = address[:city] || 'NA'
           post[:deliveryAddress][:stateOrProvince] = get_state(address)
-          post[:deliveryAddress][:country] = address[:country] if address[:country]
+          post[:deliveryAddress][:country] = get_country(address)
         end
         return unless post[:bankAccount]&.kind_of?(Hash) || post[:card]&.kind_of?(Hash)
 
@@ -515,12 +515,16 @@ module ActiveMerchant #:nodoc:
         post[:billingAddress][:postalCode] = address[:zip] if address[:zip]
         post[:billingAddress][:city] = address[:city] || 'NA'
         post[:billingAddress][:stateOrProvince] = get_state(address)
-        post[:billingAddress][:country] = address[:country] if address[:country]
+        post[:billingAddress][:country] = get_country(address)
         post[:telephoneNumber] = address[:phone_number] || address[:phone] || ''
       end
 
       def get_state(address)
         address[:state] && !address[:state].blank? ? address[:state] : 'NA'
+      end
+
+      def get_country(address)
+        address[:country].present? ? address[:country] : 'ZZ'
       end
 
       def add_invoice(post, money, options)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -530,6 +530,36 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal response.authorization, first_auth
   end
 
+  def test_successful_purchase_with_billing_default_country_code
+    options = @options.dup.update({
+      billing_address: {
+        address1: 'Infinite Loop',
+        address2: 1,
+        country: '',
+        city: 'Cupertino',
+        state: 'CA',
+        zip: '95014'
+      }
+    })
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_shipping_default_country_code
+    options = @options.dup.update({
+      shipping_address: {
+        address1: 'Infinite Loop',
+        address2: 1,
+        country: '',
+        city: 'Cupertino',
+        state: 'CA',
+        zip: '95014'
+      }
+    })
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+  end
+
   def test_successful_purchase_with_apple_pay
     response = @gateway.purchase(@amount, @apple_pay_card, @options)
     assert_success response
@@ -1234,12 +1264,17 @@ class RemoteAdyenTest < Test::Unit::TestCase
   def test_blank_country_for_purchase
     @options[:billing_address][:country] = ''
     response = @gateway.authorize(@amount, @credit_card, @options)
-    assert_failure response
-    assert_match Gateway::STANDARD_ERROR_CODE[:incorrect_address], response.error_code
+    assert_success response
   end
 
   def test_nil_state_for_purchase
     @options[:billing_address][:state] = nil
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_nil_country_for_purchase
+    @options[:billing_address][:country] = nil
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
   end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -1061,6 +1061,42 @@ class AdyenTest < Test::Unit::TestCase
     assert_equal @options[:shipping_address][:country], post[:deliveryAddress][:country]
   end
 
+  def test_default_billing_address_country
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({
+        billing_address: {
+          address1: 'Infinite Loop',
+          address2: 1,
+          country: '',
+          city: 'Cupertino',
+          state: 'CA',
+          zip: '95014'
+        }
+      }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/"country":"ZZ"/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_default_shipping_address_country
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({
+        shipping_address: {
+          address1: 'Infinite Loop',
+          address2: 1,
+          country: '',
+          city: 'Cupertino',
+          state: 'CA',
+          zip: '95014'
+        }
+      }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/"country":"ZZ"/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_address_override_that_will_swap_housenumberorname_and_street
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(address_override: true))


### PR DESCRIPTION
According to Adyen's documentation, ZZ should be provided as the country code if the country is not known or is not collected from the cardholder:

https://docs.adyen.com/api-explorer/Payment/latest/post/authorise#request-billingAddress-country https://docs.adyen.com/api-explorer/Payment/latest/post/authorise#request-deliveryAddress-country

Sending an empty string or nil value results in a validation error from Adyen's API

CER-979
Local
5741 tests, 78708 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

784 files inspected, no offenses detected

Unit
115 tests, 604 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote
142 tests, 461 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.2535% passed
*These same 11 tests (mostly related to store/unstore functionality) also fail on master