### PR TITLE
StripePI: Update authorization_from

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -121,6 +121,7 @@
 * Worldline (formerly GlobalCollect): Update API endpoints [deemeyers] #5049
 * Quickbooks: Update scrub method [almalee24] #5049
 *  Worldline (formerly GlobalCollect):Remove decrypted payment data [almalee24] #5032
+* StripePI: Update authorization_from [almalee24] #5048
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -733,7 +733,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(success, url, method, response)
-        return response.dig('error', 'charge') || response.dig('error', 'setup_intent', 'id') unless success
+        return response.dig('error', 'charge') || response.dig('error', 'setup_intent', 'id') || response['id'] unless success
 
         if url == 'customers'
           [response['id'], response.dig('sources', 'data').first&.dig('id')].join('|')

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -991,6 +991,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert response = @gateway.purchase(100, @three_ds_credit_card, options)
     assert_failure response
     assert_match 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.', response.message
+    assert_equal response.authorization, response.params['id']
   end
 
   def test_create_payment_intent_with_shipping_address


### PR DESCRIPTION
If the transaction fails with 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.' then authorization_from should return response['id']

Unit
59 tests, 308 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote
95 tests, 451 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed