### PR TITLE
Stripe PI: add optional ability for 3DS exemption on verify calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 * RedsysRest: Add support for stored credentials & 3DS exemptions [jherreraa] #5132
 * CheckoutV2: Truncate the reference id for amex transactions [yunnydang] #5151
 * CommerceHub: Add billing address name override [yunnydang] #5157
+* StripePI: Add optional ability for 3DS exemption on verify calls [yunnydang] #5160
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -172,6 +172,7 @@ module ActiveMerchant #:nodoc:
             add_fulfillment_date(post, options)
             request_three_d_secure(post, options)
             add_card_brand(post, options)
+            add_exemption(post, options)
             post[:on_behalf_of] = options[:on_behalf_of] if options[:on_behalf_of]
             post[:usage] = options[:usage] if %w(on_session off_session).include?(options[:usage])
             post[:description] = options[:description] if options[:description]
@@ -531,7 +532,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_exemption(post, options = {})
-        return unless options[:confirm]
+        return unless options[:confirm] && options[:moto]
 
         post[:payment_method_options] ||= {}
         post[:payment_method_options][:card] ||= {}

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -926,6 +926,16 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert_equal 'Y', purchase.avs_result.dig('code')
   end
 
+  def test_create_setup_intent_with_moto_exemption
+    options = @options.merge(moto: true, confirm: true)
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_setup_intent(@visa_token, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/\[moto\]=true/, data)
+    end.respond_with(successful_verify_response)
+  end
+
   private
 
   def successful_setup_purchase


### PR DESCRIPTION
This allows us to send the optional moto and confirm on create_setup_intent transactions.

Local:
5945 tests, 79911 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
61 tests, 315 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
94 tests, 425 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.8085% passed