### PR TITLE
Rapyd: Fix transaction with two digits in month and year

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -98,6 +98,7 @@
 * Add new card type Tuya. GlobalCollect & Decidir: Improve support for Tuya card type [sinourain] #4993
 * Cecabank: Encrypt credit card fields [sinourain] #4998
 * HiPay: Add unstore [gasb150] #4999
+* Rapyd: Fix transaction with two digits in month and year [javierpedrozaing] #5008
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -179,8 +179,8 @@ module ActiveMerchant #:nodoc:
 
         post[:payment_method][:type] = options[:pm_type]
         pm_fields[:number] = payment.number
-        pm_fields[:expiration_month] = payment.month.to_s
-        pm_fields[:expiration_year] = payment.year.to_s
+        pm_fields[:expiration_month] = format(payment.month, :two_digits).to_s
+        pm_fields[:expiration_year] = format(payment.year, :two_digits).to_s
         pm_fields[:name] = "#{payment.first_name} #{payment.last_name}"
         pm_fields[:cvv] = payment.verification_value.to_s unless valid_network_transaction_id?(options) || payment.verification_value.blank?
         pm_fields[:recurrence_type] = options[:recurrence_type] if options[:recurrence_type]


### PR DESCRIPTION
Description
-------------------------
[SER-1068](https://spreedly.atlassian.net/browse/SER-1068)

This commit applies a format of two digits in the month and year fields,

Unit test
-------------------------
Finished in 0.383202 seconds.

49 tests, 225 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

127.87 tests/s, 587.16 assertions/s

Remote test
-------------------------
Finished in 216.477122 seconds.

51 tests, 146 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.0392% passed

0.24 tests/s, 0.67 assertions/s

Rubocop
-------------------------
787 files inspected, no offenses detected