### PR TITLE
Priority: Allow gateway fields to be available on capture endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -104,6 +104,7 @@
 * HiPay: Add 3ds params [gasb150] #5012
 * Cecabank: Fix gateway scrub method [sinourain] #5009
 * Pin: Add the platform_adjustment field [yunnydang] #5011
+* Priority: Allow gateway fields to be available on capture [yunnydang] #5010
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/priority.rb
+++ b/lib/active_merchant/billing/gateways/priority.rb
@@ -55,7 +55,8 @@ module ActiveMerchant #:nodoc:
 
         add_merchant_id(params)
         add_amount(params, amount, options)
-        add_auth_purchase_params(params, credit_card, options)
+        add_auth_purchase_params(params, options)
+        add_credit_card(params, credit_card, 'purchase', options)
 
         commit('purchase', params: params)
       end
@@ -67,7 +68,8 @@ module ActiveMerchant #:nodoc:
 
         add_merchant_id(params)
         add_amount(params, amount, options)
-        add_auth_purchase_params(params, credit_card, options)
+        add_auth_purchase_params(params, options)
+        add_credit_card(params, credit_card, 'purchase', options)
 
         commit('purchase', params: params)
       end
@@ -100,7 +102,7 @@ module ActiveMerchant #:nodoc:
         add_merchant_id(params)
         add_amount(params, amount, options)
         params['paymentToken'] = payment_token(authorization) || options[:payment_token]
-        params['tenderType'] = options[:tender_type].present? ? options[:tender_type] : 'Card'
+        add_auth_purchase_params(params, options)
 
         commit('capture', params: params)
       end
@@ -150,9 +152,8 @@ module ActiveMerchant #:nodoc:
         params['merchantId'] = @options[:merchant_id]
       end
 
-      def add_auth_purchase_params(params, credit_card, options)
+      def add_auth_purchase_params(params, options)
         add_replay_id(params, options)
-        add_credit_card(params, credit_card, 'purchase', options)
         add_purchases_data(params, options)
         add_shipping_data(params, options)
         add_pos_data(params, options)

--- a/test/remote/gateways/remote_priority_test.rb
+++ b/test/remote/gateways/remote_priority_test.rb
@@ -70,6 +70,51 @@ class RemotePriorityTest < Test::Unit::TestCase
         }
       ]
     }
+
+    @all_gateway_fields = {
+      is_auth: true,
+      invoice: '123',
+      source: 'test',
+      replay_id: @replay_id,
+      ship_amount: 1,
+      ship_to_country: 'US',
+      ship_to_zip: '12345',
+      payment_type: '',
+      tender_type: '',
+      tax_exempt: true,
+      pos_data: {
+        cardholder_presence: 'NotPresent',
+        device_attendance: 'Unknown',
+        device_input_capability: 'KeyedOnly',
+        device_location: 'Unknown',
+        pan_capture_method: 'Manual',
+        partial_approval_support: 'Supported',
+        pin_capture_capability: 'Twelve'
+      },
+      purchases: [
+        {
+          line_item_id: 79402,
+          name: 'Book',
+          description: 'The Elements of Style',
+          quantity: 1,
+          unit_price: 1.23,
+          discount_amount: 0,
+          extended_amount: '1.23',
+          discount_rate: 0,
+          tax_amount: 1
+        },
+        {
+          line_item_id: 79403,
+          name: 'Cat Poster',
+          description: 'A sleeping cat',
+          quantity: 1,
+          unit_price: '2.34',
+          discount_amount: 0,
+          extended_amount: '2.34',
+          discount_rate: 0
+        }
+      ]
+    }
   end
 
   def test_successful_authorize
@@ -160,6 +205,15 @@ class RemotePriorityTest < Test::Unit::TestCase
 
     assert_success response
     assert_equal 'Approved or completed successfully', response.message
+  end
+
+  def test_successful_authorize_and_capture_with_auth_purchase_params
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    capture = @gateway.capture(@amount, auth.authorization, @all_gateway_fields)
+    assert_success capture
+    assert_equal 'Approved', capture.message
   end
 
   def test_successful_credit
@@ -267,7 +321,7 @@ class RemotePriorityTest < Test::Unit::TestCase
   def test_successful_verify
     response = @gateway.verify(credit_card('411111111111111'))
     assert_success response
-    assert_match 'JPMORGAN CHASE BANK, N.A.', response.params['bank']['name']
+    assert_match 'JPMORGAN CHASE BANK N.A.', response.params['bank']['name']
   end
 
   def test_failed_verify


### PR DESCRIPTION
This change is to essentially allow the gateway fields to be available on the capture endpoint. Written the remote and unit tests to confirm this. I would note that the failing remote tests return the error message of rapid refund detected, so I'm assuming the sandbox has some rate limit attached.

Local:
5800 tests, 78860 assertions, 0 failures, 26 errors, 0 pendings, 0 omissions, 0 notifications 99.5517% passed

Unit:
21 tests, 145 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
31 tests, 84 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 83.871% passed