### PR TITLE
CyberSource: Add the auth_service aggregator_id field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -109,6 +109,7 @@
 * IPG: Update handling of ChargeTotal [jcreiff] #5017
 * Plexo: Add the invoice_number field [yunnydang] #5019
 * CheckoutV2: Handle empty address in payout destination data [jcreiff] #5024
+* CyberSource: Add the auth service aggregator_id field [yunnydang] #5026
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -750,6 +750,7 @@ module ActiveMerchant #:nodoc:
               indicator = options[:commerce_indicator] || stored_credential_commerce_indicator(options)
               xml.tag!('commerceIndicator', indicator) if indicator
             end
+            xml.tag!('aggregatorID', options[:aggregator_id]) if options[:aggregator_id]
             xml.tag!('reconciliationID', options[:reconciliation_id]) if options[:reconciliation_id]
             xml.tag!('firstRecurringPayment', options[:first_recurring_payment]) if options[:first_recurring_payment]
             xml.tag!('mobileRemotePaymentType', options[:mobile_remote_payment_type]) if options[:mobile_remote_payment_type]

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -154,6 +154,13 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
+  def test_successful_authorization_with_aggregator_id
+    options = @options.merge(aggregator_id: 'ABCDE')
+    assert response = @gateway.authorize(@amount, @credit_card, options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  end
+
   def test_successful_authorize_with_solution_id
     ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
     assert response = @gateway.authorize(@amount, @credit_card, @options)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -119,6 +119,14 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_authorization_response)
   end
 
+  def test_successful_authorize_with_cc_auth_service_aggregator_id
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(aggregator_id: 'ABCDE'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<aggregatorID>ABCDE<\/aggregatorID>/, data)
+    end.respond_with(successful_authorization_response)
+  end
+
   def test_successful_credit_card_purchase_with_elo
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 


### PR DESCRIPTION
This adds the aggregator_id field

Local:
5807 tests, 78885 assertions, 0 failures, 26 errors, 0 pendings, 0 omissions, 0 notifications
99.5523% passed

Unit:
145 tests, 806 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
129 tests, 636 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.5736% passed