### PR TITLE
Support new Naranja validation algorithm

### DIFF
--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -449,6 +449,11 @@ class CreditCardMethodsTest < Test::Unit::TestCase
     assert CreditCard.valid_number?(number)
   end
 
+  def test_matching_valid_naranja_2
+    number = '5895627451682352'
+    assert_equal 'naranja', CreditCard.brand?(number)
+  end
+
   def test_matching_valid_creditel
     number = '6019330047539016'
     assert_equal 'creditel', CreditCard.brand?(number)


### PR DESCRIPTION
Description:
Naranja has a new bespoke validation check-digit formula. Like its predecessor, a variation on Luhn mod10. At least for now, Naranja PANs are valid if they pass exactly one of the two algorithms (legacy or new).

Unit Tests:
5938 tests, 79882 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop:
798 files inspected, no offenses detected


Draft Todos:
- [ ] Verify XOR for two algos
- [ ] Get a longer list of valid card numbers to test against
- [ ] Add tests for negative case
- [ ] Add tests to cover XOR case

See the algorithm description from Naranja below:

<img width="1643" alt="naranja_2024" src="https://github.com/activemerchant/active_merchant/assets/102975301/73cb2057-74be-4d36-915e-e0ce15eb1906">
