### PR TITLE
Quickbooks: Update scrubbing logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -116,6 +116,7 @@
 * GlobalCollect: Add support for encryptedPaymentData [almalee24] #5015
 * Rapyd: Adding 500 errors handling [Heavyblade] #5029
 * SumUp: Add 3DS fields [sinourain] #5030
+* Quickbooks: Update scrubbing logic [almalee24] #5033
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/quickbooks.rb
+++ b/lib/active_merchant/billing/gateways/quickbooks.rb
@@ -128,8 +128,8 @@ module ActiveMerchant #:nodoc:
           gsub(%r((oauth_nonce=\")\w+), '\1[FILTERED]').
           gsub(%r((oauth_signature=\")[a-zA-Z%0-9]+), '\1[FILTERED]').
           gsub(%r((oauth_token=\")\w+), '\1[FILTERED]').
-          gsub(%r((number\D+)\d{16}), '\1[FILTERED]').
-          gsub(%r((cvc\D+)\d{3}), '\1[FILTERED]').
+          gsub(%r((number\D+)\d+), '\1[FILTERED]').
+          gsub(%r((cvc\D+)\d+), '\1[FILTERED]').
           gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
           gsub(%r((access_token\\?":\\?")[\w\-\.]+)i, '\1[FILTERED]').
           gsub(%r((refresh_token\\?":\\?")\w+), '\1[FILTERED]').

--- a/test/remote/gateways/remote_quickbooks_test.rb
+++ b/test/remote/gateways/remote_quickbooks_test.rb
@@ -16,6 +16,12 @@ class RemoteTest < Test::Unit::TestCase
                                  state: 'CA' }),
       description: 'Store Purchase'
     }
+
+    @amex = credit_card(
+      '378282246310005',
+      verification_value: '1234',
+      brand: 'american_express'
+    )
   end
 
   def test_successful_purchase
@@ -124,6 +130,18 @@ class RemoteTest < Test::Unit::TestCase
 
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:access_token], transcript)
+    assert_scrubbed(@gateway.options[:refresh_token], transcript)
+  end
+
+  def test_transcript_scrubbing_for_amex
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @amex, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@amex.number, transcript)
+    assert_scrubbed(@amex.verification_value, transcript)
     assert_scrubbed(@gateway.options[:access_token], transcript)
     assert_scrubbed(@gateway.options[:refresh_token], transcript)
   end

--- a/test/unit/gateways/quickbooks_test.rb
+++ b/test/unit/gateways/quickbooks_test.rb
@@ -183,6 +183,10 @@ class QuickBooksTest < Test::Unit::TestCase
     assert_equal @oauth_1_gateway.scrub(pre_scrubbed_small_json), post_scrubbed_small_json
   end
 
+  def test_scrub_amex_credit_cards
+    assert_equal @oauth_1_gateway.scrub(pre_scrubbed_small_json('376414000000009', '1234')), post_scrubbed_small_json
+  end
+
   def test_default_context
     [@oauth_1_gateway, @oauth_2_gateway].each do |gateway|
       stub_comms(gateway) do
@@ -258,8 +262,8 @@ class QuickBooksTest < Test::Unit::TestCase
 
   private
 
-  def pre_scrubbed_small_json
-    "intuit.com\\r\\nContent-Length: 258\\r\\n\\r\\n\"\n<- \"{\\\"amount\\\":\\\"34.50\\\",\\\"currency\\\":\\\"USD\\\",\\\"card\\\":{\\\"number\\\":\\\"4111111111111111\\\",\\\"expMonth\\\":\\\"09\\\",\\\"expYear\\\":2016,\\\"cvc\\\":\\\"123\\\",\\\"name\\\":\\\"Bob Bobson\\\",\\\"address\\\":{\\\"streetAddress\\\":null,\\\"city\\\":\\\"Los Santos\\\",\\\"region\\\":\\\"CA\\\",\\\"country\\\":\\\"US\\\",\\\"postalCode\\\":\\\"90210\\\"}},\\\"capture\\\":\\\"true\\\"}\"\n-> \"HTTP/1.1 201 Created\\r\\n\"\n-> \"Date: Tue, 03 Mar 2015 20:00:35 GMT\\r\\n\"\n-> \"Content-Type: "
+  def pre_scrubbed_small_json(number = '4111111111111111', cvc = '123')
+    "intuit.com\\r\\nContent-Length: 258\\r\\n\\r\\n\"\n<- \"{\\\"amount\\\":\\\"34.50\\\",\\\"currency\\\":\\\"USD\\\",\\\"card\\\":{\\\"number\\\":\\\"#{number}\\\",\\\"expMonth\\\":\\\"09\\\",\\\"expYear\\\":2016,\\\"cvc\\\":\\\"#{cvc}\\\",\\\"name\\\":\\\"Bob Bobson\\\",\\\"address\\\":{\\\"streetAddress\\\":null,\\\"city\\\":\\\"Los Santos\\\",\\\"region\\\":\\\"CA\\\",\\\"country\\\":\\\"US\\\",\\\"postalCode\\\":\\\"90210\\\"}},\\\"capture\\\":\\\"true\\\"}\"\n-> \"HTTP/1.1 201 Created\\r\\n\"\n-> \"Date: Tue, 03 Mar 2015 20:00:35 GMT\\r\\n\"\n-> \"Content-Type: "
   end
 
   def post_scrubbed_small_json


### PR DESCRIPTION
Update quickbooks scrubbing to include card lengths from 13-19 digits. Update quickbooks scrubbing to include cvc codes from 3-4 digits long.

Remote:
19 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
23 tests, 120 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed