### PR TITLE
Payeezy: Pull cardholder name from billing address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -100,6 +100,7 @@
 * HiPay: Add unstore [gasb150] #4999
 * Rapyd: Fix transaction with two digits in month and year [javierpedrozaing] #5008
 * SagePay: Add support for stored credentials [almalee24] #5007
+* Payeezy: Pull cardholer name from billing address [almalee24] #5006
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -204,7 +204,7 @@ module ActiveMerchant
         params[:apikey] = @options[:apikey]
         params[:ta_token] = options[:ta_token]
         params[:type] = 'FDToken'
-        params[:credit_card] = add_card_data(payment_method)
+        params[:credit_card] = add_card_data(payment_method, options)
         params[:auth] = 'false'
       end
 
@@ -220,7 +220,7 @@ module ActiveMerchant
         elsif payment_method.is_a? NetworkTokenizationCreditCard
           add_network_tokenization(params, payment_method, options)
         else
-          add_creditcard(params, payment_method)
+          add_creditcard(params, payment_method, options)
         end
       end
 
@@ -257,17 +257,17 @@ module ActiveMerchant
         params[:token] = token
       end
 
-      def add_creditcard(params, creditcard)
-        credit_card = add_card_data(creditcard)
+      def add_creditcard(params, creditcard, options)
+        credit_card = add_card_data(creditcard, options)
 
         params[:method] = 'credit_card'
         params[:credit_card] = credit_card
       end
 
-      def add_card_data(payment_method)
+      def add_card_data(payment_method, options = {})
         card = {}
         card[:type] = CREDIT_CARD_BRAND[payment_method.brand]
-        card[:cardholder_name] = payment_method.name
+        card[:cardholder_name] = name_from_payment_method(payment_method) || name_from_address(options)
         card[:card_number] = payment_method.number
         card[:exp_date] = format_exp_date(payment_method.month, payment_method.year)
         card[:cvv] = payment_method.verification_value if payment_method.verification_value?


### PR DESCRIPTION
If payment method doesn't have name then pull it from the billing address for credit card cardholder name.

Remote:
52 tests, 212 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.0769% passed

Unit:
51 tests, 235 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed