### PR TITLE
HiPay: Add unstore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -97,6 +97,7 @@
 * Rapyd: Adding fixed_side and requested_currency options [Heavyblade] #4962
 * Add new card type Tuya. GlobalCollect & Decidir: Improve support for Tuya card type [sinourain] #4993
 * Cecabank: Encrypt credit card fields [sinourain] #4998
+* HiPay: Add unstore [gasb150] #4999
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827


### PR DESCRIPTION
SER-772
--------
Summary:
-----------
Adding to the HiPay gateway support for unstore.
Currently, HiPay implementation allows store, this commit includes the unstore method to use it.

Tests
---------
Remote Test:
Finished in 6.627757 seconds.
17 tests, 70 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit Tests:
21 tests, 54 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

RuboCop:
787 files inspected, no offenses detected