### PR TITLE
Braintree: Expose data in params

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -154,6 +154,7 @@
 * StripePI: Update eci format [almalee24] #5097
 * Paymentez: Remove reference_id flag [almalee24] #5081
 * Cybersource Rest: Add support for normalized three ds [aenand] #5105
+* Braintree: Add additional data to response [aenand] #5084
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -439,6 +439,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def avs_code_from(transaction)
+        return unless transaction
+
         transaction.avs_error_response_code ||
           avs_mapping["street: #{transaction.avs_street_address_response_code}, zip: #{transaction.avs_postal_code_response_code}"]
       end
@@ -517,7 +519,8 @@ module ActiveMerchant #:nodoc:
             'token'               => result.credit_card_details&.token,
             'debit'               => result.credit_card_details&.debit,
             'prepaid'             => result.credit_card_details&.prepaid,
-            'issuing_bank'        => result.credit_card_details&.issuing_bank
+            'issuing_bank'        => result.credit_card_details&.issuing_bank,
+            'country_of_issuance' => result.credit_card_details&.country_of_issuance
           }
         end
       end
@@ -615,7 +618,10 @@ module ActiveMerchant #:nodoc:
                    'credit_card_details' => credit_card_details(result.transaction),
                    'network_token_details' => network_token_details(result.transaction),
                    'google_pay_details' => google_pay_details(result.transaction),
-                   'apple_pay_details' => apple_pay_details(result.transaction) }
+                   'apple_pay_details' => apple_pay_details(result.transaction),
+                   'avs_response_code' => avs_code_from(result.transaction),
+                   'cvv_response_code' => result.transaction&.cvv_response_code,
+                   'gateway_message' => result.message }
         end
 
         transaction = result.transaction

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1301,6 +1301,10 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'credit_card', response.params['braintree_transaction']['payment_instrument_type']
     assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['prepaid']
     assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['debit']
+    assert_equal 'M', response.params.dig('braintree_transaction', 'cvv_response_code')
+    assert_equal 'I', response.params.dig('braintree_transaction', 'avs_response_code')
+    assert_equal 'Call Issuer. Pick Up Card.', response.params.dig('braintree_transaction', 'gateway_message')
+    assert_equal 'Unknown', response.params.dig('braintree_transaction', 'credit_card_details', 'country_of_issuance')
     assert_equal 'Unknown', response.params['braintree_transaction']['credit_card_details']['issuing_bank']
   end
 


### PR DESCRIPTION
ONE-115

The Braintree gateway is a unique AM gateway in that it uses a gateway SDK to transact. The SDK integration maens that all the gateway's params in a given response are not available unless specifically added via the AM adapter.

This commit adds avs_response_code, cvv_response_code, gateway_message, and country_of_issuance to the params in the AM response. This allows for a more standard way of surfacing data for this gateway.

Test Summary
Local:
5841 tests, 79188 assertions, 1 failures, 23 errors, 0 pendings, 0 omissions, 0 notifications 99.5891% passed
Errors/failures related to other gateways
Unit:
103 tests, 218 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Remote:
120 tests, 646 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed