### PR TITLE
SagePay: Add support for stored credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -99,6 +99,7 @@
 * Cecabank: Encrypt credit card fields [sinourain] #4998
 * HiPay: Add unstore [gasb150] #4999
 * Rapyd: Fix transaction with two digits in month and year [javierpedrozaing] #5008
+* SagePay: Add support for stored credentials [almalee24] #5007
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827


### PR DESCRIPTION
Adds support for stored credentials  on
authorize and purchase requests.

Remote:
41 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
44 tests, 164 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed