### PR TITLE
Braintree: Remove stored credential v1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * MerchantWarrior: Update phone, email, ip and store ID [almalee24] #5158
 * Credorax: Update 3DS version mapping [almalee24] #5159
 * Add Maestro card bins [yunnydang] #5172
+* Braintree: Remove stored credential v1 [almalee24] #5175
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -912,18 +912,10 @@ module ActiveMerchant #:nodoc:
         return unless (stored_credential = options[:stored_credential])
 
         add_external_vault(parameters, options)
-
-        if options[:stored_credentials_v2]
-          stored_credentials_v2(parameters, stored_credential)
-        else
-          stored_credentials_v1(parameters, stored_credential)
-        end
+        stored_credentials(parameters, stored_credential)
       end
 
-      def stored_credentials_v2(parameters, stored_credential)
-        # Differences between v1 and v2 are
-        # initial_transaction + recurring/installment should be labeled {{reason_type}}_first
-        # unscheduled in AM should map to '' at BT because unscheduled here means not on a fixed timeline or fixed amount
+      def stored_credentials(parameters, stored_credential)
         case stored_credential[:reason_type]
         when 'recurring', 'installment'
           if stored_credential[:initial_transaction]
@@ -935,20 +927,6 @@ module ActiveMerchant #:nodoc:
           parameters[:transaction_source] = stored_credential[:reason_type]
         when 'unscheduled'
           parameters[:transaction_source] = stored_credential[:initiator] == 'merchant' ? stored_credential[:reason_type] : ''
-        else
-          parameters[:transaction_source] = ''
-        end
-      end
-
-      def stored_credentials_v1(parameters, stored_credential)
-        if stored_credential[:initiator] == 'merchant'
-          if stored_credential[:reason_type] == 'installment'
-            parameters[:transaction_source] = 'recurring'
-          else
-            parameters[:transaction_source] = stored_credential[:reason_type]
-          end
-        elsif %w(recurring_first moto).include?(stored_credential[:reason_type])
-          parameters[:transaction_source] = stored_credential[:reason_type]
         else
           parameters[:transaction_source] = ''
         end

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1073,7 +1073,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_recurring_first_stored_credential_v2
     creds_options = stored_credential_options(:cardholder, :recurring, :initial)
-    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options, stored_credentials_v2: true))
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
     assert_success response
     assert_equal '1000 Approved', response.message
     assert_not_nil response.params['braintree_transaction']['network_transaction_id']
@@ -1082,7 +1082,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_follow_on_recurring_first_cit_stored_credential_v2
     creds_options = stored_credential_options(:cardholder, :recurring, id: '020190722142652')
-    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options, stored_credentials_v2: true))
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
     assert_success response
     assert_equal '1000 Approved', response.message
     assert_not_nil response.params['braintree_transaction']['network_transaction_id']
@@ -1091,7 +1091,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_follow_on_recurring_first_mit_stored_credential_v2
     creds_options = stored_credential_options(:merchant, :recurring, id: '020190722142652')
-    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options, stored_credentials_v2: true))
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
     assert_success response
     assert_equal '1000 Approved', response.message
     assert_not_nil response.params['braintree_transaction']['network_transaction_id']
@@ -1100,7 +1100,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
 
   def test_successful_one_time_mit_stored_credential_v2
     creds_options = stored_credential_options(:merchant, id: '020190722142652')
-    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options, stored_credentials_v2: true))
+    response = @gateway.purchase(@amount, credit_card('4111111111111111'), @options.merge(stored_credential: creds_options))
 
     assert_success response
     assert_equal '1000 Approved', response.message

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1165,7 +1165,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
           external_vault: {
             status: 'will_vault'
           },
-          transaction_source: ''
+          transaction_source: 'recurring_first'
         }
       )
     ).returns(braintree_result)
@@ -1181,7 +1181,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'vaulted',
             previous_network_transaction_id: '123ABC'
           },
-          transaction_source: ''
+          transaction_source: 'recurring'
         }
       )
     ).returns(braintree_result)
@@ -1197,7 +1197,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'vaulted',
             previous_network_transaction_id: '321XYZ'
           },
-          transaction_source: ''
+          transaction_source: 'recurring'
         }
       )
     ).returns(braintree_result)
@@ -1212,7 +1212,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
           external_vault: {
             status: 'will_vault'
           },
-          transaction_source: 'recurring'
+          transaction_source: 'recurring_first'
         }
       )
     ).returns(braintree_result)
@@ -1243,7 +1243,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
           external_vault: {
             status: 'will_vault'
           },
-          transaction_source: ''
+          transaction_source: 'installment_first'
         }
       )
     ).returns(braintree_result)
@@ -1259,7 +1259,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'vaulted',
             previous_network_transaction_id: '123ABC'
           },
-          transaction_source: ''
+          transaction_source: 'installment'
         }
       )
     ).returns(braintree_result)
@@ -1274,7 +1274,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
           external_vault: {
             status: 'will_vault'
           },
-          transaction_source: 'recurring'
+          transaction_source: 'installment_first'
         }
       )
     ).returns(braintree_result)
@@ -1290,7 +1290,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
             status: 'vaulted',
             previous_network_transaction_id: '123ABC'
           },
-          transaction_source: 'recurring'
+          transaction_source: 'installment'
         }
       )
     ).returns(braintree_result)
@@ -1387,7 +1387,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: { initiator: 'merchant', reason_type: 'recurring_first', initial_transaction: true } })
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: { initiator: 'merchant', reason_type: 'recurring_first', initial_transaction: true } })
   end
 
   def test_stored_credential_moto_cit_initial
@@ -1417,7 +1417,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:cardholder, :recurring, :initial) })
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :recurring, :initial) })
   end
 
   def test_stored_credential_v2_follow_on_recurring_first
@@ -1433,7 +1433,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:merchant, :recurring, id: '123ABC') })
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, id: '123ABC') })
   end
 
   def test_stored_credential_v2_installment_first
@@ -1448,7 +1448,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:cardholder, :installment, :initial) })
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :installment, :initial) })
   end
 
   def test_stored_credential_v2_follow_on_installment_first
@@ -1464,7 +1464,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:merchant, :installment, id: '123ABC') })
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :installment, id: '123ABC') })
   end
 
   def test_stored_credential_v2_unscheduled_cit_initial
@@ -1479,7 +1479,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:cardholder, :unscheduled, :initial) })
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:cardholder, :unscheduled, :initial) })
   end
 
   def test_stored_credential_v2_unscheduled_mit_initial
@@ -1494,7 +1494,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       )
     ).returns(braintree_result)
 
-    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credentials_v2: true, stored_credential: stored_credential(:merchant, :unscheduled, :initial) })
+    @gateway.purchase(100, credit_card('41111111111111111111'), { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :unscheduled, :initial) })
   end
 
   def test_raises_exeption_when_adding_bank_account_to_customer_without_billing_address


### PR DESCRIPTION
Update Stored Credential flow to keep v2.

Unit:
104 tests, 219 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
123 tests, 661 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed