### PR TITLE
Stripe and Stripe PI: add headers to response body

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@
 * DecicirPlus: Update error_message to add safety navigator [almalee24] #5187
 * Elavon: Add updated stored credential version [almalee24] #5170
 * Adyen: Add header fields to response body [yunnydang] #5184
+* Stripe and Stripe PI: Add header fields to response body [yunnydang] #5185
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -380,6 +380,17 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     refute purchase.params.dig('error', 'payment_intent', 'charges', 'data')[0]['captured']
   end
 
+  def test_unsuccessful_purchase_returns_header_response
+    options = {
+      currency: 'GBP',
+      customer: @customer
+    }
+    assert purchase = @gateway.purchase(@amount, @declined_payment_method, options)
+
+    assert_equal 'Your card was declined.', purchase.message
+    assert_not_nil purchase.params['response_headers']['stripe_should_retry']
+  end
+
   def test_successful_purchase_with_external_auth_data_3ds_1
     options = {
       currency: 'GBP',

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -207,6 +207,14 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_match(/ch_[a-zA-Z\d]+/, response.authorization)
   end
 
+  def test_unsuccessful_purchase_returns_response_headers
+    assert response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_match %r{Your card was declined}, response.message
+    assert_match Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+    assert_not_nil response.params['response_headers']['stripe_should_retry']
+  end
+
   def test_unsuccessful_purchase_with_destination_and_amount
     destination = fixtures(:stripe_destination)[:stripe_user_id]
     custom_options = @options.merge(destination: destination, destination_amount: @amount + 20)

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -315,6 +315,15 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_create_intent_response)
   end
 
+  def test_failed_authorize_with_idempotent_replayed
+    @gateway.instance_variable_set(:@response_headers, { 'idempotent-replayed' => 'true' })
+    @gateway.expects(:ssl_request).returns(failed_payment_method_response)
+
+    response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_failure response
+    assert response.params['response_headers']['idempotent_replayed'], 'true'
+  end
+
   def test_failed_error_on_requires_action
     @gateway.expects(:ssl_request).returns(failed_with_set_error_on_requires_action_response)
 


### PR DESCRIPTION
This adds some of the header fields to the response body object using the handle_response override.

Local:
5962 tests, 79990 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Stripe unit:
146 tests, 769 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Stripe remote:
77 tests, 328 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
87.013% passed

Stripe PI Unit:
61 tests, 315 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Stripe PI Remote:
95 tests, 427 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.8421% passed