### PR TITLE
Braintree Blue: Update card verfification payload billing address fields are not present

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 * Braintree: Prefer options for network_transaction_id [aenand] #5129
 * Cybersource Rest: Update support for stored credentials [aenand] #5083
 * Plexo: Add support to NetworkToken payments [euribe09] #5130
+* Braintree: Update card verfification payload if billing address fields are not present [yunnydang] #5142
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -144,16 +144,21 @@ module ActiveMerchant #:nodoc:
           exp_month = creditcard.month.to_s
           exp_year = creditcard.year.to_s
           expiration = "#{exp_month}/#{exp_year}"
+          zip = options[:billing_address].try(:[], :zip)
+          address1 = options[:billing_address].try(:[], :address1)
           payload = {
             credit_card: {
               number: creditcard.number,
               expiration_date: expiration,
-              cvv: creditcard.verification_value,
-              billing_address: {
-                postal_code: options[:billing_address][:zip]
-              }
+              cvv: creditcard.verification_value
             }
           }
+          if zip || address1
+            payload[:credit_card][:billing_address] = {}
+            payload[:credit_card][:billing_address][:postal_code] = zip if zip
+            payload[:credit_card][:billing_address][:street_address] = address1 if address1
+          end
+
           if merchant_account_id = (options[:merchant_account_id] || @merchant_account_id)
             payload[:options] = { merchant_account_id: merchant_account_id }
           end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -271,6 +271,54 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
     assert_match 'OK', response.message
     assert_equal 'M', response.cvv_result['code']
+    assert_equal 'M', response.avs_result['code']
+  end
+
+  def test_successful_credit_card_verification_without_billing_address
+    options = {
+      order_ID: '1',
+      description: 'store purchase'
+    }
+    card = credit_card('4111111111111111')
+    assert response = @gateway.verify(card, options.merge({ allow_card_verification: true, merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id] }))
+    assert_success response
+
+    assert_match 'OK', response.message
+    assert_equal 'M', response.cvv_result['code']
+    assert_equal 'I', response.avs_result['code']
+  end
+
+  def test_successful_credit_card_verification_with_only_address
+    options = {
+      order_ID: '1',
+      description: 'store purchase',
+      billing_address: {
+        address1: '456 My Street'
+      }
+    }
+    card = credit_card('4111111111111111')
+    assert response = @gateway.verify(card, options.merge({ allow_card_verification: true, merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id] }))
+    assert_success response
+
+    assert_match 'OK', response.message
+    assert_equal 'M', response.cvv_result['code']
+    assert_equal 'B', response.avs_result['code']
+  end
+
+  def test_successful_credit_card_verification_with_only_zip
+    options = {
+      order_ID: '1',
+      description: 'store purchase',
+      billing_address: {
+        zip: 'K1C2N6'
+      }
+    }
+    card = credit_card('4111111111111111')
+    assert response = @gateway.verify(card, options.merge({ allow_card_verification: true, merchant_account_id: fixtures(:braintree_blue)[:merchant_account_id] }))
+    assert_success response
+
+    assert_match 'OK', response.message
+    assert_equal 'M', response.cvv_result['code']
     assert_equal 'P', response.avs_result['code']
   end
 


### PR DESCRIPTION
This lets us gracefully return an error code or message from Braintree if the postal zip code is missing.

Local:
5923 tests, 79804 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
103 tests, 218 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
121 tests, 649 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed