### PR TITLE
Checkout V2: add support for risk data fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Plexo: Add support to NetworkToken payments [euribe09] #5130
 * Braintree: Update card verfification payload if billing address fields are not present [yunnydang] #5142
 * DLocal: Update the phone and ip fields [yunnydang] #5143
+* CheckoutV2: Add support for risk data fields [yunnydang] #5147
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -144,6 +144,7 @@ module ActiveMerchant #:nodoc:
         add_recipient_data(post, options)
         add_processing_data(post, options)
         add_payment_sender_data(post, options)
+        add_risk_data(post, options)
       end
 
       def add_invoice(post, money, options)
@@ -189,6 +190,20 @@ module ActiveMerchant #:nodoc:
         return unless options[:processing].is_a?(Hash)
 
         post[:processing] = options[:processing]
+      end
+
+      def add_risk_data(post, options)
+        return unless options[:risk].is_a?(Hash)
+
+        risk = options[:risk]
+        post[:risk] = {} unless risk.empty?
+
+        if risk[:enabled].to_s == 'true'
+          post[:risk][:enabled] = true
+          post[:risk][:device_session_id] = risk[:device_session_id] if risk[:device_session_id]
+        elsif risk[:enabled].to_s == 'false'
+          post[:risk][:enabled] = false
+        end
       end
 
       def add_payment_sender_data(post, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -650,6 +650,38 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_risk_data_true
+    options = @options.merge(
+      risk: {
+        enabled: 'true',
+        device_session_id: '12345-abcd'
+      }
+    )
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_risk_data_false
+    options = @options.merge(
+      risk: {
+        enabled: 'false'
+      }
+    )
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_purchase_with_empty_risk_data
+    options = @options.merge(
+      risk: {}
+    )
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_metadata_via_oauth
     options = @options.merge(
       metadata: {

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -86,6 +86,21 @@ class CheckoutV2Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_passing_risk_data
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, {
+        risk: {
+          enabled: 'true',
+          device_session_id: '12345-abcd'
+        }
+      })
+    end.check_request do |_method, _endpoint, data, _headers|
+      request = JSON.parse(data)['risk']
+      assert_equal request['enabled'], true
+      assert_equal request['device_session_id'], '12345-abcd'
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_passing_incremental_authorization
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.authorize(@amount, @credit_card, { incremental_authorization: 'abcd1234' })


### PR DESCRIPTION
This adds the support of sending the risk fields to checkout

Local:
5935 tests, 79871 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
68 tests, 425 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
108 tests, 259 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.2963% passed