### PR TITLE
Authorize Net: add the surcharge field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -129,6 +129,7 @@
 * XPay: Update 3DS to support 3 step process [sinourain] #5046
 * SagePay: Update API endpoints [almalee24] #5057
 * Bin Update: Add sodexo bins [yunnydang] #5061
+* Authorize Net: Add the surcharge field [yunnydang] #5062
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -272,6 +272,7 @@ module ActiveMerchant
           add_market_type_device_type(xml, payment, options)
           add_settings(xml, payment, options)
           add_user_fields(xml, amount, options)
+          add_surcharge_fields(xml, options)
           add_ship_from_address(xml, options)
           add_processing_options(xml, options)
           add_subsequent_auth_information(xml, options)
@@ -288,6 +289,7 @@ module ActiveMerchant
             add_duty_fields(xml, options)
             add_payment_method(xml, payment, options)
             add_invoice(xml, transaction_type, options)
+            add_surcharge_fields(xml, options)
             add_tax_exempt_status(xml, options)
           end
         end
@@ -706,6 +708,16 @@ module ActiveMerchant
             xml.amount(amount(duty[:amount].to_i))
             xml.name(duty[:name])
             xml.description(duty[:description])
+          end
+        end
+      end
+
+      def add_surcharge_fields(xml, options)
+        surcharge = options[:surcharge] if options[:surcharge]
+        if surcharge.is_a?(Hash)
+          xml.surcharge do
+            xml.amount(amount(surcharge[:amount].to_i)) if surcharge[:amount]
+            xml.description(surcharge[:description]) if surcharge[:description]
           end
         end
       end

--- a/test/remote/gateways/remote_authorize_net_test.rb
+++ b/test/remote/gateways/remote_authorize_net_test.rb
@@ -185,6 +185,16 @@ class RemoteAuthorizeNetTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved', response.message
   end
 
+  def test_successful_purchase_with_surcharge
+    options = @options.merge(surcharge: {
+      amount: 20,
+      description: 'test description'
+    })
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'This transaction has been approved', response.message
+  end
+
   def test_successful_purchase_with_customer
     response = @gateway.purchase(@amount, @credit_card, @options.merge(customer: 'abcd_123'))
     assert_success response

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -367,6 +367,21 @@ class AuthorizeNetTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_passes_surcharge
+    options = @options.merge(surcharge: {
+      amount: 20,
+      description: 'test description'
+    })
+    stub_comms do
+      @gateway.purchase(@amount, credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<surcharge>/, data)
+      assert_match(/<amount>0.20<\/amount>/, data)
+      assert_match(/<description>#{options[:surcharge][:description]}<\/description>/, data)
+      assert_match(/<\/surcharge>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_passes_level_3_options
     stub_comms do
       @gateway.purchase(@amount, credit_card, @options.merge(@level_3_options))


### PR DESCRIPTION
This adds the surcharge object as an optional field
Local:
5828 tests, 79061 assertions, 4 failures, 27 errors, 0 pendings, 0 omissions, 0 notifications
99.4681% passed

Unit:
123 tests, 694 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
87 tests, 310 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed