### PR TITLE
Worldpay: Remove default ECI for NT

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -153,6 +153,10 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def eci_value(payment_method)
+        payment_method.respond_to?(:eci) ? format(payment_method.eci, :two_digits) : ''
+      end
+
       def authorize_request(money, payment_method, options)
         commit('authorize', build_authorization_request(money, payment_method, options), 'AUTHORISED', 'CAPTURED', options)
       end
@@ -604,10 +608,10 @@ module ActiveMerchant #:nodoc:
               )
             end
             name = card_holder_name(payment_method, options)
-            eci = payment_method.respond_to?(:eci) ? format(payment_method.eci, :two_digits) : ''
             xml.cardHolderName name if name.present?
             xml.cryptogram payment_method.payment_cryptogram unless options[:wallet_type] == :google_pay
-            xml.eciIndicator eci.empty? ? '07' : eci
+            eci = eci_value(payment_method)
+            xml.eciIndicator eci if eci.present?
           end
         end
       end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -38,8 +38,13 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       source: :network_token,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     )
-    @nt_credit_card_without_eci = network_tokenization_credit_card(
+    @visa_nt_credit_card_without_eci = network_tokenization_credit_card(
       '4895370015293175',
+      source: :network_token,
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+    @mastercard_nt_credit_card_without_eci = network_tokenization_credit_card(
+      '5555555555554444',
       source: :network_token,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     )
@@ -175,8 +180,14 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
-  def test_successful_purchase_with_network_token_without_eci
-    assert response = @gateway.purchase(@amount, @nt_credit_card_without_eci, @options)
+  def test_successful_purchase_with_network_token_without_eci_visa
+    assert response = @gateway.purchase(@amount, @visa_nt_credit_card_without_eci, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_purchase_with_network_token_without_eci_mastercard
+    assert response = @gateway.purchase(@amount, @mastercard_nt_credit_card_without_eci, @options)
     assert_success response
     assert_equal 'SUCCESS', response.message
   end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -466,15 +466,6 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
-  def test_successful_authorize_with_network_token_without_eci
-    response = stub_comms do
-      @gateway.authorize(@amount, @nt_credit_card_without_eci, @options)
-    end.check_request do |_endpoint, data, _headers|
-      assert_match %r(<eciIndicator>07</eciIndicator>), data
-    end.respond_with(successful_authorize_response)
-    assert_success response
-  end
-
   def test_successful_purchase_with_elo
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'BRL'))


### PR DESCRIPTION
ONE-76

Removes the default ECI value for NT on Worldpay. Per Worldpay's docs on ECI they state
"If you receive an eci value with the token we suggest including in the request". AM should not add a default as that goes against Worldpay's documentation

Docs: https://developerengine.fisglobal.com/apis/wpg/tokenisation/network-payment-tokens

Test Summary
Local:
5840 tests, 79184 assertions, 1 failures, 23 errors, 0 pendings, 0 omissions, 0 notifications 99.589% passed

Tests failing unrelated to this gateway
Remote:
103 tests, 444 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.0583% passed

2 errors also failing on master