### PR TITLE
Litle: Update account type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@
 * Adyen: Add support for `metadata` object [rachelkirk] #4987
 * Xpay: New adapter basic operations added [jherreraa] #4669
 * Rapyd: Enable idempotent request support [javierpedrozaing] #4980
+* Litle: Update account type [almalee24] #4976
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -390,8 +390,9 @@ module ActiveMerchant #:nodoc:
             doc.track(payment_method.track_data)
           end
         elsif check?(payment_method)
+          account_type = payment_method.account_type || payment_method.account_holder_type
           doc.echeck do
-            doc.accType(payment_method.account_type.capitalize)
+            doc.accType(account_type&.capitalize)
             doc.accNum(payment_method.account_number)
             doc.routingNum(payment_method.routing_number)
             doc.checkNum(payment_method.number) if payment_method.number

--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -86,7 +86,8 @@ class RemoteLitleTest < Test::Unit::TestCase
       name: 'John Smith',
       routing_number: '011075150',
       account_number: '1099999999',
-      account_type: 'checking'
+      account_type: nil,
+      account_holder_type: 'checking'
     )
     @store_check = check(
       routing_number: '011100012',

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -54,7 +54,8 @@ class LitleTest < Test::Unit::TestCase
       name: 'John Smith',
       routing_number: '011075150',
       account_number: '1099999999',
-      account_type: 'checking'
+      account_type: nil,
+      account_holder_type: 'checking'
     )
 
     @long_address = {
@@ -132,6 +133,21 @@ class LitleTest < Test::Unit::TestCase
   def test_successful_purchase_with_echeck
     response = stub_comms do
       @gateway.purchase(2004, @check)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<accType>Checking</accType>), data)
+    end.respond_with(successful_purchase_with_echeck_response)
+
+    assert_success response
+
+    assert_equal '621100411297330000;echeckSales;2004', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_echeck_and_account_holder_type
+    response = stub_comms do
+      @gateway.purchase(2004, @authorize_check)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<accType>Checking</accType>), data)
     end.respond_with(successful_purchase_with_echeck_response)
 
     assert_success response


### PR DESCRIPTION
Update account type to also use account_holder_type and safeguard against it being nil.

Unit:
59 tests, 264 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
57 tests, 251 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed