### PR TITLE
Adyen: Add support for `metadata`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -79,6 +79,7 @@
 * MIT: Add test_url [jcreiff] #4977
 * VantivExpress: Fix eci bug [almalee24] #4982
 * IPG: Allow for Merchant Aggregator credential usage [DustinHaefele] #4986
+* Adyen: Add support for `metadata` object [rachelkirk] #4987
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -70,6 +70,7 @@ module ActiveMerchant #:nodoc:
         add_level_3_data(post, options)
         add_data_airline(post, options)
         add_data_lodging(post, options)
+        add_metadata(post, options)
         commit('authorise', post, options)
       end
 
@@ -745,6 +746,13 @@ module ActiveMerchant #:nodoc:
         if (address = fund_source[:billing_address])
           add_billing_address(post[:fundSource], options, address)
         end
+      end
+
+      def add_metadata(post, options = {})
+        return unless options[:metadata]
+
+        post[:metadata] ||= {}
+        post[:metadata].merge!(options[:metadata]) if options[:metadata]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1738,6 +1738,19 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_successful_purchase_with_metadata
+    metadata = {
+      field_one: 'A',
+      field_two: 'B',
+      field_three: 'C',
+      field_four: 'EASY AS ONE TWO THREE'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(metadata: metadata))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
   private
 
   def stored_credential_options(*args, ntid: nil)

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -1542,6 +1542,26 @@ class AdyenTest < Test::Unit::TestCase
     end
   end
 
+  def test_metadata_sent_through_in_authorize
+    metadata = {
+      field_one: 'A',
+      field_two: 'B',
+      field_three: 'C',
+      field_four: 'EASY AS ONE TWO THREE'
+    }
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(metadata: metadata))
+    end.check_request do |_endpoint, data, _headers|
+      parsed = JSON.parse(data)
+      assert_equal parsed['metadata']['field_one'], metadata[:field_one]
+      assert_equal parsed['metadata']['field_two'], metadata[:field_two]
+      assert_equal parsed['metadata']['field_three'], metadata[:field_three]
+      assert_equal parsed['metadata']['field_four'], metadata[:field_four]
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   private
 
   def stored_credential_options(*args, ntid: nil)


### PR DESCRIPTION
CER-1082

Metadata is an object that will allow up to 20 KV pairs per request. There are character limitations: Max 20 characters per key, max 80 per value.

Unit Tests:
116 tests, 611 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests:
143 tests, 463 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.3077% passed
* These 11 failing tests also fail on master

Local Tests:
5751 tests, 78745 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed