### PR TITLE
Shift4: Add support for avs_result

### DIFF
--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -247,6 +247,7 @@ module ActiveMerchant #:nodoc:
           message_from(action, response),
           response,
           authorization: authorization_from(action, response),
+          avs_result: avs_result_from(response),
           test: test?,
           error_code: error_code_from(action, response)
         )
@@ -283,6 +284,10 @@ module ActiveMerchant #:nodoc:
         else
           response['result'].first&.dig('transaction', 'responseCode')
         end
+      end
+
+      def avs_result_from(response)
+        AVSResult.new(code: response['result'].first&.dig('transaction', 'avs', 'result')) if response['result'].first&.dig('transaction', 'avs')
       end
 
       def authorization_from(action, response)

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -249,6 +249,8 @@ class Shift4Test < Test::Unit::TestCase
 
     assert_failure response
     assert_equal response.message, 'Transaction declined'
+    assert_equal 'A', response.avs_result['code']
+    assert_equal 'Street address matches, but postal code does not match.', response.avs_result['message']
     assert_nil response.authorization
   end
 
@@ -268,6 +270,17 @@ class Shift4Test < Test::Unit::TestCase
 
     assert_failure response
     assert_equal 'CVV value N not accepted.', response.message
+    assert response.test?
+  end
+
+  def test_successful_authorize_with_avs_result
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert_equal 'Y', response.avs_result['code']
+    assert_equal 'Street address and 5-digit postal code match.', response.avs_result['message']
     assert response.test?
   end
 
@@ -636,6 +649,12 @@ class Shift4Test < Test::Unit::TestCase
                 "transaction": {
                     "authorizationCode": "OK168Z",
                     "authSource": "E",
+                    "avs": {
+                      "postalCodeVerified":"Y",
+                      "result":"Y",
+                      "streetVerified":"Y",
+                      "valid":"Y"
+                      },
                     "invoice": "3333333309",
                     "purchaseCard": {
                         "customerReference": "457",
@@ -989,6 +1008,12 @@ class Shift4Test < Test::Unit::TestCase
             },
             "transaction": {
               "authSource":"E",
+              "avs": {
+                "postalCodeVerified":"N",
+                "result":"A",
+                "streetVerified":"Y",
+                "valid":"Y"
+                },
               "invoice":"0705626580",
               "responseCode":"D",
               "saleFlag":"S"


### PR DESCRIPTION
CER-1128

This adds support for avs_result in the gateway's response. The standard ActiveMerchant AVS mapping is used, but varies slightly from Shift4's AVS message language in their docs. This should be taken into consideration during review. No remote test was added because the avs hash is not returned in sandbox transactions. It is returned consistently in the same format in the `transaction` hash in production transcripts.

Unit:
28 tests, 176 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
29 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Local:
5814 tests, 79016 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 99.9656% passed