### PR TITLE
Cecabank: Enable network_transaction_id as GSF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -116,6 +116,7 @@
 * GlobalCollect: Add support for encryptedPaymentData [almalee24] #5015
 * Rapyd: Adding 500 errors handling [Heavyblade] #5029
 * SumUp: Add 3DS fields [sinourain] #5030
+* Cecabank: Enable network_transaction_id as GSF [javierpedrozaing] #5034
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/cecabank/cecabank_json.rb
+++ b/lib/active_merchant/billing/gateways/cecabank/cecabank_json.rb
@@ -191,7 +191,8 @@ module ActiveMerchant
           params[:frecRec] = options[:recurring_frequency]
         end
 
-        params[:mmppTxId] = stored_credential[:network_transaction_id] if stored_credential[:network_transaction_id]
+        network_transaction_id = options[:network_transaction_id].present? ? options[:network_transaction_id] : stored_credential[:network_transaction_id]
+        params[:mmppTxId] = network_transaction_id unless network_transaction_id.blank?
       end
 
       def add_three_d_secure(post, options)

--- a/test/remote/gateways/remote_cecabank_rest_json_test.rb
+++ b/test/remote/gateways/remote_cecabank_rest_json_test.rb
@@ -109,6 +109,12 @@ class RemoteCecabankTest < Test::Unit::TestCase
     assert_success purchase
   end
 
+  def test_purchase_stored_credential_with_network_transaction_id
+    @cit_options.merge!({ network_transaction_id: '999999999999999' })
+    assert purchase = @gateway.purchase(@amount, @credit_card, @cit_options)
+    assert_success purchase
+  end
+
   def test_purchase_using_auth_capture_and_stored_credential_cit
     assert authorize = @gateway.authorize(@amount, @credit_card, @cit_options)
     assert_success authorize

--- a/test/unit/gateways/cecabank_rest_json_test.rb
+++ b/test/unit/gateways/cecabank_rest_json_test.rb
@@ -78,6 +78,17 @@ class CecabankJsonTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_stored_credentials_with_network_transaction_id_as_gsf
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    @options.merge!({ network_transaction_id: '12345678901234567890' })
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_instance_of Response, response
+    assert_success response
+    assert_equal '12004172192310181720006007000#1#100', response.authorization
+    assert response.test?
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_request).returns(failed_purchase_response)
     response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
Description
-------------------------
[SER-1084](https://spreedly.atlassian.net/browse/SER-1084)

This commit enables the use of a GSF for network_transaction_id
Additionally, it adds small fix for some remote tests.

Unit test
-------------------------
Finished in 0.032086 seconds.

15 tests, 78 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

100% passed

Remote test
-------------------------
Finished in 27.137734 seconds.

17 tests, 61 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 94.1176% passed

0.63 tests/s, 2.25 assertions/s

Rubocop
-------------------------
787 files inspected, no offenses detected