### PR TITLE
MIT: Add test_url

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -76,6 +76,7 @@
 * PayTrace: Send CSC value on gateway request. [DustinHaefele] #4974
 * Orbital: Remove needless GSF for TPV [javierpedrozaing] #4959
 * Adyen: Provide ZZ as default country code [jcreiff] #4971
+* MIT: Add test_url [jcreiff] #4977
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/mit.rb
+++ b/lib/active_merchant/billing/gateways/mit.rb
@@ -7,6 +7,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class MitGateway < Gateway
       self.live_url = 'https://wpy.mitec.com.mx/ModuloUtilWS/activeCDP.htm'
+      self.test_url = 'https://scqa.mitec.com.mx/ModuloUtilWS/activeCDP.htm'
 
       self.supported_countries = ['MX']
       self.default_currency = 'MXN'
@@ -220,8 +221,12 @@ module ActiveMerchant #:nodoc:
         post[:name_client] = [payment.first_name, payment.last_name].join(' ')
       end
 
+      def url
+        test? ? test_url : live_url
+      end
+
       def commit(action, parameters)
-        raw_response = ssl_post(live_url, parameters, { 'Content-type' => 'text/plain' })
+        raw_response = ssl_post(url, parameters, { 'Content-type' => 'text/plain' })
         response = JSON.parse(decrypt(raw_response, @options[:key_session]))
 
         Response.new(


### PR DESCRIPTION
This change provides the option to send test requests to the QA endpoint of the MIT gateway at `https://scqa.mitec.com.mx/ModuloUtilWS/activeCDP.htm`

CER-1066

Local
5740 tests, 78706 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

784 files inspected, no offenses detected

Unit
9 tests, 33 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote
8 tests, 22 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed