### PR TITLE
Moneris: Update crypt_type for 3DS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Add Maestro card bins [yunnydang] #5172
 * Braintree: Remove stored credential v1 [almalee24] #5175
 * Braintree Blue: Pass overridden mid into client token for GS 3DS [sinourain] #5166
+* Moneris: Update crypt_type for 3DS [almalee24] #5162
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -218,7 +218,7 @@ module ActiveMerchant #:nodoc:
         three_d_secure_options = options[:three_d_secure]
 
         post[:threeds_version] = three_d_secure_options[:version]
-        post[:crypt_type] = three_d_secure_options[:eci]
+        post[:crypt_type] = three_d_secure_options.dig(:eci)&.to_s&.sub!(/^0/, '')
         post[:cavv] = three_d_secure_options[:cavv]
         post[:threeds_server_trans_id] = three_d_secure_options[:three_ds_server_trans_id]
         post[:ds_trans_id] = three_d_secure_options[:ds_transaction_id]

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -15,7 +15,7 @@ class MonerisTest < Test::Unit::TestCase
     @credit_card = credit_card('4242424242424242')
 
     # https://developer.moneris.com/livedemo/3ds2/reference/guide/php
-    @fully_authenticated_eci = 5
+    @fully_authenticated_eci = '02'
     @no_liability_shift_eci = 7
 
     @options = { order_id: '1', customer: '1', billing_address: address }
@@ -86,6 +86,7 @@ class MonerisTest < Test::Unit::TestCase
       assert_match(/<ds_trans_id>12345<\/ds_trans_id>/, data)
       assert_match(/<threeds_server_trans_id>d0f461f8-960f-40c9-a323-4e43a4e16aaa<\/threeds_server_trans_id>/, data)
       assert_match(/<threeds_version>2<\/threeds_version>/, data)
+      assert_match(/<crypt_type>2<\/crypt_type>/, data)
     end.respond_with(failed_cavv_purchase_response)
 
     assert_failure response


### PR DESCRIPTION
Update crypt_type to only be one digit by removing leading zero if present.

Unit:
54 tests, 294 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
53 tests, 259 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications 100% passed