### PR TITLE
CyberSource: Extend support for `gratuity_amount`, update Mastercard …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -131,6 +131,7 @@
 * Bin Update: Add sodexo bins [yunnydang] #5061
 * Authorize Net: Add the surcharge field [yunnydang] #5062
 * Paymentez: Update field for reference_id [almalee24] #5065
+* CyberSource: Extend support for `gratuity_amount` and update Mastercard NT field order [rachelkirk] #5063
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -276,6 +276,38 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(response)
   end
 
+  def test_successful_auth_with_single_element_from_other_tax
+    options = @options.merge(vat_tax_rate: '1')
+
+    assert response = @gateway.authorize(@amount, @master_credit_card, options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_single_element_from_other_tax
+    options = @options.merge(national_tax_amount: '0.05')
+
+    assert response = @gateway.purchase(@amount, @master_credit_card, options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  end
+
+  def test_successful_auth_with_gratuity_amount
+    options = @options.merge(gratuity_amount: '7.50')
+
+    assert response = @gateway.authorize(@amount, @master_credit_card, options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_gratuity_amount
+    options = @options.merge(gratuity_amount: '7.50')
+
+    assert response = @gateway.purchase(@amount, @master_credit_card, options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  end
+
   def test_successful_authorization_with_sales_slip_number
     options = @options.merge(sales_slip_number: '456')
     assert response = @gateway.authorize(@amount, @credit_card, options)
@@ -768,6 +800,33 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
     assert auth = @gateway.purchase(@amount, credit_card, @options)
     assert_successful_response(auth)
+  end
+
+  def test_successful_auth_and_capture_nt_mastercard_with_tax_options_and_no_xml_parsing_errors
+    credit_card = network_tokenization_credit_card('5555555555554444',
+                                                   brand: 'master',
+                                                   eci: '05',
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+
+    options = { ignore_avs: true, order_id: generate_unique_id, vat_tax_rate: 1.01 }
+
+    assert auth = @gateway.authorize(@amount, credit_card, options)
+    assert_successful_response(auth)
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_successful_response(capture)
+  end
+
+  def test_successful_purchase_nt_mastercard_with_tax_options_and_no_xml_parsing_errors
+    credit_card = network_tokenization_credit_card('5555555555554444',
+                                                   brand: 'master',
+                                                   eci: '05',
+                                                   payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+
+    options = { ignore_avs: true, order_id: generate_unique_id, vat_tax_rate: 1.01 }
+
+    assert response = @gateway.purchase(@amount, credit_card, options)
+    assert_successful_response(response)
   end
 
   def test_successful_authorize_with_mdd_fields


### PR DESCRIPTION
…NT fields

CER-1236

This PR adds the option to send `gratuityAmount` in purchase and auth request. Also updates the order of the request body when Mastercard Network Tokens are used in order to avoid XML parsing errors. `ucaf` parent element is called for MC NT and is not with other card brands. This was causing a conflict/parse error when tax fields are sent as part of the request.

Unit Tests:
148 tests, 818 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests:
135 tests, 668 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 94.8148% passed
*These 7 tests are also failing on master and in the last update to this gateway

Local Tests:
5827 tests, 79117 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 99.9657% passed