### PR TITLE
Elavon: Update Stored Credential behavior

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -42,13 +42,7 @@ module ActiveMerchant #:nodoc:
           xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:purchase]
           xml.ssl_amount            amount(money)
-
-          if payment_method.is_a?(String)
-            add_token(xml, payment_method)
-          else
-            add_creditcard(xml, payment_method)
-          end
-
+          add_token_or_card(xml, payment_method, options)
           add_invoice(xml, options)
           add_salestax(xml, options)
           add_currency(xml, money, options)
@@ -56,27 +50,26 @@ module ActiveMerchant #:nodoc:
           add_customer_email(xml, options)
           add_test_mode(xml, options)
           add_ip(xml, options)
-          add_auth_purchase_params(xml, options)
+          add_auth_purchase_params(xml, payment_method, options)
           add_level_3_fields(xml, options) if options[:level_3_data]
         end
         commit(request)
       end
 
-      def authorize(money, creditcard, options = {})
+      def authorize(money, payment_method, options = {})
         request = build_xml_request do |xml|
           xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:authorize]
           xml.ssl_amount            amount(money)
-
-          add_salestax(xml, options)
+          add_token_or_card(xml, payment_method, options)
           add_invoice(xml, options)
-          add_creditcard(xml, creditcard)
+          add_salestax(xml, options)
           add_currency(xml, money, options)
           add_address(xml, options)
           add_customer_email(xml, options)
           add_test_mode(xml, options)
           add_ip(xml, options)
-          add_auth_purchase_params(xml, options)
+          add_auth_purchase_params(xml, payment_method, options)
           add_level_3_fields(xml, options) if options[:level_3_data]
         end
         commit(request)
@@ -92,7 +85,7 @@ module ActiveMerchant #:nodoc:
             add_salestax(xml, options)
             add_approval_code(xml, authorization)
             add_invoice(xml, options)
-            add_creditcard(xml, options[:credit_card])
+            add_creditcard(xml, options[:credit_card], options)
             add_currency(xml, money, options)
             add_address(xml, options)
             add_customer_email(xml, options)
@@ -139,7 +132,7 @@ module ActiveMerchant #:nodoc:
           xml.ssl_transaction_type  self.actions[:credit]
           xml.ssl_amount            amount(money)
           add_invoice(xml, options)
-          add_creditcard(xml, creditcard)
+          add_creditcard(xml, creditcard, options)
           add_currency(xml, money, options)
           add_address(xml, options)
           add_customer_email(xml, options)
@@ -152,7 +145,7 @@ module ActiveMerchant #:nodoc:
         request = build_xml_request do |xml|
           xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:verify]
-          add_creditcard(xml, credit_card)
+          add_creditcard(xml, credit_card, options)
           add_address(xml, options)
           add_test_mode(xml, options)
           add_ip(xml, options)
@@ -165,7 +158,7 @@ module ActiveMerchant #:nodoc:
           xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:store]
           xml.ssl_add_token 'Y'
-          add_creditcard(xml, creditcard)
+          add_creditcard(xml, creditcard, options)
           add_address(xml, options)
           add_customer_email(xml, options)
           add_test_mode(xml, options)
@@ -174,12 +167,12 @@ module ActiveMerchant #:nodoc:
         commit(request)
       end
 
-      def update(token, creditcard, options = {})
+      def update(token, payment_method, options = {})
         request = build_xml_request do |xml|
           xml.ssl_vendor_id         @options[:ssl_vendor_id] || options[:ssl_vendor_id]
           xml.ssl_transaction_type  self.actions[:update]
-          add_token(xml, token)
-          add_creditcard(xml, creditcard)
+          xml.ssl_token token
+          add_creditcard(xml, payment_method, options)
           add_address(xml, options)
           add_customer_email(xml, options)
           add_test_mode(xml, options)
@@ -200,6 +193,14 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def add_token_or_card(xml, payment_method, options)
+        if payment_method.is_a?(String) || options[:ssl_token]
+          xml.ssl_token options[:ssl_token] || payment_method
+        else
+          add_creditcard(xml, payment_method, options)
+        end
+      end
+
       def add_invoice(xml, options)
         xml.ssl_invoice_number    url_encode_truncate((options[:order_id] || options[:invoice]), 25)
         xml.ssl_description       url_encode_truncate(options[:description], 255)
@@ -213,11 +214,11 @@ module ActiveMerchant #:nodoc:
         xml.ssl_txn_id authorization.split(';').last
       end
 
-      def add_creditcard(xml, creditcard)
+      def add_creditcard(xml, creditcard, options)
         xml.ssl_card_number   creditcard.number
         xml.ssl_exp_date      expdate(creditcard)
 
-        add_verification_value(xml, creditcard) if creditcard.verification_value?
+        add_verification_value(xml, creditcard, options)
 
         xml.ssl_first_name    url_encode_truncate(creditcard.first_name, 20)
         xml.ssl_last_name     url_encode_truncate(creditcard.last_name, 30)
@@ -230,12 +231,12 @@ module ActiveMerchant #:nodoc:
         xml.ssl_transaction_currency currency
       end
 
-      def add_token(xml, token)
-        xml.ssl_token token
-      end
+      def add_verification_value(xml, credit_card, options)
+        return unless credit_card.verification_value?
+        # Don't add cvv if this is a non-initial stored credential transaction
+        return if options[:stored_credential] && !options[:stored_credential][:initial_transaction]
 
-      def add_verification_value(xml, creditcard)
-        xml.ssl_cvv2cvc2            creditcard.verification_value
+        xml.ssl_cvv2cvc2            credit_card.verification_value
         xml.ssl_cvv2cvc2_indicator  1
       end
 
@@ -294,16 +295,16 @@ module ActiveMerchant #:nodoc:
       end
 
       # add_recurring_token is a field that can be sent in to obtain a token from Elavon for use with their tokenization program
-      def add_auth_purchase_params(xml, options)
+      def add_auth_purchase_params(xml, payment_method, options)
         xml.ssl_dynamic_dba                     options[:dba] if options.has_key?(:dba)
         xml.ssl_merchant_initiated_unscheduled  merchant_initiated_unscheduled(options) if merchant_initiated_unscheduled(options)
         xml.ssl_add_token                       options[:add_recurring_token] if options.has_key?(:add_recurring_token)
-        xml.ssl_token                           options[:ssl_token] if options[:ssl_token]
         xml.ssl_customer_code                   options[:customer] if options.has_key?(:customer)
         xml.ssl_customer_number                 options[:customer_number] if options.has_key?(:customer_number)
-        xml.ssl_entry_mode                      entry_mode(options) if entry_mode(options)
+        xml.ssl_entry_mode                      add_entry_mode(payment_method, options) if add_entry_mode(payment_method, options)
         add_custom_fields(xml, options) if options[:custom_fields]
-        add_stored_credential(xml, options) if options[:stored_credential]
+        add_stored_credential(xml, payment_method, options) if options[:stored_credential]
+        add_installment_fields(xml, options) if options.dig(:stored_credential, :reason_type) == 'installment'
       end
 
       def add_custom_fields(xml, options)
@@ -352,30 +353,48 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def add_stored_credential(xml, options)
+      def add_stored_credential(xml, payment_method, options)
+        return unless options[:stored_credential]
+
         network_transaction_id = options.dig(:stored_credential, :network_transaction_id)
-        case
-        when network_transaction_id.nil?
-          return
-        when network_transaction_id.to_s.include?('|')
-          oar_data, ps2000_data = options[:stored_credential][:network_transaction_id].split('|')
-          xml.ssl_oar_data oar_data unless oar_data.nil? || oar_data.empty?
-          xml.ssl_ps2000_data ps2000_data unless ps2000_data.nil? || ps2000_data.empty?
-        when network_transaction_id.to_s.length > 22
-          xml.ssl_oar_data options.dig(:stored_credential, :network_transaction_id)
-        else
-          xml.ssl_ps2000_data options.dig(:stored_credential, :network_transaction_id)
+        xml.ssl_recurring_flag recurring_flag(options) if recurring_flag(options)
+        xml.ssl_par_value options[:par_value] if options[:par_value]
+        xml.ssl_association_token_data options[:association_token_data] if options[:association_token_data]
+
+        unless payment_method.is_a?(String) || options[:ssl_token].present?
+          xml.ssl_approval_code options[:approval_code] if options[:approval_code]
+          if network_transaction_id.to_s.include?('|')
+            oar_data, ps2000_data = network_transaction_id.split('|')
+            xml.ssl_oar_data oar_data unless oar_data.blank?
+            xml.ssl_ps2000_data ps2000_data unless ps2000_data.blank?
+          elsif network_transaction_id.to_s.length > 22
+            xml.ssl_oar_data network_transaction_id
+          elsif network_transaction_id.present?
+            xml.ssl_ps2000_data network_transaction_id
+          end
         end
