### PR TITLE
SER-1083 Cecabank: exclude 3ds empty parameter 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -110,6 +110,7 @@
 * Plexo: Add the invoice_number field [yunnydang] #5019
 * CheckoutV2: Handle empty address in payout destination data [jcreiff] #5024
 * CyberSource: Add the auth service aggregator_id field [yunnydang] #5026
+* Cecabank: exclude 3ds empty parameter [jherreraa] #5021
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/cecabank/cecabank_json.rb
+++ b/lib/active_merchant/billing/gateways/cecabank/cecabank_json.rb
@@ -196,7 +196,7 @@ module ActiveMerchant
 
       def add_three_d_secure(post, options)
         params = post[:parametros] ||= {}
-        return params[:ThreeDsResponse] = '{}' unless three_d_secure = options[:three_d_secure]
+        return unless three_d_secure = options[:three_d_secure]
 
         params[:exencionSCA] ||= CECA_SCA_TYPES.fetch(options[:exemption_type]&.to_sym, :NONE)
 

--- a/test/remote/gateways/remote_cecabank_rest_json_test.rb
+++ b/test/remote/gateways/remote_cecabank_rest_json_test.rb
@@ -32,7 +32,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
   def test_unsuccessful_authorize
     assert response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_match '106900640', response.message
+    assert_match @gateway.options[:merchant_id], response.message
     assert_match '190', response.error_code
   end
 
@@ -47,12 +47,12 @@ class RemoteCecabankTest < Test::Unit::TestCase
   def test_unsuccessful_capture
     assert response = @gateway.capture(@amount, 'abc123', @options)
     assert_failure response
-    assert_match '106900640', response.message
+    assert_match @gateway.options[:merchant_id], response.message
     assert_match '807', response.error_code
   end
 
   def test_successful_purchase
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert response = @gateway.purchase(@amount, @credit_card, order_id: generate_unique_id)
     assert_success response
     assert_equal %i[codAut numAut referencia], JSON.parse(response.message).symbolize_keys.keys.sort
   end
@@ -60,7 +60,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_match '106900640', response.message
+    assert_match @gateway.options[:merchant_id], response.message
     assert_match '190', response.error_code
   end
 
@@ -76,7 +76,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
   def test_unsuccessful_refund
     assert response = @gateway.refund(@amount, 'reference', @options)
     assert_failure response
-    assert_match '106900640', response.message
+    assert_match @gateway.options[:merchant_id], response.message
     assert_match '15', response.error_code
   end
 
@@ -92,7 +92,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
   def test_unsuccessful_void
     assert response = @gateway.void('reference', { order_id: generate_unique_id })
     assert_failure response
-    assert_match '106900640', response.message
+    assert_match @gateway.options[:merchant_id], response.message
     assert_match '15', response.error_code
   end
 
@@ -140,7 +140,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
 
     assert purchase = @gateway.purchase(@amount, @credit_card, options)
     assert_failure purchase
-    assert_match '106900640', purchase.message
+    assert_match @gateway.options[:merchant_id], purchase.message
     assert_match '810', purchase.error_code
   end
 

--- a/test/unit/gateways/cecabank_rest_json_test.rb
+++ b/test/unit/gateways/cecabank_rest_json_test.rb
@@ -167,6 +167,18 @@ class CecabankJsonTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_purchase_without_threed_secure_data
+    @options[:three_d_secure] = nil
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      data = JSON.parse(data)
+      params = JSON.parse(Base64.decode64(data['parametros']))
+      assert_nil params['ThreeDsResponse']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_transcript_scrubbing
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end


### PR DESCRIPTION
## Summary:
This PR excludes the threeds node in the cecabank requests for the non three ds transactions

## Unit Tests
Finished in 0.033172 seconds.
15 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

## Remote tests
Finished in 24.858862 seconds.
16 tests, 59 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 93.75% passed

test test_purchase_using_stored_credential_recurring_mit fails due to gateway rules