### PR TITLE
Braintree: Add merchant_account_id to Verify

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -141,6 +141,7 @@
 * FatZebra: Adding third-party 3DS params [Heavyblade] #5066
 * SumUp: Remove Void method [sinourain] #5060
 * StripePI: Add new ApplePay and GooglePay flow [almalee24] #5075
+* Braintree: Add merchant_account_id to Verify [almalee24] #5070
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -154,6 +154,10 @@ module ActiveMerchant #:nodoc:
               }
             }
           }
+          if merchant_account_id = (options[:merchant_account_id] || @merchant_account_id)
+            payload[:options] = { merchant_account_id: merchant_account_id }
+          end
+
           commit do
             result = @braintree_gateway.verification.create(payload)
             response = Response.new(result.success?, message_from_transaction_result(result), response_options(result))

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -266,8 +266,9 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_credit_card_verification
     card = credit_card('4111111111111111')
-    assert response = @gateway.verify(card, @options.merge({ allow_card_verification: true }))
+    assert response = @gateway.verify(card, @options.merge({ allow_card_verification: true, merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id] }))
     assert_success response
+
     assert_match 'OK', response.message
     assert_equal 'M', response.cvv_result['code']
     assert_equal 'P', response.avs_result['code']
@@ -550,7 +551,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert transaction = response.params['braintree_transaction']
     assert transaction['risk_data']
     assert transaction['risk_data']['id']
-    assert_equal 'Approve', transaction['risk_data']['decision']
+    assert_equal true, ['Not Evaluated', 'Approve'].include?(transaction['risk_data']['decision'])
     assert_equal false, transaction['risk_data']['device_data_captured']
     assert_equal 'fraud_protection', transaction['risk_data']['fraud_service_provider']
   end

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -138,7 +138,15 @@ class BraintreeBlueTest < Test::Unit::TestCase
   end
 
   def test_zero_dollar_verification_transaction
+    @gateway = BraintreeBlueGateway.new(
+      merchant_id: 'test',
+      merchant_account_id: 'present',
+      public_key: 'test',
+      private_key: 'test'
+    )
+
     Braintree::CreditCardVerificationGateway.any_instance.expects(:create).
+      with(has_entries(options: { merchant_account_id: 'present' })).
       returns(braintree_result(cvv_response_code: 'M', avs_error_response_code: 'P'))
 
     card = credit_card('4111111111111111')


### PR DESCRIPTION
Send merchant_account_id to Verify when it goes through the allow_card_verification == true flow.

Remote:
120 tests, 642 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
103 tests, 218 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed