### PR TITLE
Orbital: Update to accept UCAF Indicator GSF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@
 * CommerceHub: Add billing address name override [yunnydang] #5157
 * StripePI: Add optional ability for 3DS exemption on verify calls [yunnydang] #5160
 * CyberSource: Update stored credentials [sinourain] #5136
+* Orbital: Update to accept UCAF Indicator GSF [almalee24] #5150
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -724,7 +724,7 @@ module ActiveMerchant #:nodoc:
         add_mc_sca_recurring(xml, credit_card, parameters, three_d_secure)
         add_mc_program_protocol(xml, credit_card, three_d_secure)
         add_mc_directory_trans_id(xml, credit_card, three_d_secure)
-        add_mc_ucafind(xml, credit_card, three_d_secure)
+        add_mc_ucafind(xml, credit_card, three_d_secure, parameters)
       end
 
       def add_mc_sca_merchant_initiated(xml, credit_card, parameters, three_d_secure)
@@ -753,10 +753,16 @@ module ActiveMerchant #:nodoc:
         xml.tag!(:MCDirectoryTransID, three_d_secure[:ds_transaction_id]) if three_d_secure[:ds_transaction_id]
       end
 
-      def add_mc_ucafind(xml, credit_card, three_d_secure)
+      def add_mc_ucafind(xml, credit_card, three_d_secure, options)
         return unless three_d_secure
 
-        xml.tag! :UCAFInd, '4'
+        if options[:alternate_ucaf_flow]
+          return unless %w(4 6 7).include?(three_d_secure[:eci])
+
+          xml.tag! :UCAFInd, options[:ucaf_collection_indicator] if options[:ucaf_collection_indicator]
+        else
+          xml.tag! :UCAFInd, options[:ucaf_collection_indicator] || '4'
+        end
       end
 
       #=====SCA (STORED CREDENTIAL) FIELDS=====


### PR DESCRIPTION
If alternate_ucaf_flow is true and the eci value is 4, 6, or 7 then send the ucaf passed in by customer. If alternate_ucaf_flow is not passed then only send ucaf if provided by customer if not pass default of 4.

Remote:
134 tests, 543 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
152 tests, 892 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed