### PR TITLE
PlaceToPay: Add gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/place_to_pay.rb
+++ b/lib/active_merchant/billing/gateways/place_to_pay.rb
@@ -1,0 +1,228 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PlaceToPayGateway < Gateway
+      self.test_url = 'https://api-co-dev.placetopay.ws/'
+      self.live_url = 'https://api-co.placetopay.ws/'
+
+      self.default_currency = 'COP'
+
+      self.supported_countries = ['COL']
+      self.supported_cardtypes = %i[visa master american_express discover]
+      self.homepage_url = 'https://www.placetopay.com/'
+      self.display_name = 'PlaceToPay'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        '401' => STANDARD_ERROR_CODE[:processing_error]
+      }
+
+      ISO_FORMAT_DATE = '%Y-%m-%dT%H:%M:%S%:z'
+
+      def initialize(options = {})      
+        requires!(options, :login, :secret_key)
+        @login, @secret_key = options.values_at(:login, :secret_key)
+        super
+      end 
+
+      def purchase(money, payment, options = {})
+        post = {}
+        add_auth(post, options)
+        add_payer(post, options)
+        add_payment(post, options)
+
+        if(options[:use3ds])
+          _3dsResponse = add_3d_secure(post, payment, options)
+
+          options[:identifier] = JSON.parse(_3dsResponse.params.to_json, object_class: OpenStruct).data.identifier;
+          options[:sessionToken] = JSON.parse(_3dsResponse.params.to_json, object_class: OpenStruct).data.sessionToken;  
+        end
+
+        add_instrument(post, payment, options)
+        commit(:post, 'gateway/process', post)
+      end
+
+      def capture(money, authorization, options = {})
+        post = {}
+        add_auth(post, options)
+        post[:internalReference] = options[:internalReference]
+        post[:authorization] = authorization
+        post[:action] = 'checkout'
+        commit(:post, 'gateway/transaction', post)        
+      end   
+
+      def refund(money, authorization, options = {})
+        post = {}
+        add_auth(post, options)
+        post[:internalReference] = options[:internalReference]
+        post[:authorization] = authorization                
+        post[:action] = 'reverse'
+        commit(:post, 'gateway/transaction', post)
+      end
+
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+        gsub(%r(("tranKey\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
+        gsub(/(number\\?":\\?")(\d*)/, '\1[FILTERED]').
+        gsub(/(cvv\\?":\\?")(\d*)/, '\1[FILTERED]')
+      end
+
+      private
+
+      def add_invoice(post, money, options)
+        post[:amount] = amount(money)
+        post[:currency] = (options[:currency] || currency(money))
+      end
+
+      def build_url(action, base)
+        url = base
+        url += action
+        url
+      end
+
+      def commit(method, action, parameters)
+        base_url = (test? ? test_url : live_url)
+        url = build_url(action, base_url)
+
+        begin
+          url = (test? ? test_url : live_url) + action.to_s
+          rel_path = "#{method}/v1/#{action}"
+          response = api_request(method, url, rel_path, parameters)
+
+        rescue ResponseError => e
+          raw_response = e.response.body
+          response = parse(raw_response)
+        end
+
+        Response.new(
+          success_from(action, response, options),
+          message_from(response),
+          response,
+          test: test?,
+          error_code: error_code_from(action, response, options),
+          authorization: authorization_from(response),
+          network_transaction_id: response['internalReference'],
+        )
+      end
+
+
+      def success_from(action, response, options)
+        case action
+        when :authonly.to_s, :lookup.to_s, :mpiQuery.to_s, :interests.to_s, :generate_otp.to_s,
+          :validate_otp.to_s, :capture.to_s, :search.to_s
+          return response['status'] && response['status']['status'] === RESPONSES_STATUS[:ok]
+        when :sale.to_s, :query_transaction.to_s, :refund.to_s
+          return response['status'] && response['status']['status'] === RESPONSES_STATUS[:approved]
+        else
+          return response['status']['status'];
+        end
+      end
+
+      def message_from(response)
+        response['status'] && response['status']['message'] ? response['status']['message'] :
+          COMMON_MESSAGES[:missed]
+      end
+
+      def authorization_from(response); 
+        return response['authorization']
+      end
+
+      def post_data(action, parameters = {})
+        JSON.generate(parameters)
+      end
+
+      def error_code_from(action, response, options)
+        unless success_from(action, response, options)
+          STANDARD_ERROR_CODE_MAPPING[response['reason']]
+        end
+      end
+
+      def add_auth(post, options)
+        original_nonce = generate_nonce()
+        seed = get_date_in_iso_format()
+        tranKey = generate_trans_key(original_nonce, seed)
+        post[:auth] = {
+          login: @login,
+          tranKey: tranKey,
+          seed: seed,
+          nonce: convert_to_Base64(original_nonce)
+        }
+      end
+
+      def add_payer(post, options)
+        post[:payer] = options[:payer]
+      end
+
+      def add_payment(post, options)
+        post[:payment] = options[:payment]     
+      end
+
+      def add_instrument(post, payment, options)
+        post[:instrument] = options[:instrument]
+        post[:instrument][:card][:number] = payment.number;
+        post[:instrument][:card][:expiration] = (payment.month).to_s + "/" + (payment.year).to_s;
+        post[:instrument][:card][:cvv] = payment.verification_value; 
+
+        post[:instrument][:threeDS] = {}
+        post[:instrument][:threeDS][:id] = options[:sessionToken]
+        
+      end
+
+      def add_3d_secure(post, payment, options)
+        post = {}
+        add_auth(post, options)
+        add_payment(post, options)
+        add_instrument(post, payment, options)
+        post[:returnUrl] = options[:returnUrl]
+        commit(:post, 'gateway/mpi/lookup', post)
+      end
+
+      def add_amount(post, payment, options)
+        post[:amount] = {
+          currency: options[:currency], #Allowed values: USD COP CRC EUR CAD AUD GBP MXN CLP
+          total: options[:total]
+        }
+      end
+
+      def generate_nonce
+        Digest::MD5.hexdigest(rand(10).to_s)
+      end
+
+      def get_date_in_iso_format
+        Time.now.strftime(ISO_FORMAT_DATE)
+      end      
+
+      def convert_to_Base64(value)
+        Base64.strict_encode64(value).chomp
+      end
+
+      def generate_trans_key(original_nonce, seed)
+        base_tran_key = "#{original_nonce}#{seed}#{@secret_key}"
+        key_to_digest = Digest::SHA256.digest(base_tran_key)
+        convert_to_Base64(key_to_digest)
+      end
+
+      def request_headers()
+        headers = {'Content-Type' => 'application/json'}
+        headers
+      end
+
+      def api_request(method, url, rel_path, params)
+        params == {} ? body = '' : body = params.to_json
+        raw_response = ssl_request(method, url, body, request_headers())
+        response = parse(raw_response)
+        return response
+      end
+
+      def parse(body)
+        return {} if body.empty? || body.nil?
+
+        JSON.parse(body)
+      end      
+
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -928,6 +928,11 @@ payway_dot_com:
 pin:
   api_key: "I_mo9BUUUXIwXF-avcs3LA"
 
+# Working test credentials, no need to replace
+place_to_pay_default:
+  login: 11caf20f5cd408c9b22c7f0693e2f676
+  secret_key: yLb0x2IO2lO65zq7
+
 plexo:
   client_id: YOUR_CLIENT_ID
   api_key: YOUR_API_KEY

--- a/test/remote/gateways/remote_place_to_pay_test.rb
+++ b/test/remote/gateways/remote_place_to_pay_test.rb
@@ -1,0 +1,152 @@
+require 'test_helper'
+
+class RemotePlaceToPayTest < Test::Unit::TestCase
+  def setup
+    @default_gateway = PlaceToPayGateway.new(fixtures(:place_to_pay_default))
+
+    @amount = 100
+
+    @payer = {
+      name: "Erika",
+      surname: "Howe",
+      email: "cwilliamson@hotmail.com",
+      documentType: "CC",
+      document: "3572264088",
+      mobile: "3006108300"
+    }
+    payment = {
+      description: 'Cum vitae et consequatur quas adipisci ut rem.',
+      amount: {
+        currency: @default_gateway.default_currency,
+        total: @amount
+      }
+    }
+    instrument = {
+      card: {
+        installments: 1
+      }
+    }
+
+    @credit_card_approved_diners = credit_card('36545400000008', month: 12, year: 2023, verification_value: '123', first_name: @payer[:name], last_name: @payer[:surname])
+    @credit_card_rejected_diners = credit_card('36545400000248', month: 12, year: 2023, verification_value: '123', first_name: @payer[:name], last_name: @payer[:surname])
+    @credit_card_approved_visa = credit_card('4110760000000081', month: 12, year: 2023, verification_value: '123', first_name: @payer[:name], last_name: @payer[:surname])
+    @credit_card_rejected_visa = credit_card('4110760000000016', month: 12, year: 2023, verification_value: '123', first_name: @payer[:name], last_name: @payer[:surname])
+    @credit_card_approved_3DSC_visa = credit_card('4110760000000008', month: 12, year: 2023, verification_value: '123', first_name: @payer[:name], last_name: @payer[:surname])
+
+    @authorize_options = {
+      payer: @payer,
+      payment: payment,
+      instrument: instrument
+    }    
+
+    @purchase_options = {
+      payer: @payer,
+      payment: payment,
+      instrument: instrument,
+      use3ds: true,
+      returnUrl: "https://www.your-site.com/return?reference=1234567890"
+    }
+    @refund_options = { }
+  end
+  
+
+  def test_successful_purchase_diners
+    @purchase_options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+    @purchase_options[:use3ds] = false
+    @purchase_options[:returnUrl] = nil
+    response = @default_gateway.purchase(@amount, @credit_card_approved_diners, @purchase_options)
+    assert_success response
+    assert_equal 'Aprobada', response.message
+  end
+
+  def test_failed_purchase_diners
+    @purchase_options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+    @purchase_options[:use3ds] = false
+    @purchase_options[:returnUrl] = nil    
+    response = @default_gateway.purchase(@amount, @credit_card_rejected_diners, @purchase_options)
+    assert_success response
+    assert_equal 'Rechazada', response.message
+  end
+
+  def test_successful_purchase_visa
+    @purchase_options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+    @purchase_options[:use3ds] = true
+    @purchase_options[:returnUrl] = "https://www.your-site.com/return?reference=1234567890"      
+    response = @default_gateway.purchase(@amount, @credit_card_approved_visa, @purchase_options)  
+    assert_success response
+    assert_equal 'Aprobada', response.message
+  end
+
+  def test_failed_purchase_visa
+    @purchase_options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+    @purchase_options[:use3ds] = true
+    @purchase_options[:returnUrl] = "https://www.your-site.com/return?reference=1234567890"      
+    response = @default_gateway.purchase(@amount, @credit_card_rejected_visa, @purchase_options)
+    assert_success response
+    assert_equal 'Rechazada', response.message
+  end
+
+  def test_successful_refund
+    @purchase_options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+    purchase = @default_gateway.purchase(@amount, @credit_card_approved_visa, @purchase_options)
+    assert_success purchase
+    assert_equal 'Aprobada', purchase.message
+
+    @refund_options =  { internalReference: purchase.network_transaction_id }
+    refund = @default_gateway.refund(@amount, purchase.authorization, @refund_options)
+
+    assert_success refund
+    assert_equal 'Aprobada', refund.message
+  end
+
+  def test_failed_refund
+    @purchase_options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+    purchase = @default_gateway.purchase(@amount, @credit_card_approved_visa, @purchase_options)
+    assert_success purchase
+    assert_equal 'Aprobada', purchase.message
+
+    @refund_options =  { internalReference: -1 }
+    refund = @default_gateway.refund(@amount, purchase.authorization, @refund_options)
+
+    assert_success refund
+    assert_equal 'La referencia interna provista es inválida', refund.message
+  end
+
+  def test_already_refunded
+    @purchase_options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+    purchase = @default_gateway.purchase(@amount, @credit_card_approved_visa, @purchase_options)
+    assert_success purchase
+    assert_equal 'Aprobada', purchase.message
+
+    @refund_options =  { internalReference: purchase.network_transaction_id }
+    refund = @default_gateway.refund(@amount, purchase.authorization, @refund_options)
+
+    assert_success refund
+    assert_equal 'Aprobada', refund.message
+
+    refund = @default_gateway.refund(@amount, purchase.authorization, @refund_options)
+    assert_equal 'La transacción ya ha sido reversada', refund.message
+
+  end
+
+  # def test_dump_transcript
+  #   # This test will run a purchase transaction on your gateway
+  #   # and dump a transcript of the HTTP conversation so that
+  #   # you can use that transcript as a reference while
+  #   # implementing your scrubbing logic.  You can delete
+  #   # this helper after completing your scrub implementation.
+  #   @purchase_options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+  #   dump_transcript_and_fail(@default_gateway, @amount, @credit_card_approved_visa, @purchase_options)
+  # end
+
+  # def test_transcript_scrubbing
+  #   transcript = capture_transcript(@default_gateway) do
+  #     @purchase_options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+  #     @default_gateway.purchase(@amount, @credit_card_approved_visa, @purchase_options)
+  #   end
+  #   transcript = @default_gateway.scrub(transcript)
+
+  #   assert_scrubbed(@credit_card_approved_visa.number, transcript)
+  # end
+  
+end

--- a/test/unit/gateways/place_to_pay_test.rb
+++ b/test/unit/gateways/place_to_pay_test.rb
@@ -1,0 +1,390 @@
+require 'test_helper'
+
+class PlaceToPayTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = PlaceToPayGateway.new(login: '11caf20f5cd408c9b22c7f0693e2f676', secret_key: 'yLb0x2IO2lO65zq7')
+    
+    @amount = 100
+
+    @payer = {
+      name: "Erika",
+      surname: "Howe",
+      email: "cwilliamson@hotmail.com",
+      documentType: "CC",
+      document: "3572264088",
+      mobile: "3006108300"
+    }
+    payment = {
+      description: 'Cum vitae et consequatur quas adipisci ut rem.',
+      amount: {
+        currency: @gateway.default_currency,
+        total: @amount
+      }
+    }
+    instrument = {
+      card: {
+        installments: 1
+      }
+    }
+
+    @credit_card_approved_visa = credit_card('4110760000000081', month: 12, year: 2023, verification_value: '123', first_name: @payer[:name], last_name: @payer[:surname])
+    @credit_card_rejected_visa = credit_card('4110760000000016', month: 12, year: 2023, verification_value: '123', first_name: @payer[:name], last_name: @payer[:surname])
+
+    @options = {
+      payer: @payer,
+      payment: payment,
+      instrument: instrument
+    }
+
+  end
+
+  def test_successful_purchase
+
+    @options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card_approved_visa, @options)
+    end.check_request do |_endpoint, data, _headers|
+  #     assert_match(/<description>.+<\/description>/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal 'Aprobada', response.message
+    assert_equal '999999', response.authorization
+    assert response.test? 
+  end
+
+  def test_failed_purchase
+    #@gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    @options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+    response = @gateway.purchase(@amount, @credit_card_rejected_visa, @options)
+    #assert_failure response
+    assert_equal 'Rechazada', response.message
+    #assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code  
+  end
+
+  def test_successful_refund 
+    @options[:payment][:reference] = "TEST_" + Time.now.strftime("%Y%m%d_%H%M%S%3N")
+    
+    purchase = stub_comms do
+      @gateway.purchase(@amount, @credit_card_approved_visa, @options)
+    end.check_request do |_endpoint, data, _headers|
+      # assert_match(/<description>.+<\/description>/, data)
+    end.respond_with(successful_purchase_response)
+
+    #@gateway.expects(:ssl_post).returns(successful_refund_response)
+    @refund_options =  { internalReference: purchase.network_transaction_id }
+
+    response = @gateway.refund(@amount, purchase.authorization, @refund_options)
+
+    assert_success response
+    assert_equal 'Aprobada', response.message
+  end
+
+  def test_failed_refund
+    #@gateway.expects(:ssl_post).returns(failed_refund_response)
+    response = @gateway.refund(@amount, nil)
+
+    #assert_failure response
+    assert_equal 'La referencia interna provista es inválida', response.message
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      opening connection to api-co-dev.placetopay.ws:443...
+      opened
+      starting SSL for api-co-dev.placetopay.ws:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256
+      <- "POST /gateway/process HTTP/1.1\r\nContent-Type: application/json\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: api-co-dev.placetopay.ws\r\nContent-Length: 603\r\n\r\n"
+      <- "{\"auth\":{\"login\":\"11caf20f5cd408c9b22c7f0693e2f676\",\"tranKey\":\"j0eeo7QkGKbQaL+oBTRlYC20Zup/yjE73nDfiaPbj8U=\",\"seed\":\"2023-01-03T14:41:46-03:00\",\"nonce\":\"NDVjNDhjY2UyZTJkN2ZiZGVhMWFmYzUxYzdjNmFkMjY=\"},\"payer\":{\"name\":\"Erika\",\"surname\":\"Howe\",\"email\":\"cwilliamson@hotmail.com\",\"documentType\":\"CC\",\"document\":\"3572264088\",\"mobile\":\"3006108300\"},\"payment\":{\"description\":\"Cum vitae et consequatur quas adipisci ut rem.\",\"amount\":{\"currency\":\"COP\",\"total\":100},\"reference\":\"transcript_20230103_144146279\"},\"instrument\":{\"card\":{\"installments\":1,\"number\":\"4110760000000081\",\"expiration\":\"12/12\",\"cvv\":\"123\"}}}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 988\r\n"
+      -> "Connection: close\r\n"
+      -> "Date: Tue, 03 Jan 2023 17:41:47 GMT\r\n"
+      -> "x-amzn-RequestId: 2f37d55a-3fd2-47fe-a767-aa7a58d3267b\r\n"
+      -> "x-amz-apigw-id: eLVSMHTSIAMFuLQ=\r\n"
+      -> "Cache-Control: no-cache, private\r\n"
+      -> "X-Amzn-Trace-Id: Root=1-63b468da-0b86c22c391bd4055f050798;Sampled=0\r\n"
+      -> "x-amzn-Remapped-Date: Tue, 03 Jan 2023 17:41:47 GMT\r\n"
+      -> "X-Cache: Miss from cloudfront\r\n"
+      -> "Via: 1.1 dfe38bddfe2e252d54a7cc2e361b6cb6.cloudfront.net (CloudFront)\r\n"
+      -> "X-Amz-Cf-Pop: EZE50-P1\r\n"
+      -> "X-Amz-Cf-Id: fdjSPF-Akmh9QVLa-RX108u5K2P0GB5E4LPhWVVXomgDHMZLWN3TbQ==\r\n"
+      -> "\r\n"
+      reading 988 bytes...
+      -> "{\"status\":{\"status\":\"APPROVED\",\"reason\":\"00\",\"message\":\"Aprobada\",\"date\":\"2023-01-03T12:41:47-05:00\"},\"date\":\"2023-01-03T12:41:47-05:00\",\"transactionDate\":\"2023-01-03T12:41:47-05:00\",\"internalReference\":418653,\"reference\":\"transcript_20230103_144146279\",\"paymentMethod\":\"ID_VS\",\"franchise\":\"visa\",\"franchiseName\":\"Visa\",\"issuerName\":\"BANCO DE GUAYAQUIL, S.A.\",\"amount\":{\"currency\":\"COP\",\"total\":100},\"conversion\":{\"from\":{\"currency\":\"COP\",\"total\":100},\"to\":{\"currency\":\"USD\",\"total\":0.02},\"factor\":0.000206},\"authorization\":\"999999\",\"receipt\":\"418653\",\"type\":\"AUTH_ONLY\",\"refunded\":false,\"lastDigits\":\"0081\",\"provider\":\"INTERDIN\",\"discount\":null,\"processorFields\":{\"id\":\"4294789932ba8aa7ec09d1c227ebc35f\",\"b24\":\"00\"},\"additional\":{\"merchantCode\":\"12345678\",\"terminalNumber\":\"12345678\",\"credit\":{\"code\":1,\"type\":\"00\",\"groupCode\":\"C\",\"installments\":1},\"totalAmount\":0.02,\"interestAmount\":0,\"installmentAmount\":0.02,\"iceAmount\":0,\"batch\":null,\"line\":null,\"bin\":\"411076\",\"expiration\":\"1212\"}}"
+      read 988 bytes
+      Conn close
+      PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      opening connection to api-co-dev.placetopay.ws:443...
+      opened
+      starting SSL for api-co-dev.placetopay.ws:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256
+      <- "POST /gateway/process HTTP/1.1\r\nContent-Type: application/json\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: api-co-dev.placetopay.ws\r\nContent-Length: 603\r\n\r\n"
+      <- "{\"auth\":{\"login\":\"11caf20f5cd408c9b22c7f0693e2f676\",\"tranKey\":\"[FILTERED]\",\"seed\":\"2023-01-03T14:41:46-03:00\",\"nonce\":\"NDVjNDhjY2UyZTJkN2ZiZGVhMWFmYzUxYzdjNmFkMjY=\"},\"payer\":{\"name\":\"Erika\",\"surname\":\"Howe\",\"email\":\"cwilliamson@hotmail.com\",\"documentType\":\"CC\",\"document\":\"3572264088\",\"mobile\":\"3006108300\"},\"payment\":{\"description\":\"Cum vitae et consequatur quas adipisci ut rem.\",\"amount\":{\"currency\":\"COP\",\"total\":100},\"reference\":\"transcript_20230103_144146279\"},\"instrument\":{\"card\":{\"installments\":1,\"number\":\"[FILTERED]\",\"expiration\":\"12/12\",\"cvv\":\"[FILTERED]\"}}}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 988\r\n"
+      -> "Connection: close\r\n"
+      -> "Date: Tue, 03 Jan 2023 17:41:47 GMT\r\n"
+      -> "x-amzn-RequestId: 2f37d55a-3fd2-47fe-a767-aa7a58d3267b\r\n"
+      -> "x-amz-apigw-id: eLVSMHTSIAMFuLQ=\r\n"
+      -> "Cache-Control: no-cache, private\r\n"
+      -> "X-Amzn-Trace-Id: Root=1-63b468da-0b86c22c391bd4055f050798;Sampled=0\r\n"
+      -> "x-amzn-Remapped-Date: Tue, 03 Jan 2023 17:41:47 GMT\r\n"
+      -> "X-Cache: Miss from cloudfront\r\n"
+      -> "Via: 1.1 dfe38bddfe2e252d54a7cc2e361b6cb6.cloudfront.net (CloudFront)\r\n"
+      -> "X-Amz-Cf-Pop: EZE50-P1\r\n"
+      -> "X-Amz-Cf-Id: fdjSPF-Akmh9QVLa-RX108u5K2P0GB5E4LPhWVVXomgDHMZLWN3TbQ==\r\n"
+      -> "\r\n"
+      reading 988 bytes...
+      -> "{\"status\":{\"status\":\"APPROVED\",\"reason\":\"00\",\"message\":\"Aprobada\",\"date\":\"2023-01-03T12:41:47-05:00\"},\"date\":\"2023-01-03T12:41:47-05:00\",\"transactionDate\":\"2023-01-03T12:41:47-05:00\",\"internalReference\":418653,\"reference\":\"transcript_20230103_144146279\",\"paymentMethod\":\"ID_VS\",\"franchise\":\"visa\",\"franchiseName\":\"Visa\",\"issuerName\":\"BANCO DE GUAYAQUIL, S.A.\",\"amount\":{\"currency\":\"COP\",\"total\":100},\"conversion\":{\"from\":{\"currency\":\"COP\",\"total\":100},\"to\":{\"currency\":\"USD\",\"total\":0.02},\"factor\":0.000206},\"authorization\":\"999999\",\"receipt\":\"418653\",\"type\":\"AUTH_ONLY\",\"refunded\":false,\"lastDigits\":\"0081\",\"provider\":\"INTERDIN\",\"discount\":null,\"processorFields\":{\"id\":\"4294789932ba8aa7ec09d1c227ebc35f\",\"b24\":\"00\"},\"additional\":{\"merchantCode\":\"12345678\",\"terminalNumber\":\"12345678\",\"credit\":{\"code\":1,\"type\":\"00\",\"groupCode\":\"C\",\"installments\":1},\"totalAmount\":0.02,\"interestAmount\":0,\"installmentAmount\":0.02,\"iceAmount\":0,\"batch\":null,\"line\":null,\"bin\":\"411076\",\"expiration\":\"1212\"}}"
+      read 988 bytes
+      Conn close
+      POST_SCRUBBED
+  end
+
+  def successful_purchase_response
+    <<-RESPONSE
+    {
+      "status": {
+        "status": "APPROVED",
+        "reason": "00",
+        "message": "Aprobada",
+        "date": "2023-01-03T13:02:19-05:00"
+      },
+      "date": "2023-01-03T13:02:19-05:00",
+      "transactionDate": "2023-01-03T13:02:19-05:00",
+      "internalReference": 418655,
+      "reference": "TEST_20230103_150219114",
+      "paymentMethod": "ID_VS",
+      "franchise": "visa",
+      "franchiseName": "Visa",
+      "issuerName": "BANCO DE GUAYAQUIL, S.A.",
+      "amount": {
+        "currency": "COP",
+        "total": 100
+      },
+      "conversion": {
+        "from": {
+          "currency": "COP",
+          "total": 100
+        },
+        "to": {
+          "currency": "USD",
+          "total": 0.02
+        },
+        "factor": 0.000206
+      },
+      "authorization": "999999",
+      "receipt": "418655",
+      "type": "AUTH_ONLY",
+      "refunded": false,
+      "lastDigits": "0081",
+      "provider": "INTERDIN",
+      "discount": null,
+      "processorFields": {
+        "id": "d87dee7109eca8d1d0a019788a4a06e9",
+        "b24": "00"
+      },
+      "additional": {
+        "merchantCode": "12345678",
+        "terminalNumber": "12345678",
+        "credit": {
+          "code": 1,
+          "type": "00",
+          "groupCode": "C",
+          "installments": 1
+        },
+        "totalAmount": 0.02,
+        "interestAmount": 0,
+        "installmentAmount": 0.02,
+        "iceAmount": 0,
+        "batch": null,
+        "line": null,
+        "bin": "411076",
+        "expiration": "1212"
+      }
+    }
+    RESPONSE
+  end
+
+  def failed_purchase_response; 
+    <<-RESPONSE
+    {
+      "status": {
+        "status": "REJECTED",
+        "reason": "05",
+        "message": "Rechazada",
+        "date": "2023-01-03T13:04:05-05:00"
+      },
+      "date": "2023-01-03T13:04:05-05:00",
+      "transactionDate": "2023-01-03T13:04:05-05:00",
+      "internalReference": 418656,
+      "reference": "TEST_20230103_150404971",
+      "paymentMethod": "ID_VS",
+      "franchise": "visa",
+      "franchiseName": "Visa",
+      "issuerName": "BANCO DE GUAYAQUIL, S.A.",
+      "amount": {
+        "currency": "COP",
+        "total": 100
+      },
+      "conversion": {
+        "from": {
+          "currency": "COP",
+          "total": 100
+        },
+        "to": {
+          "currency": "USD",
+          "total": 0.02
+        },
+        "factor": 0.000206
+      },
+      "authorization": "000000",
+      "receipt": "418656",
+      "type": "AUTH_ONLY",
+      "refunded": false,
+      "lastDigits": "0016",
+      "provider": "INTERDIN",
+      "discount": null,
+      "processorFields": {
+        "id": "b29bd9593277694a941db80267eae4ab",
+        "b24": "05"
+      },
+      "additional": {
+        "merchantCode": "12345678",
+        "terminalNumber": "12345678",
+        "credit": {
+          "code": 1,
+          "type": "00",
+          "groupCode": "C",
+          "installments": 1
+        },
+        "totalAmount": 0.02,
+        "interestAmount": 0,
+        "installmentAmount": 0.02,
+        "iceAmount": 0,
+        "batch": null,
+        "line": null,
+        "bin": "411076",
+        "expiration": "1212"
+      }
+    }
+    RESPONSE
+  end
+
+  def successful_refund_response; 
+    <<-RESPONSE
+    {
+      "status": {
+          "status": "APPROVED",
+          "reason": "00",
+          "message": "Aprobada",
+          "date": "2023-07-05T11:49:01-05:00"
+      },
+      "date": "2023-07-05T11:49:01-05:00",
+      "transactionDate": "2023-07-05T11:49:01-05:00",
+      "internalReference": 426507,
+      "reference": "TEST_20230705_134809919",
+      "paymentMethod": "ID_VS",
+      "franchise": "visa",
+      "franchiseName": "Visa",
+      "issuerName": "BANCO DE GUAYAQUIL, S.A.",
+      "amount": {
+          "taxes": [
+              {
+                  "kind": "valueAddedTax",
+                  "amount": 0,
+                  "base": 0
+              }
+          ],
+          "currency": "COP",
+          "total": 100
+      },
+      "conversion": {
+          "from": {
+              "currency": "COP",
+              "total": 100
+          },
+          "to": {
+              "currency": "USD",
+              "total": 0.02
+          },
+          "factor": 0.000239
+      },
+      "authorization": "000000",
+      "receipt": null,
+      "type": "CREDIT",
+      "refunded": false,
+      "lastDigits": "0081",
+      "provider": "INTERDIN",
+      "discount": null,
+      "processorFields": {
+          "id": "3ac34a0032ba5356498bcd3bde6b8297",
+          "b24": "00"
+      },
+      "additional": {
+          "merchantCode": "12345678",
+          "terminalNumber": "12345678",
+          "credit": {
+              "code": 1,
+              "type": "00",
+              "groupCode": "C",
+              "installments": 1
+          },
+          "totalAmount": 0.02,
+          "interestAmount": 0,
+          "installmentAmount": 0,
+          "iceAmount": 0,
+          "batch": null,
+          "line": null,
+          "bin": "411076",
+          "expiration": "1223"
+      }
+    }
+    RESPONSE
+  end
+
+  def failed_refund_response
+    <<-RESPONSE
+    {
+      "status": {
+          "status": "FAILED",
+          "reason": "BR",
+          "message": "El código de autorización no concuerda",
+          "date": "2023-07-05T11:52:03-05:00"
+      }
+    }
+    RESPONSE
+  end
+
+  def already_refunded_response;
+    <<-RESPONSE
+    {
+        "status": {
+            "status": "FAILED",
+            "reason": "BR",
+            "message": "La transacción ya ha sido reversada",
+            "date": "2023-07-05T11:51:07-05:00"
+        }
+    }
+    RESPONSE
+  end
+
+end


### PR DESCRIPTION
## Summary

Adding PlaceToPay gateway with support for basic functionality including purchase, capture, and refund calls.

## Tests

Remote:
7 tests, 21 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
5 tests, 17 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed