### PR TITLE
Litle: update the enhanced data field to return integer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -158,6 +158,7 @@
 * CheckoutV2: Retain and refresh OAuth access token [sinourain] #5098
 * Worldpay: Remove default ECI value [aenand] #5103
 * CyberSource: Update NT flow [almalee24] #5106
+* Litle: Update enhanced data fields to pass integers [yunnydang] #5113
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -117,8 +117,8 @@ module ActiveMerchant #:nodoc:
             doc.quantity(line_item[:quantity]) if line_item[:quantity]
             doc.unitOfMeasure(line_item[:unit_of_measure]) if line_item[:unit_of_measure]
             doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]
-            doc.itemDiscountAmount(line_item[:discount_per_line_item]) unless line_item[:discount_per_line_item] < 0
-            doc.unitCost(line_item[:unit_cost]) unless line_item[:unit_cost] < 0
+            doc.itemDiscountAmount(line_item[:discount_per_line_item].to_i) unless line_item[:discount_per_line_item].to_i < 0
+            doc.unitCost(line_item[:unit_cost].to_i) unless line_item[:unit_cost].to_i < 0
             doc.detailTax do
               doc.taxIncludedInTotal(line_item[:tax_included_in_total]) if line_item[:tax_included_in_total]
               doc.taxAmount(line_item[:tax_amount]) if line_item[:tax_amount]

--- a/test/unit/gateways/datatrans_test.rb
+++ b/test/unit/gateways/datatrans_test.rb
@@ -221,7 +221,6 @@ class DatatransTest < Test::Unit::TestCase
   def successful_void_response
     successful_capture_response
   end
- 
 
   def pre_scrubbed
     <<~PRE_SCRUBBED


### PR DESCRIPTION
Ensures we pass a integer to some of the enhanced data fields for visa and mastercard

Local:
5867 tests, 79303 assertions, 0 failures, 7 errors, 0 pendings, 0 omissions, 0 notifications
99.8807% passed

Unit:
59 tests, 264 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
57 tests, 251 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed