### PR TITLE
Rapyd: email mapping update

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -89,6 +89,7 @@
 * Braintree: Add support for more payment details fields in response [yunnydang] #4992
 * CyberSource: Add the first_recurring_payment auth service field [yunnydang] #4989
 * CommerceHub: Add dynamic descriptors [jcreiff] #4994
+* Rapyd: Update email mapping [javierpedrozaing] #4996
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -256,7 +256,10 @@ module ActiveMerchant #:nodoc:
       def add_customer_data(post, payment, options, action = '')
         phone_number = options.dig(:billing_address, :phone) || options.dig(:billing_address, :phone_number)
         post[:phone_number] = phone_number.gsub(/\D/, '') unless phone_number.nil?
-        post[:email] = options[:email] unless send_customer_object?(options)
+        if payment.is_a?(String) && options[:customer_id].present?
+          post[:receipt_email] = options[:email] unless send_customer_object?(options)
+        end
+
         return if payment.is_a?(String)
         return add_customer_id(post, options) if options[:customer_id]
 
@@ -273,6 +276,7 @@ module ActiveMerchant #:nodoc:
         customer_address = address(options)
         customer_data = {}
         customer_data[:name] = "#{payment.first_name} #{payment.last_name}" unless payment.is_a?(String)
+        customer_data[:email] = options[:email] unless payment.is_a?(String) && options[:customer_id].blank?
         customer_data[:addresses] = [customer_address] if customer_address
         customer_data
       end


### PR DESCRIPTION
Description
-------------------------
This commit update the email mapping for purchase, when we have an customer_id and the payment_method is a token we will send receipt_email instead email, otherwise the email will be sent into the customer object .
[SER-1040](https://spreedly.atlassian.net/browse/SER-1040)

Unit test
-------------------------
Finished in 0.186326 seconds.

44 tests, 208 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

236.15 tests/s, 1116.32 assertions/s

Remote test
-------------------------
Finished in 263.428138 seconds.

49 tests, 142 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.9592% passed

0.19 tests/s, 0.54 assertions/s

Rubocop
-------------------------
784 files inspected, no offenses detected