### PR TITLE
DLocal: update the phone and ip fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Cybersource Rest: Update support for stored credentials [aenand] #5083
 * Plexo: Add support to NetworkToken payments [euribe09] #5130
 * Braintree: Update card verfification payload if billing address fields are not present [yunnydang] #5142
+* DLocal: Update the phone and ip fields [yunnydang] #5143
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -118,16 +118,18 @@ module ActiveMerchant #:nodoc:
 
       def add_payer(post, card, options)
         address = options[:billing_address] || options[:address]
+        phone_number = address[:phone] || address[:phone_number] if address
+
         post[:payer] = {}
         post[:payer][:name] = card.name
         post[:payer][:email] = options[:email] if options[:email]
         post[:payer][:birth_date] = options[:birth_date] if options[:birth_date]
-        post[:payer][:phone] = address[:phone] if address && address[:phone]
+        post[:payer][:phone] = phone_number if phone_number
         post[:payer][:document] = options[:document] if options[:document]
         post[:payer][:document2] = options[:document2] if options[:document2]
         post[:payer][:user_reference] = options[:user_reference] if options[:user_reference]
         post[:payer][:event_uuid] = options[:device_id] if options[:device_id]
-        post[:payer][:onboarding_ip_address] = options[:ip] if options[:ip]
+        post[:payer][:ip] = options[:ip] if options[:ip]
         post[:payer][:address] = add_address(post, card, options)
       end
 

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -50,6 +50,12 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_match 'The payment was paid', response.message
   end
 
+  def test_successful_purchase_with_ip_and_phone
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(ip: '127.0.0.1'))
+    assert_success response
+    assert_match 'The payment was paid', response.message
+  end
+
   def test_successful_purchase_with_save_option
     response = @gateway.purchase(@amount, @credit_card, @options.merge(save: true))
     assert_success response

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -44,6 +44,15 @@ class DLocalTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_purchase_with_ip_and_phone
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(ip: '127.0.0.1'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal '127.0.0.1', JSON.parse(data)['payer']['ip']
+      assert_equal '(555)555-5555', JSON.parse(data)['payer']['phone']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_post).returns(failed_purchase_response)
 


### PR DESCRIPTION
Updates the top level `ip` and `phone` fields to correctly be mapped.
Note: the `onboarding_ip_address` is actually supposed to be within the `addtional_risk_data` object according to [DLocals documention](https://docs.dlocal.com/docs/risk-data-documentation#example-payment-with-additional-risk-data-object). Unsure why we were trying to set it as the `ip` field prior, but it wasn't being used correctly. 

Local:
5932 tests, 79858 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
46 tests, 202 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
40 tests, 110 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed