### PR TITLE
PayTrace: Always send name in billing_address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -150,6 +150,7 @@
 * SumUp: Improve success_from and message_from methods [sinourain] #5087
 * Adyen: Send new ignore_threed_dynamic for success_from [almalee24] #5078
 * Plexo: Add flow field to capture, purchase, and auth [yunnydang] #5092
+* PayTrace:Always send name in billing_address [almalee24] #5086
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/lib/active_merchant/billing/gateways/pay_trace.rb
+++ b/lib/active_merchant/billing/gateways/pay_trace.rb
@@ -265,15 +265,16 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, creditcard, options)
-        return unless options[:billing_address] || options[:address]
-
-        address = options[:billing_address] || options[:address]
         post[:billing_address] = {}
+
+        if (address = options[:billing_address] || options[:address])
+          post[:billing_address][:street_address] = address[:address1]
+          post[:billing_address][:city] = address[:city]
+          post[:billing_address][:state] = address[:state]
+          post[:billing_address][:zip] = address[:zip]
+        end
+
         post[:billing_address][:name] = creditcard.name
-        post[:billing_address][:street_address] = address[:address1]
-        post[:billing_address][:city] = address[:city]
-        post[:billing_address][:state] = address[:state]
-        post[:billing_address][:zip] = address[:zip]
       end
 
       def add_amount(post, money, options)

--- a/test/unit/gateways/pay_trace_test.rb
+++ b/test/unit/gateways/pay_trace_test.rb
@@ -43,8 +43,9 @@ class PayTraceTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_ach
+    @echeck.name = 'Test Name'
     response = stub_comms(@gateway) do
-      @gateway.purchase(@amount, @echeck, @options)
+      @gateway.purchase(@amount, @echeck, {})
     end.check_request do |endpoint, data, _headers|
       request = JSON.parse(data)
       assert_include endpoint, 'checks/sale/by_account'
@@ -52,11 +53,8 @@ class PayTraceTest < Test::Unit::TestCase
       assert_equal request['check']['account_number'], @echeck.account_number
       assert_equal request['check']['routing_number'], @echeck.routing_number
       assert_equal request['integrator_id'], @gateway.options[:integrator_id]
-      assert_equal request['billing_address']['name'], @options[:billing_address][:name]
-      assert_equal request['billing_address']['street_address'], @options[:billing_address][:address1]
-      assert_equal request['billing_address']['city'], @options[:billing_address][:city]
-      assert_equal request['billing_address']['state'], @options[:billing_address][:state]
-      assert_equal request['billing_address']['zip'], @options[:billing_address][:zip]
+      assert_equal request['billing_address']['name'], @echeck.name
+      assert_equal request.dig('billing_address', 'street_address'), nil
     end.respond_with(successful_ach_processing_response)
 
     assert_success response


### PR DESCRIPTION
If name is present in payment method send even if
billing address is nil.

Unit:
30 tests, 156 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
33 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed