### PR TITLE
Allow UCAFInd to be overridden in Orbital gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -725,9 +725,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_mc_ucafind(xml, credit_card, three_d_secure)
-        return unless three_d_secure
-
-        xml.tag! :UCAFInd, '4'
+        # for backwards-compatibility, we default to '4' if not specified in the options
+        return unless three_d_secure && (ucafind = three_d_secure.fetch(:ucaf_collection_ind, '4'))
+        xml.tag! :UCAFInd, ucafind
       end
 
       #=====SCA (STORED CREDENTIAL) FIELDS=====

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -303,7 +303,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
-  def test_three_d_secure_data_on_master_purchase
+  def test_three_d_secure_data_on_master_purchase_with_default_ucafind
     stub_comms do
       @gateway.purchase(50, credit_card(nil, brand: 'master'), @options.merge(@three_d_secure_options))
     end.check_request do |_endpoint, data, _headers|
@@ -312,6 +312,26 @@ class OrbitalGatewayTest < Test::Unit::TestCase
       assert_match %{<MCProgramProtocol>2</MCProgramProtocol>}, data
       assert_match %{<MCDirectoryTransID>97267598FAE648F28083C23433990FBC</MCDirectoryTransID>}, data
       assert_match %{<UCAFInd>4</UCAFInd>}, data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_three_d_secure_data_on_master_purchase_with_custom_ucafind
+    options = @options.merge(@three_d_secure_options)
+    options[:three_d_secure].merge!(ucaf_collection_ind: '5')
+    stub_comms do
+      @gateway.purchase(50, credit_card(nil, brand: 'master'), options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %{<UCAFInd>5</UCAFInd>}, data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_three_d_secure_data_on_master_purchase_with_nil_ucafind
+    options = @options.merge(@three_d_secure_options)
+    options[:three_d_secure].merge!(ucaf_collection_ind: nil)
+    stub_comms do
+      @gateway.purchase(50, credit_card(nil, brand: 'master'), options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_no_match(/\<UCAFInd/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
UCAFInd is always set to '4' in the Orbital gateway currently, but the documentation allows for other values too. I noticed @cgriego also created PR #3369 to support other values than '4' among other changes.

This third PR is the latest of the PRs I prepared for the Orbital gateway at the moment. If we can get those 3 PRs approved, we would be able to switch from our fork and use mainstream activemerchant.

Would you mind reviewing those PRs?

If you think we shouldn't default to '4' and break backwards compatibility, just let me know and I'll gladly update the PR.