+      end
+
+      def recurring_flag(options)
+        return unless reason = options.dig(:stored_credential, :reason_type)
+        return 1 if reason == 'recurring'
+        return 2 if reason == 'installment'
       end
 
       def merchant_initiated_unscheduled(options)
         return options[:merchant_initiated_unscheduled] if options[:merchant_initiated_unscheduled]
-        return 'Y' if options.dig(:stored_credential, :initiator) == 'merchant' && options.dig(:stored_credential, :reason_type) == 'unscheduled' || options.dig(:stored_credential, :reason_type) == 'recurring'
+        return 'Y' if options.dig(:stored_credential, :initiator) == 'merchant' && options.dig(:stored_credential, :reason_type) == 'unscheduled'
       end
 
-      def entry_mode(options)
+      def add_installment_fields(xml, options)
+        xml.ssl_payment_number options[:payment_number]
+        xml.ssl_payment_count options[:installments]
+      end
+
+      def add_entry_mode(payment_method, options)
         return options[:entry_mode] if options[:entry_mode]
-        return 12 if options[:stored_credential]
+        return if payment_method.is_a?(String) || options[:ssl_token]
+        return 12 if options.dig(:stored_credential, :reason_type) == 'unscheduled'
       end
 
       def build_xml_request

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -26,6 +26,7 @@ class ElavonTest < Test::Unit::TestCase
 
     @credit_card = credit_card
     @amount = 100
+    @stored_card = '4421912014039990'
 
     @options = {
       order_id: '1',
@@ -35,9 +36,12 @@ class ElavonTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_cvv2cvc2>123<\/ssl_cvv2cvc2>/, data)
+    end.respond_with(successful_purchase_response)
 
-    assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal '093840;180820AD3-27AEE6EF-8CA7-4811-8D1F-E420C3B5041E', response.authorization
     assert response.test?
@@ -156,13 +160,23 @@ class ElavonTest < Test::Unit::TestCase
   end
 
   def test_sends_ssl_token_field
-    response = stub_comms do
+    purchase_response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(ssl_token: '8675309'))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<ssl_token>8675309<\/ssl_token>/, data)
+      refute_match(/<ssl_card_number/, data)
     end.respond_with(successful_purchase_response)
 
-    assert_success response
+    assert_success purchase_response
+
+    authorize_response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(ssl_token: '8675309'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_token>8675309<\/ssl_token>/, data)
+      refute_match(/<ssl_card_number/, data)
+    end.respond_with(successful_authorization_response)
+
+    assert_success authorize_response
   end
 
   def test_successful_authorization_with_dynamic_dba
@@ -348,7 +362,7 @@ class ElavonTest < Test::Unit::TestCase
     ps2000_data = 'A8181831435010530042VE'
     network_transaction_id = "#{oar_data}|#{ps2000_data}"
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { network_transaction_id: network_transaction_id }))
+      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { initiator: 'merchant', reason_type: 'recurring', network_transaction_id: network_transaction_id }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<ssl_oar_data>#{oar_data}<\/ssl_oar_data>/, data)
       assert_match(/<ssl_ps2000_data>#{ps2000_data}<\/ssl_ps2000_data>/, data)
@@ -360,10 +374,10 @@ class ElavonTest < Test::Unit::TestCase
     ps2000_data = nil
     network_transaction_id = "#{oar_data}|#{ps2000_data}"
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { network_transaction_id: network_transaction_id }))
+      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { initiator: 'merchant', reason_type: 'recurring', network_transaction_id: network_transaction_id }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<ssl_oar_data>#{oar_data}<\/ssl_oar_data>/, data)
-      refute_match(/<ssl_ps2000_data>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
     end.respond_with(successful_purchase_response)
   end
 
@@ -372,9 +386,9 @@ class ElavonTest < Test::Unit::TestCase
     ps2000_data = 'A8181831435010530042VE'
     network_transaction_id = "#{oar_data}|#{ps2000_data}"
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { network_transaction_id: network_transaction_id }))
+      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { initiator: 'merchant', reason_type: 'recurring', network_transaction_id: network_transaction_id }))
     end.check_request do |_endpoint, data, _headers|
-      refute_match(/<ssl_oar_data>/, data)
+      refute_match(/<ssl_oar_data/, data)
       assert_match(/<ssl_ps2000_data>#{ps2000_data}<\/ssl_ps2000_data>/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -382,20 +396,272 @@ class ElavonTest < Test::Unit::TestCase
   def test_oar_transaction_id_without_pipe
     oar_data = '010012318808182231420000047554200000000000093840023122123188'
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { network_transaction_id: oar_data }))
+      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { initiator: 'merchant', reason_type: 'recurring', network_transaction_id: oar_data }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<ssl_oar_data>#{oar_data}<\/ssl_oar_data>/, data)
-      refute_match(/<ssl_ps2000_data>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
     end.respond_with(successful_purchase_response)
   end
 
   def test_ps2000_transaction_id_without_pipe
     ps2000_data = 'A8181831435010530042VE'
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { network_transaction_id: ps2000_data }))
+      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential: { initiator: 'merchant', reason_type: 'recurring', network_transaction_id: ps2000_data }))
     end.check_request do |_endpoint, data, _headers|
-      refute_match(/<ssl_oar_data>/, data)
+      refute_match(/<ssl_oar_data/, data)
       assert_match(/<ssl_ps2000_data>#{ps2000_data}<\/ssl_ps2000_data>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_pass_in_initial_recurring_request
+    recurring_params = {
+      stored_credential: {
+        initial_transaction: 'Y',
+        reason_type: 'recurring',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(recurring_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_cvv2cvc2>123<\/ssl_cvv2cvc2>/, data)
+      assert_match(/<ssl_recurring_flag>1<\/ssl_recurring_flag>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
+      refute_match(/<ssl_oar_data/, data)
+      refute_match(/<ssl_approval_code/, data)
+      refute_match(/<ssl_entry_mode/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_pass_in_recurring_request
+    recurring_params = {
+      approval_code: '1234566',
+      stored_credential: {
+        reason_type: 'recurring',
+        initiator: 'merchant',
+        network_transaction_id: '010012130901291622040000047554200000000000155836402916121309|A7540295892588345510A'
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(recurring_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_ps2000_data>A7540295892588345510A<\/ssl_ps2000_data>/, data)
+      assert_match(/<ssl_oar_data>010012130901291622040000047554200000000000155836402916121309<\/ssl_oar_data>/, data)
+      assert_match(/<ssl_approval_code>1234566<\/ssl_approval_code>/, data)
+      assert_match(/<ssl_recurring_flag>1<\/ssl_recurring_flag>/, data)
+      refute_match(/<ssl_entry_mode/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_pass_in_installment_request
+    installment_params = {
+      installments: '4',
+      payment_number: '2',
+      approval_code: '1234566',
+      stored_credential: {
+        reason_type: 'installment',
+        initiator: 'merchant',
+        network_transaction_id: '010012130901291622040000047554200000000000155836402916121309|A7540295892588345510A'
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(installment_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_ps2000_data>A7540295892588345510A<\/ssl_ps2000_data>/, data)
+      assert_match(/<ssl_oar_data>010012130901291622040000047554200000000000155836402916121309<\/ssl_oar_data>/, data)
+      assert_match(/<ssl_approval_code>1234566<\/ssl_approval_code>/, data)
+      assert_match(/<ssl_recurring_flag>2<\/ssl_recurring_flag>/, data)
+      assert_match(/<ssl_payment_number>2<\/ssl_payment_number>/, data)
+      assert_match(/<ssl_payment_count>4<\/ssl_payment_count>/, data)
+      refute_match(/<ssl_entry_mode/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_pass_in_unscheduled_with_additional_data_request
+    unscheduled_params = {
+      approval_code: '1234566',
+      par_value: '1234567890',
+      association_token_data: '1',
+      stored_credential: {
+        reason_type: 'unscheduled',
+        initiator: 'merchant',
+        network_transaction_id: '010012130901291622040000047554200000000000155836402916121309|A7540295892588345510A'
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(unscheduled_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_ps2000_data>A7540295892588345510A<\/ssl_ps2000_data>/, data)
+      assert_match(/<ssl_oar_data>010012130901291622040000047554200000000000155836402916121309<\/ssl_oar_data>/, data)
+      assert_match(/<ssl_approval_code>1234566<\/ssl_approval_code>/, data)
+      assert_match(/<ssl_merchant_initiated_unscheduled>Y<\/ssl_merchant_initiated_unscheduled>/, data)
+      assert_match(/<ssl_entry_mode>12<\/ssl_entry_mode>/, data)
+      assert_match(/<ssl_par_value>1234567890<\/ssl_par_value>/, data)
+      assert_match(/<ssl_association_token_data>1<\/ssl_association_token_data>/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_tokenized_card_initial_recurring_request
+    recurring_params = {
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring',
+        initiator: 'cardholder',
+        network_transaction_id: nil
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @stored_card, @options.merge(recurring_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_recurring_flag>1<\/ssl_recurring_flag>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
+      refute_match(/<ssl_oar_data/, data)
+      refute_match(/<ssl_approval_code/, data)
+      refute_match(/<ssl_entry_mode/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_tokenized_card_recurring_request
+    recurring_params = {
+      stored_credential: {
+        reason_type: 'recurring',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @stored_card, @options.merge(recurring_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_recurring_flag>1<\/ssl_recurring_flag>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
+      refute_match(/<ssl_oar_data/, data)
+      refute_match(/<ssl_approval_code/, data)
+      refute_match(/<ssl_entry_mode/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_tokenized_card_installment_request
+    installment_params = {
+      installments: '4',
+      payment_number: '2',
+      stored_credential: {
+        reason_type: 'installment',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @stored_card, @options.merge(installment_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_recurring_flag>2<\/ssl_recurring_flag>/, data)
+      assert_match(/<ssl_payment_number>2<\/ssl_payment_number>/, data)
+      assert_match(/<ssl_payment_count>4<\/ssl_payment_count>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
+      refute_match(/<ssl_oar_data/, data)
+      refute_match(/<ssl_approval_code/, data)
+      refute_match(/<ssl_entry_mode/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_tokenized_card_unscheduled_with_additional_data_request
+    unscheduled_params = {
+      par_value: '1234567890',
+      association_token_data: '1',
+      stored_credential: {
+        reason_type: 'unscheduled',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @stored_card, @options.merge(unscheduled_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_merchant_initiated_unscheduled>Y<\/ssl_merchant_initiated_unscheduled>/, data)
+      assert_match(/<ssl_par_value>1234567890<\/ssl_par_value>/, data)
+      assert_match(/<ssl_association_token_data>1<\/ssl_association_token_data>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
+      refute_match(/<ssl_oar_data/, data)
+      refute_match(/<ssl_approval_code/, data)
+      refute_match(/<ssl_entry_mode/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_manual_token_recurring_request
+    recurring_params = {
+      ssl_token: '4421912014039990',
+      stored_credential: {
+        reason_type: 'recurring',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(recurring_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_recurring_flag>1<\/ssl_recurring_flag>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
+      refute_match(/<ssl_oar_data/, data)
+      refute_match(/<ssl_approval_code/, data)
+      refute_match(/<ssl_entry_mode/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_manual_token_installment_request
+    installment_params = {
+      ssl_token: '4421912014039990',
+      installments: '4',
+      payment_number: '2',
+      stored_credential: {
+        reason_type: 'installment',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(installment_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_recurring_flag>2<\/ssl_recurring_flag>/, data)
+      assert_match(/<ssl_payment_number>2<\/ssl_payment_number>/, data)
+      assert_match(/<ssl_payment_count>4<\/ssl_payment_count>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
+      refute_match(/<ssl_oar_data/, data)
+      refute_match(/<ssl_approval_code/, data)
+      refute_match(/<ssl_entry_mode/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_stored_credential_manual_token_unscheduled_with_additional_data_request
+    unscheduled_params = {
+      ssl_token: '4421912014039990',
+      par_value: '1234567890',
+      association_token_data: '1',
+      stored_credential: {
+        reason_type: 'unscheduled',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    }
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(unscheduled_params))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_merchant_initiated_unscheduled>Y<\/ssl_merchant_initiated_unscheduled>/, data)
+      assert_match(/<ssl_par_value>1234567890<\/ssl_par_value>/, data)
+      assert_match(/<ssl_association_token_data>1<\/ssl_association_token_data>/, data)
+      refute_match(/<ssl_ps2000_data/, data)
+      refute_match(/<ssl_oar_data/, data)
+      refute_match(/<ssl_approval_code/, data)
+      refute_match(/<ssl_entry_mode/, data)
+      refute_match(/<ssl_cvv2cvc2/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
To satisfy new Elavon API requirements, including recurring_flag, approval_code for non-tokenized PMs, installment_count and _number, and situational par_value and association_token_data fields.

This also now allows Authorize transactions with a token/stored card.

Remote (Same 5 Failures on Master):
39 tests, 162 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 87.1795% passed

Unit:
53 tests, 298 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed