### PR TITLE
AuthorizeNet: Remove turn_on_nt_flow

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -133,6 +133,7 @@
 * Paymentez: Update field for reference_id [almalee24] #5065
 * CyberSource: Extend support for `gratuity_amount` and update Mastercard NT field order [rachelkirk] #5063
 * XPay: Refactor basic transactions after implement 3DS 3steps API [sinourain] #5058
+* AuthorizeNet: Remove turn_on_nt flow [almalee24] #5056
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -426,7 +426,7 @@ module ActiveMerchant
       end
 
       def network_token?(payment_method, options, action)
-        payment_method.class == NetworkTokenizationCreditCard && action != :credit && options[:turn_on_nt_flow]
+        payment_method.class == NetworkTokenizationCreditCard && action != :credit
       end
 
       def camel_case_lower(key)
@@ -507,7 +507,6 @@ module ActiveMerchant
               xml.cardNumber(truncate(credit_card.number, 16))
               xml.expirationDate(format(credit_card.month, :two_digits) + '/' + format(credit_card.year, :four_digits))
               xml.cardCode(credit_card.verification_value) if credit_card.valid_card_verification_value?(credit_card.verification_value, credit_card.brand)
-              xml.cryptogram(credit_card.payment_cryptogram) if credit_card.is_a?(NetworkTokenizationCreditCard) && action != :credit
             end
           end
         end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -69,7 +69,7 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_google_pay
     @payment_token.source = :google_pay
-    response = @gateway.purchase(@amount, @payment_token, @options.merge(turn_on_nt_flow: true))
+    response = @gateway.purchase(@amount, @payment_token, @options)
 
     assert_success response
     assert response.test?
@@ -78,16 +78,6 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_apple_pay
-    @payment_token.source = :apple_pay
-    response = @gateway.purchase(@amount, @payment_token, @options.merge(turn_on_nt_flow: true))
-
-    assert_success response
-    assert response.test?
-    assert_equal 'This transaction has been approved', response.message
-    assert response.authorization
-  end
-
-  def test_successful_purchase_with_apple_pay_without_turn_on_nt_flow_field
     @payment_token.source = :apple_pay
     response = @gateway.purchase(@amount, @payment_token, @options)
 

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -271,8 +271,8 @@ class AuthorizeNetTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @payment_token)
     end.check_request do |_endpoint, data, _headers|
-      assert_no_match(/<isPaymentToken>true<\/isPaymentToken>/, data)
-      assert_match(/<cardCode>/, data)
+      assert_match(/<isPaymentToken>true<\/isPaymentToken>/, data)
+      assert_no_match(/<cardCode>/, data)
     end.respond_with(successful_authorize_response)
 
     assert response
@@ -283,7 +283,7 @@ class AuthorizeNetTest < Test::Unit::TestCase
 
   def test_successful_apple_pay_purchase
     response = stub_comms do
-      @gateway.purchase(@amount, @payment_token, { turn_on_nt_flow: true })
+      @gateway.purchase(@amount, @payment_token, {})
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<isPaymentToken>true<\/isPaymentToken>/, data)
       assert_no_match(/<cardCode>/, data)


### PR DESCRIPTION
Remove turn_on_nt_flow so that all network tokens
such as ApplePay fall done to dd_network_token method Unit:
122 tests, 688 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
85 tests, 304 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed