### PR TITLE
Litle: Add 141 and 142 as successful responses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -181,6 +181,7 @@
 * Cybersource Rest: Support L2/L3 data [aenand] #5117
 * Worldpay: Support L2/L3 data [aenand] #5117
 * Support UATP cardtype [javierpedrozaing] #5137
+* Litle: Add 141 and 142 as successful responses [almalee24] #5135
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -561,7 +561,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(kind, parsed)
-        return %w(000 001 010).any?(parsed[:response]) unless kind == :registerToken
+        return %w(000 001 010 141 142).any?(parsed[:response]) unless kind == :registerToken
 
         %w(000 801 802).include?(parsed[:response])
       end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -82,6 +82,26 @@ class LitleTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_prepaid_card_141
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_for_prepaid_cards_141)
+
+    assert_success response
+    assert_equal 'Consumer non-reloadable prepaid card, Approved', response.message
+    assert_equal '141', response.params['response']
+  end
+
+  def test_successful_purchase_prepaid_card_142
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_for_prepaid_cards_142)
+
+    assert_success response
+    assert_equal 'Consumer single-use virtual card number, Approved', response.message
+    assert_equal '142', response.params['response']
+  end
+
   def test_successful_purchase_with_010_response
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
@@ -826,6 +846,48 @@ class LitleTest < Test::Unit::TestCase
           <responseTime>2018-01-09T14:02:20</responseTime>
           <message>Approved</message>
         </echeckSalesResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_purchase_for_prepaid_cards_141
+    %(
+      <litleOnlineResponse version="9.14" xmlns="http://www.litle.com/schema" response="0" message="Valid Format">
+        <saleResponse id="486344231" reportGroup="Report Group" customerId="10000009">
+          <litleTxnId>456342657452</litleTxnId>
+          <orderId>123456</orderId>
+          <response>141</response>
+          <responseTime>2024-04-09T19:50:30</responseTime>
+          <postDate>2024-04-09</postDate>
+          <message>Consumer non-reloadable prepaid card, Approved</message>
+          <authCode>382410</authCode>
+          <fraudResult>
+            <avsResult>01</avsResult>
+            <cardValidationResult>M</cardValidationResult>
+          </fraudResult>
+          <networkTransactionId>MPMMPMPMPMPU</networkTransactionId>
+        </saleResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_purchase_for_prepaid_cards_142
+    %(
+      <litleOnlineResponse version="9.14" xmlns="http://www.litle.com/schema" response="0" message="Valid Format">
+        <saleResponse id="486344231" reportGroup="Report Group" customerId="10000009">
+          <litleTxnId>456342657452</litleTxnId>
+          <orderId>123456</orderId>
+          <response>142</response>
+          <responseTime>2024-04-09T19:50:30</responseTime>
+          <postDate>2024-04-09</postDate>
+          <message>Consumer single-use virtual card number, Approved</message>
+          <authCode>382410</authCode>
+          <fraudResult>
+            <avsResult>01</avsResult>
+            <cardValidationResult>M</cardValidationResult>
+          </fraudResult>
+          <networkTransactionId>MPMMPMPMPMPU</networkTransactionId>
+        </saleResponse>
       </litleOnlineResponse>
     )
   end


### PR DESCRIPTION
141 and 142 are successful responses for prepaid cards.

Unit:
61 tests, 274 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
57 tests, 250 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.2456% passed