### PR TITLE
Redsys Rest: Fix handling of missing CVV

### DIFF
--- a/lib/active_merchant/billing/gateways/redsys_rest.rb
+++ b/lib/active_merchant/billing/gateways/redsys_rest.rb
@@ -332,7 +332,7 @@ module ActiveMerchant #:nodoc:
         post['DS_MERCHANT_TITULAR'] = CGI.escape(name)
         post['DS_MERCHANT_PAN'] = card.number
         post['DS_MERCHANT_EXPIRYDATE'] = "#{year[2..3]}#{month}"
-        post['DS_MERCHANT_CVV2'] = card.verification_value if card.verification_value?
+        post['DS_MERCHANT_CVV2'] = card.verification_value if card.verification_value.present?
       end
 
       def determine_action(options)


### PR DESCRIPTION
This accounts for the potential scenario where `card` is `CreditCard` rather than `ActiveMerchant::Billing::CreditCard`, and therefore doesn't have access to `verification_value?` as a method