### PR TITLE
Adyen: Update "unexpected 3DS authentication response" error message …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -148,6 +148,7 @@
 * Updates to StripePI scrub and Paymentez success_from [almalee24] #5090
 * Bin Update: Add Routex bin [yunnydang] #5089
 * SumUp: Improve success_from and message_from methods [sinourain] #5087
+* Adyen: Send new ignore_threed_dynamic for success_from [almalee24] #5078
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -827,7 +827,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(action, response, options)
-        if %w[RedirectShopper ChallengeShopper].include?(response.dig('resultCode')) && !options[:execute_threed] && !options[:threed_dynamic]
+        if %w[RedirectShopper ChallengeShopper].include?(response.dig('resultCode')) && !options[:execute_threed] && (!options[:threed_dynamic] || options[:ignore_threed_dynamic])
           response['refusalReason'] = 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.'
           return false
         end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -180,6 +180,13 @@ class AdyenTest < Test::Unit::TestCase
     assert_match 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.', response.message
   end
 
+  def test_failed_authorize_with_unexpected_3ds_with_flag_ignore_threed_dynamic
+    @gateway.expects(:ssl_post).returns(successful_authorize_with_3ds_response)
+    response = @gateway.authorize(@amount, @three_ds_enrolled_card, @options.merge!(threed_dynamic: true, ignore_threed_dynamic: true))
+    assert_failure response
+    assert_match 'Received unexpected 3DS authentication response, but a 3DS initiation flag was not included in the request.', response.message
+  end
+
   def test_successful_authorize_with_recurring_contract_type
     stub_comms do
       @gateway.authorize(100, @credit_card, @options.merge({ recurring_contract_type: 'ONECLICK' }))


### PR DESCRIPTION
…logic

Update "unexpected 3DS authentication response" error message logic to look for !options[:execute_threed] to cover all instances where the request didn't expect to perform 3DS.

Unit:
116 tests, 611 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
143 tests, 463 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.3077% passed