### PR TITLE
Braintree and Worldpay: support overriding NTID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@
 == HEAD
 * Bump Ruby version to 3.1 [dustinhaefele] #5104
 * FlexCharge: Update inquire method to use the new orders end-point
+* Worldpay: Prefer options for network_transaction_id [aenand] #5129
+* Braintree: Prefer options for network_transaction_id [aenand] #5129
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -906,7 +906,7 @@ module ActiveMerchant #:nodoc:
         # specifically requested. This will be the default behavior in a future release.
         return unless (stored_credential = options[:stored_credential])
 
-        add_external_vault(parameters, stored_credential, options)
+        add_external_vault(parameters, options)
 
         if options[:stored_credentials_v2]
           stored_credentials_v2(parameters, stored_credential)
@@ -949,7 +949,8 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_external_vault(parameters, stored_credential, options = {})
+      def add_external_vault(parameters, options = {})
+        stored_credential = options[:stored_credential]
         parameters[:external_vault] = {}
         if stored_credential[:initial_transaction]
           parameters[:external_vault][:status] = 'will_vault'

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -906,7 +906,7 @@ module ActiveMerchant #:nodoc:
         # specifically requested. This will be the default behavior in a future release.
         return unless (stored_credential = options[:stored_credential])
 
-        add_external_vault(parameters, stored_credential)
+        add_external_vault(parameters, stored_credential, options)
 
         if options[:stored_credentials_v2]
           stored_credentials_v2(parameters, stored_credential)
@@ -949,13 +949,13 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_external_vault(parameters, stored_credential)
+      def add_external_vault(parameters, stored_credential, options = {})
         parameters[:external_vault] = {}
         if stored_credential[:initial_transaction]
           parameters[:external_vault][:status] = 'will_vault'
         else
           parameters[:external_vault][:status] = 'vaulted'
-          parameters[:external_vault][:previous_network_transaction_id] = stored_credential[:network_transaction_id]
+          parameters[:external_vault][:previous_network_transaction_id] = options[:network_transaction_id] || stored_credential[:network_transaction_id]
         end
       end
 

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -686,7 +686,7 @@ module ActiveMerchant #:nodoc:
         stored_credential_params = generate_stored_credential_params(is_initial_transaction, reason)
 
         xml.storedCredentials stored_credential_params do
-          xml.schemeTransactionIdentifier options[:stored_credential][:network_transaction_id] if options[:stored_credential][:network_transaction_id] && !is_initial_transaction
+          xml.schemeTransactionIdentifier network_transaction_id(options) if network_transaction_id(options) && !is_initial_transaction
         end
       end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1189,6 +1189,22 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, id: '123ABC') })
   end
 
+  def test_stored_credential_prefers_options_for_ntid
+    Braintree::TransactionGateway.any_instance.expects(:sale).with(
+      standard_purchase_params.merge(
+        {
+          external_vault: {
+            status: 'vaulted',
+            previous_network_transaction_id: '321XYZ'
+          },
+          transaction_source: ''
+        }
+      )
+    ).returns(braintree_result)
+
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', network_transaction_id: '321XYZ', stored_credential: stored_credential(:cardholder, :recurring, id: '123ABC') })
+  end
+
   def test_stored_credential_recurring_mit_initial
     Braintree::TransactionGateway.any_instance.expects(:sale).with(
       standard_purchase_params.merge(


### PR DESCRIPTION
COMP-160

Adds support for the Braintree Blue and Worldpay gateways for merchants to override and bring their own NTID instead of relying on the standardized NTID framework

Test Summary
Local:
5908 tests, 79610 assertions, 0 failures, 23 errors, 0 pendings, 0 omissions, 0 notifications 99.6107% passed
Unit:
Worldpay:
119 tests, 672 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Braintree:
104 tests, 219 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Remote:
Worldpay:
104 tests, 447 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.1154% passed
Braintree:
120 tests, 646 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed