### PR TITLE
Checkout V2: Retain and refresh OAuth access token

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -155,6 +155,7 @@
 * Paymentez: Remove reference_id flag [almalee24] #5081
 * Cybersource Rest: Add support for normalized three ds [aenand] #5105
 * Braintree: Add additional data to response [aenand] #5084
+* CheckoutV2: Retain and refresh OAuth access token [sinourain] #5098
 
 
 == Version 1.135.0 (August 24, 2023)


### PR DESCRIPTION
This changes contains:
- Retain OAuth access token to be used on subsequent transactions and refreshed when it expires

Spreedly reference:
[ECS-2996](https://spreedly.atlassian.net/browse/ECS-2996)

Unit:
66 tests, 403 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
2902.89 tests/s, 17725.19 assertions/s

Remote:
103 tests, 254 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
0.63 tests/s, 1.56 assertions/s