### PR TITLE
Shift4V2: Adding store for bank account and cc

### DIFF
--- a/lib/active_merchant/billing/gateways/securion_pay.rb
+++ b/lib/active_merchant/billing/gateways/securion_pay.rb
@@ -193,7 +193,8 @@ module ActiveMerchant #:nodoc:
           post[:card] = card
           add_address(post, options)
         elsif creditcard.kind_of?(String)
-          post[:card] = creditcard
+          key = creditcard.match(/^pm_/) ? :paymentMethod : :card
+          post[key] = creditcard
         else
           raise ArgumentError.new("Unhandled payment method #{creditcard.class}.")
         end

--- a/test/unit/gateways/shift4_v2_test.rb
+++ b/test/unit/gateways/shift4_v2_test.rb
@@ -29,9 +29,7 @@ class Shift4V2Test < SecurionPayTest
   end
 
   def test_successful_store_and_unstore
-    @gateway.expects(:ssl_post).returns(successful_authorize_response)
     @gateway.expects(:ssl_post).returns(successful_new_customer_response)
-    @gateway.expects(:ssl_post).returns(successful_void_response)
 
     store = @gateway.store(@credit_card, @options)
     assert_success store


### PR DESCRIPTION
## Summary:

This PR enables Shift4v2 to implement TPV on Bank accounts and adds support to store CreditCards directly on the 'cards' end-point

[SER-1219](https://spreedly.atlassian.net/browse/SER-1219)

## Tests

### Remote Test:
Finished in 52.459288 seconds.
47 tests, 166 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 40.844376 seconds.
5848 tests, 79304 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
792 files inspected, no offenses detected