### PR TITLE
Braintree Blue: Add more payment detail objects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,6 +86,7 @@
 * Wompi: Add support for `tip_in_cents` [rachelkirk] #4983
 * HiPay: Add Gateway [gasb150] #4979
 * Xpay: New adapter basic operations added [jherreraa] #4669
+* Braintree: Add support for more payment details fields in response [yunnydang] #4992
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -607,6 +607,23 @@ module ActiveMerchant #:nodoc:
           'issuing_bank'        => transaction.credit_card_details.issuing_bank
         }
 
+        network_token_details = {
+          'debit'               => transaction.network_token_details.debit,
+          'prepaid'             => transaction.network_token_details.prepaid,
+          'issuing_bank'        => transaction.network_token_details.issuing_bank
+        }
+
+        google_pay_details = {
+          'debit'               => transaction.google_pay_details.debit,
+          'prepaid'             => transaction.google_pay_details.prepaid
+        }
+
+        apple_pay_details = {
+          'debit'               => transaction.apple_pay_details.debit,
+          'prepaid'             => transaction.apple_pay_details.prepaid,
+          'issuing_bank'        => transaction.apple_pay_details.issuing_bank
+        }
+
         if transaction.risk_data
           risk_data = {
             'id'                      => transaction.risk_data.id,
@@ -631,6 +648,9 @@ module ActiveMerchant #:nodoc:
           'amount'                       => transaction.amount.to_s,
           'status'                       => transaction.status,
           'credit_card_details'          => credit_card_details,
+          'network_token_details'        => network_token_details,
+          'apple_pay_details'            => apple_pay_details,
+          'google_pay_details'           => google_pay_details,
           'customer_details'             => customer_details,
           'billing_details'              => billing_details,
           'shipping_details'             => shipping_details,
@@ -641,7 +661,8 @@ module ActiveMerchant #:nodoc:
           'processor_response_code'      => response_code_from_result(result),
           'processor_authorization_code' => transaction.processor_authorization_code,
           'recurring'                    => transaction.recurring,
-          'payment_receipt'              => payment_receipt
+          'payment_receipt'              => payment_receipt,
+          'payment_instrument_type'      => transaction.payment_instrument_type
         }
       end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1266,13 +1266,56 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_not_nil response.params['braintree_transaction']['processor_authorization_code']
   end
 
-  def test_successful_purchase_with_with_prepaid_debit_issuing_bank
+  def test_successful_credit_card_purchase_with_prepaid_debit_issuing_bank
     assert response = @gateway.purchase(@amount, @credit_card)
     assert_success response
     assert_equal '1000 Approved', response.message
     assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['prepaid']
     assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['debit']
     assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['issuing_bank']
+  end
+
+  def test_successful_network_token_purchase_with_prepaid_debit_issuing_bank
+    assert response = @gateway.purchase(@amount, @nt_credit_card)
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'Unknown', response.params['braintree_transaction']['network_token_details']['prepaid']
+    assert_equal 'Unknown', response.params['braintree_transaction']['network_token_details']['debit']
+    assert_equal 'Unknown', response.params['braintree_transaction']['network_token_details']['issuing_bank']
+  end
+
+  def test_successful_google_pay_purchase_with_prepaid_debit
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: '2024',
+      source: :google_pay,
+      transaction_id: '123456789',
+      eci: '05'
+    )
+
+    assert response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'Unknown', response.params['braintree_transaction']['google_pay_details']['prepaid']
+    assert_equal 'Unknown', response.params['braintree_transaction']['google_pay_details']['debit']
+  end
+
+  def test_successful_apple_pay_purchase_with_prepaid_debit_issuing_bank
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+
+    assert response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'Unknown', response.params['braintree_transaction']['apple_pay_details']['prepaid']
+    assert_equal 'Unknown', response.params['braintree_transaction']['apple_pay_details']['debit']
+    assert_equal 'Unknown', response.params['braintree_transaction']['apple_pay_details']['issuing_bank']
   end
 
   def test_successful_purchase_with_global_id


### PR DESCRIPTION
This adds the apple pay, google pay, and network token details object. Will also surface the payment instrument type so we can know which one was used

Local:
5754 tests, 78658 assertions, 0 failures, 26 errors, 0 pendings, 0 omissions, 0 notifications
99.5481% passed

Unit:
102 tests, 216 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
114 tests, 548 assertions, 6 failures, 4 errors, 0 pendings, 0 omissions, 0 notifications
91.2281% passed