### PR TITLE
Update CheckoutV2 3DS message & error code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * Braintree: Remove stored credential v1 [almalee24] #5175
 * Braintree Blue: Pass overridden mid into client token for GS 3DS [sinourain] #5166
 * Moneris: Update crypt_type for 3DS [almalee24] #5162
+* CheckoutV2: Update 3DS message & error code [almalee24] #5177
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -661,12 +661,7 @@ module ActiveMerchant #:nodoc:
         elsif response['error_type']
           response['error_type'] + ': ' + response['error_codes'].first
         else
-          response_summary = if options[:threeds_response_message]
-                               response['response_summary'] || response.dig('actions', 0, 'response_summary')
-                             else
-                               response['response_summary']
-                             end
-
+          response_summary = response['response_summary'] || response.dig('actions', 0, 'response_summary')
           response_summary || response['response_code'] || response['status'] || response['message'] || 'Unable to read error message'
         end
       end
@@ -696,11 +691,7 @@ module ActiveMerchant #:nodoc:
         elsif response['error_type']
           response['error_type']
         else
-          response_code = if options[:threeds_response_message]
-                            response['response_code'] || response.dig('actions', 0, 'response_code')
-                          else
-                            response['response_code']
-                          end
+          response_code = response['response_code'] || response.dig('actions', 0, 'response_code')
 
           STANDARD_ERROR_CODE_MAPPING[response_code]
         end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -431,23 +431,13 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_equal Gateway::STANDARD_ERROR_CODE[:invalid_number], response.error_code
   end
 
-  def test_failed_purchase_3ds_with_threeds_response_message
-    response = stub_comms(@gateway, :ssl_request) do
-      @gateway.purchase(@amount, @credit_card, { execute_threed: true, exemption: 'no_preference', challenge_indicator: 'trusted_listing', threeds_response_message: true })
-    end.respond_with(failed_purchase_3ds_response)
-
-    assert_failure response
-    assert_equal 'Insufficient Funds', response.message
-    assert_equal nil, response.error_code
-  end
-
-  def test_failed_purchase_3ds_without_threeds_response_message
+  def test_failed_purchase_3ds
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, { execute_threed: true, exemption: 'no_preference', challenge_indicator: 'trusted_listing' })
     end.respond_with(failed_purchase_3ds_response)
 
     assert_failure response
-    assert_equal 'Declined', response.message
+    assert_equal 'Insufficient Funds', response.message
     assert_equal nil, response.error_code
   end
 


### PR DESCRIPTION
Update CheckoutV2 3DS message & error code to keep waht was bening threed_response_message

Unit:
67 tests, 420 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote:
111 tests, 274 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed