### PR TITLE
Rapyd: Improve and fix error messages

### DIFF
--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -323,6 +323,8 @@ module ActiveMerchant #:nodoc:
         rel_path = "#{method}/v1/#{action}"
         response = api_request(method, url(action, @options[:url_override]), rel_path, parameters)
 
+        return response unless response.is_a?(Hash) && response.dig('status', 'status')
+
         Response.new(
           success_from(response),
           message_from(response),
@@ -383,7 +385,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(response)
-        response.dig('status', 'status') == 'SUCCESS' && response.dig('status', 'error') != 'ERR'
+        response.dig('status', 'status') == 'SUCCESS' && response.dig('status', 'error') != 'ERR' && response.dig('status', 'message') == ''
       end
 
       def message_from(response)
@@ -402,7 +404,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def error_code_from(response)
-        response.dig('status', 'error_code') unless success_from(response)
+        error_code = response.dig('status', 'error_code') unless success_from(response)
+        response_code = response.dig('status', 'response_code') unless success_from(response)
+        response_code unless error_code
       end
 
       def handle_response(response)

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -231,7 +231,7 @@ class RapydTest < Test::Unit::TestCase
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_equal 'ERROR_PROCESSING_CARD - [05]', response.error_code
+    assert_equal 'ERROR_PROCESSING_CARD - [05]', response.params['status']['response_code']
   end
 
   def test_successful_authorize


### PR DESCRIPTION
Description
-------------------------
[SER-1045](https://spreedly.atlassian.net/browse/SER-1045)

This commit update the way to get error codes and sucess transactions.

Rapyd always respond with error_code and response_code fields, and these fields have the same value now we get both fields in case one of them is empty.

To differentiate when we get a 200 code with an error message from Rapyd, we have included one validation when the message field is empty to determine if the transaction is a success transaction or not.

Finally this commit add a small fix when the Rapyd response is not a hash

Unit test
-------------------------
Finished in 0.159334 seconds.

49 tests, 225 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

100% passed

307.53 tests/s, 1412.13 assertions/s

Remote test
-------------------------
Finished in 234.681137 seconds.

53 tests, 147 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

94.3396% passed

0.23 tests/s, 0.63 assertions/s

Rubocop
-------------------------
787 files inspected, 1 offense detected

There is 1 offense not related to this commit