### PR TITLE
Stripe Payment Intents: Update expand latest_attempt on create_setup

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -579,7 +579,7 @@ module ActiveMerchant #:nodoc:
 
       def add_source_owner(post, creditcard, options)
         post[:owner] = {}
-        post[:owner][:name] = creditcard.name if creditcard.name
+        post[:owner][:name] = creditcard.name if creditcard.respond_to?(:name) && creditcard.name
         post[:owner][:email] = options[:email] if options[:email]
 
         if address = options[:billing_address] || options[:address]

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -705,7 +705,7 @@ module ActiveMerchant #:nodoc:
         success = success_from(response, options)
 
         card_checks = card_from_response(response)
-        avs_code = avs_code_from(card_checks)
+        avs_code = AVS_CODE_TRANSLATOR["line1: #{card_checks['address_line1_check']}, zip: #{card_checks['address_zip_check'] || card_checks['address_postal_code_check']}"]
         cvc_code = CVC_CODE_TRANSLATOR[card_checks['cvc_check']]
         Response.new(
           success,
@@ -791,12 +791,6 @@ module ActiveMerchant #:nodoc:
         response['card'] || response['active_card'] || response['source'] ||
           response.dig('charges', 'data', 0, 'payment_method_details', 'card', 'checks') ||
           response.dig('latest_attempt', 'payment_method_details', 'card', 'checks') || {}
-      end
-
-      def avs_code_from(card_checks)
-        return 'I' if card_checks['address_postal_code_check'].nil? && card_checks['address_line1_check'].nil? && card_checks['address_zip_check'].nil?
-
-        AVS_CODE_TRANSLATOR["line1: #{card_checks['address_line1_check']}, zip: #{card_checks['address_zip_check'] || card_checks['address_postal_code_check']}"]
       end
 
       def emv_authorization_from_response(response)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -790,7 +790,7 @@ module ActiveMerchant #:nodoc:
         # StripePI puts the AVS and CVC check significantly deeper into the response object
         response['card'] || response['active_card'] || response['source'] ||
           response.dig('charges', 'data', 0, 'payment_method_details', 'card', 'checks') ||
-          response.dig('latest_attempt', 'payment_method_details', 'card', 'checks') {}
+          response.dig('latest_attempt', 'payment_method_details', 'card', 'checks') || {}
       end
 
       def avs_code_from(card_checks)

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -145,6 +145,7 @@ module ActiveMerchant #:nodoc:
             post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
             post[:usage] = options[:usage] if %w(on_session off_session).include?(options[:usage])
             post[:description] = options[:description] if options[:description]
+            post[:expand] = ['latest_attempt']
 
             commit(:post, 'setup_intents', post, options)
           end

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1433,6 +1433,8 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert verify = @gateway.verify(@visa_card, options)
     assert_equal 'US', verify.responses[0].params.dig('card', 'country')
     assert_equal 'succeeded', verify.params['status']
+    assert_equal 'M', verify.cvv_result['code']
+    assert_equal 'I', verify.avs_result['code']
   end
 
   def test_failed_verify

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1434,7 +1434,6 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'US', verify.responses[0].params.dig('card', 'country')
     assert_equal 'succeeded', verify.params['status']
     assert_equal 'M', verify.cvv_result['code']
-    assert_equal 'I', verify.avs_result['code']
   end
 
   def test_failed_verify


### PR DESCRIPTION
Stripe Payment Intents: Update expand latest_attempt on create_setup_intent

This expansion allows a user to get the avs and cvc check results from the create_setup_intent call

[ECS-3375](https://spreedly.atlassian.net/browse/ECS-3375)