### PR TITLE
Cybersource: Update NT flow

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -157,6 +157,7 @@
 * Braintree: Add additional data to response [aenand] #5084
 * CheckoutV2: Retain and refresh OAuth access token [sinourain] #5098
 * Worldpay: Remove default ECI value [aenand] #5103
+* CyberSource: Update NT flow [almalee24] #5106
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -57,13 +57,23 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       '4111111111111111',
       brand: 'visa',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      source: :network_token
     )
     @amex_network_token = network_tokenization_credit_card(
       '378282246310005',
       brand: 'american_express',
       eci: '05',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      source: :network_token
+    )
+
+    @mastercard_network_token = network_tokenization_credit_card(
+      '5555555555554444',
+      brand: 'master',
+      eci: '05',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      source: :network_token
     )
 
     @amount = 100
@@ -741,6 +751,14 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_network_tokenization_with_amex_cc_and_basic_cryptogram
     assert auth = @gateway.authorize(@amount, @amex_network_token, @options)
+    assert_successful_response(auth)
+
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_successful_response(capture)
+  end
+
+  def test_network_tokenization_with_mastercard
+    assert auth = @gateway.authorize(@amount, @mastercard_network_token, @options)
     assert_successful_response(auth)
 
     assert capture = @gateway.capture(@amount, auth.authorization)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -28,7 +28,13 @@ class CyberSourceTest < Test::Unit::TestCase
                                                                  brand: 'master',
                                                                  transaction_id: '123',
                                                                  eci: '05',
+                                                                 source: :network_token,
                                                                  payment_cryptogram: '111111111100cryptogram')
+    @amex_network_token = network_tokenization_credit_card('378282246310005',
+                                                           brand: 'american_express',
+                                                           eci: '05',
+                                                           payment_cryptogram: '111111111100cryptogram',
+                                                           source: :network_token)
     @apple_pay = network_tokenization_credit_card('4111111111111111',
                                                   brand: 'visa',
                                                   transaction_id: '123',
@@ -52,7 +58,8 @@ class CyberSourceTest < Test::Unit::TestCase
           national_tax: '5'
         }
       ],
-      currency: 'USD'
+      currency: 'USD',
+      reconciliation_id: '181537'
     }
 
     @subscription_options = {
@@ -169,7 +176,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_purchase_includes_reconciliation_id
     stub_comms do
-      @gateway.purchase(100, @credit_card, order_id: '1', reconciliation_id: '181537')
+      @gateway.purchase(100, @credit_card, @options.merge(order_id: '1'))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<reconciliationID>181537<\/reconciliationID>/, data)
     end.respond_with(successful_purchase_response)
@@ -307,7 +314,7 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_authorize_includes_reconciliation_id
     stub_comms do
-      @gateway.authorize(100, @credit_card, order_id: '1', reconciliation_id: '181537')
+      @gateway.authorize(100, @credit_card, @options.merge(order_id: '1'))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<reconciliationID>181537<\/reconciliationID>/, data)
     end.respond_with(successful_authorization_response)
@@ -548,25 +555,6 @@ class CyberSourceTest < Test::Unit::TestCase
       }
     })
     assert response = @gateway.purchase(@amount, credit_card, options)
-    assert_success response
-  end
-
-  def test_successful_network_token_purchase_subsequent_auth_visa
-    @gateway.expects(:ssl_post).with do |_host, request_body|
-      assert_match %r'<cavv>111111111100cryptogram</cavv>', request_body
-      assert_match %r'<commerceIndicator>vbv</commerceIndicator>', request_body
-      assert_not_match %r'<commerceIndicator>internet</commerceIndicator>', request_body
-      true
-    end.returns(successful_purchase_response)
-
-    options = @options.merge({
-      stored_credential: {
-        initiator: 'merchant',
-        reason_type: 'unscheduled',
-        network_transaction_id: '016150703802094'
-      }
-    })
-    assert response = @gateway.purchase(@amount, @network_token, options)
     assert_success response
   end
 
@@ -999,7 +987,9 @@ class CyberSourceTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @network_token, @options)
     end.check_request do |_endpoint, body, _headers|
       assert_xml_valid_to_xsd(body)
