### PR TITLE
Datatrans:  Add support for verify transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/datatrans.rb
+++ b/lib/active_merchant/billing/gateways/datatrans.rb
@@ -35,6 +35,13 @@ module ActiveMerchant #:nodoc:
         authorize(money, payment, options.merge(auto_settle: true))
       end
 
+      def verify(payment, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(100, payment, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
       def authorize(money, payment, options = {})
         post = { refno: options.fetch(:order_id, '') }
         add_payment_method(post, payment)

--- a/test/remote/gateways/remote_datatrans_test.rb
+++ b/test/remote/gateways/remote_datatrans_test.rb
@@ -195,6 +195,16 @@ class RemoteDatatransTest < Test::Unit::TestCase
     assert_equal 'Action denied : Wrong transaction status', response.message
   end
 
+  def test_successful_verify
+    verify_response = @gateway.verify(@credit_card, @options)
+    assert_success verify_response
+  end
+
+  def test_failed_verify
+    verify_response = @gateway.verify(@credit_card, @options.merge({ currency: 'DKK' }))
+    assert_failure verify_response
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/datatrans_test.rb
+++ b/test/unit/gateways/datatrans_test.rb
@@ -98,6 +98,17 @@ class DatatransTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_verify_with_credit_card
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.verify(@credit_card, @options)
+    end.check_request do |_action, endpoint, data, _headers|
+      parsed_data = JSON.parse(data)
+      common_assertions_authorize_purchase(endpoint, parsed_data) unless parsed_data.empty?
+    end.respond_with(successful_authorize_response, successful_void_response)
+
+    assert_success response
+  end
+
   def test_purchase_with_network_token
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @nt_credit_card, @options)


### PR DESCRIPTION
SER-1302

Description
-------------------------
Add support to make verify transactions with authorize and void using a multiresponse thread

Unit test
-------------------------
25 tests, 136 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote test
-------------------------
23 tests, 57 assertions, 2 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications 90.9091% passed

Rubocop
-------------------------
798 files inspected, no offenses detected