### PR TITLE
MerchantWarrior: Update phone, email, ip and store_ID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * CyberSource: Update stored credentials [sinourain] #5136
 * Orbital: Update to accept UCAF Indicator GSF [almalee24] #5150
 * CyberSource: Add addtional invoiceHeader fields [yunnydang] #5161
+* MerchantWarrior: Update phone, email, ip and store ID [almalee24] #5158
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/merchant_warrior.rb
+++ b/lib/active_merchant/billing/gateways/merchant_warrior.rb
@@ -33,6 +33,7 @@ module ActiveMerchant #:nodoc:
         add_recurring_flag(post, options)
         add_soft_descriptors(post, options)
         add_three_ds(post, options)
+        post['storeID'] = options[:store_id] if options[:store_id]
         commit('processAuth', post)
       end
 
@@ -45,6 +46,7 @@ module ActiveMerchant #:nodoc:
         add_recurring_flag(post, options)
         add_soft_descriptors(post, options)
         add_three_ds(post, options)
+        post['storeID'] = options[:store_id] if options[:store_id]
         commit('processCard', post)
       end
 
@@ -113,9 +115,9 @@ module ActiveMerchant #:nodoc:
         post['customerCity'] = address[:city]
         post['customerAddress'] = address[:address1]
         post['customerPostCode'] = address[:zip]
-        post['customerIP'] = address[:ip]
-        post['customerPhone'] = address[:phone]
-        post['customerEmail'] = address[:email]
+        post['customerIP'] = address[:ip] || options[:ip]
+        post['customerPhone'] = address[:phone] || address[:phone_number]
+        post['customerEmail'] = address[:email] || options[:email]
       end
 
       def add_order_id(post, options)

--- a/test/unit/gateways/merchant_warrior_test.rb
+++ b/test/unit/gateways/merchant_warrior_test.rb
@@ -17,7 +17,10 @@ class MerchantWarriorTest < Test::Unit::TestCase
 
     @options = {
       address: address,
-      transaction_product: 'TestProduct'
+      transaction_product: 'TestProduct',
+      email: 'user@aol.com',
+      ip: '1.2.3.4',
+      store_id: 'My Store'
     }
     @three_ds_secure = {
       version: '2.2.0',
@@ -145,9 +148,7 @@ class MerchantWarriorTest < Test::Unit::TestCase
       state: 'NY',
       country: 'US',
       zip: '11111',
-      phone: '555-1212',
-      email: 'user@aol.com',
-      ip: '1.2.3.4'
+      phone: '555-1212'
     }
 
     stub_comms do
@@ -162,6 +163,40 @@ class MerchantWarriorTest < Test::Unit::TestCase
       assert_match(/customerIP=1.2.3.4/, data)
       assert_match(/customerPhone=555-1212/, data)
       assert_match(/customerEmail=user%40aol.com/, data)
+      assert_match(/storeID=My\+Store/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_address_with_phone_number
+    options = {
+      address: {
+        name: 'Bat Man',
+        address1: '123 Main',
+        city: 'Brooklyn',
+        state: 'NY',
+        country: 'US',
+        zip: '11111',
+        phone_number: '555-1212'
+      },
+      transaction_product: 'TestProduct',
+      email: 'user@aol.com',
+      ip: '1.2.3.4',
+      store_id: 'My Store'
+    }
+
+    stub_comms do
+      @gateway.purchase(@success_amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/customerName=Bat\+Man/, data)
+      assert_match(/customerCountry=US/, data)
+      assert_match(/customerState=NY/, data)
+      assert_match(/customerCity=Brooklyn/, data)
+      assert_match(/customerAddress=123\+Main/, data)
+      assert_match(/customerPostCode=11111/, data)
+      assert_match(/customerIP=1.2.3.4/, data)
+      assert_match(/customerPhone=555-1212/, data)
+      assert_match(/customerEmail=user%40aol.com/, data)
+      assert_match(/storeID=My\+Store/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Updae customerPhone to grab phone from phone or phone_number in options. If address doesn't contain ip and email then grab them directly from options. Add new field called storeID.

Unit:
29 tests, 164 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
20 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed