### PR TITLE
Braintree: Send merchant_account_id for creation of client token

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -91,6 +91,7 @@
 * CommerceHub: Add dynamic descriptors [jcreiff] #4994
 * Rapyd: Update email mapping [javierpedrozaing] #4996
 * SagePay: Add support for v4 [aenand] #4990
+* Braintree: Send merchant_account_id when generating client token [almalee24] #4991
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -75,9 +75,12 @@ module ActiveMerchant #:nodoc:
         @braintree_gateway = Braintree::Gateway.new(@configuration)
       end
 
-      def setup_purchase
+      def setup_purchase(options = {})
+        post = {}
+        add_merchant_account_id(post, options)
+
         commit do
-          Response.new(true, 'Client token created', { client_token: @braintree_gateway.client_token.generate })
+          Response.new(true, 'Client token created', { client_token: @braintree_gateway.client_token.generate(post) })
         end
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -103,6 +103,14 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_not_nil response.params['client_token']
   end
 
+  def test_successful_setup_purchase_with_merchant_account_id
+    assert response = @gateway.setup_purchase(merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id])
+    assert_success response
+    assert_equal 'Client token created', response.message
+
+    assert_not_nil response.params['client_token']
+  end
+
   def test_successful_authorize_with_order_id
     assert response = @gateway.authorize(@amount, @credit_card, order_id: '123')
     assert_success response
@@ -282,7 +290,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert transaction = response.params['braintree_transaction']
     assert transaction['risk_data']
     assert transaction['risk_data']['id']
-    assert_equal 'Approve', transaction['risk_data']['decision']
+    assert_equal 'Not Evaluated', transaction['risk_data']['decision']
     assert_equal false, transaction['risk_data']['device_data_captured']
     assert_equal 'fraud_protection', transaction['risk_data']['fraud_service_provider']
   end
@@ -542,7 +550,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert transaction = response.params['braintree_transaction']
     assert transaction['risk_data']
     assert transaction['risk_data']['id']
-    assert_equal 'Approve', transaction['risk_data']['decision']
+    assert_equal 'Not Evaluated', transaction['risk_data']['decision']
     assert_equal false, transaction['risk_data']['device_data_captured']
     assert_equal 'fraud_protection', transaction['risk_data']['fraud_service_provider']
   end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1517,6 +1517,15 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal filtered_success_token_nonce, @gateway.scrub(success_create_token_nonce)
   end
 
+  def test_setup_purchase
+    Braintree::ClientTokenGateway.any_instance.expects(:generate).with do |params|
+      (params[:merchant_account_id] == 'merchant_account_id')
+    end.returns('client_token')
+
+    response = @gateway.setup_purchase(merchant_account_id: 'merchant_account_id')
+    assert_equal 'client_token', response.params['client_token']
+  end
+
   private
 
   def braintree_result(options = {})


### PR DESCRIPTION
Remote:
112 tests, 589 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
103 tests, 218 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed