### PR TITLE
HiPay: Scrub/Refund/Void

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -93,6 +93,7 @@
 * SagePay: Add support for v4 [aenand] #4990
 * Braintree: Send merchant_account_id when generating client token [almalee24] #4991
 * CheckoutV2: Update reponse message for 3DS transactions [almalee24] #4975
+* HiPay: Scrub/Refund/Void [gasb150] #4995
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/hi_pay.rb
+++ b/lib/active_merchant/billing/gateways/hi_pay.rb
@@ -51,22 +51,41 @@ module ActiveMerchant #:nodoc:
       end
 
       def capture(money, authorization, options)
-        post = {}
-        post[:operation] = 'capture'
-        post[:currency] = (options[:currency] || currency(money))
-        transaction_ref, _card_token, _payment_product = authorization.split('|')
-        commit('capture', post, { transaction_reference: transaction_ref })
+        reference_operation(money, authorization, options.merge({ operation: 'capture' }))
       end
 
       def store(payment_method, options = {})
         tokenize(payment_method, options.merge({ multiuse: '1' }))
       end
 
-      def scrub(transcrip)
-        # code
+      def refund(money, authorization, options)
+        reference_operation(money, authorization, options.merge({ operation: 'refund' }))
+      end
+
+      def void(authorization, options)
+        reference_operation(nil, authorization, options.merge({ operation: 'cancel' }))
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: Basic )[\w =]+), '\1[FILTERED]').
+          gsub(%r((card_number=)\w+), '\1[FILTERED]\2').
+          gsub(%r((cvc=)\w+), '\1[FILTERED]\2')
       end
 
       private
+
+      def reference_operation(money, authorization, options)
+        post = {}
+        post[:operation] = options[:operation]
+        post[:currency] = (options[:currency] || currency(money))
+        post[:amount] = amount(money) if options[:operation] == 'refund' || options[:operation] == 'capture'
+        commit(options[:operation], post, { transaction_reference: authorization.split('|').first })
+      end
 
       def add_product_data(post, options)
         post[:orderid] = options[:order_id] if options[:order_id]
@@ -143,6 +162,10 @@ module ActiveMerchant #:nodoc:
           response['state'] == 'completed'
         when 'capture'
           response['status'] == '118' && response['message'] == 'Captured'
+        when 'refund'
+          response['status'] == '124' && response['message'] == 'Refund Requested'
+        when 'cancel'
+          response['status'] == '175' && response['message'] == 'Authorization Cancellation requested'
         when 'store'
           response.include? 'token'
         else
@@ -170,7 +193,7 @@ module ActiveMerchant #:nodoc:
         case action
         when 'store'
           "#{token_url}/create"
-        when 'capture'
+        when 'capture', 'refund', 'cancel'
           endpoint = "maintenance/transaction/#{options[:transaction_reference]}"
           base_url(endpoint)
         else

--- a/test/remote/gateways/remote_hi_pay_test.rb
+++ b/test/remote/gateways/remote_hi_pay_test.rb
@@ -70,13 +70,11 @@ class RemoteHiPayTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options.merge({ billing_address: @billing_address }))
 
     assert_success response
-    assert_equal response.message, 'Captured'
   end
 
   def test_successful_capture
     authorize_response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success authorize_response
-    assert_include 'Authorized', authorize_response.message
 
     response = @gateway.capture(@amount, authorize_response.authorization, @options)
     assert_success response
@@ -92,23 +90,88 @@ class RemoteHiPayTest < Test::Unit::TestCase
 
     response = @gateway.authorize(@amount, store_response.authorization, @options)
     assert_success response
-    assert_include 'Authorized', response.message
   end
 
   def test_successful_multiple_purchases_with_single_store
     store_response = @gateway.store(@credit_card, @options)
-    assert_nil store_response.message
     assert_success store_response
-    assert_not_empty store_response.authorization
 
     response1 = @gateway.purchase(@amount, store_response.authorization, @options)
     assert_success response1
-    assert_include 'Captured', response1.message
 
     @options[:order_id] = "Sp_ORDER_2_#{SecureRandom.random_number(1000000000)}"
 
     response2 = @gateway.purchase(@amount, store_response.authorization, @options)
     assert_success response2
-    assert_include 'Captured', response2.message
+  end
+
+  def test_successful_refund
+    purchase_response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase_response
+
+    response = @gateway.refund(@amount, purchase_response.authorization, @options)
+    assert_success response
+    assert_include 'Refund Requested', response.message
+    assert_include response.params['authorizedAmount'], '5.00'
+    assert_include response.params['capturedAmount'], '5.00'
+    assert_include response.params['refundedAmount'], '5.00'
+  end
+
+  def test_successful_partial_capture_refund
+    authorize_response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize_response
+    assert_include authorize_response.params['authorizedAmount'], '5.00'
+    assert_include authorize_response.params['capturedAmount'], '0.00'
+    assert_equal authorize_response.params['refundedAmount'], '0.00'
+
+    capture_response = @gateway.capture(@amount - 100, authorize_response.authorization, @options)
+    assert_success capture_response
+    assert_equal authorize_response.authorization, capture_response.authorization
+    assert_include capture_response.params['authorizedAmount'], '5.00'
+    assert_include capture_response.params['capturedAmount'], '4.00'
+    assert_equal capture_response.params['refundedAmount'], '0.00'
+
+    response = @gateway.refund(@amount - 200, capture_response.authorization, @options)
+    assert_success response
+    assert_include response.params['authorizedAmount'], '5.00'
+    assert_include response.params['capturedAmount'], '4.00'
+    assert_include response.params['refundedAmount'], '3.00'
+  end
+
+  def test_failed_refund_because_auth_no_captured
+    authorize_response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize_response
+
+    response = @gateway.refund(@amount, authorize_response.authorization, @options)
+    assert_failure response
+    assert_include 'Operation Not Permitted : transaction not captured', response.message
+  end
+
+  def test_successful_void
+    authorize_response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success authorize_response
+
+    response = @gateway.void(authorize_response.authorization, @options)
+    assert_success response
+    assert_include 'Authorization Cancellation requested', response.message
+  end
+
+  def test_failed_void_because_captured_transaction
+    purchase_response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase_response
+
+    response = @gateway.void(purchase_response.authorization, @options)
+    assert_failure response
+    assert_include 'Action denied : Wrong transaction status', response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
   end
 end

--- a/test/unit/gateways/hi_pay_test.rb
+++ b/test/unit/gateways/hi_pay_test.rb
@@ -150,12 +150,52 @@ class HiPayTest < Test::Unit::TestCase
         "https://stage-secure-gateway.hipay-tpp.com/rest/v1/maintenance/transaction/#{transaction_reference}",
         all_of(
           includes('operation=capture'),
-          includes('currency=EUR')
+          includes('currency=EUR'),
+          includes('amount=1.00')
         ),
         anything
       ).
       returns(successful_capture_response)
     @gateway.capture(@amount, transaction_reference, @options)
+  end
+
+  def test_refund
+    @gateway.expects(:ssl_post).with('https://stage-secure2-vault.hipay-tpp.com/rest/v2/token/create', anything, anything).returns(successful_tokenize_response)
+    @gateway.expects(:ssl_post).with('https://stage-secure-gateway.hipay-tpp.com/rest/v1/order', anything, anything).returns(successful_capture_response)
+
+    authorize_response = @gateway.purchase(@amount, @credit_card, @options)
+    transaction_reference, _card_token, _brand = authorize_response.authorization.split('|')
+    @gateway.expects(:ssl_post).
+      with(
+        "https://stage-secure-gateway.hipay-tpp.com/rest/v1/maintenance/transaction/#{transaction_reference}",
+        all_of(
+          includes('operation=refund'),
+          includes('currency=EUR'),
+          includes('amount=1.00')
+        ),
+        anything
+      ).
+      returns(successful_refund_response)
+    @gateway.refund(@amount, transaction_reference, @options)
+  end
+
+  def test_void
+    @gateway.expects(:ssl_post).with('https://stage-secure2-vault.hipay-tpp.com/rest/v2/token/create', anything, anything).returns(successful_tokenize_response)
+    @gateway.expects(:ssl_post).with('https://stage-secure-gateway.hipay-tpp.com/rest/v1/order', anything, anything).returns(successful_authorize_response)
+
+    authorize_response = @gateway.authorize(@amount, @credit_card, @options)
+    transaction_reference, _card_token, _brand = authorize_response.authorization.split('|')
+    @gateway.expects(:ssl_post).
+      with(
+        "https://stage-secure-gateway.hipay-tpp.com/rest/v1/maintenance/transaction/#{transaction_reference}",
+        all_of(
+          includes('operation=cancel'),
+          includes('currency=EUR')
+        ),
+        anything
+      ).
+      returns(successful_void_response)
+    @gateway.void(transaction_reference, @options)
   end
 
   def test_required_client_id_and_client_secret
