### PR TITLE
Braintree: Surface the paypal_details in response object

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -117,6 +117,7 @@
 * Rapyd: Adding 500 errors handling [Heavyblade] #5029
 * SumUp: Add 3DS fields [sinourain] #5030
 * Cecabank: Enable network_transaction_id as GSF [javierpedrozaing] #5034
+* Braintree: Surface the paypal_details in response object [yunnydang] #5043
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -627,6 +627,11 @@ module ActiveMerchant #:nodoc:
           'issuing_bank'        => transaction.apple_pay_details.issuing_bank
         }
 
+        paypal_details = {
+          'payer_id'            => transaction.paypal_details.payer_id,
+          'payer_email'         => transaction.paypal_details.payer_email,
+        }
+
         if transaction.risk_data
           risk_data = {
             'id'                      => transaction.risk_data.id,
@@ -654,6 +659,7 @@ module ActiveMerchant #:nodoc:
           'network_token_details'        => network_token_details,
           'apple_pay_details'            => apple_pay_details,
           'google_pay_details'           => google_pay_details,
+          'paypal_details'               => paypal_details,
           'customer_details'             => customer_details,
           'billing_details'              => billing_details,
           'shipping_details'             => shipping_details,

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1274,6 +1274,15 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_not_nil response.params['braintree_transaction']['processor_authorization_code']
   end
 
+  def test_successful_purchase_and_return_paypal_details_object
+    @non_payal_link_gateway = BraintreeGateway.new(fixtures(:braintree_blue_non_linked_paypal))
+    assert response = @non_payal_link_gateway.purchase(400000, 'fake-paypal-one-time-nonce', @options.merge(payment_method_nonce: 'fake-paypal-one-time-nonce'))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+    assert_equal 'paypal_payer_id', response.params['braintree_transaction']['paypal_details']['payer_id']
+    assert_equal 'payer@example.com', response.params['braintree_transaction']['paypal_details']['payer_email']
+  end
+
   def test_successful_credit_card_purchase_with_prepaid_debit_issuing_bank
     assert response = @gateway.purchase(@amount, @credit_card)
     assert_success response


### PR DESCRIPTION
This returns the paypal_details in the response object on paypal transaction so that we can surface the payer_id and payer_email fields for Braintree. 

Note: The remote test written requires a separate fixtures set.

Local:
5813 tests, 78910 assertions, 2 failures, 26 errors, 0 pendings, 0 omissions, 0 notifications
99.5183% passed

Unit:
103 tests, 218 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
116 tests, 607 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.2759% passed