### PR TITLE
Plexo: Update Network Token implementation

### DIFF
--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -24,7 +24,8 @@ class RemotePlexoTest < Test::Unit::TestCase
       },
       identification_type: '1',
       identification_value: '123456',
-      billing_address: address
+      billing_address: address,
+      invoice_number: '12345abcde'
     }
 
     @cancel_options = {
@@ -41,10 +42,22 @@ class RemotePlexoTest < Test::Unit::TestCase
         month: '12',
         year: Time.now.year
     })
+
+    @decrypted_network_token = NetworkTokenizationCreditCard.new(
+      {
+        first_name: 'Joe', last_name: 'Doe',
+        brand: 'visa',
+        payment_cryptogram: 'UnVBR0RlYm42S2UzYWJKeWJBdWQ=',
+        number: '5555555555554444',
+        source: :network_token,
+        month: '12',
+        year: Time.now.year
+      }
+    )
   end
 
   def test_successful_purchase_with_network_token
-    response = @gateway.purchase(@amount, @network_token_credit_card, @options.merge({ invoice_number: '12345abcde' }))
+    response = @gateway.purchase(@amount, @decrypted_network_token, @options.merge({ invoice_number: '12345abcde' }))
     assert_success response
     assert_equal 'You have been mocked.', response.message
   end

--- a/test/unit/gateways/plexo_test.rb
+++ b/test/unit/gateways/plexo_test.rb
@@ -346,9 +346,9 @@ class PlexoTest < Test::Unit::TestCase
       assert_equal request['Amount']['Currency'], 'UYU'
       assert_equal request['Amount']['Details']['TipAmount'], '5'
       assert_equal request['Flow'], 'direct'
-      assert_equal @network_token_credit_card.number, request['paymentMethod']['Card']['Number']
-      assert_equal @network_token_credit_card.payment_cryptogram, request['paymentMethod']['Card']['Cryptogram']
-      assert_equal @network_token_credit_card.first_name, request['paymentMethod']['Card']['Cardholder']['FirstName']
+      assert_equal @network_token_credit_card.number, request['paymentMethod']['NetworkToken']['Number']
+      assert_equal @network_token_credit_card.payment_cryptogram, request['paymentMethod']['NetworkToken']['Cryptogram']
+      assert_equal @network_token_credit_card.first_name, request['paymentMethod']['NetworkToken']['Cardholder']['FirstName']
     end.respond_with(successful_network_token_response)
 
     assert_success purchase


### PR DESCRIPTION
Description
-------------------------
[SER-1377](https://spreedly.atlassian.net/browse/SER-1377)

This commit update the previous implementation of NT in order to use network token instead if card

Unit test
-------------------------
Finished in 0.033159 seconds.

25 tests, 137 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

753.94 tests/s, 4131.61 assertions/s

Remote test
-------------------------
32 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 9 omissions, 0 notifications 100% passed

Rubocop
-------------------------
798 files inspected, no offenses detected