### PR TITLE
Litle: Add tests for network tokenization

### DIFF
--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -42,6 +42,16 @@ class LitleTest < Test::Unit::TestCase
         payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
       }
     )
+    @decrypted_network_token = NetworkTokenizationCreditCard.new(
+      {
+        source: :network_token,
+        month: '02',
+        year: '2050',
+        brand: 'master',
+        number:  '5112010000000000',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    )
     @amount = 100
     @options = {}
     @check = check(
@@ -361,6 +371,14 @@ class LitleTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @decrypted_google_pay)
     end.check_request do |_endpoint, data, _headers|
       assert_match '<orderSource>androidpay</orderSource>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_add_network_token_order_source
+    stub_comms do
+      @gateway.purchase(@amount, @decrypted_network_token)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<orderSource>ecommerce</orderSource>', data
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Summary:
------------------------------
Add unit and remote tests for network token
transactions

[SER-1270](https://spreedly.atlassian.net/browse/SER-1270)

Remote Test:
------------------------------
Finished in 88.332434 seconds.
60 tests, 261 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit Test:
------------------------------
Finished in 45.844644 seconds.
5931 tests, 79847 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
------------------------------
798 files inspected, no offenses detected