### PR TITLE
FatZebra: Adding third-party 3DS params

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -138,6 +138,7 @@
 * RedsysRest: Omit CVV from requests when not present [jcreiff] #5077
 * Bin Update: Add Unionpay bin [yunnydang] #5079
 * MerchantWarrior: Adding support for 3DS Global fields [Heavyblade] #5072
+* FatZebra: Adding third-party 3DS params [Heavyblade] #5066
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -28,6 +28,7 @@ module ActiveMerchant #:nodoc:
         add_order_id(post, options)
         add_ip(post, options)
         add_metadata(post, options)
+        add_three_ds(post, options)
 
         commit(:post, 'purchases', post)
       end
@@ -41,6 +42,7 @@ module ActiveMerchant #:nodoc:
         add_order_id(post, options)
         add_ip(post, options)
         add_metadata(post, options)
+        add_three_ds(post, options)
 
         post[:capture] = false
 
@@ -125,14 +127,40 @@ module ActiveMerchant #:nodoc:
       def add_extra_options(post, options)
         extra = {}
         extra[:ecm] = '32' if options[:recurring]
-        extra[:cavv] = options[:cavv] || options.dig(:three_d_secure, :cavv) if options[:cavv] || options.dig(:three_d_secure, :cavv)
-        extra[:xid] = options[:xid] || options.dig(:three_d_secure, :xid) if options[:xid] || options.dig(:three_d_secure, :xid)
-        extra[:sli] = options[:sli] || options.dig(:three_d_secure, :eci) if options[:sli] || options.dig(:three_d_secure, :eci)
         extra[:name] = options[:merchant] if options[:merchant]
         extra[:location] = options[:merchant_location] if options[:merchant_location]
         extra[:card_on_file] = options.dig(:extra, :card_on_file) if options.dig(:extra, :card_on_file)
         extra[:auth_reason]  = options.dig(:extra, :auth_reason) if options.dig(:extra, :auth_reason)
+
+        unless options[:three_d_secure].present?
+          extra[:sli] = options[:sli] if options[:sli]
+          extra[:xid] = options[:xid] if options[:xid]
+          extra[:cavv] = options[:cavv] if options[:cavv]
+        end
+
         post[:extra] = extra if extra.any?
+      end
+
+      def add_three_ds(post, options)
+        return unless three_d_secure = options[:three_d_secure]
+
+        post[:extra] = {
+          sli: three_d_secure[:eci],
+          xid: three_d_secure[:xid],
+          cavv: three_d_secure[:cavv],
+          par: three_d_secure[:authentication_response_status],
+          ver: formatted_enrollment(three_d_secure[:enrolled]),
+          threeds_version: three_d_secure[:version],
+          ds_transaction_id: three_d_secure[:ds_transaction_id]
+        }.compact
+      end
+
+      def formatted_enrollment(val)
+        case val
+        when 'Y', 'N', 'U' then val
+        when true, 'true' then 'Y'
+        when false, 'false' then 'N'
+        end
       end
 
       def add_order_id(post, options)

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -227,4 +227,34 @@ class RemoteFatZebraTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
   end
+
+  def test_successful_purchase_with_3DS
+    @options[:three_d_secure] = {
+      version: '2.0',
+      cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
+      eci: '05',
+      ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_failed_purchase_with_3DS
+    @options[:three_d_secure] = {
+      version: '3.0',
+      cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
+      eci: '05',
+      ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match(/version is not valid/, response.message)
+  end
 end


### PR DESCRIPTION
## Summary:

Adds the needed fields to support 3DS Global on FatZebra Gateway

[SER-1170](https://spreedly.atlassian.net/browse/SER-1170)

## Tests

### Remote Test:
Finished in 87.765183 seconds.
29 tests, 101 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.1034% passed

*Note Failing Test*: We have to remote tests failing because seems to be a change on the sandbox behavior when a transaction doesn't include a cvv

### Unit Tests:
Finished in 68.736139 seconds.
5808 tests, 78988 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
792 files inspected, no offenses detected