### PR TITLE
RedsysRest: Add support for stored credentials & 3DS exemptions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 * DLocal: Update the phone and ip fields [yunnydang] #5143
 * CheckoutV2: Add support for risk data fields [yunnydang] #5147
 * Pin Payments: Add new 3DS params mentioned in Pin Payments docs [hudakh] #4720
+* RedsysRest: Add support for stored credentials & 3DS exemptions [jherreraa] #5132
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860


### PR DESCRIPTION
[ECS-3450](https://spreedly.atlassian.net/browse/ECS-3450)

## Summary:

This PR updates adds stored credendials and 3ds exemptions for redsys rest

Unit tests
----------------
Finished in 0.023518 seconds.

28 tests, 118 assertions, 0 failures,
0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote tests
----------------
Finished in 33.326868 seconds.

26 tests, 93 assertions, 1 failures,
0 errors, 0 pendings, 0 omissions, 0 notifications 96.1538% passed

0.78 tests/s, 2.79 assertions/s

-> failure not related to changes