### PR TITLE
Braintree Blue: Refactor and add payment details to failed transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -123,6 +123,7 @@
 * Worldline (formerly GlobalCollect):Remove decrypted payment data [almalee24] #5032
 * StripePI: Update authorization_from [almalee24] #5048
 * FirstPay: Add REST JSON transaction methods [sinourain] #5035
+* Braintree: Add payment details to failed transaction hash [yunnydang] #5050
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827


### PR DESCRIPTION
This refactors a slight portion of the transaction hash regarding the payment details object that is being returned depending on which payment method is used. Also returns the these objects on failing transactions and added small fixes to previously failing tests. Also fixes some rubocop related issues.

Local:
5816 tests, 78913 assertions, 2 failures, 30 errors, 0 pendings, 0 omissions, 0 notifications
99.4498% passed

Unit:
103 tests, 218 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
120 tests, 634 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
