### PR TITLE
Braintree: Pass overridden mid into client token for GS 3DS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * Credorax: Update 3DS version mapping [almalee24] #5159
 * Add Maestro card bins [yunnydang] #5172
 * Braintree: Remove stored credential v1 [almalee24] #5175
+* Braintree Blue: Pass overridden mid into client token for GS 3DS [sinourain] #5166
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/braintree/token_nonce.rb
+++ b/lib/active_merchant/billing/gateways/braintree/token_nonce.rb
@@ -18,10 +18,10 @@ module ActiveMerchant #:nodoc:
         "https://payments#{'.sandbox' if sandbox}.braintree-api.com/graphql"
       end
 
-      def create_token_nonce_for_payment_method(payment_method)
+      def create_token_nonce_for_payment_method(payment_method, options = {})
         headers = {
           'Accept' => 'application/json',
-          'Authorization' => "Bearer #{client_token}",
+          'Authorization' => "Bearer #{client_token(options)['authorizationFingerprint']}",
           'Content-Type' => 'application/json',
           'Braintree-Version' => '2018-05-10'
         }
@@ -34,9 +34,9 @@ module ActiveMerchant #:nodoc:
         return token, message
       end
 
-      def client_token
-        base64_token = @braintree_gateway.client_token.generate
-        JSON.parse(Base64.decode64(base64_token))['authorizationFingerprint']
+      def client_token(options = {})
+        base64_token = @braintree_gateway.client_token.generate({ merchant_account_id: options[:merchant_account_id] || @options[:merchant_account_id] }.compact)
+        JSON.parse(Base64.decode64(base64_token))
       end
 
       private

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -1036,7 +1036,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_bank_account_to_customer(payment_method, options)
-        bank_account_nonce, error_message = TokenNonce.new(@braintree_gateway, options).create_token_nonce_for_payment_method payment_method
+        bank_account_nonce, error_message = TokenNonce.new(@braintree_gateway, options).create_token_nonce_for_payment_method(payment_method, options)
         return Response.new(false, error_message) unless bank_account_nonce.present?
 
         result = @braintree_gateway.payment_method.create(

--- a/test/remote/gateways/remote_braintree_token_nonce_test.rb
+++ b/test/remote/gateways/remote_braintree_token_nonce_test.rb
@@ -26,8 +26,25 @@ class RemoteBraintreeTokenNonceTest < Test::Unit::TestCase
 
   def test_client_token_generation
     generator = TokenNonce.new(@braintree_backend)
-    token = generator.client_token
-    assert_not_nil token
+    client_token = generator.client_token
+    assert_not_nil client_token
+    assert_not_nil client_token['authorizationFingerprint']
+  end
+
+  def test_client_token_generation_with_mid
+    @options[:merchant_account_id] = '1234'
+    generator = TokenNonce.new(@braintree_backend, @options)
+    client_token = generator.client_token
+    assert_not_nil client_token
+    assert_equal client_token['merchantAccountId'], '1234'
+  end
+
+  def test_client_token_generation_with_a_new_mid
+    @options[:merchant_account_id] = '1234'
+    generator = TokenNonce.new(@braintree_backend, @options)
+    client_token = generator.client_token({ merchant_account_id: '5678' })
+    assert_not_nil client_token
+    assert_equal client_token['merchantAccountId'], '5678'
   end
 
   def test_successfully_create_token_nonce_for_bank_account


### PR DESCRIPTION
Summary:
------------------------------
Add merchant_account_id for the Client Token Generate and returns a string which contains all authorization and configuration information that the client needs to initialize the client SDK to communicate with Braintree

[ECS-3617](https://spreedly.atlassian.net/browse/ECS-3617) [ECS-3607](https://spreedly.atlassian.net/browse/ECS-3607)

Remote Test:
------------------------------
Finished in 6.262003 seconds.
7 tests, 15 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
1.12 tests/s, 2.40 assertions/s

Unit Tests:
------------------------------
Finished in 38.744354 seconds.
5956 tests, 79952 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
153.73 tests/s, 2063.58 assertions/s

RuboCop:
------------------------------
798 files inspected, no offenses detected