### PR TITLE
Pin Gateway: Add the platform_adjustment field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,6 +103,7 @@
 * Payeezy: Pull cardholer name from billing address [almalee24] #5006
 * HiPay: Add 3ds params [gasb150] #5012
 * Cecabank: Fix gateway scrub method [sinourain] #5009
+* Pin: Add the platform_adjustment field [yunnydang] #5011
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -31,6 +31,7 @@ module ActiveMerchant #:nodoc:
         add_capture(post, options)
         add_metadata(post, options)
         add_3ds(post, options)
+        add_platform_adjustment(post, options)
 
         commit(:post, 'charges', post, options)
       end
@@ -173,6 +174,10 @@ module ActiveMerchant #:nodoc:
 
       def add_metadata(post, options)
         post[:metadata] = options[:metadata] if options[:metadata]
+      end
+
+      def add_platform_adjustment(post, options)
+        post[:platform_adjustment] = options[:platform_adjustment] if options[:platform_adjustment]
       end
 
       def add_3ds(post, options)

--- a/test/remote/gateways/remote_pin_test.rb
+++ b/test/remote/gateways/remote_pin_test.rb
@@ -47,6 +47,20 @@ class RemotePinTest < Test::Unit::TestCase
     assert_equal options_with_metadata[:metadata][:purchase_number], response.params['response']['metadata']['purchase_number']
   end
 
+  def test_successful_purchase_with_platform_adjustment
+    options_with_platform_adjustment = {
+      platform_adjustment: {
+        amount: 30,
+        currency: 'AUD'
+      }
+    }
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(options_with_platform_adjustment))
+    assert_success response
+    assert_equal true, response.params['response']['captured']
+    assert_equal options_with_platform_adjustment[:platform_adjustment][:amount], response.params['response']['platform_adjustment']['amount']
+    assert_equal options_with_platform_adjustment[:platform_adjustment][:currency], response.params['response']['platform_adjustment']['currency']
+  end
+
   def test_successful_purchase_with_reference
     response = @gateway.purchase(@amount, @credit_card, @options.merge(reference: 'statement descriptor'))
     assert_success response

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -89,6 +89,20 @@ class PinTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_send_platform_adjustment
+    options_with_platform_adjustment = {
+      platform_adjustment: {
+        amount: 30,
+        currency: 'AUD'
+      }
+    }
+
+    post = {}
+    @gateway.send(:add_platform_adjustment, post, @options.merge(options_with_platform_adjustment))
+    assert_equal 30, post[:platform_adjustment][:amount]
+    assert_equal 'AUD', post[:platform_adjustment][:currency]    
+  end
+
   def test_unsuccessful_request
     @gateway.expects(:ssl_request).returns(failed_purchase_response)
 


### PR DESCRIPTION
This just adds the ability to add the platform_adjustment to charges

Local:
5801 tests, 78838 assertions, 1 failures, 27 errors, 0 pendings, 0 omissions, 0 notifications 99.5346% passed

Unit:
44 tests, 144 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
21 tests, 65 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed