### PR TITLE
VantiveExpress: Fix eci bug

### DIFF
--- a/lib/active_merchant/billing/gateways/vantiv_express.rb
+++ b/lib/active_merchant/billing/gateways/vantiv_express.rb
@@ -1,6 +1,6 @@
 require 'nokogiri'
 require 'securerandom'
-
+require 'pry'
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class VantivExpressGateway < Gateway
@@ -157,7 +157,7 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment, options = {})
         action = payment.is_a?(Check) ? 'CheckSale' : 'CreditCardSale'
-        eci = payment.is_a?(NetworkTokenizationCreditCard) ? parse_eci(payment) : nil
+        eci = parse_eci(payment)
 
         request = build_xml_request do |xml|
           xml.send(action, xmlns: live_url) do
@@ -174,7 +174,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorize(money, payment, options = {})
-        eci = payment.is_a?(NetworkTokenizationCreditCard) ? parse_eci(payment) : nil
+        eci = parse_eci(payment)
 
         request = build_xml_request do |xml|
           xml.CreditCardAuthorization(xmlns: live_url) do
@@ -221,7 +221,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def credit(money, payment, options = {})
-        eci = payment.is_a?(NetworkTokenizationCreditCard) ? parse_eci(payment) : nil
+        eci = parse_eci(payment)
 
         request = build_xml_request do |xml|
           xml.CreditCardCredit(xmlns: live_url) do
@@ -264,7 +264,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def verify(payment, options = {})
-        eci = payment.is_a?(NetworkTokenizationCreditCard) ? parse_eci(payment) : nil
+        eci = parse_eci(payment)
 
         request = build_xml_request do |xml|
           xml.CreditCardAVSOnly(xmlns: live_url) do
@@ -348,8 +348,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse_eci(payment)
-        eci = payment.eci
-        eci[0] == '0' ? eci.sub!(/^0/, '') : eci
+        return nil unless payment.is_a?(NetworkTokenizationCreditCard)
+
+        if (eci = payment.eci)
+          eci = eci[0] == '0' ? eci.sub!(/^0/, '') : eci
+          return eci
+        else
+          payment.brand == 'american_express' ? '9' : '6'
+        end
       end
 
       def market_code(money, options, network_token_eci)
@@ -524,7 +530,7 @@ module ActiveMerchant #:nodoc:
 
         if response['transaction']
           authorization = "#{response.dig('transaction', 'transactionid')}|#{amount}"
-          authorization << "|#{parse_eci(payment)}" if payment.is_a?(NetworkTokenizationCreditCard)
+          authorization << "|#{parse_eci(payment)}" if parse_eci(payment)
           authorization
         end
       end

--- a/test/remote/gateways/remote_vantiv_express_test.rb
+++ b/test/remote/gateways/remote_vantiv_express_test.rb
@@ -230,6 +230,14 @@ class RemoteVantivExpressTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_apple_pay_no_eci
+    @apple_pay_network_token.eci = nil
+
+    response = @gateway.purchase(1202, @apple_pay_network_token, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_purchase_with_apple_pay
     response = @gateway.purchase(@amount, @apple_pay_network_token, @options)
     assert_success response


### PR DESCRIPTION
If a ApplePay or GooglePay does not have an eci value then it would be considered not secure for Visa/MC/Discover so we need to send 6 and for Amex send 9. MotoECICode is considered a required value for ApplePay and GooglePay.