### PR TITLE
CommerceHub: Add dynamic descriptors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -88,6 +88,7 @@
 * Xpay: New adapter basic operations added [jherreraa] #4669
 * Braintree: Add support for more payment details fields in response [yunnydang] #4992
 * CyberSource: Add the first_recurring_payment auth service field [yunnydang] #4989
+* CommerceHub: Add dynamic descriptors [jcreiff] #4994
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -55,6 +55,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, money, options)
         add_transaction_details(post, options, 'capture')
         add_reference_transaction_details(post, authorization, options, :capture)
+        add_dynamic_descriptors(post, options)
 
         commit('sale', post, options)
       end
@@ -220,6 +221,21 @@ module ActiveMerchant #:nodoc:
         add_transaction_interaction(post, options)
         add_billing_address(post, payment, options)
         add_shipping_address(post, options)
+        add_dynamic_descriptors(post, options)
+      end
+
+      def add_dynamic_descriptors(post, options)
+        dynamic_descriptors_fields = %i[mcc merchant_name customer_service_number service_entitlement dynamic_descriptors_address]
+        return unless dynamic_descriptors_fields.any? { |key| options.include?(key) }
+
+        dynamic_descriptors = {}
+        dynamic_descriptors[:mcc] = options[:mcc] if options[:mcc]
+        dynamic_descriptors[:merchantName] = options[:merchant_name] if options [:merchant_name]
+        dynamic_descriptors[:customerServiceNumber] = options[:customer_service_number] if options[:customer_service_number]
+        dynamic_descriptors[:serviceEntitlement] = options[:service_entitlement] if options[:service_entitlement]
+        dynamic_descriptors[:address] = options[:dynamic_descriptors_address] if options[:dynamic_descriptors_address]
+
+        post[:dynamicDescriptors] = dynamic_descriptors
       end
 
       def add_reference_transaction_details(post, authorization, options, action = nil)

--- a/test/remote/gateways/remote_commerce_hub_test.rb
+++ b/test/remote/gateways/remote_commerce_hub_test.rb
@@ -48,6 +48,20 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
       xid: '&x_MD5_Hash=abfaf1d1df004e3c27d5d2e05929b529&x_state=BC&x_reference_3=&x_auth_code=ET141870&x_fp_timestamp=1231877695',
       version: '2.2.0'
     }
+    @dynamic_descriptors = {
+      mcc: '1234',
+      merchant_name: 'Spreedly',
+      customer_service_number: '555444321',
+      service_entitlement: '123444555',
+      dynamic_descriptors_address: {
+        'street': '123 Main Street',
+        'houseNumberOrName': 'Unit B',
+        'city': 'Atlanta',
+        'stateOrProvince': 'GA',
+        'postalCode': '30303',
+        'country': 'US'
+      }
+    }
   end
 
   def test_successful_purchase
@@ -135,6 +149,12 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_dynamic_descriptors
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(@dynamic_descriptors))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
@@ -148,14 +168,21 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
-  # Commenting out until we are able to resolve issue with capture transactions failing at gateway
-  # def test_successful_authorize_and_capture
-  #   authorize = @gateway.authorize(@amount, @credit_card, @options)
-  #   assert_success authorize
+  def test_successful_authorize_and_capture
+    authorize = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize
 
-  #   capture = @gateway.capture(@amount, authorize.authorization)
-  #   assert_success capture
-  # end
+    capture = @gateway.capture(@amount, authorize.authorization)
+    assert_success capture
+  end
+
+  def test_successful_authorize_and_capture_with_dynamic_descriptors
+    authorize = @gateway.authorize(@amount, @credit_card, @options.merge(@dynamic_descriptors))
+    assert_success authorize
+
+    capture = @gateway.capture(@amount, authorize.authorization, @options.merge(@dynamic_descriptors))
+    assert_success capture
+  end
 
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)


### PR DESCRIPTION
Adds the option to send dynamic descriptors on auth/capture or purchase

https://developer.fiserv.com/product/CommerceHub/docs/?path=docs/Resources/Guides/Dynamic-Descriptor.md&branch=main

CER-1077

LOCAL
5758 tests, 78786 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
784 files inspected, no offenses detected

UNIT
28 tests, 194 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

REMOTE
-> When running the full remote test suite, I see between 16-18 failures each time, each of which has the message `"The transaction limit was exceeded. Please try again!"`

When I run the failing tests individually, all of them pass, with a few exceptions: `test_successful_credit` (merchant account configuration) `test_successful_purchase_with_encrypted_credit_card` (merchant account configuration) `test_successful_store_with_purchase` (invalid expiration date?)

None of these failures appear to be related to the changes here.