### PR TITLE
Rapyd: Enable idempotent request support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -81,6 +81,7 @@
 * IPG: Allow for Merchant Aggregator credential usage [DustinHaefele] #4986
 * Adyen: Add support for `metadata` object [rachelkirk] #4987
 * Xpay: New adapter basic operations added [jherreraa] #4669
+* Rapyd: Enable idempotent request support [javierpedrozaing] #4980
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -112,6 +112,11 @@ module ActiveMerchant #:nodoc:
         add_ewallet(post, options)
         add_payment_fields(post, options)
         add_payment_urls(post, options)
+        add_idempotency(options)
+      end
+
+      def add_idempotency(options)
+        @options[:idempotency] = options[:idempotency_key] if options[:idempotency_key]
       end
 
       def add_address(post, creditcard, options)
@@ -347,8 +352,9 @@ module ActiveMerchant #:nodoc:
           'access_key' => @options[:access_key],
           'salt' => salt,
           'timestamp' => timestamp,
-          'signature' => generate_hmac(rel_path, salt, timestamp, payload)
-        }
+          'signature' => generate_hmac(rel_path, salt, timestamp, payload),
+          'idempotency' => @options[:idempotency]
+        }.delete_if { |_, value| value.nil? }
       end
 
       def generate_hmac(rel_path, salt, timestamp, payload)


### PR DESCRIPTION
Description
-------------------------
[SER-1023](https://spreedly.atlassian.net/browse/SER-1023)

This commit adds an idempotency attribute to headers in order to support idempotent requests, Rapyd manage it, taking into account the idempotency value and the amount to determine if a transaction is idempotent or no.

Unit test
-------------------------
Finished in 0.504217 seconds.

42 tests, 196 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

83.30 tests/s, 388.72 assertions/s

Remote test
-------------------------
49 tests, 142 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.9592% passed

Rubocop
-------------------------
784 files inspected, no offenses detected