### PR TITLE
Wompi: Add support for `tip_in_cents`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -83,6 +83,7 @@
 * Xpay: New adapter basic operations added [jherreraa] #4669
 * Rapyd: Enable idempotent request support [javierpedrozaing] #4980
 * Litle: Update account type [almalee24] #4976
+* Wompi: Add support for `tip_in_cents` [rachelkirk] #4983
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/wompi.rb
+++ b/lib/active_merchant/billing/gateways/wompi.rb
@@ -34,6 +34,7 @@ module ActiveMerchant #:nodoc:
           public_key: public_key
         }
         add_invoice(post, money, options)
+        add_tip_in_cents(post, options)
         add_card(post, payment, options)
 
         commit('sale', post, '/transactions_sync')
@@ -139,6 +140,10 @@ module ActiveMerchant #:nodoc:
         post[:installments] = installments
         post[:card_holder] = card.name
         post[:cvc] = cvc if cvc && !cvc.empty?
+      end
+
+      def add_tip_in_cents(post, options)
+        post[:tip_in_cents] = options[:tip_in_cents].to_i if options[:tip_in_cents]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_wompi_test.rb
+++ b/test/remote/gateways/remote_wompi_test.rb
@@ -34,6 +34,11 @@ class RemoteWompiTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_tip_in_cents
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(tip_in_cents: 300))
+    assert_success response
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/wompi_test.rb
+++ b/test/unit/gateways/wompi_test.rb
@@ -148,6 +148,20 @@ class WompiTest < Test::Unit::TestCase
     assert_equal 'La entidad solicitada no existe', response.message
   end
 
+  def test_successful_purchase_with_tip_in_cents
+    response = stub_comms(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options.merge(tip_in_cents: 300))
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['tip_in_cents'], 300
+      assert_match @amount.to_s, data
+    end.respond_with(successful_purchase_response)
+    assert_success response
+
+    assert_equal '113879-1635300853-71494', response.authorization
+    assert response.test?
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed


### PR DESCRIPTION
CER-1062

Remote Tests:
14 tests, 27 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 71.4286% passed
Some remote tests are failing due to a missing email, will address in a different ticket.

Unit Tests:
13 tests, 65 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Local Tests:
5740 tests, 78712 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed