### PR TITLE
HiPay:  Fix parse authorization string

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -170,6 +170,7 @@
 * FlexCharge: Add ThirdParty 3DS params [javierpedrozaing] #5121
 * FlexCharge: Add support for TPV store [edgarv09] #5120
 * CheckoutV2: Add sender payment fields to purchase and auth [yunnydang] #5124
+* HiPay: Fix parse authorization string [javierpedrozaing] #5119
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/test/unit/gateways/hi_pay_test.rb
+++ b/test/unit/gateways/hi_pay_test.rb
@@ -146,6 +146,28 @@ class HiPayTest < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
   end
 
+  def test_authorization_string_with_nil_values
+    auth_string_nil_value_first = @gateway.send :authorization_string, [nil, '123456', 'visa']
+    assert_equal '123456|visa', auth_string_nil_value_first
+
+    auth_string_nil_values = @gateway.send :authorization_string, [nil, 'token', nil]
+    assert_equal 'token', auth_string_nil_values
+
+    auth_string_two_nil_values = @gateway.send :authorization_string, [nil, nil, 'visa']
+    assert_equal 'visa', auth_string_two_nil_values
+
+    auth_string_nil_values = @gateway.send :authorization_string, ['reference', nil, nil]
+    assert_equal 'reference', auth_string_nil_values
+
+    auth_string_nil_values = @gateway.send :authorization_string, [nil, nil, nil]
+    assert_equal '', auth_string_nil_values
+  end
+
+  def test_authorization_string_with_full_values
+    complete_auth_string = @gateway.send :authorization_string, %w(86786788 123456 visa)
+    assert_equal '86786788|123456|visa', complete_auth_string
+  end
+
   def test_purhcase_with_credit_card; end
 
   def test_capture


### PR DESCRIPTION
Description
-------------------------
This commit fixes the parse authorization string when the first value is nil also fixes a issue trying to get the payment_method.brand when the payment method is not a credit card

Unit test
-------------------------
Finished in 0.800901 seconds.

23 tests, 59 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

28.72 tests/s, 73.67 assertions/s

Remote test
-------------------------
Finished in 9.141401 seconds.

1 tests, 6 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

0.11 tests/s, 0.66 assertions/s

Rubocop
-------------------------
795 files inspected, no offenses detected