### PR TITLE
Rapyd: Adding 500 errors handling

### DIFF
--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -308,7 +308,8 @@ module ActiveMerchant #:nodoc:
       def parse(body)
         return {} if body.empty? || body.nil?
 
-        JSON.parse(body)
+        parsed = JSON.parse(body)
+        parsed.is_a?(Hash) ? parsed : { 'status' => { 'status' => parsed } }
       end
 
       def url(action, url_override = nil)
@@ -333,6 +334,10 @@ module ActiveMerchant #:nodoc:
           test: test?,
           error_code: error_code_from(response)
         )
+      rescue ActiveMerchant::ResponseError => e
+        response = e.response.body.present? ? parse(e.response.body) : { 'status' => { 'response_code' => e.response.msg } }
+        message = response['status'].slice('message', 'response_code').values.compact_blank.first || ''
+        Response.new(false, message, response, test: test?)
       end
 
       # We need to revert the work of ActiveSupport JSON encoder to prevent discrepancies
@@ -396,6 +401,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response)
+        return '' unless response.is_a?(Hash)
+
         id = response.dig('data') ? response.dig('data', 'id') : response.dig('status', 'operation_id')
 
         "#{id}|#{response.dig('data', 'default_payment_method')}"

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -261,7 +261,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void('')
     assert_failure response
-    assert_equal 'UNAUTHORIZED_API_CALL', response.message
+    assert_equal 'NOT_FOUND', response.message
   end
 
   def test_successful_verify
@@ -337,7 +337,7 @@ class RemoteRapydTest < Test::Unit::TestCase
     transcript = @gateway.scrub(transcript)
 
     assert_scrubbed(@credit_card.number, transcript)
-    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(/"#{@credit_card.verification_value}"/, transcript)
     assert_scrubbed(@gateway.options[:secret_key], transcript)
     assert_scrubbed(@gateway.options[:access_key], transcript)
   end

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -598,7 +598,43 @@ class RapydTest < Test::Unit::TestCase
     end
   end
 
+  def test_handling_500_errors
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(response_500)
+
+    assert_failure response
+    assert_equal 'some_error_message', response.message
+  end
+
+  def test_handling_500_errors_with_blank_message
+    response_without_message = response_500
+    response_without_message.body = response_without_message.body.gsub('some_error_message', '')
+
+    response = stub_comms(@gateway, :raw_ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(response_without_message)
+
+    assert_failure response
+    assert_equal 'ERROR_PAYMENT_METHODS_GET', response.message
+  end
+
   private
+
+  def response_500
+    OpenStruct.new(
+      code: 500,
+      body:  {
+        status: {
+          error_code: 'ERROR_PAYMENT_METHODS_GET',
+          status: 'ERROR',
+          message: 'some_error_message',
+          response_code: 'ERROR_PAYMENT_METHODS_GET',
+          operation_id: '77703d8c-6636-48fc-bc2f-1154b5d29857'
+        }
+      }.to_json
+    )
+  end
 
   def pre_scrubbed
     '


### PR DESCRIPTION
### Summary
Adds to the Rapyd gateway the ability to handle 500 errors coming from the gateway.

[SER-1081](https://spreedly.atlassian.net/browse/SER-1081)

### Tests

#### Unit
Finished in 87.534566 seconds.
24 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

#### Remote
Finished in 68.736139 seconds.
5808 tests, 78988 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

#### Rubocop
787 files inspected, no offenses detected