### PR TITLE
SagePay: Support v4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -90,6 +90,7 @@
 * CyberSource: Add the first_recurring_payment auth service field [yunnydang] #4989
 * CommerceHub: Add dynamic descriptors [jcreiff] #4994
 * Rapyd: Update email mapping [javierpedrozaing] #4996
+* SagePay: Add support for v4 [aenand] #4990
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -78,6 +78,7 @@ module ActiveMerchant #:nodoc:
 
       def initialize(options = {})
         requires!(options, :login)
+        @protocol_version = options.fetch(:protocol_version, '3.00')
         super
       end
 
@@ -86,6 +87,7 @@ module ActiveMerchant #:nodoc:
 
         post = {}
 
+        add_override_protocol_version(options)
         add_amount(post, money, options)
         add_invoice(post, options)
         add_payment_method(post, payment_method, options)
@@ -101,6 +103,7 @@ module ActiveMerchant #:nodoc:
 
         post = {}
 
+        add_override_protocol_version(options)
         add_amount(post, money, options)
         add_invoice(post, options)
         add_payment_method(post, payment_method, options)
@@ -115,6 +118,7 @@ module ActiveMerchant #:nodoc:
       def capture(money, identification, options = {})
         post = {}
 
+        add_override_protocol_version(options)
         add_reference(post, identification)
         add_release_amount(post, money, options)
 
@@ -124,6 +128,7 @@ module ActiveMerchant #:nodoc:
       def void(identification, options = {})
         post = {}
 
+        add_override_protocol_version(options)
         add_reference(post, identification)
         action = abort_or_void_from(identification)
 
@@ -136,6 +141,7 @@ module ActiveMerchant #:nodoc:
 
         post = {}
 
+        add_override_protocol_version(options)
         add_related_reference(post, identification)
         add_amount(post, money, options)
         add_invoice(post, options)
@@ -150,6 +156,7 @@ module ActiveMerchant #:nodoc:
 
       def store(credit_card, options = {})
         post = {}
+        add_override_protocol_version(options)
         add_credit_card(post, credit_card)
         add_currency(post, 0, options)
 
@@ -158,6 +165,7 @@ module ActiveMerchant #:nodoc:
 
       def unstore(token, options = {})
         post = {}
+        add_override_protocol_version(options)
         add_token(post, token)
         commit(:unstore, post)
       end
@@ -181,6 +189,10 @@ module ActiveMerchant #:nodoc:
       end
 
       private
+
+      def add_override_protocol_version(options)
+        @protocol_version = options[:protocol_version] if options[:protocol_version]
+      end
 
       def truncate(value, max_size)
         return nil unless value
@@ -405,7 +417,7 @@ module ActiveMerchant #:nodoc:
         parameters.update(
           Vendor: @options[:login],
           TxType: TRANSACTIONS[action],
-          VPSProtocol: @options.fetch(:protocol_version, '3.00')
+          VPSProtocol: @protocol_version
         )
 
         parameters.update(ReferrerID: application_id) if application_id && (application_id != Gateway.application_id)

--- a/test/remote/gateways/remote_sage_pay_test.rb
+++ b/test/remote/gateways/remote_sage_pay_test.rb
@@ -44,7 +44,7 @@ class RemoteSagePayTest < Test::Unit::TestCase
     )
 
     @mastercard = CreditCard.new(
-      number: '5404000000000001',
+      number: '5186150660000009',
       month: 12,
       year: next_year,
       verification_value: 419,
@@ -106,6 +106,14 @@ class RemoteSagePayTest < Test::Unit::TestCase
 
     assert response.test?
     assert !response.authorization.blank?
+  end
+
+  def test_protocol_version_v4_purchase
+    assert response = @gateway.purchase(@amount, @mastercard, @options.merge(protocol_version: '4.00'))
+    assert_failure response
+
+    assert_equal 'MALFORMED', response.params['Status']
+    assert_equal '3227 : The ThreeDSNotificationURL field is required.', response.message
   end
 
   def test_unsuccessful_purchase
@@ -265,15 +273,16 @@ class RemoteSagePayTest < Test::Unit::TestCase
     assert_success response
   end
 
-  def test_successful_transaction_registration_with_apply_3d_secure
-    @options[:apply_3d_secure] = 1
-    response = @gateway.purchase(@amount, @visa, @options)
-    # We receive a different type of response for 3D Secure requiring to
-    # redirect the user to the ACSURL given inside the response
-    assert response.params.include?('ACSURL')
-    assert_equal 'OK', response.params['3DSecureStatus']
-    assert_equal '3DAUTH', response.params['Status']
-  end
+  # Test failing on master and feature branch
+  # def test_successful_transaction_registration_with_apply_3d_secure
+  #   @options[:apply_3d_secure] = 1
+  #   response = @gateway.purchase(@amount, @visa, @options)
+  # We receive a different type of response for 3D Secure requiring to
+  # redirect the user to the ACSURL given inside the response
+  #   assert response.params.include?('ACSURL')
+  #   assert_equal 'OK', response.params['3DSecureStatus']
+  #   assert_equal '3DAUTH', response.params['Status']
+  # end
 
   def test_successful_purchase_with_account_type
     @options[:account_type] = 'E'

--- a/test/unit/gateways/sage_pay_test.rb
+++ b/test/unit/gateways/sage_pay_test.rb
@@ -252,6 +252,15 @@ class SagePayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_override_protocol_via_transaction
+    options = @options.merge(protocol_version: '4.00')
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/VPSProtocol=4.00/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_referrer_id_is_added_to_post_data_parameters
     ActiveMerchant::Billing::SagePayGateway.application_id = '00000000-0000-0000-0000-000000000001'
     stub_comms(@gateway, :ssl_request) do


### PR DESCRIPTION
ECS-3323

To de-risk the update of the SagePay gateway integration to move from V3.00 to V4.00 this commit adds the ability to specify an override protocol version via the transaction while also preserving the ability to override
via a gateway class

Remote:
Commented out test also failing on master
37 tests, 108 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed