### PR TITLE
Paymentez: Update field for reference_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -130,6 +130,7 @@
 * SagePay: Update API endpoints [almalee24] #5057
 * Bin Update: Add sodexo bins [yunnydang] #5061
 * Authorize Net: Add the surcharge field [yunnydang] #5062
+* Paymentez: Update field for reference_id [almalee24] #5065
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -213,12 +213,13 @@ module ActiveMerchant #:nodoc:
         three_d_secure_options = options[:three_d_secure]
         return unless three_d_secure_options
 
+        reference_id = options[:new_reference_id_field] ? three_d_secure_options[:ds_transaction_id] : three_d_secure_options[:three_ds_server_trans_id]
         auth_data = {
           cavv: three_d_secure_options[:cavv],
           xid: three_d_secure_options[:xid],
           eci: three_d_secure_options[:eci],
           version: three_d_secure_options[:version],
-          reference_id: three_d_secure_options[:three_ds_server_trans_id],
+          reference_id: reference_id,
           status: three_d_secure_options[:authentication_response_status] || three_d_secure_options[:directory_response_status]
         }.compact
 

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -11,7 +11,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
     @elo_credit_card = credit_card(
       '6362970000457013',
       month: 10,
-      year: 2022,
+      year: Time.now.year + 1,
       first_name: 'John',
       last_name: 'Smith',
       verification_value: '737',
@@ -32,7 +32,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
     @eci = '01'
     @three_ds_v1_version = '1.0.2'
     @three_ds_v2_version = '2.1.0'
-    @three_ds_server_trans_id = 'three-ds-v2-trans-id'
+    @three_ds_server_trans_id = 'ffffffff-9002-51a3-8000-0000000345a2'
     @authentication_response_status = 'Y'
 
     @three_ds_v1_mpi = {

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -32,6 +32,7 @@ class PaymentezTest < Test::Unit::TestCase
     @three_ds_v2_version = '2.1.0'
     @three_ds_server_trans_id = 'three-ds-v2-trans-id'
     @authentication_response_status = 'Y'
+    @directory_server_transaction_id = 'directory_server_transaction_id'
 
     @three_ds_v1_mpi = {
       cavv: @cavv,
@@ -45,7 +46,8 @@ class PaymentezTest < Test::Unit::TestCase
       eci: @eci,
       version: @three_ds_v2_version,
       three_ds_server_trans_id: @three_ds_server_trans_id,
-      authentication_response_status: @authentication_response_status
+      authentication_response_status: @authentication_response_status,
+      ds_transaction_id: @directory_server_transaction_id
     }
   end
 
@@ -191,13 +193,14 @@ class PaymentezTest < Test::Unit::TestCase
   end
 
   def test_authorize_3ds2_mpi_fields
+    @options.merge!(new_reference_id_field: true)
     @options[:three_d_secure] = @three_ds_v2_mpi
 
     expected_auth_data = {
       cavv: @cavv,
       eci: @eci,
       version: @three_ds_v2_version,
-      reference_id: @three_ds_server_trans_id,
+      reference_id: @directory_server_transaction_id,
       status: @authentication_response_status
     }
 


### PR DESCRIPTION
directory_server_transaction_id should be used
to populate Paymentez.

Unit
30 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote
34 tests, 85 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed