### PR TITLE
Credorax: Update 3DS version mapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 * Orbital: Update to accept UCAF Indicator GSF [almalee24] #5150
 * CyberSource: Add addtional invoiceHeader fields [yunnydang] #5161
 * MerchantWarrior: Update phone, email, ip and store ID [almalee24] #5158
+* Credorax: Update 3DS version mapping [almalee24] #5159
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -415,7 +415,7 @@ module ActiveMerchant #:nodoc:
           three_d_secure_options[:eci],
           three_d_secure_options[:cavv]
         )
-        post[:'3ds_version'] = three_d_secure_options[:version]&.start_with?('2') ? '2.0' : three_d_secure_options[:version]
+        post[:'3ds_version'] = three_d_secure_options[:version] == '2' ? '2.0' : three_d_secure_options[:version]
         post[:'3ds_dstrxid'] = three_d_secure_options[:ds_transaction_id]
       end
 

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -9,11 +9,21 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     @credit_card = credit_card('4176661000001015', verification_value: '281', month: '12')
     @fully_auth_card = credit_card('5223450000000007', brand: 'mastercard', verification_value: '090', month: '12')
     @declined_card = credit_card('4176661000001111', verification_value: '681', month: '12')
-    @three_ds_card = credit_card('4761739000060016', verification_value: '212', month: '12')
+    @three_ds_card = credit_card('5455330200000016', verification_value: '737', month: '10', year: Time.now.year + 2)
+    @address = {
+      name:     'Jon Smith',
+      address1: '123 Your Street',
+      address2: 'Apt 2',
+      city:     'Toronto',
+      state:    'ON',
+      zip:      'K2C3N7',
+      country:  'CA',
+      phone_number: '(123)456-7890'
+    }
     @options = {
       order_id: '1',
       currency: 'EUR',
-      billing_address: address,
+      billing_address: @address,
       description: 'Store Purchase'
     }
     @normalized_3ds_2_options = {
@@ -21,8 +31,8 @@ class RemoteCredoraxTest < Test::Unit::TestCase
       shopper_email: 'john.smith@test.com',
       shopper_ip: '77.110.174.153',
       shopper_reference: 'John Smith',
-      billing_address: address(),
-      shipping_address: address(),
+      billing_address: @address,
+      shipping_address: @address,
       order_id: '123',
       execute_threed: true,
       three_ds_version: '2',
@@ -348,7 +358,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
 
     capture = @gateway.capture(0, auth.authorization)
     assert_failure capture
-    assert_equal 'Invalid amount', capture.message
+    assert_equal 'System malfunction', capture.message
   end
 
   def test_successful_purchase_and_void
@@ -482,7 +492,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
   def test_failed_credit_with_zero_amount
     response = @gateway.credit(0, @declined_card, @options)
     assert_failure response
-    assert_equal 'Invalid amount', response.message
+    assert_equal 'Transaction not allowed for cardholder', response.message
   end
 
   def test_successful_verify

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -505,7 +505,7 @@ class CredoraxTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, options_with_normalized_3ds)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/i8=#{eci}%3A#{cavv}%3Anone/, data)
-      assert_match(/3ds_version=2.0/, data)
+      assert_match(/3ds_version=2/, data)
       assert_match(/3ds_dstrxid=#{ds_transaction_id}/, data)
     end.respond_with(successful_purchase_response)
   end
@@ -526,7 +526,7 @@ class CredoraxTest < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, options_with_normalized_3ds)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/i8=#{eci}%3Anone%3Anone/, data)
-      assert_match(/3ds_version=2.0/, data)
+      assert_match(/3ds_version=2.2.0/, data)
       assert_match(/3ds_dstrxid=#{ds_transaction_id}/, data)
     end.respond_with(successful_purchase_response)
   end


### PR DESCRIPTION
Update so that if a 3DS version starts with 2 it doesn't default to 2.0 but on what is passed in for the three_ds_version field.

Unit:
82 tests, 394 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
51 tests, 173 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 88.2353% passed