### PR TITLE
StripePI: Update eci format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -150,7 +150,8 @@
 * SumUp: Improve success_from and message_from methods [sinourain] #5087
 * Adyen: Send new ignore_threed_dynamic for success_from [almalee24] #5078
 * Plexo: Add flow field to capture, purchase, and auth [yunnydang] #5092
-* PayTrace:Always send name in billing_address [almalee24] #5086
+* PayTrace: Always send name in billing_address [almalee24] #5086
+* StripePI: Update eci format [almalee24] #5097
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -458,8 +458,18 @@ module ActiveMerchant #:nodoc:
         post[:payment_method_options][:card][:network_token] ||= {}
         post[:payment_method_options][:card][:network_token] = {
           cryptogram: payment_method.respond_to?(:payment_cryptogram) ? payment_method.payment_cryptogram : options[:cryptogram],
-          electronic_commerce_indicator: payment_method.respond_to?(:eci) ? payment_method.eci : options[:eci]
+          electronic_commerce_indicator: format_eci(payment_method, options)
         }.compact
+      end
+
+      def format_eci(payment_method, options)
+        eci_value = payment_method.respond_to?(:eci) ? payment_method.eci : options[:eci]
+
+        if eci_value&.length == 1
+          "0#{eci_value}"
+        else
+          eci_value
+        end
       end
 
       def extract_token_from_string_and_maybe_add_customer_id(post, payment_method)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -235,6 +235,8 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       currency: 'GBP',
       new_ap_gp_route: true
     }
+    @google_pay.eci = '5'
+    assert_match('5', @google_pay.eci)
 
     auth = @gateway.authorize(@amount, @google_pay, options)
     assert auth.success?

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -521,9 +521,13 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       currency: 'GBP',
       new_ap_gp_route: true
     }
+    @google_pay.eci = '5'
+    assert_match('5', @google_pay.eci)
+
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @google_pay, options)
     end.check_request do |_method, _endpoint, data, _headers|
+      assert_match('payment_method_options[card][network_token][electronic_commerce_indicator]=05', data)
       assert_match('payment_method_data[card][network_token][tokenization_method]=google_pay_dpan', data)
     end.respond_with(successful_create_intent_response)
   end
@@ -534,9 +538,12 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       billing_address: address,
       new_ap_gp_route: true
     }
+    @google_pay.eci = nil
+
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @google_pay, options)
     end.check_request do |_method, _endpoint, data, _headers|
+      assert_not_match('payment_method_options[card][network_token][electronic_commerce_indicator]', data)
       assert_match('payment_method_data[billing_details][name]=Jim+Smith', data)
       assert_match('payment_method_data[card][network_token][tokenization_method]=google_pay_dpan', data)
     end.respond_with(successful_create_intent_response_with_google_pay_and_billing_address)


### PR DESCRIPTION
Update eci format to always be two digits.

Unit:
60 tests, 311 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
93 tests, 444 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed