### PR TITLE
CheckoutV2: add sender object for purchase and auth

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -169,6 +169,7 @@
 * DataTrans: Add ThirdParty 3DS params [gasb150] #5118
 * FlexCharge: Add ThirdParty 3DS params [javierpedrozaing] #5121
 * FlexCharge: Add support for TPV store [edgarv09] #5120
+* CheckoutV2: Add sender payment fields to purchase and auth [yunnydang] #5124
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -143,6 +143,7 @@ module ActiveMerchant #:nodoc:
         add_marketplace_data(post, options)
         add_recipient_data(post, options)
         add_processing_data(post, options)
+        add_payment_sender_data(post, options)
       end
 
       def add_invoice(post, money, options)
@@ -171,9 +172,12 @@ module ActiveMerchant #:nodoc:
         post[:recipient][:last_name] = recipient[:last_name] if recipient[:last_name]
 
         if address = recipient[:address]
+          address1 = address[:address1] || address[:address_line1]
+          address2 = address[:address2] || address[:address_line2]
+
           post[:recipient][:address] = {}
-          post[:recipient][:address][:address_line1] = address[:address_line1] if address[:address_line1]
-          post[:recipient][:address][:address_line2] = address[:address_line2] if address[:address_line2]
+          post[:recipient][:address][:address_line1] = address1 if address1
+          post[:recipient][:address][:address_line2] = address2 if address2
           post[:recipient][:address][:city] = address[:city] if address[:city]
           post[:recipient][:address][:state] = address[:state] if address[:state]
           post[:recipient][:address][:zip] = address[:zip] if address[:zip]
@@ -185,6 +189,40 @@ module ActiveMerchant #:nodoc:
         return unless options[:processing].is_a?(Hash)
 
         post[:processing] = options[:processing]
+      end
+
+      def add_payment_sender_data(post, options)
+        return unless options[:sender].is_a?(Hash)
+
+        sender = options[:sender]
+
+        post[:sender] = {}
+        post[:sender][:type] = sender[:type] if sender[:type]
+        post[:sender][:first_name] = sender[:first_name] if sender[:first_name]
+        post[:sender][:last_name] = sender[:last_name] if sender[:last_name]
+        post[:sender][:dob] = sender[:dob] if sender[:dob]
+        post[:sender][:reference] = sender[:reference] if sender[:reference]
+        post[:sender][:company_name] = sender[:company_name] if sender[:company_name]
+
+        if address = sender[:address]
+          address1 = address[:address1] || address[:address_line1]
+          address2 = address[:address2] || address[:address_line2]
+
+          post[:sender][:address] = {}
+          post[:sender][:address][:address_line1] = address1 if address1
+          post[:sender][:address][:address_line2] = address2 if address2
+          post[:sender][:address][:city] = address[:city] if address[:city]
+          post[:sender][:address][:state] = address[:state] if address[:state]
+          post[:sender][:address][:zip] = address[:zip] if address[:zip]
+          post[:sender][:address][:country] = address[:country] if address[:country]
+        end
+
+        if identification = sender[:identification]
+          post[:sender][:identification] = {}
+          post[:sender][:identification][:type] = identification[:type] if identification[:type]
+          post[:sender][:identification][:number] = identification[:number] if identification[:number]
+          post[:sender][:identification][:issuing_country] = identification[:issuing_country] if identification[:issuing_country]
+        end
       end
 
       def add_authorization_type(post, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -151,12 +151,12 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
         reference: '012345',
         reference_type: 'other',
         source_of_funds: 'debit',
-          identification: {
-            type: 'passport',
-            number: 'ABC123',
-            issuing_country: 'US',
-            date_of_expiry: '2027-07-07'
-          }
+        identification: {
+          type: 'passport',
+          number: 'ABC123',
+          issuing_country: 'US',
+          date_of_expiry: '2027-07-07'
+        }
       }
     )
   end
@@ -608,8 +608,8 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
         first_name: 'john',
         last_name: 'johnny',
         address: {
-          address_line1: '123 High St.',
-          address_line2: 'Flat 456',
+          address1: '123 High St.',
+          address2: 'Flat 456',
           city: 'London',
           state: 'str',
           zip: 'SW1A 1AA',
@@ -618,6 +618,34 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
       }
     )
     response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_sender_data
+    options = @options.merge(
+      sender: {
+        type: 'individual',
+        dob: '1985-05-15',
+        first_name: 'Jane',
+        last_name: 'Doe',
+        address: {
+          address_line1: '123 High St.',
+          address_line2: 'Flat 456',
+          city: 'London',
+          state: 'str',
+          zip: 'SW1A 1AA',
+          country: 'GB'
+        },
+        reference: '8285282045818',
+        identification: {
+          type: 'passport',
+          number: 'ABC123',
+          issuing_country: 'GB'
+        }
+      }
+    )
+    response = @gateway_oauth.purchase(@amount, @credit_card, options)
     assert_success response
     assert_equal 'Succeeded', response.message
   end


### PR DESCRIPTION
This allow us to add the sender object to auth and purchase.

Note: There is a discrepancy with the address fields for recipient and sender. Recipient is expecting address_line1/address_line2. Sender is expecting address1/address2 since sender for for payout is already using those field names. Will have to document this.

Local:
5903 tests, 79624 assertions, 0 failures, 7 errors, 0 pendings, 0 omissions, 0 notifications
99.8814% passed

Unit:
67 tests, 421 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
106 tests, 255 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.2264% passed