### PR TITLE
NMI: Adding GooglePay and ApplePay

### DIFF
--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -10,15 +10,26 @@ class RemoteNmiTest < Test::Unit::TestCase
       routing_number: '123123123',
       account_number: '123123123'
     )
-    @apple_pay_card = network_tokenization_credit_card(
+    @apple_pay = network_tokenization_credit_card(
       '4111111111111111',
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
       month: '01',
-      year: '2024',
+      year: Time.new.year + 2,
       source: :apple_pay,
       eci: '5',
       transaction_id: '123456789'
     )
+
+    @google_pay = network_tokenization_credit_card(
+      '4111111111111111',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      month: '01',
+      year: Time.new.year + 2,
+      source: :google_pay,
+      transaction_id: '123456789',
+      eci: '05'
+    )
+
     @options = {
       order_id: generate_unique_id,
       billing_address: address,
@@ -130,17 +141,33 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert_equal 'FAILED', response.message
   end
 
-  def test_successful_purchase_with_apple_pay_card
-    assert @gateway.supports_network_tokenization?
-    assert response = @gateway.purchase(@amount, @apple_pay_card, @options)
+  def test_successful_purchase_with_apple_pay
+    assert @gateway_secure.supports_network_tokenization?
+    assert response = @gateway_secure.purchase(@amount, @apple_pay, @options)
     assert_success response
     assert response.test?
     assert_equal 'Succeeded', response.message
     assert response.authorization
   end
 
-  def test_failed_purchase_with_apple_pay_card
-    assert response = @gateway.purchase(99, @apple_pay_card, @options)
+  def test_successful_purchase_with_google_pay
+    assert @gateway_secure.supports_network_tokenization?
+    assert response = @gateway_secure.purchase(@amount, @google_pay, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+    assert response.authorization
+  end
+
+  def test_failed_purchase_with_apple_pay
+    assert response = @gateway_secure.purchase(1, @apple_pay, @options)
+    assert_failure response
+    assert response.test?
+    assert_equal 'DECLINE', response.message
+  end
+
+  def test_failed_purchase_with_google_pay
+    assert response = @gateway_secure.purchase(1, @google_pay, @options)
     assert_failure response
     assert response.test?
     assert_equal 'DECLINE', response.message
@@ -482,12 +509,23 @@ class RemoteNmiTest < Test::Unit::TestCase
 
   def test_network_tokenization_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
-      @gateway.purchase(@amount, @apple_pay_card, @options)
+      @gateway.purchase(@amount, @apple_pay, @options)
     end
     clean_transcript = @gateway.scrub(transcript)
 
-    assert_scrubbed(@apple_pay_card.number, clean_transcript)
-    assert_scrubbed(@apple_pay_card.payment_cryptogram, clean_transcript)
+    assert_scrubbed(@apple_pay.number, clean_transcript)
+    assert_scrubbed(@apple_pay.payment_cryptogram, clean_transcript)
+    assert_password_scrubbed(clean_transcript)
+  end
+
+  def test_transcript_scrubbing_with_google_pay
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @google_pay, @options)
+    end
+
+    clean_transcript = @gateway.scrub(transcript)
+    assert_scrubbed(@apple_pay.number, clean_transcript)
+    assert_scrubbed(@apple_pay.payment_cryptogram, clean_transcript)
     assert_password_scrubbed(clean_transcript)
   end
 


### PR DESCRIPTION
Description
-------------------------
This commit add support to create transaction with GooglePay and ApplePay.
This payment methods are working for nmi_secure.

[SER-1295](https://spreedly.atlassian.net/browse/SER-1295)

Unit test
-------------------------
Finished in 11.283174 seconds.

59 tests, 475 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

100% passed

5.23 tests/s, 42.10 assertions/s

Remote test
-------------------------
Finished in 115.513346 seconds.

55 tests, 199 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications

78.1818% passed

0.48 tests/s, 1.72 assertions/s

Rubocop
-------------------------
798 files inspected, no offenses detected