### PR TITLE
Plexo: Add flow field to capture, purchase, and auth

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -149,6 +149,7 @@
 * Bin Update: Add Routex bin [yunnydang] #5089
 * SumUp: Improve success_from and message_from methods [sinourain] #5087
 * Adyen: Send new ignore_threed_dynamic for success_from [almalee24] #5078
+* Plexo: Add flow field to capture, purchase, and auth [yunnydang] #5092
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -67,6 +67,7 @@ module ActiveMerchant #:nodoc:
       def verify(credit_card, options = {})
         post = {}
         post[:ReferenceId] = options[:reference_id] || generate_unique_id
+        post[:Flow] = 'direct'
         post[:MerchantId] = options[:merchant_id] || @credentials[:merchant_id]
         post[:StatementDescriptor] = options[:statement_descriptor] if options[:statement_descriptor]
         post[:CustomerId] = options[:customer_id] if options[:customer_id]
@@ -106,6 +107,7 @@ module ActiveMerchant #:nodoc:
         post[:Installments] = options[:installments] if options[:installments]
         post[:StatementDescriptor] = options[:statement_descriptor] if options[:statement_descriptor]
         post[:CustomerId] = options[:customer_id] if options[:customer_id]
+        post[:Flow] = 'direct'
 
         add_payment_method(post, payment, options)
         add_items(post, options[:items])

--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -103,9 +103,12 @@ class RemotePlexoTest < Test::Unit::TestCase
   end
 
   def test_failed_capture
-    response = @gateway.capture(@amount, '123')
+    auth = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure auth
+
+    response = @gateway.capture(@amount, auth.authorization)
     assert_failure response
-    assert_equal 'An internal error occurred. Contact support.', response.message
+    assert_equal 'The selected payment state is not valid.', response.message
   end
 
   def test_successful_refund
@@ -125,9 +128,12 @@ class RemotePlexoTest < Test::Unit::TestCase
   end
 
   def test_failed_refund
-    response = @gateway.refund(@amount, '123', @cancel_options)
+    auth = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure auth
+
+    response = @gateway.refund(@amount, auth.authorization, @cancel_options)
     assert_failure response
-    assert_equal 'An internal error occurred. Contact support.', response.message
+    assert_equal 'The selected payment state is not valid.', response.message
   end
 
   def test_successful_void
@@ -139,9 +145,12 @@ class RemotePlexoTest < Test::Unit::TestCase
   end
 
   def test_failed_void
-    response = @gateway.void('123', @cancel_options)
+    auth = @gateway.authorize(@amount, @declined_card, @options)
+    assert_failure auth
+
+    response = @gateway.void(auth.authorization, @cancel_options)
     assert_failure response
-    assert_equal 'An internal error occurred. Contact support.', response.message
+    assert_equal 'The selected payment state is not valid.', response.message
   end
 
   def test_successful_verify
@@ -284,6 +293,6 @@ class RemotePlexoTest < Test::Unit::TestCase
     assert_success purchase
 
     assert void = @gateway.void(purchase.authorization, @cancel_options)
-    assert_success void
+    assert_failure void
   end
 end


### PR DESCRIPTION
Hardcodes the flow field to be 'direct'.  It is recommended as it could break the payment requests at some point.

Local:
5845 tests, 79178 assertions, 0 failures, 26 errors, 0 pendings, 0 omissions, 0 notifications
99.5552% passed

Unit:
24 tests, 127 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
31 tests, 60 assertions, 0 failures, 0 errors, 0 pendings, 3 omissions, 0 notifications
100% passed

Note: some of the remote tests were experiencing code related errors so I had fixed them in this PR as well.