### PR TITLE
Add new UATP card type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -176,6 +176,7 @@
 * NMI: Add NTID override [yunnydang] #5134
 * Cybersource Rest: Support L2/L3 data [aenand] #5117
 * Worldpay: Support L2/L3 data [aenand] #5117
+* Support UATP cardtype [javierpedrozaing] #5137
 
 == Version 1.135.0 (August 24, 2023)
 * PaymentExpress: Correct endpoints [steveh] #4827

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -41,6 +41,7 @@ module ActiveMerchant #:nodoc:
     # * Panal
     # * Verve
     # * Tuya
+    # * UATP
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -136,6 +137,7 @@ module ActiveMerchant #:nodoc:
       # * +'panal'+
       # * +'verve'+
       # * +'tuya'+
+      # * +'uatp'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -53,7 +53,8 @@ module ActiveMerchant #:nodoc:
         'hipercard' => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), HIPERCARD_RANGES) },
         'panal' => ->(num) { num&.size == 16 && in_bin_range?(num.slice(0, 6), PANAL_RANGES) },
         'verve' => ->(num) { (16..19).cover?(num&.size) && in_bin_range?(num.slice(0, 6), VERVE_RANGES) },
-        'tuya' => ->(num) { num =~ /^588800\d{10}$/ }
+        'tuya' => ->(num) { num =~ /^588800\d{10}$/ },
+        'uatp' => ->(num) { num =~ /^(1175|1290)\d{11}$/ }
       }
 
       SODEXO_NO_LUHN = ->(num) { num =~ /^(505864|505865)\d{10}$/ }

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -568,6 +568,27 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert_false CreditCard.valid_number?('5888_0000_0000_0030')
   end
 
+  def test_should_detect_uatp_card_brand
+    assert_equal 'uatp', CreditCard.brand?('117500000000000')
+    assert_equal 'uatp', CreditCard.brand?('117515279008103')
+    assert_equal 'uatp', CreditCard.brand?('129001000000000')
+  end
+
+  def test_should_validate_uatp_card
+    assert_true CreditCard.valid_number?('117515279008103')
+    assert_true CreditCard.valid_number?('116901000000000')
+    assert_true CreditCard.valid_number?('195724000000000')
+    assert_true CreditCard.valid_number?('192004000000000')
+    assert_true CreditCard.valid_number?('135410014004955')
+  end
+
+  def test_should_detect_invalid_uatp_card
+    assert_false CreditCard.valid_number?('117515279008104')
+    assert_false CreditCard.valid_number?('116901000000001')
+    assert_false CreditCard.valid_number?('195724000000001')
+    assert_false CreditCard.valid_number?('192004000000001')
+  end
+
   def test_credit_card?
     assert credit_card.credit_card?
   end


### PR DESCRIPTION
Description
-------------------------
This commit enable AUTP card type to be used as a valid credit card

Unit test
-------------------------
Finished in 0.041087 seconds.

70 tests, 661 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

1703.70 tests/s, 16087.81 assertions/s

Rubocop
-------------------------
798 files inspected, no offenses detected