-      assert_match %r'<ccAuthService run=\"true\">\n  <cavv>111111111100cryptogram</cavv>\n  <commerceIndicator>vbv</commerceIndicator>\n  <xid>111111111100cryptogram</xid>\n</ccAuthService>\n<businessRules>\n</businessRules>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', body
+      assert_match %r(<networkTokenCryptogram>111111111100cryptogram</networkTokenCryptogram>), body
+      assert_match %r(<commerceIndicator>internet</commerceIndicator>), body
+      assert_match %r(<transactionType>3</transactionType>), body
     end.respond_with(successful_purchase_response)
 
     assert_success response
@@ -1017,9 +1007,13 @@ class CyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_auth_with_network_tokenization_for_mastercard
-    @gateway.expects(:ssl_post).with do |_host, request_body|
-      assert_xml_valid_to_xsd(request_body)
-      assert_match %r'<ucaf>\n  <authenticationData>111111111100cryptogram</authenticationData>\n  <collectionIndicator>2</collectionIndicator>\n</ucaf>\n<ccAuthService run=\"true\">\n  <commerceIndicator>spa</commerceIndicator>\n</ccAuthService>\n<businessRules>\n</businessRules>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
+    @gateway.expects(:ssl_post).with do |_host, body|
+      assert_xml_valid_to_xsd(body)
+      assert_match %r(<networkTokenCryptogram>111111111100cryptogram</networkTokenCryptogram>), body
+      assert_match %r(<commerceIndicator>internet</commerceIndicator>), body
+      assert_match %r(<transactionType>3</transactionType>), body
+      assert_match %r(<requestorID>trid_123</requestorID>), body
+      assert_match %r(<paymentSolution>014</paymentSolution>), body
       true
     end.returns(successful_purchase_response)
 
@@ -1028,17 +1022,21 @@ class CyberSourceTest < Test::Unit::TestCase
       brand: 'master',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: '111111111100cryptogram'
+      payment_cryptogram: '111111111100cryptogram',
+      source: :network_token
     )
 
-    assert response = @gateway.authorize(@amount, credit_card, @options)
+    assert response = @gateway.authorize(@amount, credit_card, @options.merge!(trid: 'trid_123'))
     assert_success response
   end
 
   def test_successful_purchase_network_tokenization_mastercard
     @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_xml_valid_to_xsd(request_body)
-      assert_match %r'<ucaf>\n  <authenticationData>111111111100cryptogram</authenticationData>\n  <collectionIndicator>2</collectionIndicator>\n</ucaf>\n<ccAuthService run=\"true\">\n  <commerceIndicator>spa</commerceIndicator>\n</ccAuthService>\n<ccCaptureService run=\"true\">\n</ccCaptureService>\n<businessRules>\n</businessRules>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
+      assert_match %r'<networkTokenCryptogram>111111111100cryptogram</networkTokenCryptogram>', request_body
+      assert_match %r'<commerceIndicator>internet</commerceIndicator>', request_body
+      assert_match %r'<paymentSolution>014</paymentSolution>', request_body
+      assert_not_match %r'<authenticationData>111111111100cryptogram</authenticationData>', request_body
       true
     end.returns(successful_purchase_response)
 
@@ -1046,10 +1044,28 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_network_tokenization_amex
+    @gateway.expects(:ssl_post).with do |_host, request_body|
+      assert_xml_valid_to_xsd(request_body)
+      assert_match %r'<networkTokenCryptogram>111111111100cryptogram</networkTokenCryptogram>', request_body
+      assert_match %r'<commerceIndicator>internet</commerceIndicator>', request_body
+      assert_not_match %r'<paymentSolution>014</paymentSolution>', request_body
+      assert_not_match %r'<paymentSolution>015</paymentSolution>', request_body
+      true
+    end.returns(successful_purchase_response)
+
+    assert response = @gateway.purchase(@amount, @amex_network_token, @options)
+    assert_success response
+  end
+
   def test_successful_auth_with_network_tokenization_for_amex
     @gateway.expects(:ssl_post).with do |_host, request_body|
       assert_xml_valid_to_xsd(request_body)
-      assert_match %r'<ccAuthService run=\"true\">\n  <cavv>MTExMTExMTExMTAwY3J5cHRvZ3I=\n</cavv>\n  <commerceIndicator>aesk</commerceIndicator>\n  <xid>YW0=\n</xid>\n</ccAuthService>\n<businessRules>\n</businessRules>\n<paymentNetworkToken>\n  <transactionType>1</transactionType>\n</paymentNetworkToken>', request_body
+      assert_match %r'<networkTokenCryptogram>MTExMTExMTExMTAwY3J5cHRvZ3JhbQ==\n</networkTokenCryptogram>', request_body
+      assert_match %r'<commerceIndicator>internet</commerceIndicator>', request_body
+      assert_not_match %r'<paymentSolution>014</paymentSolution>', request_body
+      assert_not_match %r'<paymentSolution>015</paymentSolution>', request_body
+      assert_match %r'<reconciliationID>181537</reconciliationID>', request_body
       true
     end.returns(successful_purchase_response)
 
