### PR TITLE
HiPay:  Add Gateway

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -84,6 +84,7 @@
 * Rapyd: Enable idempotent request support [javierpedrozaing] #4980
 * Litle: Update account type [almalee24] #4976
 * Wompi: Add support for `tip_in_cents` [rachelkirk] #4983
+* HiPay: Add Gateway [gasb150] #4979
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/hi_pay.rb
+++ b/lib/active_merchant/billing/gateways/hi_pay.rb
@@ -1,0 +1,203 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class HiPayGateway < Gateway
+      # to add more check => payment_product_list: https://developer.hipay.com/api-explorer/api-online-payments#/payments/generateHostedPaymentPage
+      PAYMENT_PRODUCT = {
+        'visa' => 'visa',
+        'master' => 'mastercard'
+      }
+
+      self.test_url = 'https://stage-secure-gateway.hipay-tpp.com/rest'
+      self.live_url = 'https://secure-gateway.hipay-tpp.com/rest'
+
+      self.supported_countries = %w[FR]
+      self.default_currency = 'EUR'
+      self.money_format = :dollars
+      self.supported_cardtypes = %i[visa master american_express]
+
+      self.homepage_url = 'https://hipay.com/'
+      self.display_name = 'HiPay'
+
+      def initialize(options = {})
+        requires!(options, :username, :password)
+        @username = options[:username]
+        @password = options[:password]
+        super
+      end
+
+      def purchase(money, payment_method, options = {})
+        authorize(money, payment_method, options.merge({ operation: 'Sale' }))
+      end
+
+      def authorize(money, payment_method, options = {})
+        MultiResponse.run do |r|
+          if payment_method.is_a?(CreditCard)
+            response = r.process { tokenize(payment_method, options) }
+            card_token = response.params['token']
+          elsif payment_method.is_a?(String)
+            _transaction_ref, card_token, payment_product = payment_method.split('|')
+          end
+
+          post = {
+            payment_product: payment_product&.downcase || PAYMENT_PRODUCT[payment_method.brand],
+            operation: options[:operation] || 'Authorization',
+            cardtoken: card_token
+          }
+          add_address(post, options)
+          add_product_data(post, options)
+          add_invoice(post, money, options)
+          r.process { commit('order', post) }
+        end
+      end
+
+      def capture(money, authorization, options)
+        post = {}
+        post[:operation] = 'capture'
+        post[:currency] = (options[:currency] || currency(money))
+        transaction_ref, _card_token, _payment_product = authorization.split('|')
+        commit('capture', post, { transaction_reference: transaction_ref })
+      end
+
+      def store(payment_method, options = {})
+        tokenize(payment_method, options.merge({ multiuse: '1' }))
+      end
+
+      def scrub(transcrip)
+        # code
+      end
+
+      private
+
+      def add_product_data(post, options)
+        post[:orderid] = options[:order_id] if options[:order_id]
+        post[:description] = options[:description]
+      end
+
+      def add_invoice(post, money, options)
+        post[:currency] = (options[:currency] || currency(money))
+        post[:amount] = amount(money)
+      end
+
+      def add_credit_card(post, credit_card)
+        post[:card_number] = credit_card.number
+        post[:card_expiry_month] = credit_card.month
+        post[:card_expiry_year] = credit_card.year
+        post[:card_holder] = credit_card.name
+        post[:cvc] = credit_card.verification_value
+      end
+
+      def add_address(post, options)
+        return unless billing_address = options[:billing_address]
+
+        post[:streetaddress] = billing_address[:address1] if billing_address[:address1]
+        post[:streetaddress2] = billing_address[:address2] if billing_address[:address2]
+        post[:city] = billing_address[:city] if billing_address[:city]
+        post[:recipient_info] = billing_address[:company] if billing_address[:company]
+        post[:state] = billing_address[:state] if billing_address[:state]
+        post[:country] = billing_address[:country] if billing_address[:country]
+        post[:zipcode] = billing_address[:zip] if billing_address[:zip]
+        post[:country] = billing_address[:country] if billing_address[:country]
+        post[:phone] = billing_address[:phone] if billing_address[:phone]
+      end
+
+      def tokenize(payment_method, options = {})
+        post = {}
+        add_credit_card(post, payment_method)
+        post[:multi_use] = options[:multiuse] ? '1' : '0'
+        post[:generate_request_id] = '0'
+        commit('store', post, options)
+      end
+
+      def parse(body)
+        return {} if body.blank?
+
+        JSON.parse(body)
+      end
+
+      def commit(action, post, options = {})
+        raw_response = begin
+                          ssl_post(url(action, options), post_data(post), request_headers)
+                       rescue ResponseError => e
+                         e.response.body
+                        end
+
+        response = parse(raw_response)
+
+        Response.new(
+          success_from(action, response),
+          message_from(action, response),
+          response,
+          authorization: authorization_from(action, response),
+          test: test?,
+          error_code: error_code_from(action, response)
+        )
+      end
+
+      def error_code_from(action, response)
+        response['code'].to_s unless success_from(action, response)
+      end
+
+      def success_from(action, response)
+        case action
+        when 'order'
+          response['state'] == 'completed'
+        when 'capture'
+          response['status'] == '118' && response['message'] == 'Captured'
+        when 'store'
+          response.include? 'token'
+        else
+          false
+        end
+      end
+
+      def message_from(action, response)
+        response['message']
+      end
+
+      def authorization_from(action, response)
+        authorization_string(response['transactionReference'], response['token'], response['brand'])
+      end
+
+      def authorization_string(*args)
+        args.join('|')
+      end
+
+      def post_data(params)
+        params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+      end
+
+      def url(action, options = {})
+        case action
+        when 'store'
+          "#{token_url}/create"
+        when 'capture'
+          endpoint = "maintenance/transaction/#{options[:transaction_reference]}"
+          base_url(endpoint)
+        else
+          base_url(action)
+        end
+      end
+
+      def base_url(endpoint)
+        "#{test? ? test_url : live_url}/v1/#{endpoint}"
+      end
+
+      def token_url
+        "https://#{'stage-' if test?}secure2-vault.hipay-tpp.com/rest/v2/token"
+      end
+
+      def basic_auth
+        Base64.strict_encode64("#{@username}:#{@password}")
+      end
+
+      def request_headers
+        headers = {
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/x-www-form-urlencoded',
+          'Authorization' => "Basic #{basic_auth}"
+        }
+        headers
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -462,6 +462,10 @@ hdfc:
   login: LOGIN
   password: PASSWORD
 
+hi_pay:
+  username: "USERNAME"
+  password: "PASSWORD"
+
 # Working credentials, no need to replace
 hps:
   secret_api_key: "skapi_cert_MYl2AQAowiQAbLp5JesGKh7QFkcizOP2jcX9BrEMqQ"

--- a/test/remote/gateways/remote_hi_pay_test.rb
+++ b/test/remote/gateways/remote_hi_pay_test.rb
@@ -1,0 +1,114 @@
+require 'test_helper'
+
+class RemoteHiPayTest < Test::Unit::TestCase
+  def setup
+    @gateway = HiPayGateway.new(fixtures(:hi_pay))
+    @bad_gateway = HiPayGateway.new(username: 'bad', password: 'password')
+
+    @amount = 500
+    @credit_card = credit_card('4111111111111111', verification_value: '514', first_name: 'John', last_name: 'Smith', month: 12, year: 2025)
+    @bad_credit_card = credit_card('5144144373781246')
+    @master_credit_card = credit_card('5399999999999999')
+
+    @options = {
+      order_id: "Sp_ORDER_#{SecureRandom.random_number(1000000000)}",
+      description: 'An authorize',
+      email: 'john.smith@test.com'
+    }
+
+    @billing_address = address
+  end
+
+  def test_successful_authorize
+    response = @gateway.authorize(@amount, @credit_card, @options)
+
+    assert_success response
+    assert_equal response.message, 'Authorized'
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_include 'Captured', response.message
+
+    assert_kind_of MultiResponse, response
+    assert_equal 2, response.responses.size
+  end
+
+  def test_successful_purchase_with_mastercard
+    response = @gateway.purchase(@amount, @master_credit_card, @options)
+    assert_success response
+    assert_include 'Captured', response.message
+
+    assert_kind_of MultiResponse, response
+    assert_equal 2, response.responses.size
+  end
+
+  def test_failed_purchase_due_failed_tokenization
+    response = @bad_gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_include 'Incorrect Credentials _ Username and/or password is incorrect', response.message
+    assert_include '1000001', response.error_code
+
+    assert_kind_of MultiResponse, response
+    # Failed in tokenization step
+    assert_equal 1, response.responses.size
+  end
+
+  def test_failed_purchase_due_authentication_requested
+    response = @gateway.purchase(@amount, @bad_credit_card, @options)
+    assert_failure response
+    assert_include 'Authentication requested', response.message
+    assert_include '1000001', response.error_code
+
+    assert_kind_of MultiResponse, response
+    # Complete tokenization, failed in the purhcase step
+    assert_equal 2, response.responses.size
+  end
+
+  def test_successful_purchase_with_billing_address
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ billing_address: @billing_address }))
+
+    assert_success response
+    assert_equal response.message, 'Captured'
+  end
+
+  def test_successful_capture
+    authorize_response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize_response
+    assert_include 'Authorized', authorize_response.message
+
+    response = @gateway.capture(@amount, authorize_response.authorization, @options)
+    assert_success response
+    assert_include 'Captured', response.message
+    assert_equal authorize_response.authorization, response.authorization
+  end
+
+  def test_successful_authorize_with_store
+    store_response = @gateway.store(@credit_card, @options)
+    assert_nil store_response.message
+    assert_success store_response
+    assert_not_empty store_response.authorization
+
+    response = @gateway.authorize(@amount, store_response.authorization, @options)
+    assert_success response
+    assert_include 'Authorized', response.message
+  end
+
+  def test_successful_multiple_purchases_with_single_store
+    store_response = @gateway.store(@credit_card, @options)
+    assert_nil store_response.message
+    assert_success store_response
+    assert_not_empty store_response.authorization
+
+    response1 = @gateway.purchase(@amount, store_response.authorization, @options)
+    assert_success response1
+    assert_include 'Captured', response1.message
+
+    @options[:order_id] = "Sp_ORDER_2_#{SecureRandom.random_number(1000000000)}"
+
+    response2 = @gateway.purchase(@amount, store_response.authorization, @options)
+    assert_success response2
+    assert_include 'Captured', response2.message
+  end
+end

--- a/test/unit/gateways/hi_pay_test.rb
+++ b/test/unit/gateways/hi_pay_test.rb
@@ -1,0 +1,243 @@
+require 'test_helper'
+
+class HiPayTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = HiPayGateway.new(fixtures(:hi_pay))
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: SecureRandom.random_number(1000000000),
+      description: 'Short_description',
+      email: 'john.smith@test.com'
+    }
+
+    @billing_address = address
+  end
+
+  def test_tokenize_pm_with_authorize
+    @gateway.expects(:ssl_post).
+      with(
+        'https://stage-secure2-vault.hipay-tpp.com/rest/v2/token/create',
+        all_of(
+          includes("card_number=#{@credit_card.number}"),
+          includes("card_expiry_month=#{@credit_card.month}"),
+          includes("card_expiry_year=#{@credit_card.year}"),
+          includes("card_holder=#{@credit_card.first_name}+#{@credit_card.last_name}"),
+          includes("cvc=#{@credit_card.verification_value}"),
+          includes('multi_use=0'),
+          includes('generate_request_id=0')
+        ),
+        anything
+      ).
+      returns(successful_tokenize_response)
+    @gateway.expects(:ssl_post).with('https://stage-secure-gateway.hipay-tpp.com/rest/v1/order', anything, anything).returns(successful_authorize_response)
+    @gateway.authorize(@amount, @credit_card, @options)
+  end
+
+  def test_tokenize_pm_with_store
+    @gateway.expects(:ssl_post).
+      with(
+        'https://stage-secure2-vault.hipay-tpp.com/rest/v2/token/create',
+        all_of(
+          includes("card_number=#{@credit_card.number}"),
+          includes("card_expiry_month=#{@credit_card.month}"),
+          includes("card_expiry_year=#{@credit_card.year}"),
+          includes("card_holder=#{@credit_card.first_name}+#{@credit_card.last_name}"),
+          includes("cvc=#{@credit_card.verification_value}"),
+          includes('multi_use=1'),
+          includes('generate_request_id=0')
+        ),
+        anything
+      ).
+      returns(successful_tokenize_response)
+    @gateway.store(@credit_card, @options)
+  end
+
+  def test_authorize_with_credit_card
+    @gateway.expects(:ssl_post).
+      with(
+        'https://stage-secure2-vault.hipay-tpp.com/rest/v2/token/create',
+        all_of(
+          includes("card_number=#{@credit_card.number}"),
+          includes("card_expiry_month=#{@credit_card.month}"),
+          includes("card_expiry_year=#{@credit_card.year}"),
+          includes("card_holder=#{@credit_card.first_name}+#{@credit_card.last_name}"),
+          includes("cvc=#{@credit_card.verification_value}"),
+          includes('multi_use=0'),
+          includes('generate_request_id=0')
+        ),
+        anything
+      ).
+      returns(successful_tokenize_response)
+
+    tokenize_response_token = JSON.parse(successful_tokenize_response)['token']
+
+    @gateway.expects(:ssl_post).
+      with('https://stage-secure-gateway.hipay-tpp.com/rest/v1/order',
+           all_of(
+             includes('payment_product=visa'),
+             includes('operation=Authorization'),
+             regexp_matches(%r{orderid=\d+}),
+             includes("description=#{@options[:description]}"),
+             includes('currency=EUR'),
+             includes('amount=1.00'),
+             includes("cardtoken=#{tokenize_response_token}")
+           ),
+           anything).
+      returns(successful_capture_response)
+
+    @gateway.authorize(@amount, @credit_card, @options)
+  end
+
+  def test_authorize_with_credit_card_and_billing_address
+    @gateway.expects(:ssl_post).returns(successful_tokenize_response)
+
+    tokenize_response_token = JSON.parse(successful_tokenize_response)['token']
+
+    @gateway.expects(:ssl_post).
+      with('https://stage-secure-gateway.hipay-tpp.com/rest/v1/order',
+           all_of(
+             includes('payment_product=visa'),
+             includes('operation=Authorization'),
+             includes('streetaddress=456+My+Street'),
+             includes('streetaddress2=Apt+1'),
+             includes('city=Ottawa'),
+             includes('recipient_info=Widgets+Inc'),
+             includes('state=ON'),
+             includes('country=CA'),
+             includes('zipcode=K1C2N6'),
+             includes('phone=%28555%29555-5555'),
+             regexp_matches(%r{orderid=\d+}),
+             includes("description=#{@options[:description]}"),
+             includes('currency=EUR'),
+             includes('amount=1.00'),
+             includes("cardtoken=#{tokenize_response_token}")
+           ),
+           anything).
+      returns(successful_capture_response)
+
+    @gateway.authorize(@amount, @credit_card, @options.merge({ billing_address: @billing_address }))
+  end
+
+  def test_purchase_with_stored_pm
+    stub_comms do
+      @gateway.purchase(@amount, 'authorization_value|card_token|card_brand', @options)
+    end.check_request do |_endpoint, data, _headers|
+      params = data.split('&').map { |param| param.split('=') }.to_h
+      assert_equal 'card_brand', params['payment_product']
+      assert_equal 'Sale', params['operation']
+      assert_equal @options[:order_id].to_s, params['orderid']
+      assert_equal @options[:description], params['description']
+      assert_equal 'EUR', params['currency']
+      assert_equal '1.00', params['amount']
+      assert_equal 'card_token', params['cardtoken']
+    end.respond_with(successful_capture_response)
+  end
+
+  def test_purhcase_with_credit_card; end
+
+  def test_capture
+    @gateway.expects(:ssl_post).with('https://stage-secure2-vault.hipay-tpp.com/rest/v2/token/create', anything, anything).returns(successful_tokenize_response)
+    @gateway.expects(:ssl_post).with('https://stage-secure-gateway.hipay-tpp.com/rest/v1/order', anything, anything).returns(successful_authorize_response)
+
+    authorize_response = @gateway.authorize(@amount, @credit_card, @options)
+    transaction_reference, _card_token, _brand = authorize_response.authorization.split('|')
+    @gateway.expects(:ssl_post).
+      with(
+        "https://stage-secure-gateway.hipay-tpp.com/rest/v1/maintenance/transaction/#{transaction_reference}",
+        all_of(
+          includes('operation=capture'),
+          includes('currency=EUR')
+        ),
+        anything
+      ).
+      returns(successful_capture_response)
+    @gateway.capture(@amount, transaction_reference, @options)
+  end
+
+  def test_required_client_id_and_client_secret
+    error = assert_raises ArgumentError do
+      HiPayGateway.new
+    end
+
+    assert_equal 'Missing required parameter: username', error.message
+  end
+
+  def test_supported_card_types
+    assert_equal HiPayGateway.supported_cardtypes, %i[visa master american_express]
+  end
+
+  def test_supported_countries
+    assert_equal HiPayGateway.supported_countries, ['FR']
+  end
+
+  # def test_support_scrubbing_flag_enabled
+  #   assert @gateway.supports_scrubbing?
+  # end
+
+  def test_detecting_successfull_response_from_capture
+    assert @gateway.send :success_from, 'capture', { 'status' => '118', 'message' => 'Captured' }
+  end
+
+  def test_detecting_successfull_response_from_purchase
+    assert @gateway.send :success_from, 'order', { 'state' => 'completed' }
+  end
+
+  def test_detecting_successfull_response_from_authorize
+    assert @gateway.send :success_from, 'order', { 'state' => 'completed' }
+  end
+
+  def test_detecting_successfull_response_from_store
+    assert @gateway.send :success_from, 'store', { 'token' => 'random_token' }
+  end
+
+  def test_get_response_message_from_messages_key
+    message = @gateway.send :message_from, 'order', { 'message' => 'hello' }
+    assert_equal 'hello', message
+  end
+
+  def test_get_response_message_from_message_user
+    message = @gateway.send :message_from, 'order', { other_key: 'something_else' }
+    assert_nil message
+  end
+
+  def test_url_generation_from_action
+    action = 'test'
+    assert_equal "#{@gateway.test_url}/v1/#{action}", @gateway.send(:url, action)
+  end
+
+  def test_request_headers_building
+    gateway = HiPayGateway.new(username: 'abc123', password: 'def456')
+    headers = gateway.send :request_headers
+
+    assert_equal 'application/json', headers['Accept']
+    assert_equal 'application/x-www-form-urlencoded', headers['Content-Type']
+    assert_equal 'Basic YWJjMTIzOmRlZjQ1Ng==', headers['Authorization']
+  end
+
+  # def test_scrub
+  #   assert @gateway.supports_scrubbing?
+
+  #   pre_scrubbed = File.read('test/unit/transcripts/alelo_purchase')
+  #   post_scrubbed = File.read('test/unit/transcripts/alelo_purchase_scrubbed')
+
+  #   assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  # end
+
+  private
+
+  def successful_tokenize_response
+    '{"token":"5fc03718289f58d1ce38482faa79aa4c640c44a5d182ad3d849761ed9ea33155","request_id":"0","card_id":"9fd81707-8f41-4a01-b6ed-279954336ada","multi_use":0,"brand":"VISA","pan":"411111xxxxxx1111","card_holder":"John Smith","card_expiry_month":"12","card_expiry_year":"2025","issuer":"JPMORGAN CHASE BANK, N.A.","country":"US","card_type":"CREDIT","forbidden_issuer_country":false}'
+  end
+
+  def successful_authorize_response
+    '{"state":"completed","reason":"","forwardUrl":"","test":"true","mid":"00001331069","attemptId":"1","authorizationCode":"no_code","transactionReference":"800271033524","dateCreated":"2023-12-05T23:36:43+0000","dateUpdated":"2023-12-05T23:36:48+0000","dateAuthorized":"2023-12-05T23:36:48+0000","status":"116","message":"Authorized","authorizedAmount":"500.00","capturedAmount":"0.00","refundedAmount":"0.00","creditedAmount":"0.00","decimals":"2","currency":"EUR","ipAddress":"0.0.0.0","ipCountry":"","deviceId":"","cdata1":"","cdata2":"","cdata3":"","cdata4":"","cdata5":"","cdata6":"","cdata7":"","cdata8":"","cdata9":"","cdata10":"","avsResult":"","eci":"7","paymentProduct":"visa","paymentMethod":{"token":"5fc03718289f58d1ce38482faa79aa4c640c44a5d182ad3d849761ed9ea33155","cardId":"9fd81707-8f41-4a01-b6ed-279954336ada","brand":"VISA","pan":"411111******1111","cardHolder":"JOHN SMITH","cardExpiryMonth":"12","cardExpiryYear":"2025","issuer":"JPMORGAN CHASE BANK, N.A.","country":"US"},"threeDSecure":{"eci":"","authenticationStatus":"Y","authenticationMessage":"Authentication Successful","authenticationToken":"","xid":""},"fraudScreening":{"scoring":"0","result":"ACCEPTED","review":""},"order":{"id":"Sp_ORDER_272437225","dateCreated":"2023-12-05T23:36:43+0000","attempts":"1","amount":"500.00","shipping":"0.00","tax":"0.00","decimals":"2","currency":"EUR","customerId":"","language":"en_US","email":""},"debitAgreement":{"id":"","status":""}}'
+  end
+
+  def successful_capture_response
+    '{"operation":"capture","test":"true","mid":"00001331069","authorizationCode":"no_code","transactionReference":"800271033524","dateCreated":"2023-12-05T23:36:43+0000","dateUpdated":"2023-12-05T23:37:21+0000","dateAuthorized":"2023-12-05T23:36:48+0000","status":"118","message":"Captured","authorizedAmount":"500.00","capturedAmount":"500.00","refundedAmount":"0.00","decimals":"2","currency":"EUR"}'
+  end
+end


### PR DESCRIPTION
SER-719
SER-772
------

Summary:
-------
Adding HiPay gateway with support for basic functionality including authorize, purchase, capture, and store calls.

HiPay requires the tokenization of the CreditCards that's why this first implementation includes the tokenization and store methods.

The store and tokenization methods are different in the "multiuse" param. With this a tokenized PM can be used once(tokenization) or several times(store)

Tests
------
Remote Test:
Finished in 6.627757 seconds.
8 tests, 35 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit Tests:
18 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
787 files inspected, no offenses detected