### PR TITLE
Plexo: add the invoice_number field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -107,6 +107,7 @@
 * Priority: Allow gateway fields to be available on capture [yunnydang] #5010
 * Add payment_data to NetworkTokenizationCreditCard [almalee24] #4888
 * IPG: Update handling of ChargeTotal [jcreiff] #5017
+* Plexo: Add the invoice_number field [yunnydang] #5019
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -76,6 +76,7 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options[:metadata])
         add_amount(money, post, options)
         add_browser_details(post, options)
+        add_invoice_number(post, options)
 
         commit('/verify', post, options)
       end
@@ -111,6 +112,7 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options[:metadata])
         add_amount(money, post, options)
         add_browser_details(post, options)
+        add_invoice_number(post, options)
       end
 
       def header(parameters = {})
@@ -184,6 +186,10 @@ module ActiveMerchant #:nodoc:
         post[:BrowserDetails] = {}
         post[:BrowserDetails][:DeviceFingerprint] = browser_details[:finger_print] if browser_details[:finger_print]
         post[:BrowserDetails][:IpAddress] = browser_details[:ip] if browser_details[:ip]
+      end
+
+      def add_invoice_number(post, options)
+        post[:InvoiceNumber] = options[:invoice_number] if options[:invoice_number]
       end
 
       def add_payment_method(post, payment, options)

--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -43,6 +43,24 @@ class RemotePlexoTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_invoice_number
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ invoice_number: '12345abcde' }))
+    assert_success response
+    assert_equal '12345abcde', response.params['invoiceNumber']
+  end
+
+  def test_successfully_send_merchant_id
+    # ensures that we can set and send the merchant_id and get a successful response
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ merchant_id: 3243 }))
+    assert_success response
+    assert_equal 3243, response.params['merchant']['id']
+
+    # ensures that we can set and send the merchant_id and expect a failed response for invalid merchant_id
+    response = @gateway.purchase(@amount, @credit_card, @options.merge({ merchant_id: 1234 }))
+    assert_failure response
+    assert_equal 'The requested Merchant was not found.', response.message
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
@@ -133,6 +151,11 @@ class RemotePlexoTest < Test::Unit::TestCase
 
   def test_successful_verify_with_custom_amount
     response = @gateway.verify(@credit_card, @options.merge({ verify_amount: '400' }))
+    assert_success response
+  end
+
+  def test_successful_verify_with_invoice_number
+    response = @gateway.verify(@credit_card, @options.merge({ invoice_number: '12345abcde' }))
     assert_success response
   end
 

--- a/test/unit/gateways/plexo_test.rb
+++ b/test/unit/gateways/plexo_test.rb
@@ -119,6 +119,24 @@ class PlexoTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_successful_authorize_with_invoice_number
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ invoice_number: '12345abcde' }))
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['InvoiceNumber'], '12345abcde'
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_successful_authorize_with_merchant_id
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge({ merchant_id: 1234 }))
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['MerchantId'], 1234
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_successful_reordering_of_amount_in_authorize
     @gateway.expects(:ssl_post).returns(successful_authorize_response)
 
@@ -277,6 +295,24 @@ class PlexoTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       request = JSON.parse(data)
       assert_equal request['Amount']['Total'], '9.00'
+    end.respond_with(successful_verify_response)
+  end
+
+  def test_successful_verify_with_invoice_number
+    stub_comms do
+      @gateway.verify(@credit_card, @options.merge({ invoice_number: '12345abcde' }))
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['InvoiceNumber'], '12345abcde'
+    end.respond_with(successful_verify_response)
+  end
+
+  def test_successful_verify_with_merchant_id
+    stub_comms do
+      @gateway.verify(@credit_card, @options.merge({ merchant_id: 1234 }))
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['MerchantId'], 1234
     end.respond_with(successful_verify_response)
   end
 


### PR DESCRIPTION
This adds the optional invoice_number field and adds more remote and unit tests for the merchant_id field

Local:
5806 tests, 78878 assertions, 1 failures, 27 errors, 0 pendings, 0 omissions, 0 notifications
99.535% passed

Unit:
24 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
31 tests, 53 assertions, 1 failures, 2 errors, 0 pendings, 3 omissions, 0 notifications
89.2857% passed