### PR TITLE
CheckoutV2: truncate the reference id for amex transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 * CheckoutV2: Add support for risk data fields [yunnydang] #5147
 * Pin Payments: Add new 3DS params mentioned in Pin Payments docs [hudakh] #4720
 * RedsysRest: Add support for stored credentials & 3DS exemptions [jherreraa] #5132
+* CheckoutV2: Truncate the reference id for amex transactions [yunnydang] #5151
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -33,6 +33,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         post[:capture] = false
         build_auth_or_purchase(post, amount, payment_method, options)
+
         options[:incremental_authorization] ? commit(:incremental_authorize, post, options, options[:incremental_authorization]) : commit(:authorize, post, options)
       end
 
@@ -145,6 +146,7 @@ module ActiveMerchant #:nodoc:
         add_processing_data(post, options)
         add_payment_sender_data(post, options)
         add_risk_data(post, options)
+        truncate_amex_reference_id(post, options, payment_method)
       end
 
       def add_invoice(post, money, options)
@@ -158,6 +160,10 @@ module ActiveMerchant #:nodoc:
         end
         post[:metadata] = {}
         post[:metadata][:udf5] = application_id || 'ActiveMerchant'
+      end
+
+      def truncate_amex_reference_id(post, options, payment_method)
+        post[:reference] = truncate(options[:order_id], 30) if payment_method.respond_to?(:brand) && payment_method.brand == 'american_express'
       end
 
       def add_recipient_data(post, options)


### PR DESCRIPTION
This is to truncate the reference id for Amex auth and purchase transactions. I left the the original add_invoice(post, amount, options) method alone because other types of endpoints utilize it but do not pass the payment_method object. If calling purchase or authorization, and you happen to pass an amex payment method, then the reference id will be overwritten/shortened

Local:
5937 tests, 79881 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
68 tests, 425 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
111 tests, 269 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.3964% passed