@@ -218,14 +258,10 @@ class HiPayTest < Test::Unit::TestCase
     assert_equal 'Basic YWJjMTIzOmRlZjQ1Ng==', headers['Authorization']
   end
 
-  # def test_scrub
-  #   assert @gateway.supports_scrubbing?
-
-  #   pre_scrubbed = File.read('test/unit/transcripts/alelo_purchase')
-  #   post_scrubbed = File.read('test/unit/transcripts/alelo_purchase_scrubbed')
-
-  #   assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
-  # end
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
 
   private
 
@@ -239,5 +275,119 @@ class HiPayTest < Test::Unit::TestCase
 
   def successful_capture_response
     '{"operation":"capture","test":"true","mid":"00001331069","authorizationCode":"no_code","transactionReference":"800271033524","dateCreated":"2023-12-05T23:36:43+0000","dateUpdated":"2023-12-05T23:37:21+0000","dateAuthorized":"2023-12-05T23:36:48+0000","status":"118","message":"Captured","authorizedAmount":"500.00","capturedAmount":"500.00","refundedAmount":"0.00","decimals":"2","currency":"EUR"}'
+  end
+
+  def successful_refund_response
+    '{"operation":"refund","test":"true","mid":"00001331069","authorizationCode":"no_code","transactionReference":"800272279241","dateCreated":"2023-12-12T16:36:46+0000","dateUpdated":"2023-12-12T16:36:54+0000","dateAuthorized":"2023-12-12T16:36:50+0000","status":"124","message":"Refund Requested","authorizedAmount":"500.00","capturedAmount":"500.00","refundedAmount":"500.00","decimals":"2","currency":"EUR"}'
+  end
+
+  def successful_void_response
+    '{"operation":"cancel","test":"true","mid":"00001331069","authorizationCode":"no_code","transactionReference":"800272279254","dateCreated":"2023-12-12T16:38:49+0000","dateUpdated":"2023-12-12T16:38:55+0000","dateAuthorized":"2023-12-12T16:38:53+0000","status":"175","message":"Authorization Cancellation requested","authorizedAmount":"500.00","capturedAmount":"0.00","refundedAmount":"0.00","decimals":"2","currency":"EUR"}'
+  end
+
+  def pre_scrubbed
+    <<~PRE_SCRUBBED
+      opening connection to stage-secure2-vault.hipay-tpp.com:443...
+      opened
+      starting SSL for stage-secure2-vault.hipay-tpp.com:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384
+      <- "POST /rest/v2/token/create HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/json\r\nAuthorization: Basic OTQ2NTgzNjUuc3RhZ2Utc2VjdXJlLWdhdGV3YXkuaGlwYXktdHBwLmNvbTpUZXN0X1JoeXBWdktpUDY4VzNLQUJ4eUdoS3Zlcw==\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: stage-secure2-vault.hipay-tpp.com\r\nContent-Length: 136\r\n\r\n"
+      <- "card_number=4111111111111111&card_expiry_month=12&card_expiry_year=2025&card_holder=John+Smith&cvc=514&multi_use=0&generate_request_id=0"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Tue, 12 Dec 2023 14:49:44 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "Vary: Authorization\r\n"
+      -> "Cache-Control: max-age=0, must-revalidate, private\r\n"
+      -> "Expires: Tue, 12 Dec 2023 14:49:44 GMT\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "Set-Cookie: PHPSESSID=j9bfv7gaml9uslij70e15kvrm6; path=/; HttpOnly\r\n"
+      -> "Strict-Transport-Security: max-age=86400\r\n"
+      -> "\r\n"
+      -> "17c\r\n"
+      reading 380 bytes...
+      -> "{\"token\":\"0acbbfcbd5bf202a05acc0e9c00f79158a2fe8b60caad2213b09e901b89dc28e\",\"request_id\":\"0\",\"card_id\":\"9fd81707-8f41-4a01-b6ed-279954336ada\",\"multi_use\":0,\"brand\":\"VISA\",\"pan\":\"411111xxxxxx1111\",\"card_holder\":\"John Smith\",\"card_expiry_month\":\"12\",\"card_expiry_year\":\"2025\",\"issuer\":\"JPMORGAN CHASE BANK, N.A.\",\"country\":\"US\",\"card_type\":\"CREDIT\",\"forbidden_issuer_country\":false}"
+      reading 2 bytes...
+      -> "\r\n"
+      0
+      \r\nConn close
+      opening connection to stage-secure-gateway.hipay-tpp.com:443...
+      opened
+      starting SSL for stage-secure-gateway.hipay-tpp.com:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384
+      <- "POST /rest/v1/order HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/json\r\nAuthorization: Basic OTQ2NTgzNjUuc3RhZ2Utc2VjdXJlLWdhdGV3YXkuaGlwYXktdHBwLmNvbTpUZXN0X1JoeXBWdktpUDY4VzNLQUJ4eUdoS3Zlcw==\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: stage-secure-gateway.hipay-tpp.com\r\nContent-Length: 186\r\n\r\n"
+      <- "payment_product=visa&operation=Sale&cardtoken=0acbbfcbd5bf202a05acc0e9c00f79158a2fe8b60caad2213b09e901b89dc28e&order_id=Sp_ORDER_100432071&description=An+authorize&currency=EUR&amount=500"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "date: Tue, 12 Dec 2023 14:49:45 GMT\r\n"
+      -> "expires: Thu, 19 Nov 1981 08:52:00 GMT\r\n"
+      -> "cache-control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\n"
+      -> "pragma: no-cache\r\n"
+      -> "access-control-allow-origin: \r\n"
+      -> "access-control-allow-headers: \r\n"
+      -> "access-control-allow-credentials: true\r\n"
+      -> "content-length: 1472\r\n"
+      -> "content-type: application/json; encoding=UTF-8\r\n"
+      -> "connection: close\r\n"
+      -> "\r\n"
+      reading 1472 bytes...
+      -> "{\"state\":\"completed\",\"reason\":\"\",\"forwardUrl\":\"\",\"test\":\"true\",\"mid\":\"00001331069\",\"attemptId\":\"1\",\"authorizationCode\":\"no_code\",\"transactionReference\":\"800272278410\",\"referenceToPay\":\"\",\"dateCreated\":\"2023-12-12T14:49:45+0000\",\"dateUpdated\":\"2023-12-12T14:49:50+0000\",\"dateAuthorized\":\"2023-12-12T14:49:49+0000\",\"status\":\"118\",\"message\":\"Captured\",\"authorizedAmount\":\"500.00\",\"capturedAmount\":\"500.00\",\"refundedAmount\":\"0.00\",\"creditedAmount\":\"0.00\",\"decimals\":\"2\",\"currency\":\"EUR\",\"ipAddress\":\"0.0.0.0\",\"ipCountry\":\"\",\"deviceId\":\"\",\"cdata1\":\"\",\"cdata2\":\"\",\"cdata3\":\"\",\"cdata4\":\"\",\"cdata5\":\"\",\"cdata6\":\"\",\"cdata7\":\"\",\"cdata8\":\"\",\"cdata9\":\"\",\"cdata10\":\"\",\"avsResult\":\"\",\"eci\":\"7\",\"paymentProduct\":\"visa\",\"paymentMethod\":{\"token\":\"0acbbfcbd5bf202a05acc0e9c00f79158a2fe8b60caad2213b09e901b89dc28e\",\"cardId\":\"9fd81707-8f41-4a01-b6ed-279954336ada\",\"brand\":\"VISA\",\"pan\":\"411111******1111\",\"cardHolder\":\"JOHN SMITH\",\"cardExpiryMonth\":\"12\",\"cardExpiryYear\":\"2025\",\"issuer\":\"JPMORGAN CHASE BANK, N.A.\",\"country\":\"US\"},\"threeDSecure\":{\"eci\":\"\",\"authenticationStatus\":\"Y\",\"authenticationMessage\":\"Authentication Successful\",\"authenticationToken\":\"\",\"xid\":\"\"},\"fraudScreening\":{\"scoring\":\"0\",\"result\":\"ACCEPTED\",\"review\":\"\"},\"order\":{\"id\":\"Sp_ORDER_100432071\",\"dateCreated\":\"2023-12-12T14:49:45+0000\",\"attempts\":\"1\",\"amount\":\"500.00\",\"shipping\":\"0.00\",\"tax\":\"0.00\",\"decimals\":\"2\",\"currency\":\"EUR\",\"customerId\":\"\",\"language\":\"en_US\",\"email\":\"\"},\"debitAgreement\":{\"id\":\"\",\"status\":\"\"}}"
+      reading 1472 bytes...
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<~POST_SCRUBBED
+      opening connection to stage-secure2-vault.hipay-tpp.com:443...
+      opened
+      starting SSL for stage-secure2-vault.hipay-tpp.com:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384
+      <- "POST /rest/v2/token/create HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/json\r\nAuthorization: Basic [FILTERED]\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: stage-secure2-vault.hipay-tpp.com\r\nContent-Length: 136\r\n\r\n"
+      <- "card_number=[FILTERED]&card_expiry_month=12&card_expiry_year=2025&card_holder=John+Smith&cvc=[FILTERED]&multi_use=0&generate_request_id=0"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Server: nginx\r\n"
+      -> "Date: Tue, 12 Dec 2023 14:49:44 GMT\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Connection: close\r\n"
+      -> "Vary: Authorization\r\n"
+      -> "Cache-Control: max-age=0, must-revalidate, private\r\n"
+      -> "Expires: Tue, 12 Dec 2023 14:49:44 GMT\r\n"
+      -> "X-XSS-Protection: 1; mode=block\r\n"
+      -> "Set-Cookie: PHPSESSID=j9bfv7gaml9uslij70e15kvrm6; path=/; HttpOnly\r\n"
+      -> "Strict-Transport-Security: max-age=86400\r\n"
+      -> "\r\n"
+      -> "17c\r\n"
+      reading 380 bytes...
+      -> "{\"token\":\"0acbbfcbd5bf202a05acc0e9c00f79158a2fe8b60caad2213b09e901b89dc28e\",\"request_id\":\"0\",\"card_id\":\"9fd81707-8f41-4a01-b6ed-279954336ada\",\"multi_use\":0,\"brand\":\"VISA\",\"pan\":\"411111xxxxxx1111\",\"card_holder\":\"John Smith\",\"card_expiry_month\":\"12\",\"card_expiry_year\":\"2025\",\"issuer\":\"JPMORGAN CHASE BANK, N.A.\",\"country\":\"US\",\"card_type\":\"CREDIT\",\"forbidden_issuer_country\":false}"
+      reading 2 bytes...
+      -> "\r\n"
+      0
+      \r\nConn close
+      opening connection to stage-secure-gateway.hipay-tpp.com:443...
+      opened
+      starting SSL for stage-secure-gateway.hipay-tpp.com:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384
+      <- "POST /rest/v1/order HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept: application/json\r\nAuthorization: Basic [FILTERED]\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nHost: stage-secure-gateway.hipay-tpp.com\r\nContent-Length: 186\r\n\r\n"
+      <- "payment_product=visa&operation=Sale&cardtoken=0acbbfcbd5bf202a05acc0e9c00f79158a2fe8b60caad2213b09e901b89dc28e&order_id=Sp_ORDER_100432071&description=An+authorize&currency=EUR&amount=500"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "date: Tue, 12 Dec 2023 14:49:45 GMT\r\n"
+      -> "expires: Thu, 19 Nov 1981 08:52:00 GMT\r\n"
+      -> "cache-control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\n"
+      -> "pragma: no-cache\r\n"
+      -> "access-control-allow-origin: \r\n"
+      -> "access-control-allow-headers: \r\n"
+      -> "access-control-allow-credentials: true\r\n"
+      -> "content-length: 1472\r\n"
+      -> "content-type: application/json; encoding=UTF-8\r\n"
+      -> "connection: close\r\n"
+      -> "\r\n"
+      reading 1472 bytes...
+      -> "{\"state\":\"completed\",\"reason\":\"\",\"forwardUrl\":\"\",\"test\":\"true\",\"mid\":\"00001331069\",\"attemptId\":\"1\",\"authorizationCode\":\"no_code\",\"transactionReference\":\"800272278410\",\"referenceToPay\":\"\",\"dateCreated\":\"2023-12-12T14:49:45+0000\",\"dateUpdated\":\"2023-12-12T14:49:50+0000\",\"dateAuthorized\":\"2023-12-12T14:49:49+0000\",\"status\":\"118\",\"message\":\"Captured\",\"authorizedAmount\":\"500.00\",\"capturedAmount\":\"500.00\",\"refundedAmount\":\"0.00\",\"creditedAmount\":\"0.00\",\"decimals\":\"2\",\"currency\":\"EUR\",\"ipAddress\":\"0.0.0.0\",\"ipCountry\":\"\",\"deviceId\":\"\",\"cdata1\":\"\",\"cdata2\":\"\",\"cdata3\":\"\",\"cdata4\":\"\",\"cdata5\":\"\",\"cdata6\":\"\",\"cdata7\":\"\",\"cdata8\":\"\",\"cdata9\":\"\",\"cdata10\":\"\",\"avsResult\":\"\",\"eci\":\"7\",\"paymentProduct\":\"visa\",\"paymentMethod\":{\"token\":\"0acbbfcbd5bf202a05acc0e9c00f79158a2fe8b60caad2213b09e901b89dc28e\",\"cardId\":\"9fd81707-8f41-4a01-b6ed-279954336ada\",\"brand\":\"VISA\",\"pan\":\"411111******1111\",\"cardHolder\":\"JOHN SMITH\",\"cardExpiryMonth\":\"12\",\"cardExpiryYear\":\"2025\",\"issuer\":\"JPMORGAN CHASE BANK, N.A.\",\"country\":\"US\"},\"threeDSecure\":{\"eci\":\"\",\"authenticationStatus\":\"Y\",\"authenticationMessage\":\"Authentication Successful\",\"authenticationToken\":\"\",\"xid\":\"\"},\"fraudScreening\":{\"scoring\":\"0\",\"result\":\"ACCEPTED\",\"review\":\"\"},\"order\":{\"id\":\"Sp_ORDER_100432071\",\"dateCreated\":\"2023-12-12T14:49:45+0000\",\"attempts\":\"1\",\"amount\":\"500.00\",\"shipping\":\"0.00\",\"tax\":\"0.00\",\"decimals\":\"2\",\"currency\":\"EUR\",\"customerId\":\"\",\"language\":\"en_US\",\"email\":\"\"},\"debitAgreement\":{\"id\":\"\",\"status\":\"\"}}"
+      reading 1472 bytes...
+      Conn close
+    POST_SCRUBBED
   end
 end


### PR DESCRIPTION
SER-720
SER-721
----
Summary:
----
Adding to the HiPay gateway support for scrub, refund, and void.

HiPay allows partial capture and partial refunds, this commit include the amount to use it.

Tests
----
Remote Test:
Finished in 6.627757 seconds.
15 tests, 62 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit Tests:
21 tests, 61 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

RuboCop:
787 files inspected, no offenses detected