### PR TITLE
CheckoutV2: Handle empty address in payout destination data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -108,6 +108,7 @@
 * Add payment_data to NetworkTokenizationCreditCard [almalee24] #4888
 * IPG: Update handling of ChargeTotal [jcreiff] #5017
 * Plexo: Add the invoice_number field [yunnydang] #5019
+* CheckoutV2: Handle empty address in payout destination data [jcreiff] #5024
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -398,14 +398,15 @@ module ActiveMerchant #:nodoc:
         post[:destination][:account_holder][:identification][:issuing_country] = options.dig(:destination, :account_holder, :identification, :issuing_country) if options.dig(:destination, :account_holder, :identification, :issuing_country)
         post[:destination][:account_holder][:identification][:date_of_expiry] = options.dig(:destination, :account_holder, :identification, :date_of_expiry) if options.dig(:destination, :account_holder, :identification, :date_of_expiry)
 
-        address = options[:billing_address] || options[:address] # destination address will come from the tokenized card billing address
-        post[:destination][:account_holder][:billing_address] = {}
-        post[:destination][:account_holder][:billing_address][:address_line1] = address[:address1] unless address[:address1].blank?
-        post[:destination][:account_holder][:billing_address][:address_line2] = address[:address2] unless address[:address2].blank?
-        post[:destination][:account_holder][:billing_address][:city] = address[:city] unless address[:city].blank?
-        post[:destination][:account_holder][:billing_address][:state] = address[:state] unless address[:state].blank?
-        post[:destination][:account_holder][:billing_address][:country] = address[:country] unless address[:country].blank?
-        post[:destination][:account_holder][:billing_address][:zip] = address[:zip] unless address[:zip].blank?
+        if address = options[:billing_address] || options[:address] # destination address will come from the tokenized card billing address
+          post[:destination][:account_holder][:billing_address] = {}
+          post[:destination][:account_holder][:billing_address][:address_line1] = address[:address1] unless address[:address1].blank?
+          post[:destination][:account_holder][:billing_address][:address_line2] = address[:address2] unless address[:address2].blank?
+          post[:destination][:account_holder][:billing_address][:city] = address[:city] unless address[:city].blank?
+          post[:destination][:account_holder][:billing_address][:state] = address[:state] unless address[:state].blank?
+          post[:destination][:account_holder][:billing_address][:country] = address[:country] unless address[:country].blank?
+          post[:destination][:account_holder][:billing_address][:zip] = address[:zip] unless address[:zip].blank?
+        end
       end
 
       def add_marketplace_data(post, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -704,7 +704,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
 
   def test_successful_money_transfer_payout_via_credit_corporate_account_holder_type
     @credit_card.name = 'ACME, Inc.'
-    response = @gateway_oauth.credit(@amount, @credit_card, @payout_options.merge(account_holder_type: 'corporate'))
+    response = @gateway_oauth.credit(@amount, @credit_card, @payout_options.merge(account_holder_type: 'corporate', payout: true))
     assert_success response
     assert_equal 'Succeeded', response.message
   end
@@ -713,6 +713,13 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @credit_card.first_name = 'John'
     @credit_card.last_name = 'Doe'
     response = @gateway_oauth.credit(@amount, @credit_card, @payout_options.merge({ account_holder_type: 'individual', payout: nil }))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_money_transfer_payout_handles_blank_destination_address
+    @payout_options[:billing_address] = nil
+    response = @gateway_oauth.credit(@amount, @credit_card, @payout_options.merge({ account_holder_type: 'individual', payout: true }))
     assert_success response
     assert_equal 'Succeeded', response.message
   end


### PR DESCRIPTION
Prevent NoMethodError from being thrown when no billing address is present in options

CER-1182

LOCAL
5806 tests, 78980 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

787 files inspected, no offenses detected

UNIT
64 tests, 384 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

REMOTE
99 tests, 238 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.9899% passed

The single failing remote test is test_successful_refund_via_oauth, which is unrelated to this change and is also failing on master