### PR TITLE
Shift4: update response mapping

### DIFF
--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -180,13 +180,13 @@ class RemoteShift4Test < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    response = @gateway.purchase(@amount, @declined_card, @options)
+    response = @gateway.purchase(1500000000, @credit_card, @options)
     assert_failure response
-    assert_include response.message, 'Card  for Merchant Id 0008628968 not found'
+    assert_include response.message, 'Transaction declined'
   end
 
   def test_failure_on_referral_transactions
-    response = @gateway.purchase(67800, @credit_card, @options)
+    response = @gateway.purchase(99999899, @credit_card, @options)
     assert_failure response
     assert_include 'Transaction declined', response.message
   end
@@ -197,10 +197,18 @@ class RemoteShift4Test < Test::Unit::TestCase
     assert_include response.message, 'Card  for Merchant Id 0008628968 not found'
   end
 
-  def test_failed_authorize_with_error_message
-    response = @gateway.authorize(@amount, @unsupported_card, @options)
+  def test_failed_authorize_with_failure_amount
+    # this amount triggers failure according to Shift4 docs
+    response = @gateway.authorize(1500000000, @credit_card, @options)
     assert_failure response
-    assert_equal response.message, 'Format \'UTF8: An unexpected continuatio\' invalid or incompatible with argument'
+    assert_equal response.message, 'Transaction declined'
+  end
+
+  def test_failed_authorize_with_error_message
+    # this amount triggers failure according to Shift4 docs
+    response = @gateway.authorize(1500000000, @credit_card, @options)
+    assert_failure response
+    assert_equal response.message, 'Transaction declined'
   end
 
   def test_failed_capture
@@ -210,9 +218,9 @@ class RemoteShift4Test < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    response = @gateway.refund(@amount, 'YC', @options)
+    response = @gateway.refund(1919, @credit_card, @options)
     assert_failure response
-    assert_include response.message, 'record not posted'
+    assert_include response.message, 'Transaction declined'
   end
 
   def test_successful_credit
@@ -222,9 +230,9 @@ class RemoteShift4Test < Test::Unit::TestCase
   end
 
   def test_failed_credit
-    response = @gateway.credit(@amount, @declined_card, @options)
+    response = @gateway.credit(1919, @credit_card, @options)
     assert_failure response
-    assert_include response.message, 'Card type not recognized'
+    assert_include response.message, 'Transaction declined'
   end
 
   def test_successful_refund

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -245,9 +245,10 @@ class Shift4Test < Test::Unit::TestCase
 
   def test_failed_purchase
     @gateway.expects(:ssl_request).returns(failed_purchase_response)
+    response = @gateway.purchase(@amount, @credit_card, @options)
 
-    response = @gateway.purchase(@amount, 'abc', @options)
     assert_failure response
+    assert_equal response.message, 'Transaction declined'
     assert_nil response.authorization
   end
 
@@ -257,6 +258,16 @@ class Shift4Test < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_failure response
     assert_nil response.authorization
+    assert response.test?
+  end
+
+  def test_failed_authorize_with_host_response
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(failed_authorize_with_hostResponse_response)
+
+    assert_failure response
+    assert_equal 'CVV value N not accepted.', response.message
     assert response.test?
   end
 
@@ -272,9 +283,10 @@ class Shift4Test < Test::Unit::TestCase
   def test_failed_refund
     @gateway.expects(:ssl_request).returns(failed_refund_response)
 
-    response = @gateway.refund(@amount, 'abc', @options)
+    response = @gateway.refund(1919, @credit_card, @options)
     assert_failure response
-    assert_nil response.authorization
+    assert_equal response.error_code, 'D'
+    assert_equal response.message, 'Transaction declined'
     assert response.test?
   end
 
@@ -920,18 +932,72 @@ class Shift4Test < Test::Unit::TestCase
   def failed_purchase_response
     <<-RESPONSE
       {
-          "result": [
-              {
-                  "error": {
-                      "longText": "Token contains invalid characters UTGAPI08CE",
-                      "primaryCode": 9864,
-                      "shortText": "Invalid Token"
-                  },
-                  "server": {
-                      "name": "UTGAPI08CE"
-                  }
+        "result": [
+          {
+            "dateTime":"2024-01-12T15:11:10.000-08:00",
+            "receiptColumns":30,
+            "amount": {
+              "total":15000000
+            },
+            "card": {
+              "type":"VS",
+              "entryMode":"M",
+              "number":"XXXXXXXXXXXX2224",
+              "present":"N",
+              "securityCode": {
+                "result":"M",
+                "valid":"Y"
+              },
+              "token": {
+                "value":"2224028jbvt7g0ne"
               }
-          ]
+            },
+            "clerk": {
+              "numericId":1
+            },
+            "customer": {
+              "firstName":"John",
+              "lastName":"Smith"
+            },
+            "device": {
+              "capability": {
+                "magstripe":"Y",
+                "manualEntry":"Y"
+              }
+            },
+            "merchant": {
+              "mid":8628968,
+              "name":"Spreedly - ECom"
+            },
+            "receipt": [
+              {
+                "key":"MaskedPAN",
+                "printValue":"XXXXXXXXXXXX2224"
+              },
+              {
+                "key":"CardEntryMode",
+                "printName":"ENTRY METHOD",
+                "printValue":"KEYED"
+              },
+              {
+                "key":"SignatureRequired",
+                "printValue":"N"
+              }
+            ],
+            "server": {
+              "name":"UTGAPI11CE"
+            },
+            "transaction": {
+              "authSource":"E",
+              "invoice":"0705626580",
+              "responseCode":"D",
+              "saleFlag":"S"
+            },
+            "universalToken": {
+              "value":"400010-2F1AA405-001AA4-000026B7-1766C44E9E8"
+            }
+          }
+        ]
       }
     RESPONSE
   end
@@ -958,19 +1024,68 @@ class Shift4Test < Test::Unit::TestCase
   def failed_refund_response
     <<-RESPONSE
       {
-          "result": [
-              {
-                  "error": {
-                      "longText": "record not posted ENGINE21CE",
-                      "primaryCode": 9844,
-                      "shortText": "I/O ERROR"
-                  },
-                  "server": {
-                      "name": "UTGAPI05CE"
-                  }
-              }
+        "result":
+          [
+            {
+              "dateTime": "2024-01-05T13:38:03.000-08:00",
+              "receiptColumns": 30,
+              "amount": {
+                "total": 19.19
+              },
+              "card": {
+                "type": "VS",
+                "entryMode": "M",
+                "number": "XXXXXXXXXXXX2224",
+                "present": "N",
+                "token": {
+                  "value": "2224htm77ctttszk"
+                }
+              },
+              "clerk": {
+                "numericId": 1
+              },
+              "device": {
+                "capability": {
+                  "magstripe": "Y",
+                  "manualEntry": "Y"
+                }
+              },
+              "merchant": {
+                "name": "Spreedly - ECom"
+              },
+              "receipt": [
+                {
+                  "key": "MaskedPAN",
+                  "printValue": "XXXXXXXXXXXX2224"
+                },
+                {
+                  "key": "CardEntryMode",
+                  "printName": "ENTRY METHOD",
+                  "printValue": "KEYED"
+                },
+                {
+                  "key": "SignatureRequired",
+                  "printValue": "N"
+                }
+              ],
+              "server":
+                {
+                  "name": "UTGAPI04CE"
+                },
+              "transaction":
+                {
+                  "authSource": "E",
+                  "invoice": "0704283292",
+                  "responseCode": "D",
+                  "saleFlag": "C"
+                },
+              "universalToken":
+                {
+                  "value": "400010-2F1AA405-001AA4-000026B7-1766C44E9E8"
+                }
+            }
           ]
-      }
+        }
     RESPONSE
   end
 
@@ -1067,6 +1182,74 @@ class Shift4Test < Test::Unit::TestCase
           }
         ]
       }
+    RESPONSE
+  end
+
+  def failed_authorize_with_host_response
+    <<-RESPONSE
+     {
+      "result": [
+        {
+          "dateTime": "2022-09-16T01:40:51.000-07:00",
+          "card": {
+            "type": "VS",
+            "entryMode": "M",
+            "number": "XXXXXXXXXXXX2224",
+            "present": "N",
+            "securityCode": {
+              "result": "M",
+              "valid": "Y"
+            },
+            "token": {
+              "value": "2224xzsetmjksx13"
+            }
+          },
+          "customer": {
+            "firstName": "John",
+            "lastName": "Smith"
+          },
+          "device": {
+            "capability": {
+              "magstripe": "Y",
+              "manualEntry": "Y"
+            }
+          },
+          "merchant": {
+            "name": "Spreedly - ECom"
+          },
+          "server": {
+            "name": "UTGAPI12CE"
+          },
+          "transaction": {
+            "authSource":"E",
+            "avs": {
+              "postalCodeVerified":"Y",
+              "result":"Y",
+              "streetVerified":"Y",
+              "valid":"Y"
+              },
+            "cardOnFile": {
+              "transactionId":"010512168564062",
+              "indicator":"01",
+              "scheduledIndicator":"02",
+              "usageIndicator":"01"
+              },
+            "invoice":"0704938459384",
+            "hostResponse": {
+              "reasonCode":"N7",
+              "reasonDescription":"CVV value N not accepted."
+              },
+            "responseCode":"D",
+            "retrievalReference":"400500170391",
+            "saleFlag":"S",
+            "vendorReference":"2490464558001"
+          },
+          "universalToken": {
+            "value": "400010-2F1AA405-001AA4-000026B7-1766C44E9E8"
+          }
+        }
+      ]
+     }
     RESPONSE
   end
 end


### PR DESCRIPTION
CER_1094

This change updates a few response methods to return more accurate codes and messages instead of the currently existing standard error code mapping. The previously implemented standard error code mapping was not great. It was returning messages not direct from the gateway, which was perhaps an old standard but there have been requests to make the messages returned aligned with the gateway's actual response.

Failed sandbox transactions do not return the `hostResponse`, which is from the card networks, but they do return `responseCode: D`. I've made some extensive updates to test cases and responses to more accurately reflect the gateway's responses in production transactions.