### PR TITLE
Worldpay: Provide option to use default ECI value

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -65,6 +65,8 @@ Metrics/CyclomaticComplexity:
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
   Max: 163
+  IgnoredMethods: 
+    - 'setup'
 
 # Offense count: 2
 # Configuration parameters: CountKeywordArgs.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -171,6 +171,7 @@
 * FlexCharge: Add support for TPV store [edgarv09] #5120
 * CheckoutV2: Add sender payment fields to purchase and auth [yunnydang] #5124
 * HiPay: Fix parse authorization string [javierpedrozaing] #5119
+* Worldpay: Add support for deafult ECI value [aenand] #5126
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -153,8 +153,12 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      def eci_value(payment_method)
-        payment_method.respond_to?(:eci) ? format(payment_method.eci, :two_digits) : ''
+      def eci_value(payment_method, options)
+        eci = payment_method.respond_to?(:eci) ? format(payment_method.eci, :two_digits) : ''
+
+        return eci unless eci.empty?
+
+        options[:use_default_eci] ? '07' : eci
       end
 
       def authorize_request(money, payment_method, options)
@@ -610,7 +614,7 @@ module ActiveMerchant #:nodoc:
             name = card_holder_name(payment_method, options)
             xml.cardHolderName name if name.present?
             xml.cryptogram payment_method.payment_cryptogram unless options[:wallet_type] == :google_pay
-            eci = eci_value(payment_method)
+            eci = eci_value(payment_method, options)
             xml.eciIndicator eci if eci.present?
           end
           add_stored_credential_options(xml, options)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -166,6 +166,16 @@ class RemoteWorldpayTest < Test::Unit::TestCase
       transaction_id: '123456789',
       eci: '05'
     )
+
+    @google_pay_network_token_without_eci = network_tokenization_credit_card(
+      '4444333322221111',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: Time.new.year + 2,
+      source: :google_pay,
+      transaction_id: '123456789',
+      eci: '05'
+    )
   end
 
   def test_successful_purchase
@@ -210,6 +220,22 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
   def test_successful_authorize_with_card_holder_name_google_pay
     response = @gateway.authorize(@amount, @google_pay_network_token, @options)
+    assert_success response
+    assert_equal @amount, response.params['amount_value'].to_i
+    assert_equal 'GBP', response.params['amount_currency_code']
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_authorize_without_eci_google_pay
+    response = @gateway.authorize(@amount, @google_pay_network_token_without_eci, @options)
+    assert_success response
+    assert_equal @amount, response.params['amount_value'].to_i
+    assert_equal 'GBP', response.params['amount_currency_code']
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_authorize_with_default_eci_google_pay
+    response = @gateway.authorize(@amount, @google_pay_network_token_without_eci, @options.merge({ use_default_eci: true }))
     assert_success response
     assert_equal @amount, response.params['amount_value'].to_i
     assert_equal 'GBP', response.params['amount_currency_code']

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -75,6 +75,15 @@ class WorldpayTest < Test::Unit::TestCase
       eci: '05'
     )
 
+    @google_pay_network_token_without_eci = network_tokenization_credit_card(
+      '4444333322221111',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: Time.new.year + 2,
+      source: :google_pay,
+      transaction_id: '123456789'
+    )
+
     @level_two_data = {
       level_2_data: {
         invoice_reference_number: 'INV12233565',
@@ -1477,6 +1486,24 @@ class WorldpayTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @google_pay_network_token, @options)
     end.check_request(skip_response: true) do |_endpoint, data, _headers|
       assert_match %r(<EMVCO_TOKEN-SSL type="GOOGLEPAY">), data
+      assert_match %r(<eciIndicator>05</eciIndicator>), data
+    end
+  end
+
+  def test_google_pay_without_eci_value
+    stub_comms do
+      @gateway.authorize(@amount, @google_pay_network_token_without_eci, @options)
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      assert_match %r(<EMVCO_TOKEN-SSL type="GOOGLEPAY">), data
+    end
+  end
+
+  def test_google_pay_with_use_default_eci_value
+    stub_comms do
+      @gateway.authorize(@amount, @google_pay_network_token_without_eci, @options.merge({ use_default_eci: true }))
+    end.check_request(skip_response: true) do |_endpoint, data, _headers|
+      assert_match %r(<EMVCO_TOKEN-SSL type="GOOGLEPAY">), data
+      assert_match %r(<eciIndicator>07</eciIndicator>), data
     end
   end
 


### PR DESCRIPTION
A previous commit removed the default ECI value for NT type payment methods (apple pay, google pay, and network tokens) from the Worldpay integration. This value was previously '07' and added if an ECI was not present. This commit removed the default behavior as this was not compliant with GooglePay standards and Worldpay's documentation indicated it was an option field.

Upon implementing, some merchants have found issues with Mastercard Google Pay transactions lacking an ECI. This is an attempt at an opt-in revert where if a merchant needs to go back to the original commit they can do so by passing in use_default_eci.

Test Summary
Local:
5906 tests, 79606 assertions, 0 failures, 23 errors, 0 pendings, 0 omissions, 0 notifications 99.6106% passed
Unit:
120 tests, 675 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Remote:
106 tests, 455 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.1698% passed