### PR TITLE
Paymentez: Updates success_from method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -163,6 +163,7 @@
 * Cybersource Rest: Add support for network tokens [aenand] #5107
 * Decidir: Add support for customer object [rachelkirk] #5071
 * Worldpay: Add support for stored credentials with network tokens [aenand] #5114
+* Paymentez: Update success_from method for refunds [almalee24] #5116
 
 
 == Version 1.135.0 (August 24, 2023)

--- a/lib/active_merchant/billing/gateways/paymentez.rb
+++ b/lib/active_merchant/billing/gateways/paymentez.rb
@@ -291,10 +291,20 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(response, action = nil)
-        if action == 'refund'
-          response.dig('transaction', 'status_detail') == 7 || SUCCESS_STATUS.include?(response.dig('transaction', 'current_status') || response['status'])
+        transaction_current_status = response.dig('transaction', 'current_status')
+        request_status = response['status']
+        transaction_status = response.dig('transaction', 'status')
+        default_response = SUCCESS_STATUS.include?(transaction_current_status || request_status || transaction_status)
+
+        case action
+        when 'refund'
+          if transaction_current_status && request_status
+            transaction_current_status&.upcase == 'CANCELLED' && request_status&.downcase == 'success'
+          else
+            default_response
+          end
         else
-          SUCCESS_STATUS.include?(response.dig('transaction', 'current_status') || response['status'])
+          default_response
         end
       end
 


### PR DESCRIPTION
Update success_from method to take current_status for the first message to evaluate.
If the transaction type is refund the  successful current_status base
on CANCELLED if status is also success

Remote
34 tests, 85 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit
33 tests, 137 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed