### PR TITLE
Add L2/L3 data for cybersource rest and worldpay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -174,6 +174,8 @@
 * Worldpay: Add support for deafult ECI value [aenand] #5126
 * DLocal: Update stored credentials [sinourain] #5112
 * NMI: Add NTID override [yunnydang] #5134
+* Cybersource Rest: Support L2/L3 data [aenand] #5117
+* Worldpay: Support L2/L3 data [aenand] #5117
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -106,6 +106,23 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def add_level_2_data(post, options)
+        return unless options[:purchase_order_number]
+
+        post[:orderInformation][:invoiceDetails] ||= {}
+        post[:orderInformation][:invoiceDetails][:purchaseOrderNumber] = options[:purchase_order_number]
+      end
+
+      def add_level_3_data(post, options)
+        return unless options[:line_items]
+
+        post[:orderInformation][:lineItems] = options[:line_items]
+        post[:processingInformation][:purchaseLevel] = '3'
+        post[:orderInformation][:shipping_details] = { shipFromPostalCode: options[:ships_from_postal_code] }
+        post[:orderInformation][:amountDetails] ||= {}
+        post[:orderInformation][:amountDetails][:discountAmount] = options[:discount_amount]
+      end
+
       def add_three_ds(post, payment_method, options)
         return unless three_d_secure = options[:three_d_secure]
 
@@ -149,6 +166,8 @@ module ActiveMerchant #:nodoc:
           add_partner_solution_id(post)
           add_stored_credentials(post, payment, options)
           add_three_ds(post, payment, options)
+          add_level_2_data(post, options)
+          add_level_3_data(post, options)
         end.compact
       end
 
@@ -477,7 +496,8 @@ module ActiveMerchant #:nodoc:
       def add_invoice_number(post, options)
         return unless options[:invoice_number].present?
 
-        post[:orderInformation][:invoiceDetails] = { invoiceNumber: options[:invoice_number] }
+        post[:orderInformation][:invoiceDetails] ||= {}
+        post[:orderInformation][:invoiceDetails][:invoiceNumber] = options[:invoice_number]
       end
 
       def add_partner_solution_id(post)

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -275,10 +275,10 @@ module ActiveMerchant #:nodoc:
 
         add_optional_data_level_two_and_three(xml, data)
 
-        data[:item].each { |item| add_items_into_level_three_data(xml, item.symbolize_keys, data) } if data.include?(:item)
+        data[:line_items].each { |item| add_line_items_into_level_three_data(xml, item.symbolize_keys, data) } if data.include?(:line_items)
       end
 
-      def add_items_into_level_three_data(xml, item, data)
+      def add_line_items_into_level_three_data(xml, item, data)
         xml.item do
           xml.description item[:description] if item[:description]
           xml.productCode item[:product_code] if item[:product_code]

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -306,8 +306,7 @@ module ActiveMerchant #:nodoc:
             add_amount(xml, sub_total_amount, data)
           end
           xml.itemTotalWithTax do
-            total_amount = item[:quantity].to_i * (item[:unit_cost].to_i - item[:discount_amount].to_i + item[:tax_amount].to_i)
-            add_amount(xml, total_amount, data)
+            add_amount(xml, item[:total_amount], data)
           end
           xml.itemDiscountAmount do
             add_amount(xml, item[:discount_amount], data)

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -273,19 +273,6 @@ module ActiveMerchant #:nodoc:
           end
         end
 
-        # xml.discountName data[:discount_name] if data.include?(:discount_name)
-        # xml.discountCode data[:discount_code] if data.include?(:discount_code)
-
-        # add_date_element(xml, 'shippingDate', data[:shipping_date]) if data.include?(:shipping_date)
-
-        # if data.include?(:shipping_courier)
-        #   xml.shippingCourier(
-        #     data[:shipping_courier][:priority],
-        #     data[:shipping_courier][:tracking_number],
-        #     data[:shipping_courier][:name]
-        #   )
-        # end
-
         add_optional_data_level_two_and_three(xml, data)
 
         data[:item].each { |item| add_items_into_level_three_data(xml, item.symbolize_keys, data) } if data.include?(:item)

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -585,4 +585,49 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @master_card, @options)
     assert_success auth
   end
+
+  def test_successful_purchase_with_level_2_data
+    response = @gateway.purchase(@amount, @visa_card, @options.merge({ purchase_order_number: '13829012412' }))
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_nil response.params['_links']['capture']
+  end
+
+  def test_successful_purchase_with_level_2_and_3_data
+    options = {
+      purchase_order_number: '6789',
+      discount_amount: '150',
+      ships_from_postal_code: '90210',
+      line_items: [
+        {
+          productName: 'Product Name',
+          kind: 'debit',
+          quantity: 10,
+          unitPrice: '9.5000',
+          totalAmount: '95.00',
+          taxAmount: '5.00',
+          discountAmount: '0.00',
+          productCode: '54321',
+          commodityCode: '98765'
+        },
+        {
+          productName: 'Other Product Name',
+          kind: 'debit',
+          quantity: 1,
+          unitPrice: '2.5000',
+          totalAmount: '90.00',
+          taxAmount: '2.00',
+          discountAmount: '1.00',
+          productCode: '54322',
+          commodityCode: '98766'
+        }
+      ]
+    }
+    assert response = @gateway.purchase(@amount, @visa_card, @options.merge(options))
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_nil response.params['_links']['capture']
+  end
 end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -72,28 +72,28 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         discount_amount: '1',
         shipping_amount: '50',
         duty_amount: '20',
-        item: [{
+        line_items: [{
           description: 'Laptop 14',
           product_code: 'LP00125',
           commodity_code: 'COM00125',
           quantity: '2',
           unit_cost: '1500',
           unit_of_measure: 'each',
-          item_discount_amount: '200',
+          discount_amount: '200',
           tax_amount: '500',
           total_amount: '3300'
         },
-               {
-                 description: 'Laptop 15',
-                        product_code: 'LP00125',
-                        commodity_code: 'COM00125',
-                        quantity: '2',
-                        unit_cost: '1500',
-                        unit_of_measure: 'each',
-                        item_discount_amount: '200',
-                        tax_amount: '500',
-                        total_amount: '3300'
-               }]
+                     {
+                       description: 'Laptop 15',
+                              product_code: 'LP00125',
+                              commodity_code: 'COM00125',
+                              quantity: '2',
+                              unit_cost: '1500',
+                              unit_of_measure: 'each',
+                              discount_amount: '200',
+                              tax_amount: '500',
+                              total_amount: '3300'
+                     }]
       }
     }
 
@@ -691,13 +691,13 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_purchase_level_three_data_without_item_mastercard
-    @level_three_data[:level_3_data][:item] = [{
+    @level_three_data[:level_3_data][:line_items] = [{
     }]
     @credit_card.brand = 'master'
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@level_three_data))
     assert_failure response
     assert_equal response.error_code, '2'
-    assert_equal response.params['error'].gsub(/\"+/, ''), 'The content of element type item must match (description,productCode?,commodityCode?,quantity?,unitCost?,unitOfMeasure?,itemTotal?,itemTotalWithTax?,itemDiscountAmount?,taxAmount?,categories?,pageURL?,imageURL?).'
+    assert_equal response.params['error'].gsub(/\"+/, ''), 'The content of element type item must match (description,productCode?,commodityCode?,quantity?,unitCost?,unitOfMeasure?,itemTotal?,itemTotalWithTax?,itemDiscountAmount?,itemTaxRate?,lineDiscountIndicator?,itemLocalTaxRate?,itemLocalTaxAmount?,taxAmount?,categories?,pageURL?,imageURL?).'
   end
 
   def test_successful_purchase_with_level_two_and_three_fields

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -80,17 +80,19 @@ class RemoteWorldpayTest < Test::Unit::TestCase
           unit_cost: '1500',
           unit_of_measure: 'each',
           item_discount_amount: '200',
-          tax_amount: '500'
+          tax_amount: '500',
+          total_amount: '3300'
         },
                {
                  description: 'Laptop 15',
-                 product_code: 'LP00125',
-                 commodity_code: 'COM00125',
-                 quantity: '2',
-                 unit_cost: '1500',
-                 unit_of_measure: 'each',
-                 item_discount_amount: '200',
-                 tax_amount: '500'
+                        product_code: 'LP00125',
+                        commodity_code: 'COM00125',
+                        quantity: '2',
+                        unit_cost: '1500',
+                        unit_of_measure: 'each',
+                        item_discount_amount: '200',
+                        tax_amount: '500',
+                        total_amount: '3300'
                }]
       }
     }

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -59,11 +59,8 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         invoice_reference_number: 'INV12233565',
         customer_reference: 'CUST00000101',
         card_acceptor_tax_id: 'VAT1999292',
-        sales_tax: {
-          amount: '20',
-          exponent: '2',
-          currency: 'USD'
-        }
+        tax_amount: '20',
+        ship_from_postal_code:  '43245'
       }
     }
 
@@ -71,58 +68,30 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       level_3_data: {
         customer_reference: 'CUST00000102',
         card_acceptor_tax_id: 'VAT1999285',
-        sales_tax: {
-          amount: '20',
-          exponent: '2',
-          currency: 'USD'
-        },
-        discount_amount: {
-          amount: '1',
-          exponent: '2',
-          currency: 'USD'
-        },
-        shipping_amount: {
-          amount: '50',
-          exponent: '2',
-          currency: 'USD'
-        },
-        duty_amount: {
-          amount: '20',
-          exponent: '2',
-          currency: 'USD'
-        },
-        item: {
+        tax_amount: '20',
+        discount_amount: '1',
+        shipping_amount: '50',
+        duty_amount: '20',
+        item: [{
           description: 'Laptop 14',
           product_code: 'LP00125',
           commodity_code: 'COM00125',
           quantity: '2',
-          unit_cost: {
-            amount: '1500',
-            exponent: '2',
-            currency: 'USD'
-          },
+          unit_cost: '1500',
           unit_of_measure: 'each',
-          item_total: {
-            amount: '3000',
-            exponent: '2',
-            currency: 'USD'
-          },
-          item_total_with_tax: {
-            amount: '3500',
-            exponent: '2',
-            currency: 'USD'
-          },
-          item_discount_amount: {
-            amount: '200',
-            exponent: '2',
-            currency: 'USD'
-          },
-          tax_amount: {
-            amount: '500',
-            exponent: '2',
-            currency: 'USD'
-          }
-        }
+          item_discount_amount: '200',
+          tax_amount: '500'
+        },
+               {
+                 description: 'Laptop 15',
+                 product_code: 'LP00125',
+                 commodity_code: 'COM00125',
+                 quantity: '2',
+                 unit_cost: '1500',
+                 unit_of_measure: 'each',
+                 item_discount_amount: '200',
+                 tax_amount: '500'
+               }]
       }
     }
 
@@ -705,7 +674,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_level_two_fields_and_sales_tax_zero
-    @level_two_data[:level_2_data][:sales_tax][:amount] = 0
+    @level_two_data[:level_2_data][:tax_amount] = 0
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@level_two_data))
     assert_success response
     assert_equal true, response.params['ok']
@@ -720,12 +689,13 @@ class RemoteWorldpayTest < Test::Unit::TestCase
   end
 
   def test_unsuccessful_purchase_level_three_data_without_item_mastercard
-    @level_three_data[:level_3_data][:item] = {}
+    @level_three_data[:level_3_data][:item] = [{
+    }]
     @credit_card.brand = 'master'
     assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@level_three_data))
     assert_failure response
     assert_equal response.error_code, '2'
-    assert_equal response.params['error'].gsub(/\"+/, ''), 'The content of element type item is incomplete, it must match (description,productCode?,commodityCode?,quantity?,unitCost?,unitOfMeasure?,itemTotal?,itemTotalWithTax?,itemDiscountAmount?,taxAmount?,categories?,pageURL?,imageURL?).'
+    assert_equal response.params['error'].gsub(/\"+/, ''), 'The content of element type item must match (description,productCode?,commodityCode?,quantity?,unitCost?,unitOfMeasure?,itemTotal?,itemTotalWithTax?,itemDiscountAmount?,taxAmount?,categories?,pageURL?,imageURL?).'
   end
 
   def test_successful_purchase_with_level_two_and_three_fields

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -117,7 +117,8 @@ class WorldpayTest < Test::Unit::TestCase
           unit_cost: '1500',
           unit_of_measure: 'each',
           item_discount_amount: '200',
-          tax_amount: '500'
+          tax_amount: '500',
+          total_amount: '4000'
         },
                {
                  description: 'Laptop 15',
@@ -127,7 +128,8 @@ class WorldpayTest < Test::Unit::TestCase
                  unit_cost: '1000',
                  unit_of_measure: 'each',
                  item_discount_amount: '200',
-                 tax_amount: '500'
+                 tax_amount: '500',
+                 total_amount: '3000'
                }]
       }
     }

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -109,7 +109,7 @@ class WorldpayTest < Test::Unit::TestCase
         discount_amount: '1',
         shipping_amount: '50',
         duty_amount: '20',
-        item: [{
+        line_items: [{
           description: 'Laptop 14',
           product_code: 'LP00125',
           commodity_code: 'COM00125',
@@ -117,20 +117,22 @@ class WorldpayTest < Test::Unit::TestCase
           unit_cost: '1500',
           unit_of_measure: 'each',
           item_discount_amount: '200',
+          discount_amount: '0',
           tax_amount: '500',
           total_amount: '4000'
         },
-               {
-                 description: 'Laptop 15',
-                 product_code: 'LP00120',
-                 commodity_code: 'COM00125',
-                 quantity: '2',
-                 unit_cost: '1000',
-                 unit_of_measure: 'each',
-                 item_discount_amount: '200',
-                 tax_amount: '500',
-                 total_amount: '3000'
-               }]
+                     {
+                       description: 'Laptop 15',
+                       product_code: 'LP00120',
+                       commodity_code: 'COM00125',
+                       quantity: '2',
+                       unit_cost: '1000',
+                       unit_of_measure: 'each',
+                       item_discount_amount: '200',
+                       tax_amount: '500',
+                       discount_amount: '0',
+                       total_amount: '3000'
+                     }]
       }
     }
   end


### PR DESCRIPTION
Worldpay:
Refactor L2/L3 data for Worldpay to be more in line with how active merchant gateways expect this data. It also lowers the burden for what merchants must provide to use L2/L3 data
    
Test Summary
Local:
5883 tests, 79441 assertions, 0 failures, 23 errors, 0 pendings, 0 omissions, 0 notifications
99.609% passed
Unit:
117 tests, 668 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
103 tests, 444 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.0583% passed

Cybersource Rest
Adds support for L2 and L3 data to the Cybersource Rest
    
Test Summary
Local:
5882 tests, 79430 assertions, 0 failures, 23 errors, 0 pendings, 0 omissions, 0 notifications
99.609% passed
Unit:
36 tests, 189 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
54 tests, 168 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
87.037% passed