### PR TITLE
GlobalCollect: Remove decrypted payment data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -120,6 +120,7 @@
 * Braintree: Surface the paypal_details in response object [yunnydang] #5043
 * Worldline (formerly GlobalCollect): Update API endpoints [deemeyers] #5049
 * Quickbooks: Update scrub method [almalee24] #5049
+*  Worldline (formerly GlobalCollect):Remove decrypted payment data [almalee24] #5032
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -629,7 +629,7 @@ module ActiveMerchant #:nodoc:
 
         paypal_details = {
           'payer_id'            => transaction.paypal_details.payer_id,
-          'payer_email'         => transaction.paypal_details.payer_email,
+          'payer_email'         => transaction.paypal_details.payer_email
         }
 
         if transaction.risk_data

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -696,7 +696,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(method, url, parameters = nil, options = {})
-
         add_expand_parameters(parameters, options) if parameters
 
         return Response.new(false, 'Invalid API Key provided') unless key_valid?(options)

--- a/test/remote/gateways/remote_global_collect_test.rb
+++ b/test/remote/gateways/remote_global_collect_test.rb
@@ -27,21 +27,10 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
       source: :apple_pay
     )
 
-    @google_pay = network_tokenization_credit_card(
-      '4567350000427977',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      month: '01',
-      year: Time.new.year + 2,
+    @google_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       source: :google_pay,
-      transaction_id: '123456789',
-      eci: '05'
-    )
-
-    @google_pay_pan_only = credit_card(
-      '4567350000427977',
-      month: '01',
-      year: Time.new.year + 2
-    )
+      payment_data: "{ 'version': 'EC_v1', 'data': 'QlzLxRFnNP9/GTaMhBwgmZ2ywntbr9'}"
+    })
 
     @accepted_amount = 4005
     @rejected_amount = 2997
@@ -131,29 +120,10 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
     assert_equal 'Succeeded', capture.message
   end
 
-  def test_successful_purchase_with_google_pay
+  def test_failed_purchase_with_google_pay
     options = @preprod_options.merge(requires_approval: false)
-    response = @gateway_preprod.purchase(4500, @google_pay, options)
-    assert_success response
-    assert_equal 'Succeeded', response.message
-    assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
-  end
-
-  def test_successful_purchase_with_google_pay_pan_only
-    options = @preprod_options.merge(requires_approval: false, customer: 'GP1234ID', google_pay_pan_only: true)
-    response = @gateway_preprod.purchase(4500, @google_pay_pan_only, options)
-
-    assert_success response
-    assert_equal 'Succeeded', response.message
-    assert_equal 'CAPTURE_REQUESTED', response.params['payment']['status']
-  end
-
-  def test_unsuccessful_purchase_with_google_pay_pan_only
-    options = @preprod_options.merge(requires_approval: false, google_pay_pan_only: true, customer: '')
-    response = @gateway_preprod.purchase(4500, @google_pay_pan_only, options)
-
+    response = @gateway_direct.purchase(4500, @google_pay, options)
     assert_failure response
-    assert_equal 'order.customer.merchantCustomerId is missing for UCOF', response.message
   end
 
   def test_successful_purchase_with_fraud_fields
@@ -618,16 +588,6 @@ class RemoteGlobalCollectTest < Test::Unit::TestCase
 
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@gateway.options[:secret_api_key], transcript)
-  end
-
-  def test_scrub_google_payment
-    options = @preprod_options.merge(requires_approval: false)
-    transcript = capture_transcript(@gateway) do
-      @gateway_preprod.purchase(@amount, @google_pay, options)
-    end
-    transcript = @gateway.scrub(transcript)
-    assert_scrubbed(@google_pay.payment_cryptogram, transcript)
-    assert_scrubbed(@google_pay.number, transcript)
   end
 
   def test_scrub_apple_payment

--- a/test/unit/gateways/global_collect_test.rb
+++ b/test/unit/gateways/global_collect_test.rb
@@ -20,21 +20,10 @@ class GlobalCollectTest < Test::Unit::TestCase
       source: :apple_pay
     )
 
-    @google_pay_network_token = network_tokenization_credit_card(
-      '4444333322221111',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      month: '01',
-      year: Time.new.year + 2,
+    @google_pay_network_token = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
       source: :google_pay,
-      transaction_id: '123456789',
-      eci: '05'
-    )
-
-    @google_pay_pan_only = credit_card(
-      '4444333322221111',
-      month: '01',
-      year: Time.new.year + 2
-    )
+      payment_data: "{ 'version': 'EC_v1', 'data': 'QlzLxRFnNP9/GTaMhBwgmZ2ywntbr9'}"
+    })
 
     @declined_card = credit_card('5424180279791732')
     @accepted_amount = 4005
@@ -121,14 +110,6 @@ class GlobalCollectTest < Test::Unit::TestCase
     end
   end
 
-  def test_purchase_request_with_google_pay_pan_only
-    stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@accepted_amount, @google_pay_pan_only, @options.merge(customer: 'GP1234ID', google_pay_pan_only: true))
-    end.check_request(skip_response: true) do |_method, _endpoint, data, _headers|
-      assert_equal '320', JSON.parse(data)['mobilePaymentMethodSpecificInput']['paymentProductId']
-    end
-  end
-
   def test_add_payment_for_credit_card
     post = {}
     options = {}
@@ -150,26 +131,7 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_includes post.keys.first, 'mobilePaymentMethodSpecificInput'
     assert_equal post['mobilePaymentMethodSpecificInput']['paymentProductId'], '320'
     assert_equal post['mobilePaymentMethodSpecificInput']['authorizationMode'], 'FINAL_AUTHORIZATION'
-    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['dpan'], '4444333322221111'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['cryptogram'], 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['eci'], '05'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], "01#{payment.year.to_s[-2..-1]}"
-    assert_equal 'TOKENIZED_CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
-  end
-
-  def test_add_payment_for_google_pay_pan_only
-    post = {}
-    options = { google_pay_pan_only: true }
-    payment = @google_pay_pan_only
-    @gateway.send('add_payment', post, payment, options)
-    assert_includes post.keys.first, 'mobilePaymentMethodSpecificInput'
-    assert_equal post['mobilePaymentMethodSpecificInput']['paymentProductId'], '320'
-    assert_equal post['mobilePaymentMethodSpecificInput']['authorizationMode'], 'FINAL_AUTHORIZATION'
-    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['pan'], '4444333322221111'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], "01#{payment.year.to_s[-2..-1]}"
-    assert_equal 'CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
+    assert_equal post['mobilePaymentMethodSpecificInput']['encryptedPaymentData'], @google_pay_network_token.payment_data
   end
 
   def test_add_payment_for_apple_pay
@@ -185,47 +147,6 @@ class GlobalCollectTest < Test::Unit::TestCase
     assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['cryptogram'], 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['eci'], '05'
     assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate'], '1024'
-  end
-
-  def test_add_decrypted_data_google_pay_pan_only
-    post = { 'mobilePaymentMethodSpecificInput' => {} }
-    payment = @google_pay_pan_only
-    options = { google_pay_pan_only: true }
-    expirydate = '0124'
-
-    @gateway.send('add_decrypted_payment_data', post, payment, options, expirydate)
-    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['pan'], '4444333322221111'
-    assert_equal 'CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
-  end
-
-  def test_add_decrypted_data_for_google_pay
-    post = { 'mobilePaymentMethodSpecificInput' => {} }
-    payment = @google_pay_network_token
-    options = {}
-    expirydate = '0124'
-
-    @gateway.send('add_decrypted_payment_data', post, payment, options, expirydate)
-    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['cryptogram'], 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['eci'], '05'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['dpan'], '4444333322221111'
-    assert_equal 'TOKENIZED_CARD', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['paymentMethod']
-    assert_equal '0124', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate']
-  end
-
-  def test_add_decrypted_data_for_apple_pay
-    post = { 'mobilePaymentMethodSpecificInput' => {} }
-    payment = @google_pay_network_token
-    options = {}
-    expirydate = '0124'
-
-    @gateway.send('add_decrypted_payment_data', post, payment, options, expirydate)
-    assert_includes post['mobilePaymentMethodSpecificInput'].keys, 'decryptedPaymentData'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['cryptogram'], 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['eci'], '05'
-    assert_equal post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['dpan'], '4444333322221111'
-    assert_equal '0124', post['mobilePaymentMethodSpecificInput']['decryptedPaymentData']['expiryDate']
   end
 
   def test_purchase_request_with_apple_pay

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -237,7 +237,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).returns(failed_verify_response)
 
     assert create = @gateway.verify(@credit_card)
-    assert_equal "seti_nhtadoeunhtaobjntaheodu", create.authorization
+    assert_equal 'seti_nhtadoeunhtaobjntaheodu', create.authorization
   end
 
   def test_connected_account


### PR DESCRIPTION
Remove support for GooglePay decrypted payment data since they only support encrypted payment data.

Unit:
40 tests, 197 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed