### PR TITLE
FlexCharge fix `add_payment_method` bug

### DIFF
--- a/lib/active_merchant/billing/gateways/flex_charge.rb
+++ b/lib/active_merchant/billing/gateways/flex_charge.rb
@@ -195,24 +195,26 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment_method(post, credit_card, address, options)
-        return unless credit_card.number.present?
-
         payment_method = case credit_card
                          when String
                            { Token: true, cardNumber: credit_card }
-                         else
-                           {
-                             holderName: credit_card.name,
-                             cardType: 'CREDIT',
-                             cardBrand: credit_card.brand&.upcase,
-                             cardCountry: address[:country],
-                             expirationMonth: credit_card.month,
-                             expirationYear: credit_card.year,
-                             cardBinNumber: credit_card.number[0..5],
-                             cardLast4Digits: credit_card.number[-4..-1],
-                             cardNumber: credit_card.number,
-                             Token: false
-                           }
+                         when CreditCard
+                           if credit_card.number
+                             {
+                               holderName: credit_card.name,
+                               cardType: 'CREDIT',
+                               cardBrand: credit_card.brand&.upcase,
+                               cardCountry: address[:country],
+                               expirationMonth: credit_card.month,
+                               expirationYear: credit_card.year,
+                               cardBinNumber: credit_card.number[0..5],
+                               cardLast4Digits: credit_card.number[-4..-1],
+                               cardNumber: credit_card.number,
+                               Token: false
+                             }
+                           else
+                             {}
+                           end
                          end
         post[:paymentMethod] = payment_method.compact
       end

--- a/test/unit/gateways/flex_charge_test.rb
+++ b/test/unit/gateways/flex_charge_test.rb
@@ -185,6 +185,16 @@ class FlexChargeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_token
+    payment = 'bb114473-43fc-46c4-9082-ea3dfb490509'
+
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, payment, @options)
+    end.respond_with(successful_access_token_response, successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_failed_refund
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.refund(@amount, 'reference', @options)


### PR DESCRIPTION
Fix bug where `add_payment_method` was incorrectly returned early if the payment value was a token