### PR TITLE
Paymentez: Remove reference_id flag

### DIFF
--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -213,13 +213,12 @@ module ActiveMerchant #:nodoc:
         three_d_secure_options = options[:three_d_secure]
         return unless three_d_secure_options
 
-        reference_id = options[:new_reference_id_field] ? three_d_secure_options[:ds_transaction_id] : three_d_secure_options[:three_ds_server_trans_id]
         auth_data = {
           cavv: three_d_secure_options[:cavv],
           xid: three_d_secure_options[:xid],
           eci: three_d_secure_options[:eci],
           version: three_d_secure_options[:version],
-          reference_id: reference_id,
+          reference_id: three_d_secure_options[:ds_transaction_id],
           status: three_d_secure_options[:authentication_response_status] || three_d_secure_options[:directory_response_status]
         }.compact
 

--- a/test/remote/gateways/remote_paymentez_test.rb
+++ b/test/remote/gateways/remote_paymentez_test.rb
@@ -32,7 +32,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
     @eci = '01'
     @three_ds_v1_version = '1.0.2'
     @three_ds_v2_version = '2.1.0'
-    @three_ds_server_trans_id = 'ffffffff-9002-51a3-8000-0000000345a2'
+    @ds_server_trans_id = 'ffffffff-9002-51a3-8000-0000000345a2'
     @authentication_response_status = 'Y'
 
     @three_ds_v1_mpi = {
@@ -46,7 +46,7 @@ class RemotePaymentezTest < Test::Unit::TestCase
       cavv: @cavv,
       eci: @eci,
       version: @three_ds_v2_version,
-      three_ds_server_trans_id: @three_ds_server_trans_id,
+      ds_transaction_id: @ds_server_trans_id,
       authentication_response_status: @authentication_response_status
     }
   end

--- a/test/unit/gateways/paymentez_test.rb
+++ b/test/unit/gateways/paymentez_test.rb
@@ -30,7 +30,6 @@ class PaymentezTest < Test::Unit::TestCase
     @eci = '01'
     @three_ds_v1_version = '1.0.2'
     @three_ds_v2_version = '2.1.0'
-    @three_ds_server_trans_id = 'three-ds-v2-trans-id'
     @authentication_response_status = 'Y'
     @directory_server_transaction_id = 'directory_server_transaction_id'
 
@@ -45,7 +44,6 @@ class PaymentezTest < Test::Unit::TestCase
       cavv: @cavv,
       eci: @eci,
       version: @three_ds_v2_version,
-      three_ds_server_trans_id: @three_ds_server_trans_id,
       authentication_response_status: @authentication_response_status,
       ds_transaction_id: @directory_server_transaction_id
     }
@@ -120,7 +118,7 @@ class PaymentezTest < Test::Unit::TestCase
       cavv: @cavv,
       eci: @eci,
       version: @three_ds_v2_version,
-      reference_id: @three_ds_server_trans_id,
+      reference_id: @directory_server_transaction_id,
       status: @authentication_response_status
     }
 


### PR DESCRIPTION
Remove reference_id flag and the only field no populating reference_id will be ds_transaction_id

Remote:
34 tests, 85 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
30 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed.