### PR TITLE
CyberSource: bugfix - send correct card type/code for carnet

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -62,7 +62,8 @@ module ActiveMerchant #:nodoc:
         jcb: '007',
         dankort: '034',
         maestro: '042',
-        elo: '054'
+        elo: '054',
+        carnet: '058'
       }
 
       @@decision_codes = {

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -28,7 +28,8 @@ module ActiveMerchant #:nodoc:
         maestro: '042',
         master: '002',
         unionpay: '062',
-        visa: '001'
+        visa: '001',
+        carnet: '058'
       }
 
       WALLET_PAYMENT_SOLUTION = {

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -17,6 +17,7 @@ class CyberSourceRestTest < Test::Unit::TestCase
       year: 2031
     )
     @master_card = credit_card('2222420000001113', brand: 'master')
+    @carnet_card = credit_card('5062280000000000', brand: 'carnet')
 
     @visa_network_token = network_tokenization_credit_card(
       '4111111111111111',
@@ -583,6 +584,15 @@ class CyberSourceRestTest < Test::Unit::TestCase
       assert_equal '3', request['processingInformation']['purchaseLevel']
       assert_equal '150', request['orderInformation']['amountDetails']['discountAmount']
       assert_equal '90210', request['orderInformation']['shipping_details']['shipFromPostalCode']
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_accurate_card_type_and_code_for_carnet
+    stub_comms do
+      @gateway.purchase(100, @carnet_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal '058', request['paymentInformation']['card']['type']
     end.respond_with(successful_purchase_response)
   end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -18,6 +18,7 @@ class CyberSourceTest < Test::Unit::TestCase
     @master_credit_card = credit_card('4111111111111111', brand: 'master')
     @elo_credit_card = credit_card('5067310000000010', brand: 'elo')
     @declined_card = credit_card('801111111111111', brand: 'visa')
+    @carnet_card = credit_card('5062280000000000', brand: 'carnet')
     @network_token = network_tokenization_credit_card('4111111111111111',
                                                       brand: 'visa',
                                                       transaction_id: '123',
@@ -1987,6 +1988,14 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_routing_number_formatting_with_canadian_routing_number_and_padding
     assert_equal @gateway.send(:format_routing_number, '012345678', { currency: 'CAD' }), '12345678'
+  end
+
+  def test_accurate_card_type_and_code_for_carnet
+    stub_comms do
+      @gateway.purchase(100, @carnet_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<cardType>058<\/cardType>/, data)
+    end.respond_with(successful_purchase_response)
   end
 
   private


### PR DESCRIPTION
CER-1567

Sends code '058' for carnet card type in legacy CyberSource and CyberSource REST gateways

Local Tests
5947 tests, 79917 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CyberSource Legacy

Unit Tests
160 tests, 946 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests
136 tests, 676 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.8529% passed
*7 tests also failing on master

CyberSource REST

Unit Tests
40 tests, 216 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests
52 tests, 171 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
