### PR TITLE
Plexo: Add support to NetworkToken payments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * Worldpay: Prefer options for network_transaction_id [aenand] #5129
 * Braintree: Prefer options for network_transaction_id [aenand] #5129
 * Cybersource Rest: Update support for stored credentials [aenand] #5083
+* Plexo: Add support to NetworkToken payments [euribe09] #5130
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -92,7 +92,8 @@ module ActiveMerchant #:nodoc:
           gsub(%r(("Number\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
           gsub(%r(("Cvc\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
           gsub(%r(("InvoiceNumber\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
-          gsub(%r(("MerchantId\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]')
+          gsub(%r(("MerchantId\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
+          gsub(%r(("Cryptogram\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]')
       end
 
       private
@@ -207,6 +208,7 @@ module ActiveMerchant #:nodoc:
 
           add_card_holder(post[:paymentMethod][:Card], payment, options)
         end
+        post[:paymentMethod][:Card][:Cryptogram] = payment.payment_cryptogram if payment&.is_a?(NetworkTokenizationCreditCard)
       end
 
       def add_card_holder(card, payment, options)

--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -31,6 +31,22 @@ class RemotePlexoTest < Test::Unit::TestCase
       description: 'Test desc',
       reason: 'requested by client'
     }
+
+    @network_token_credit_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new({
+      first_name: 'Santiago', last_name: 'Navatta',
+        brand: 'Mastercard',
+        payment_cryptogram: 'UnVBR0RlYm42S2UzYWJKeWJBdWQ=',
+        number: '5555555555554444',
+        source: :network_token,
+        month: '12',
+        year: Time.now.year
+    })
+  end
+
+  def test_successful_purchase_with_network_token
+    response = @gateway.purchase(@amount, @network_token_credit_card, @options.merge({ invoice_number: '12345abcde' }))
+    assert_success response
+    assert_equal 'You have been mocked.', response.message
   end
 
   def test_successful_purchase


### PR DESCRIPTION
Add support to NetworkToken payments
SER-1240

Test summary:
Local:
5910 tests, 79650 assertions, 0 failures, 17 errors, 0 pendings, 0 omissions, 0 notifications 99.7124% passed
Unit:
25 tests, 134 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
Remote:
32 tests, 36 assertions, 21 failures, 3 errors, 0 pendings, 3 omissions, 0 notifications 17.2414% passed