### PR TITLE
CyberSource: add the first_recurring_payment auth service field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -87,6 +87,7 @@
 * HiPay: Add Gateway [gasb150] #4979
 * Xpay: New adapter basic operations added [jherreraa] #4669
 * Braintree: Add support for more payment details fields in response [yunnydang] #4992
+* CyberSource: Add the first_recurring_payment auth service field [yunnydang] #4989
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -751,6 +751,7 @@ module ActiveMerchant #:nodoc:
               xml.tag!('commerceIndicator', indicator) if indicator
             end
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
+            xml.tag!('firstRecurringPayment', options[:first_recurring_payment]) if options[:first_recurring_payment]
             xml.tag!('mobileRemotePaymentType', options[:mobile_remote_payment_type]) if options[:mobile_remote_payment_type]
           end
         end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -94,6 +94,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       original_amount: '4',
       reference_data_code: 'ABC123',
       invoice_number: '123',
+      first_recurring_payment: true,
       mobile_remote_payment_type: 'A1',
       vat_tax_rate: '1'
     }

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -111,6 +111,14 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_authorization_response)
   end
 
+  def test_successful_authorize_with_cc_auth_service_first_recurring_payment
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(first_recurring_payment: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<firstRecurringPayment>true<\/firstRecurringPayment>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
   def test_successful_credit_card_purchase_with_elo
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 


### PR DESCRIPTION
add the first_recurring_payment field to ccAuthService

local:
5755 tests, 78661 assertions, 0 failures, 26 errors, 0 pendings, 0 omissions, 0 notifications
99.5482% passed

Unit:
144 tests, 803 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
128 tests, 639 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.0938% passed