### PR TITLE
Worldpay: Update stored creds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -162,6 +162,7 @@
 * Litle: Update commodity code and line item total fields [yunnydang] #5115
 * Cybersource Rest: Add support for network tokens [aenand] #5107
 * Decidir: Add support for customer object [rachelkirk] #5071
+* Worldpay: Add support for stored credentials with network tokens [aenand] #5114
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -613,6 +613,7 @@ module ActiveMerchant #:nodoc:
             eci = eci_value(payment_method)
             xml.eciIndicator eci if eci.present?
           end
+          add_stored_credential_options(xml, options)
         end
       end
 
@@ -698,7 +699,7 @@ module ActiveMerchant #:nodoc:
         stored_credential_params = generate_stored_credential_params(is_initial_transaction, reason)
 
         xml.storedCredentials stored_credential_params do
-          xml.schemeTransactionIdentifier options[:stored_credential][:network_transaction_id] if options[:stored_credential][:network_transaction_id] && !is_initial_transaction
+          xml.schemeTransactionIdentifier network_transaction_id(options) if network_transaction_id(options) && !is_initial_transaction
         end
       end
 

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -699,7 +699,7 @@ module ActiveMerchant #:nodoc:
         stored_credential_params = generate_stored_credential_params(is_initial_transaction, reason)
 
         xml.storedCredentials stored_credential_params do
-          xml.schemeTransactionIdentifier network_transaction_id(options) if network_transaction_id(options) && !is_initial_transaction
+          xml.schemeTransactionIdentifier options[:stored_credential][:network_transaction_id] if options[:stored_credential][:network_transaction_id] && !is_initial_transaction
         end
       end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -180,6 +180,14 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_purchase_with_network_token_and_stored_credentials
+    stored_credential_params = stored_credential(:initial, :unscheduled, :merchant)
+
+    assert response = @gateway.purchase(@amount, @nt_credit_card, @options.merge({ stored_credential: stored_credential_params }))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_successful_purchase_with_network_token_without_eci_visa
     assert response = @gateway.purchase(@amount, @visa_nt_credit_card_without_eci, @options)
     assert_success response

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -346,9 +346,9 @@ class WorldpayTest < Test::Unit::TestCase
   end
 
   def test_authorize_with_nt_passes_standard_stored_credential_options
-    stored_credential_params = stored_credential(:used, :unscheduled, :merchant, network_transaction_id: 20005060720116005060)
+    stored_credential_params = stored_credential(:used, :unscheduled, :merchant, network_transaction_id: 20_005_060_720_116_005_060)
     response = stub_comms do
-      @gateway.authorize(@amount, @nt_credit_card, @options.merge({stored_credential: stored_credential_params}))
+      @gateway.authorize(@amount, @nt_credit_card, @options.merge({ stored_credential: stored_credential_params }))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"UNSCHEDULED\"\>/, data)
       assert_match(/<schemeTransactionIdentifier\>20005060720116005060\<\/schemeTransactionIdentifier\>/, data)

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -345,6 +345,17 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_authorize_with_nt_passes_standard_stored_credential_options
+    stored_credential_params = stored_credential(:used, :unscheduled, :merchant, network_transaction_id: 20005060720116005060)
+    response = stub_comms do
+      @gateway.authorize(@amount, @nt_credit_card, @options.merge({stored_credential: stored_credential_params}))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"UNSCHEDULED\"\>/, data)
+      assert_match(/<schemeTransactionIdentifier\>20005060720116005060\<\/schemeTransactionIdentifier\>/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_authorize_passes_correct_stored_credential_options_for_first_recurring
     options = @options.merge(
       stored_credential_usage: 'FIRST',

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -315,22 +315,6 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
-  def test_authorize_prefers_non_normal_ntid
-    stored_credential_params = stored_credential(:used, :recurring, :merchant, network_transaction_id: '3812908490218390214124')
-    options = @options.merge(
-      stored_credential_transaction_id: '000000000000020005060720116005060'
-    )
-
-    options.merge!({ stored_credential: stored_credential_params })
-    response = stub_comms do
-      @gateway.authorize(@amount, @credit_card, options)
-    end.check_request do |_endpoint, data, _headers|
-      assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"RECURRING\"\>/, data)
-      assert_match(/<schemeTransactionIdentifier\>000000000000020005060720116005060\<\/schemeTransactionIdentifier\>/, data)
-    end.respond_with(successful_authorize_response)
-    assert_success response
-  end
-
   def test_authorize_passes_stored_credential_options
     options = @options.merge(
       stored_credential_usage: 'USED',
@@ -339,6 +323,21 @@ class WorldpayTest < Test::Unit::TestCase
     )
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"UNSCHEDULED\"\>/, data)
+      assert_match(/<schemeTransactionIdentifier\>000000000000020005060720116005060\<\/schemeTransactionIdentifier\>/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_authorize_with_nt_passes_stored_credential_options
+    options = @options.merge(
+      stored_credential_usage: 'USED',
+      stored_credential_initiated_reason: 'UNSCHEDULED',
+      stored_credential_transaction_id: '000000000000020005060720116005060'
+    )
+    response = stub_comms do
+      @gateway.authorize(@amount, @nt_credit_card, options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"UNSCHEDULED\"\>/, data)
       assert_match(/<schemeTransactionIdentifier\>000000000000020005060720116005060\<\/schemeTransactionIdentifier\>/, data)


### PR DESCRIPTION
COMP-42

Adds tests to ensure stored credentials are passed for network tokens and adds the ability to override the NTID from the standard framework

Test Summary
Local:
5867 tests, 79281 assertions, 0 failures, 23 errors, 0 pendings, 0 omissions, 0 notifications 99.608% passed
Unit:
117 tests, 662 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Remote:
104 tests, 447 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.0769% passed