### PR TITLE
Adyen: Update failed for network token cryptogram

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -134,6 +134,7 @@
 * CyberSource: Extend support for `gratuity_amount` and update Mastercard NT field order [rachelkirk] #5063
 * XPay: Refactor basic transactions after implement 3DS 3steps API [sinourain] #5058
 * AuthorizeNet: Remove turn_on_nt flow [almalee24] #5056
+* Adyen: Update cryptogram field for NTs [almalee24] #5055
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -194,7 +194,8 @@ module ActiveMerchant #:nodoc:
           gsub(%r(("cavv\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
           gsub(%r(("bankLocationId\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
           gsub(%r(("iban\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
-          gsub(%r(("bankAccountNumber\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]')
+          gsub(%r(("bankAccountNumber\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
+          gsub(%r(("tokenAuthenticationVerificationValue\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]')
       end
 
       private
@@ -622,9 +623,11 @@ module ActiveMerchant #:nodoc:
 
         post[:mpiData] = {}
         post[:mpiData][:authenticationResponse] = 'Y'
-        post[:mpiData][:cavv] = payment.payment_cryptogram
         post[:mpiData][:directoryResponse] = 'Y'
         post[:mpiData][:eci] = payment.eci || '07'
+
+        cryptogram_field = payment.source == :network_token ? :tokenAuthenticationVerificationValue : :cavv
+        post[:mpiData][cryptogram_field] = payment.payment_cryptogram
       end
 
       def add_recurring_contract(post, options = {})

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -1226,9 +1226,14 @@ class AdyenTest < Test::Unit::TestCase
   end
 
   def test_authorize_with_network_token
-    @gateway.expects(:ssl_post).returns(successful_authorize_response)
+    response = stub_comms do
+      @gateway.authorize(@amount, @nt_credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      parsed = JSON.parse(data)
+      assert_equal 'EHuWW9PiBkWvqE5juRwDzAUFBAk=', parsed['mpiData']['tokenAuthenticationVerificationValue']
+      assert_equal '07', parsed['mpiData']['eci']
+    end.respond_with(successful_authorize_response)
 
-    response = @gateway.authorize(@amount, @nt_credit_card, @options)
     assert_success response
   end
 


### PR DESCRIPTION
For v68 and later the network token cryptogram needs to be sent to mpi.tokenAuthenticationVerificationValue

Remote:
143 tests, 463 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.3077% passed

Unit:
116 tests, 613 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed