### PR TITLE
MerchantWarrior: Addding support for 3DS Global fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -137,6 +137,7 @@
 * CheckoutV2: Add processing and recipient fields [yunnydang] #5068
 * RedsysRest: Omit CVV from requests when not present [jcreiff] #5077
 * Bin Update: Add Unionpay bin [yunnydang] #5079
+* MerchantWarrior: Adding support for 3DS Global fields [Heavyblade] #5072
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -32,6 +32,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method)
         add_recurring_flag(post, options)
         add_soft_descriptors(post, options)
+        add_three_ds(post, options)
         commit('processAuth', post)
       end
 
@@ -43,6 +44,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method)
         add_recurring_flag(post, options)
         add_soft_descriptors(post, options)
+        add_three_ds(post, options)
         commit('processCard', post)
       end
 
@@ -182,6 +184,18 @@ module ActiveMerchant #:nodoc:
             transaction_id
           ).downcase
         )
+      end
+
+      def add_three_ds(post, options)
+        return unless three_d_secure = options[:three_d_secure]
+
+        post.merge!({
+          threeDSEci: three_d_secure[:eci],
+          threeDSXid: three_d_secure[:xid] || three_d_secure[:ds_transaction_id],
+          threeDSCavv: three_d_secure[:cavv],
+          threeDSStatus: three_d_secure[:authentication_response_status],
+          threeDSV2Version: three_d_secure[:version]
+        }.compact)
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_merchant_warrior_test.rb
+++ b/test/remote/gateways/remote_merchant_warrior_test.rb
@@ -192,4 +192,34 @@ class RemoteMerchantWarriorTest < Test::Unit::TestCase
     assert_scrubbed(@gateway.options[:api_passphrase], transcript)
     assert_scrubbed(@gateway.options[:api_key], transcript)
   end
+
+  def test_successful_purchase_with_three_ds
+    @options[:three_d_secure] = {
+      version: '2.2.0',
+      cavv: 'e1E3SN0xF1lDp9js723iASu3wrA=',
+      eci: '05',
+      xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
+
+    assert response = @gateway.purchase(@success_amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+  end
+
+  def test_successful_purchase_with_three_ds_transaction_id
+    @options[:three_d_secure] = {
+      version: '2.2.0',
+      cavv: 'e1E3SN0xF1lDp9js723iASu3wrA=',
+      eci: '05',
+      ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
+
+    assert response = @gateway.purchase(@success_amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction approved', response.message
+  end
 end


### PR DESCRIPTION
## Summary:

Adds the needed fields to support 3DS Global on MerchantWarrior Gateway

[SER-1169](https://spreedly.atlassian.net/browse/SER-1169)

## Tests

### Remote Test:
Finished in 70.785752 seconds.
20 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 37.981802 seconds.
5838 tests, 79224 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
792 files inspected, no offenses detected