### PR TITLE
Stripe PI: Allow passing payment_method_types when creating intents

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* StripePI: Allow passing payment_method_types when creating Payment Intents [alexdunae] #4671
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860
 * TNS: Use the specified order_id in request if available [yunnydang] #4880
 * Cybersource: Support recurring apple pay [aenand] #4874

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -28,6 +28,7 @@ module ActiveMerchant #:nodoc:
             result = add_payment_method_token(post, payment_method, options)
             return result if result.is_a?(ActiveMerchant::Billing::Response)
 
+            add_payment_method_types(post, options)
             add_network_token_cryptogram_and_eci(post, payment_method)
             add_external_three_d_secure_auth_data(post, options)
             add_metadata(post, options)

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -795,6 +795,17 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), scrubbed
   end
 
+  def test_passing_payment_method_types_to_purchase
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @visa_token, {
+        currency: 'CAD',
+        payment_method_types: %w[card acss_debit]
+      })
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match('payment_method_types[0]=card&payment_method_types[1]=acss_debit', data)
+    end.respond_with(successful_create_intent_response)
+  end
+
   def test_succesful_purchase_with_initial_cit_unscheduled
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @visa_token, {


### PR DESCRIPTION
Fixes https://github.com/activemerchant/active_merchant/issues/4671

As of Stripe's 2023-08-16 API version ( https://stripe.com/docs/upgrades#2023-08-16 ) they now require `payment_method_types` to be set when passing `error_on_requires_action`.

This change allows manually specifying `payment_method_types` when you create a payment intent.