### PR TITLE
Checkout V2: Update authorization from Basic to Bearer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * Braintree Blue: Pass overridden mid into client token for GS 3DS [sinourain] #5166
 * Moneris: Update crypt_type for 3DS [almalee24] #5162
 * CheckoutV2: Update 3DS message & error code [almalee24] #5177
+* CheckoutV2: Update Authorization from Basic to Bearer [sinourain] #5109
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -580,14 +580,16 @@ module ActiveMerchant #:nodoc:
       end
 
       def headers(action, options)
-        auth_token = @options[:access_token] ? "Bearer #{@options[:access_token]}" : @options[:secret_key]
-        auth_token = @options[:public_key] if action == :tokens
-        headers = {
-          'Authorization' => auth_token,
-          'Content-Type' => 'application/json;charset=UTF-8'
-        }
+        headers = { 'Authorization' => auth_token(action), 'Content-Type' => 'application/json;charset=UTF-8' }
         headers['Cko-Idempotency-Key'] = options[:idempotency_key] if options[:idempotency_key]
+
         headers
+      end
+
+      def auth_token(action)
+        return @options[:public_key] if action == :tokens
+
+        "Bearer #{@options[:access_token] || @options[:secret_key]}"
       end
 
       def tokenize(payment_method, options = {})


### PR DESCRIPTION
Start sending requests using http Auth:Bearer

Spreedly reference:
[ECS-3487](https://spreedly.atlassian.net/browse/ECS-3487)

Unit:
66 tests, 403 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
2821.48 tests/s, 17228.11 assertions/s

Remote:
103 tests, 254 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
0.63 tests/s, 1.56 assertions/s