### PR TITLE
Rapyd: Adding 500 errors handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -114,6 +114,7 @@
 * Moneris: Add the customer id field [yunnydang] #5028
 * Kushki: Add the product_details field [yunnydang] #5027
 * GlobalCollect: Add support for encryptedPaymentData [almalee24] #5015
+* Rapyd: Adding 500 errors handling [Heavyblade] #5029
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -255,13 +255,27 @@ class RemoteRapydTest < Test::Unit::TestCase
 
     assert void = @gateway.void(auth.authorization)
     assert_failure void
-    assert_equal 'ERROR_PAYMENT_METHOD_TYPE_DOES_NOT_SUPPORT_PAYMENT_CANCELLATION', void.error_code
+    assert_equal 'ERROR_PAYMENT_METHOD_TYPE_DOES_NOT_SUPPORT_PAYMENT_CANCELLATION', void.params['status']['response_code']
+  end
+
+  def test_failed_authorize_with_payment_method_type_error
+    auth = @gateway_payment_redirect.authorize(@amount, @credit_card, @options.merge(pm_type: 'worng_type'))
+    assert_failure auth
+    assert_equal 'ERROR', auth.params['status']['status']
+    assert_equal 'ERROR_GET_PAYMENT_METHOD_TYPE', auth.params['status']['response_code']
+  end
+
+  def test_failed_purchase_with_zero_amount
+    response = @gateway_payment_redirect.purchase(0, @credit_card, @options)
+    assert_failure response
+    assert_equal 'ERROR', response.params['status']['status']
+    assert_equal 'ERROR_CARD_VALIDATION_CAPTURE_TRUE', response.params['status']['response_code']
   end
 
   def test_failed_void
     response = @gateway.void('')
     assert_failure response
-    assert_equal 'UNAUTHORIZED_API_CALL', response.message
+    assert_equal 'NOT_FOUND', response.message
   end
 
   def test_successful_verify
@@ -320,6 +334,7 @@ class RemoteRapydTest < Test::Unit::TestCase
 
     unstore = @gateway.unstore('')
     assert_failure unstore
+    assert_equal 'NOT_FOUND', unstore.message
   end
 
   def test_invalid_login
@@ -337,7 +352,7 @@ class RemoteRapydTest < Test::Unit::TestCase
     transcript = @gateway.scrub(transcript)
 
     assert_scrubbed(@credit_card.number, transcript)
-    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(/"#{@credit_card.verification_value}"/, transcript)
     assert_scrubbed(@gateway.options[:secret_key], transcript)
     assert_scrubbed(@gateway.options[:access_key], transcript)
   end


### PR DESCRIPTION
## Description: 

This PR adds changes to handle 400s and 500s errors coming from the Gateway, for that:

- Rescues 500 errors with a proper ActiveMerchant::Response object.
- Structures a hash object in case of 400s that return just a String.
- Selects the error_code and message from the response using what is available.
- Fixes transcript test errors.

[SER-1081](https://spreedly.atlassian.net/browse/SER-1081)
[SER-1045](https://spreedly.atlassian.net/browse/SER-1045)

## Test

### Remote Test:

Finished in 87.534566 seconds.
24 tests, 71 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Unit Tests:

Finished in 68.736139 seconds.
5808 tests, 78988 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
787 files inspected, no offenses detected