### PR TITLE
Decidir: Add support for `customer` object

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -161,6 +161,7 @@
 * Litle: Update enhanced data fields to pass integers [yunnydang] #5113
 * Litle: Update commodity code and line item total fields [yunnydang] #5115
 * Cybersource Rest: Add support for network tokens [aenand] #5107
+* Decidir: Add support for customer object [rachelkirk] #5071
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -127,6 +127,7 @@ module ActiveMerchant #:nodoc:
         add_payment(post, credit_card, options)
         add_aggregate_data(post, options) if options[:aggregate_data]
         add_sub_payments(post, options)
+        add_customer_data(post, options)
       end
 
       def add_payment_method_id(credit_card, options)
@@ -239,6 +240,14 @@ module ActiveMerchant #:nodoc:
         aggregate_data[:merchant_email] = data[:merchant_email] if data[:merchant_email]
         aggregate_data[:merchant_phone] = data[:merchant_phone] if data[:merchant_phone]
         post[:aggregate_data] = aggregate_data
+      end
+
+      def add_customer_data(post, options = {})
+        return unless options[:customer_email] || options[:customer_id]
+
+        post[:customer] = {}
+        post[:customer][:id] = options[:customer_id] if options[:customer_id]
+        post[:customer][:email] = options[:customer_email] if options[:customer_email]
       end
 
       def add_sub_payments(post, options)

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -171,6 +171,18 @@ class RemoteDecidirTest < Test::Unit::TestCase
     assert_equal 'approved', response.message
   end
 
+  def test_successful_purchase_with_customer_object
+    customer_options = {
+      customer_id: 'John',
+      customer_email: 'decidir@decidir.com'
+    }
+
+    assert response = @gateway_for_purchase.purchase(@amount, @credit_card, @options.merge(customer_options))
+    assert_success response
+
+    assert_equal 'approved', response.message
+  end
+
   def test_failed_purchase_with_bad_csmdds
     options = {
       fraud_detection: {

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -166,6 +166,19 @@ class DecidirTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_customer_object
+    options = @options.merge(customer_id: 'John', customer_email: 'decidir@decidir.com')
+
+    response = stub_comms(@gateway_for_purchase, :ssl_request) do
+      @gateway_for_purchase.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert data =~ /"email":"decidir@decidir.com"/
+      assert data =~ /"id":"John"/
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_failed_purchase
     @gateway_for_purchase.expects(:ssl_request).returns(failed_purchase_response)
 


### PR DESCRIPTION
This adds support for adding `email` and `id` to the request nested in customer object.

CER-1189

Remote Tests:
26 tests, 92 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96.1538% passed
*1 remote test also failing on master

Unit Tests:
41 tests, 199 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Local Tests:
5833 tests, 79189 assertions, 4 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications 99.9143% passed