### PR TITLE
Checkout: Update reponse message for 3DS transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -92,6 +92,7 @@
 * Rapyd: Update email mapping [javierpedrozaing] #4996
 * SagePay: Add support for v4 [aenand] #4990
 * Braintree: Send merchant_account_id when generating client token [almalee24] #4991
+* CheckoutV2: Update reponse message for 3DS transactions [almalee24] #4975
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827


### PR DESCRIPTION
After a redirect from 3DS transactions the verify_payment method is usually called which returns the response_summary inside actions.

Unit:
64 tests, 378 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
98 tests, 236 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed