### PR TITLE
Adyen: Add header fields to response body

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@
 * CheckoutV2: Update 3DS message & error code [almalee24] #5177
 * DecicirPlus: Update error_message to add safety navigator [almalee24] #5187
 * Elavon: Add updated stored credential version [almalee24] #5170
+* Adyen: Add header fields to response body [yunnydang] #5184
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -262,6 +262,16 @@ class AdyenTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_failure_authorize_with_transient_error
+    @gateway.instance_variable_set(:@response_headers, { 'transient-error' => 'error_will_robinson' })
+    @gateway.expects(:ssl_post).returns(failed_authorize_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+    assert response.params['response_headers']['transient_error'], 'error_will_robinson'
+    assert response.test?
+  end
+
   def test_standard_error_code_mapping
     @gateway.expects(:ssl_post).returns(failed_billing_field_response)
 


### PR DESCRIPTION
This adds the header fields and values to the response body object in the parse method. By using the handle_response override, we can set an instance variable of the headers and merge it into the response body. The 12 remote test failures are also the same ones that fail on the master branch. 

Local:
5961 tests, 79980 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
120 tests, 630 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
144 tests, 471 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.6667% passed