### PR TITLE
Moneris: Add the customer id field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -111,6 +111,7 @@
 * CheckoutV2: Handle empty address in payout destination data [jcreiff] #5024
 * CyberSource: Add the auth service aggregator_id field [yunnydang] #5026
 * Cecabank: exclude 3ds empty parameter [jherreraa] #5021
+* Moneris: Add the customer id field [yunnydang] #5028
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -54,6 +54,7 @@ module ActiveMerchant #:nodoc:
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
         add_external_mpi_fields(post, options)
         add_stored_credential(post, options)
+        add_cust_id(post, options)
         action = if post[:cavv] || options[:three_d_secure]
                    'cavv_preauth'
                  elsif post[:data_key].blank?
@@ -78,6 +79,7 @@ module ActiveMerchant #:nodoc:
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
         add_external_mpi_fields(post, options)
         add_stored_credential(post, options)
+        add_cust_id(post, options)
         action = if post[:cavv] || options[:three_d_secure]
                    'cavv_purchase'
                  elsif post[:data_key].blank?
@@ -246,6 +248,10 @@ module ActiveMerchant #:nodoc:
         post[:issuer_id] = options[:issuer_id] if options[:issuer_id]
         post[:payment_indicator] = options[:payment_indicator] if options[:payment_indicator]
         post[:payment_information] = options[:payment_information] if options[:payment_information]
+      end
+
+      def add_cust_id(post, options)
+        post[:cust_id] = options[:cust_id] if options[:cust_id]
       end
 
       def add_stored_credential(post, options)

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -68,6 +68,14 @@ class MonerisRemoteTest < Test::Unit::TestCase
     assert_not_empty response.params['issuer_id']
   end
 
+  def test_successful_first_purchase_with_cust_id
+    gateway = MonerisGateway.new(fixtures(:moneris))
+    assert response = gateway.purchase(@amount, @credit_card, @options.merge(cust_id: 'test1234'))
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
   def test_successful_purchase_with_cof_enabled_and_no_cof_options
     gateway = MonerisGateway.new(fixtures(:moneris))
     assert response = gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -58,6 +58,17 @@ class MonerisTest < Test::Unit::TestCase
     assert_equal '69785-0_98;a131684dbecc1d89d9927c539ed3791b', response.authorization
   end
 
+  def test_successful_purchase_with_cust_id
+    response = stub_comms do
+      @gateway.purchase(100, @credit_card, @options.merge(cust_id: 'test1234'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<cust_id>test1234<\/cust_id>/, data)
+    end.respond_with(successful_cavv_purchase_response)
+
+    assert_success response
+    assert_equal '69785-0_98;a131684dbecc1d89d9927c539ed3791b', response.authorization
+  end
+
   def test_failed_mpi_cavv_purchase
     options = @options.merge(
       three_d_secure: {


### PR DESCRIPTION
This simply adds the cust_id field for purchase and authorization

Local:
5808 tests, 78890 assertions, 0 failures, 26 errors, 0 pendings, 0 omissions, 0 notifications 99.5523% passed

Unit:
54 tests, 293 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
53 tests, 259 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications 100% passed