### PR TITLE
CyberSource: Add addtional invoiceHeader fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@
 * StripePI: Add optional ability for 3DS exemption on verify calls [yunnydang] #5160
 * CyberSource: Update stored credentials [sinourain] #5136
 * Orbital: Update to accept UCAF Indicator GSF [almalee24] #5150
+* CyberSource: Add addtional invoiceHeader fields [yunnydang] #5161
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -609,12 +609,24 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_merchant_descriptor(xml, options)
-        return unless options[:merchant_descriptor] || options[:user_po] || options[:taxable] || options[:reference_data_code] || options[:invoice_number]
+        return unless options[:merchant_descriptor] ||
+                      options[:user_po] ||
+                      options[:taxable] ||
+                      options[:reference_data_code] ||
+                      options[:invoice_number] ||
+                      options[:merchant_descriptor_city] ||
+                      options[:submerchant_id] ||
+                      options[:merchant_descriptor_state] ||
+                      options[:merchant_descriptor_country]
 
         xml.tag! 'invoiceHeader' do
           xml.tag! 'merchantDescriptor', options[:merchant_descriptor] if options[:merchant_descriptor]
+          xml.tag! 'merchantDescriptorCity', options[:merchant_descriptor_city] if options[:merchant_descriptor_city]
+          xml.tag! 'merchantDescriptorState', options[:merchant_descriptor_state] if options[:merchant_descriptor_state]
+          xml.tag! 'merchantDescriptorCountry', options[:merchant_descriptor_country] if options[:merchant_descriptor_country]
           xml.tag! 'userPO', options[:user_po] if options[:user_po]
           xml.tag! 'taxable', options[:taxable] if options[:taxable]
+          xml.tag! 'submerchantID', options[:submerchant_id] if options[:submerchant_id]
           xml.tag! 'referenceDataCode', options[:reference_data_code] if options[:reference_data_code]
           xml.tag! 'invoiceNumber', options[:invoice_number] if options[:invoice_number]
         end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -96,6 +96,10 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       ignore_cvv: 'true',
       commerce_indicator: 'internet',
       user_po: 'ABC123',
+      merchant_descriptor_country: 'US',
+      merchant_descriptor_state: 'NY',
+      merchant_descriptor_city: 'test123',
+      submerchant_id: 'AVSBSGDHJMNGFR',
       taxable: true,
       sales_slip_number: '456',
       airline_agent_code: '7Q',
@@ -129,6 +133,8 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     + '1111111115555555222233101abcdefghijkl7777777777777777777777777promotionCde'
   end
 
+  # Scrubbing is working but may fail at the @credit_card.verification_value assertion
+  # if the the 3 digits are showing up in the Cybersource requestID
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -248,11 +248,15 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_purchase_includes_invoice_header
     stub_comms do
-      @gateway.purchase(100, @credit_card, merchant_descriptor: 'Spreedly', reference_data_code: '3A', invoice_number: '1234567')
+      @gateway.purchase(100, @credit_card, merchant_descriptor: 'Spreedly', reference_data_code: '3A', invoice_number: '1234567', merchant_descriptor_city: 'test123', submerchant_id: 'AVSBSGDHJMNGFR', merchant_descriptor_country: 'US', merchant_descriptor_state: 'NY')
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<merchantDescriptor>Spreedly<\/merchantDescriptor>/, data)
       assert_match(/<referenceDataCode>3A<\/referenceDataCode>/, data)
       assert_match(/<invoiceNumber>1234567<\/invoiceNumber>/, data)
+      assert_match(/<merchantDescriptorCity>test123<\/merchantDescriptorCity>/, data)
+      assert_match(/<submerchantID>AVSBSGDHJMNGFR<\/submerchantID>/, data)
+      assert_match(/<merchantDescriptorCountry>US<\/merchantDescriptorCountry>/, data)
+      assert_match(/<merchantDescriptorState>NY<\/merchantDescriptorState>/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Adds the merchant_descriptor_city and submerchant_id fields

Local:
5944 tests, 79910 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
159 tests, 945 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
136 tests, 675 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.8529% passed