@@ -1058,7 +1074,8 @@ class CyberSourceTest < Test::Unit::TestCase
       brand: 'american_express',
       transaction_id: '123',
       eci: '05',
-      payment_cryptogram: Base64.encode64('111111111100cryptogram')
+      payment_cryptogram: Base64.encode64('111111111100cryptogram'),
+      source: :network_token
     )
 
     assert response = @gateway.authorize(@amount, credit_card, @options)
@@ -1214,6 +1231,214 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response = @gateway.authorize(100, @credit_card, @options.merge(currency: 'JPY'))
     assert_success response
   end
+
+  # CITs/MITs For Network Tokens
+
+  def test_cit_unscheduled_network_token
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: 'unscheduled',
+      initial_transaction: true
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\<reconciliationID\>181537/, data)
+      assert_match(/\<networkTokenCryptogram\>111111111100cryptogram/, data)
+      assert_match(/\<paymentSolution\>015/, data)
+      assert_match(/\<transactionType\>3/, data)
+      assert_match(/\<subsequentAuthFirst\>true/, data)
+      assert_match(/\<commerceIndicator\>internet/, data)
+      assert_not_match(/\<subsequentAuthStoredCredential\>/, data)
+      assert_not_match(/\<subsequentAuth\>true/, data)
+      assert_not_match(/\<subsequentAuthTransactionID\>016150703802094/, data)
+    end.respond_with(successful_authorization_response)
+    assert response.success?
+  end
+
+  def test_mit_unscheduled_network_token
+    @options[:stored_credential] = {
+      initiator: 'merchant',
+      reason_type: 'unscheduled',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\<reconciliationID\>181537/, data)
+      assert_match(/\<networkTokenCryptogram\>111111111100cryptogram/, data)
+      assert_match(/\<paymentSolution\>015/, data)
+      assert_match(/\<transactionType\>3/, data)
+      assert_not_match(/\<subsequentAuthFirst\>true/, data)
+      assert_match(/\<subsequentAuthStoredCredential\>true/, data)
+      assert_match(/\<subsequentAuth\>true/, data)
+      assert_match(/\<subsequentAuthTransactionID\>016150703802094/, data)
+      assert_match(/\<commerceIndicator\>internet/, data)
+    end.respond_with(successful_authorization_response)
+    assert response.success?
+  end
+
+  def test_subsequent_cit_unscheduled_network_token
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: 'unscheduled',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\<reconciliationID\>181537/, data)
+      assert_match(/\<networkTokenCryptogram\>111111111100cryptogram/, data)
+      assert_match(/\<paymentSolution\>015/, data)
+      assert_match(/\<transactionType\>3/, data)
+      assert_not_match(/\<subsequentAuthFirst\>true/, data)
+      assert_match(/\<subsequentAuthStoredCredential\>true/, data)
+      assert_not_match(/\<subsequentAuth\>true/, data)
+      assert_not_match(/\<subsequentAuthTransactionID\>016150703802094/, data)
+      assert_match(/\<commerceIndicator\>internet/, data)
+    end.respond_with(successful_authorization_response)
+    assert response.success?
+  end
+
+  def test_cit_installment_network_token
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: 'installment',
+      initial_transaction: true
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\<reconciliationID\>181537/, data)
+      assert_match(/\<networkTokenCryptogram\>111111111100cryptogram/, data)
+      assert_match(/\<paymentSolution\>015/, data)
+      assert_match(/\<transactionType\>3/, data)
+      assert_match(/\<subsequentAuthFirst\>true/, data)
+      assert_match(/\<commerceIndicator\>internet/, data)
+      assert_not_match(/\<subsequentAuthStoredCredential\>/, data)
+      assert_not_match(/\<subsequentAuth\>true/, data)
+      assert_not_match(/\<subsequentAuthTransactionID\>016150703802094/, data)
+    end.respond_with(successful_authorization_response)
+    assert response.success?
+  end
+
+  def test_mit_installment_network_token
+    @options[:stored_credential] = {
+      initiator: 'merchant',
+      reason_type: 'installment',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\<reconciliationID\>181537/, data)
+      assert_match(/\<networkTokenCryptogram\>111111111100cryptogram/, data)
+      assert_match(/\<paymentSolution\>015/, data)
+      assert_match(/\<transactionType\>3/, data)
+      assert_not_match(/\<subsequentAuthFirst\>true/, data)
+      assert_not_match(/\<subsequentAuthStoredCredential\>true/, data)
+      assert_match(/\<subsequentAuth\>true/, data)
+      assert_match(/\<subsequentAuthTransactionID\>016150703802094/, data)
+      assert_match(/\<commerceIndicator\>internet/, data)
+    end.respond_with(successful_authorization_response)
+    assert response.success?
+  end
+
+  def test_subsequent_cit_installment_network_token
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: 'installment',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\<reconciliationID\>181537/, data)
+      assert_match(/\<networkTokenCryptogram\>111111111100cryptogram/, data)
+      assert_match(/\<paymentSolution\>015/, data)
+      assert_match(/\<transactionType\>3/, data)
+      assert_not_match(/\<subsequentAuthFirst\>/, data)
+      assert_match(/\<subsequentAuthStoredCredential\>true/, data)
+      assert_not_match(/\<subsequentAuth\>true/, data)
+      assert_not_match(/\<subsequentAuthTransactionID\>016150703802094/, data)
+      assert_match(/\<commerceIndicator\>internet/, data)
+    end.respond_with(successful_authorization_response)
+    assert response.success?
+  end
+
+  def test_cit_recurring_network_token
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: 'recurring',
+      initial_transaction: true
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\<reconciliationID\>181537/, data)
+      assert_match(/\<networkTokenCryptogram\>111111111100cryptogram/, data)
+      assert_match(/\<paymentSolution\>015/, data)
+      assert_match(/\<transactionType\>3/, data)
+      assert_match(/\<subsequentAuthFirst\>true/, data)
+      assert_match(/\<commerceIndicator\>internet/, data)
+      assert_not_match(/\<subsequentAuthStoredCredential\>/, data)
+      assert_not_match(/\<subsequentAuth\>true/, data)
+      assert_not_match(/\<subsequentAuthTransactionID\>016150703802094/, data)
+    end.respond_with(successful_authorization_response)
+    assert response.success?
+  end
+
+  def test_mit_recurring_network_token
+    @options[:stored_credential] = {
+      initiator: 'merchant',
+      reason_type: 'recurring',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\<reconciliationID\>181537/, data)
+      assert_match(/\<networkTokenCryptogram\>111111111100cryptogram/, data)
+      assert_match(/\<paymentSolution\>015/, data)
+      assert_match(/\<transactionType\>3/, data)
+      assert_not_match(/\<subsequentAuthFirst\>true/, data)
+      assert_not_match(/\<subsequentAuthStoredCredential\>true/, data)
+      assert_match(/\<subsequentAuth\>true/, data)
+      assert_match(/\<subsequentAuthTransactionID\>016150703802094/, data)
+      assert_match(/\<commerceIndicator\>internet/, data)
+    end.respond_with(successful_authorization_response)
+    assert response.success?
+  end
+
+  def test_subsequent_cit_recurring_network_token
+    @options[:stored_credential] = {
+      initiator: 'cardholder',
+      reason_type: 'recurring',
+      initial_transaction: false,
+      network_transaction_id: '016150703802094'
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/\<reconciliationID\>181537/, data)
+      assert_match(/\<networkTokenCryptogram\>111111111100cryptogram/, data)
+      assert_match(/\<paymentSolution\>015/, data)
+      assert_match(/\<transactionType\>3/, data)
+      assert_not_match(/\<subsequentAuthFirst\>/, data)
+      assert_match(/\<subsequentAuthStoredCredential\>true/, data)
+      assert_not_match(/\<subsequentAuth\>true/, data)
+      assert_not_match(/\<subsequentAuthTransactionID\>016150703802094/, data)
+      assert_match(/\<commerceIndicator\>internet/, data)
+    end.respond_with(successful_authorization_response)
+    assert response.success?
+  end
+
+  # CITs/MITs for Network Tokens
 
   def test_malformed_xml_handling
     @gateway.expects(:ssl_post).returns(malformed_xml_response)
@@ -1566,6 +1791,10 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_scrub_network_token
+    assert_equal @gateway.scrub(pre_scrubbed_network_token), post_scrubbed_network_token
+  end
+
   def test_supports_scrubbing?
     assert @gateway.supports_scrubbing?
   end
@@ -1727,23 +1956,25 @@ class CyberSourceTest < Test::Unit::TestCase
     end
   end
 
-  def test_raises_error_on_network_token_with_an_underlying_discover_card
-    error = assert_raises ArgumentError do
-      credit_card = network_tokenization_credit_card('4111111111111111', brand: 'discover', payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+  def test_returns_error_on_network_token_with_an_underlying_discover_card
+    credit_card = network_tokenization_credit_card('4111111111111111', brand: 'discover', payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=', source: :network_token)
+    response = @gateway.authorize(100, credit_card, @options)
 
-      @gateway.authorize(100, credit_card, @options)
-    end
-    assert_equal 'Payment method discover is not supported, check https://developer.cybersource.com/docs/cybs/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html', error.message
+    assert_equal response.message, 'Discover is not supported by NetworkToken at CyberSource, check https://developer.cybersource.com/docs/cybs/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html'
   end
 
-  def test_raises_error_on_network_token_with_an_underlying_apms
-    error = assert_raises ArgumentError do
-      credit_card = network_tokenization_credit_card('4111111111111111', brand: 'sodexo', payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=')
+  def test_returns_error_on_apple_pay_with_an_underlying_discover_card
+    credit_card = network_tokenization_credit_card('4111111111111111', brand: 'discover', payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=', source: :apple_pay)
+    response = @gateway.purchase(100, credit_card, @options)
 
-      @gateway.authorize(100, credit_card, @options)
-    end
+    assert_equal response.message, 'Discover is not supported by ApplePay at CyberSource, check https://developer.cybersource.com/docs/cybs/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html'
+  end
 
-    assert_equal 'Payment method sodexo is not supported, check https://developer.cybersource.com/docs/cybs/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html', error.message
+  def test_returns_error_on_google_pay_with_an_underlying_discover_card
+    credit_card = network_tokenization_credit_card('4111111111111111', brand: 'discover', payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=', source: :google_pay)
+    response = @gateway.store(credit_card, @options)
+
+    assert_equal response.message, 'Discover is not supported by GooglePay at CyberSource, check https://developer.cybersource.com/docs/cybs/en-us/payments/developer/all/rest/payments/CreatingOnlineAuth/CreatingAuthReqPNT.html'
   end
 
   def test_routing_number_formatting_with_regular_routing_number
@@ -1801,6 +2032,54 @@ class CyberSourceTest < Test::Unit::TestCase
     SSL established
     <- "POST /commerce/1.x/transactionProcessor HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: ics2wstest.ic3.com\r\nContent-Length: 2459\r\n\r\n"
     <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <s:Header>\n    <wsse:Security s:mustUnderstand=\"1\" xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\n      <wsse:UsernameToken>\n        <wsse:Username>test</wsse:Username>\n        <wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\">DT3MZm8t8BsDZC9ZoKl592lvlRbQCcEXmEcYlh3gZObo6zTLQdf2m5klbqXlTq31iTJ5/Ctl/Z5LFE60GFnWGR8Cn5GeXuToZNbMHAvZKZ3sw9tC3Hf4U3Dj8XS2EI4OBvA1jcw38hd3VEm0ZZCAQEDZCC+AnM2ya9417zqynYjwgSyPOfh6CfMlSJKTgxQJLot7jFxYNvM/s9yBZoh37wJZUXdZ9Bf/CH6O3tKzafbyfn5rK25+GeYN9koih4O8c+PLQepzj5miiR7bikFzgEnsVs6LaZdLM8Sx/XVXk+60h02lg/a6KdS3kmUvnTGOihg5JUnl2JucBpH/P4aQYZ==</wsse:Password>\n      </wsse:UsernameToken>\n    </wsse:Security>\n  </s:Header>\n  <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n    <requestMessage xmlns=\"urn:schemas-cybersource-com:transaction-data-1.109\">\n      <merchantID>test</merchantID>\n      <merchantReferenceCode>734dda9bb6446f2f2638ab7faf34682f</merchantReferenceCode>\n      <clientLibrary>Ruby Active Merchant</clientLibrary>\n      <clientLibraryVersion>1.50.0</clientLibraryVersion>\n      <clientEnvironment>x86_64-darwin14.0</clientEnvironment>\n<billTo>\n  <firstName>Longbob</firstName>\n  <lastName>Longsen</lastName>\n  <street1>456 My Street</street1>\n  <street2>Apt 1</street2>\n  <city>Ottawa</city>\n  <state>NC</state>\n  <postalCode>K1C2N6</postalCode>\n  <country>US</country>\n  <company>Widgets Inc</company>\n  <phoneNumber>(555)555-5555</phoneNumber>\n  <email>someguy1232@fakeemail.net</email>\n</billTo>\n<shipTo>\n  <firstName>Longbob</firstName>\n  <lastName>Longsen</lastName>\n  <street1/>\n  <city/>\n  <state/>\n  <postalCode/>\n  <country/>\n  <email>someguy1232@fakeemail.net</email>\n</shipTo>\n<purchaseTotals>\n  <currency>USD</currency>\n  <grandTotalAmount>1.00</grandTotalAmount>\n</purchaseTotals>\n<card>\n  <accountNumber>4111111111111111</accountNumber>\n  <expirationMonth>09</expirationMonth>\n  <expirationYear>2016</expirationYear>\n  <cvNumber>123</cvNumber>\n  <cardType>001</cardType>\n</card>\n<ccAuthService run=\"true\"/>\n<ccCaptureService run=\"true\"/>\n<businessRules>\n  <ignoreAVSResult>true</ignoreAVSResult>\n  <ignoreCVResult>true</ignoreCVResult>\n</businessRules>\n    </requestMessage>\n  </s:Body>\n</s:Envelope>\n"
+    -> "HTTP/1.1 200 OK\r\n"
+    -> "Server: Apache-Coyote/1.1\r\n"
+    -> "X-OPNET-Transaction-Trace: pid=18901,requestid=08985faa-d84a-4200-af8a-1d0a4d50f391\r\n"
+    -> "Set-Cookie: _op_aixPageId=a_233cede6-657e-481e-977d-a4a886dafd37; Path=/\r\n"
+    -> "Content-Type: text/xml\r\n"
+    -> "Content-Length: 1572\r\n"
+    -> "Date: Fri, 05 Jun 2015 13:01:57 GMT\r\n"
+    -> "Connection: close\r\n"
+    -> "\r\n"
+    reading 1572 bytes...
+    -> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n<soap:Header>\n<wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsu:Timestamp xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"Timestamp-513448318\"><wsu:Created>2015-06-05T13:01:57.974Z</wsu:Created></wsu:Timestamp></wsse:Security></soap:Header><soap:Body><c:replyMessage xmlns:c=\"urn:schemas-cybersource-com:transaction-data-1.109\"><c:merchantReferenceCode>734dda9bb6446f2f2638ab7faf34682f</c:merchantReferenceCode><c:requestID>4335093172165000001515</c:requestID><c:decision>ACCEPT</c:decision><c:reasonCode>100</c:reasonCode><c:requestToken>Ahj//wSR1gMBn41YRu/WIkGLlo3asGzCbBky4VOjHT9/xXHSYBT9/xXHSbSA+RQkhk0ky3SA3+mwMCcjrAYDPxqwjd+sKWXL</c:requestToken><c:purchaseTotals><c:currency>USD</c:currency></c:purchaseTotals><c:ccAuthReply><c:reasonCode>100</c:reasonCode><c:amount>1.00</c:amount><c:authorizationCode>888888</c:authorizationCode><c:avsCode>X</c:avsCode><c:avsCodeRaw>I1</c:avsCodeRaw><c:cvCode/><c:authorizedDateTime>2015-06-05T13:01:57Z</c:authorizedDateTime><c:processorResponse>100</c:processorResponse><c:reconciliationID>19475060MAIKBSQG</c:reconciliationID></c:ccAuthReply><c:ccCaptureReply><c:reasonCode>100</c:reasonCode><c:requestDateTime>2015-06-05T13:01:57Z</c:requestDateTime><c:amount>1.00</c:amount><c:reconciliationID>19475060MAIKBSQG</c:reconciliationID></c:ccCaptureReply></c:replyMessage></soap:Body></soap:Envelope>"
+    read 1572 bytes
+    Conn close
+    PRE_SCRUBBED
+  end
+
+  def pre_scrubbed_network_token
+    <<-PRE_SCRUBBED
+    opening connection to ics2wstest.ic3.com:443...
+    opened
+    starting SSL for ics2wstest.ic3.com:443...
+    SSL established
+    <- "POST /commerce/1.x/transactionProcessor HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: ics2wstest.ic3.com\r\nContent-Length: 2459\r\n\r\n"
+    <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <s:Header>\n    <wsse:Security s:mustUnderstand=\"1\" xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\n      <wsse:UsernameToken>\n        <wsse:Username>l</wsse:Username>\n        <wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\">p</wsse:Password>\n      </wsse:UsernameToken>\n    </wsse:Security>\n  </s:Header>\n  <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n    <requestMessage xmlns=\"urn:schemas-cybersource-com:transaction-data-1.201\">\n      <merchantID>l</merchantID>\n      <merchantReferenceCode>1000</merchantReferenceCode>\n      <clientLibrary>Ruby Active Merchant</clientLibrary>\n      <clientLibraryVersion>1.135.0</clientLibraryVersion>\n      <clientEnvironment>arm64-darwin22</clientEnvironment>\n<billTo>\n  <firstName>Longbob</firstName>\n  <lastName>Longsen</lastName>\n  <street1>Unspecified</street1>\n  <city>Unspecified</city>\n  <state>NC</state>\n  <postalCode>00000</postalCode>\n  <country>US</country>\n  <email>null@cybersource.com</email>\n  <ipAddress>127.0.0.1</ipAddress>\n</billTo>\n<shipTo>\n  <firstName>Longbob</firstName>\n  <lastName>Longsen</lastName>\n  <street1/>\n  <city/>\n  <state/>\n  <postalCode/>\n  <email>null@cybersource.com</email>\n</shipTo>\n<item id=\"0\">\n  <unitPrice>1.00</unitPrice>\n  <quantity>2</quantity>\n  <productCode>default</productCode>\n  <productName>Giant Walrus</productName>\n  <productSKU>WA323232323232323</productSKU>\n  <taxAmount>10</taxAmount>\n  <nationalTax>5</nationalTax>\n</item>\n<purchaseTotals>\n  <currency>USD</currency>\n  <grandTotalAmount>1.00</grandTotalAmount>\n</purchaseTotals>\n<card>\n  <accountNumber>5555555555554444</accountNumber>\n  <expirationMonth>09</expirationMonth>\n  <expirationYear>2025</expirationYear>\n  <cvNumber>123</cvNumber>\n  <cardType>002</cardType>\n</card>\n<ccAuthService run=\"true\">\n  <networkTokenCryptogram>111111111100cryptogram</networkTokenCryptogram>\n  <commerceIndicator>internet</commerceIndicator>\n</ccAuthService>\n<businessRules>\n</businessRules>\n<paymentNetworkToken>\n  <requestorID>trid_123</requestorID>\n  <transactionType>3</transactionType>\n</paymentNetworkToken>\n<paymentSolution>014</paymentSolution>\n    </requestMessage>\n  </s:Body>\n</s:Envelope>\n"
+    -> "HTTP/1.1 200 OK\r\n"
+    -> "Server: Apache-Coyote/1.1\r\n"
+    -> "X-OPNET-Transaction-Trace: pid=18901,requestid=08985faa-d84a-4200-af8a-1d0a4d50f391\r\n"
+    -> "Set-Cookie: _op_aixPageId=a_233cede6-657e-481e-977d-a4a886dafd37; Path=/\r\n"
+    -> "Content-Type: text/xml\r\n"
+    -> "Content-Length: 1572\r\n"
+    -> "Date: Fri, 05 Jun 2015 13:01:57 GMT\r\n"
+    -> "Connection: close\r\n"
+    -> "\r\n"
+    reading 1572 bytes...
+    -> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n<soap:Header>\n<wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsu:Timestamp xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"Timestamp-513448318\"><wsu:Created>2015-06-05T13:01:57.974Z</wsu:Created></wsu:Timestamp></wsse:Security></soap:Header><soap:Body><c:replyMessage xmlns:c=\"urn:schemas-cybersource-com:transaction-data-1.109\"><c:merchantReferenceCode>734dda9bb6446f2f2638ab7faf34682f</c:merchantReferenceCode><c:requestID>4335093172165000001515</c:requestID><c:decision>ACCEPT</c:decision><c:reasonCode>100</c:reasonCode><c:requestToken>Ahj//wSR1gMBn41YRu/WIkGLlo3asGzCbBky4VOjHT9/xXHSYBT9/xXHSbSA+RQkhk0ky3SA3+mwMCcjrAYDPxqwjd+sKWXL</c:requestToken><c:purchaseTotals><c:currency>USD</c:currency></c:purchaseTotals><c:ccAuthReply><c:reasonCode>100</c:reasonCode><c:amount>1.00</c:amount><c:authorizationCode>888888</c:authorizationCode><c:avsCode>X</c:avsCode><c:avsCodeRaw>I1</c:avsCodeRaw><c:cvCode/><c:authorizedDateTime>2015-06-05T13:01:57Z</c:authorizedDateTime><c:processorResponse>100</c:processorResponse><c:reconciliationID>19475060MAIKBSQG</c:reconciliationID></c:ccAuthReply><c:ccCaptureReply><c:reasonCode>100</c:reasonCode><c:requestDateTime>2015-06-05T13:01:57Z</c:requestDateTime><c:amount>1.00</c:amount><c:reconciliationID>19475060MAIKBSQG</c:reconciliationID></c:ccCaptureReply></c:replyMessage></soap:Body></soap:Envelope>"
+    read 1572 bytes
+    Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed_network_token
+    <<-PRE_SCRUBBED
+    opening connection to ics2wstest.ic3.com:443...
+    opened
+    starting SSL for ics2wstest.ic3.com:443...
+    SSL established
+    <- "POST /commerce/1.x/transactionProcessor HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: ics2wstest.ic3.com\r\nContent-Length: 2459\r\n\r\n"
+    <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <s:Header>\n    <wsse:Security s:mustUnderstand=\"1\" xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\n      <wsse:UsernameToken>\n        <wsse:Username>l</wsse:Username>\n        <wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\">[FILTERED]</wsse:Password>\n      </wsse:UsernameToken>\n    </wsse:Security>\n  </s:Header>\n  <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n    <requestMessage xmlns=\"urn:schemas-cybersource-com:transaction-data-1.201\">\n      <merchantID>l</merchantID>\n      <merchantReferenceCode>1000</merchantReferenceCode>\n      <clientLibrary>Ruby Active Merchant</clientLibrary>\n      <clientLibraryVersion>1.135.0</clientLibraryVersion>\n      <clientEnvironment>arm64-darwin22</clientEnvironment>\n<billTo>\n  <firstName>Longbob</firstName>\n  <lastName>Longsen</lastName>\n  <street1>Unspecified</street1>\n  <city>Unspecified</city>\n  <state>NC</state>\n  <postalCode>00000</postalCode>\n  <country>US</country>\n  <email>null@cybersource.com</email>\n  <ipAddress>127.0.0.1</ipAddress>\n</billTo>\n<shipTo>\n  <firstName>Longbob</firstName>\n  <lastName>Longsen</lastName>\n  <street1/>\n  <city/>\n  <state/>\n  <postalCode/>\n  <email>null@cybersource.com</email>\n</shipTo>\n<item id=\"0\">\n  <unitPrice>1.00</unitPrice>\n  <quantity>2</quantity>\n  <productCode>default</productCode>\n  <productName>Giant Walrus</productName>\n  <productSKU>WA323232323232323</productSKU>\n  <taxAmount>10</taxAmount>\n  <nationalTax>5</nationalTax>\n</item>\n<purchaseTotals>\n  <currency>USD</currency>\n  <grandTotalAmount>1.00</grandTotalAmount>\n</purchaseTotals>\n<card>\n  <accountNumber>[FILTERED]</accountNumber>\n  <expirationMonth>09</expirationMonth>\n  <expirationYear>2025</expirationYear>\n  <cvNumber>[FILTERED]</cvNumber>\n  <cardType>002</cardType>\n</card>\n<ccAuthService run=\"true\">\n  <networkTokenCryptogram>[FILTERED]</networkTokenCryptogram>\n  <commerceIndicator>internet</commerceIndicator>\n</ccAuthService>\n<businessRules>\n</businessRules>\n<paymentNetworkToken>\n  <requestorID>[FILTERED]</requestorID>\n  <transactionType>3</transactionType>\n</paymentNetworkToken>\n<paymentSolution>014</paymentSolution>\n    </requestMessage>\n  </s:Body>\n</s:Envelope>\n"
     -> "HTTP/1.1 200 OK\r\n"
     -> "Server: Apache-Coyote/1.1\r\n"
     -> "X-OPNET-Transaction-Trace: pid=18901,requestid=08985faa-d84a-4200-af8a-1d0a4d50f391\r\n"


### PR DESCRIPTION
Update NT flow to send cryptogram in networkTokenCryptogram. If it's
a regular transaction commerceIndicator should be internet. If it's a
CIT or MIT commerceIndicator could be installment, recurring or internet
for unscheduled. subsequentAuthStoredCredential should be sent for all
subsequent transactions.

Remote:
136 tests, 676 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.8529% passed

Unit:
158 tests, 941 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed