### PR TITLE
SER-1387 and SER-1338 fix shipping address and idempotency key

### DIFF
--- a/test/remote/gateways/remote_flex_charge_test.rb
+++ b/test/remote/gateways/remote_flex_charge_test.rb
@@ -115,6 +115,14 @@ class RemoteFlexChargeTest < Test::Unit::TestCase
     assert_equal 'APPROVED', response.message
   end
 
+  def test_successful_purchase_mit_with_billing_address
+    set_credentials!
+    @options[:billing_address] = address.merge(name: 'Jhon Doe', country: 'US')
+    response = @gateway.purchase(@amount, @credit_card_mit, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+  end
+
   def test_successful_authorize_cit
     @cit_options[:phone] = '998888'
     set_credentials!

--- a/test/unit/gateways/flex_charge_test.rb
+++ b/test/unit/gateways/flex_charge_test.rb
@@ -25,6 +25,7 @@ class FlexChargeTest < Test::Unit::TestCase
       cavv_result_code: '111',
       timezone_utc_offset: '-5',
       billing_address: address.merge(name: 'Cure Tester'),
+      shipping_address: address.merge(name: 'Jhon Doe', country: 'US'),
       sense_key: 'abc123',
       extra_data: { hello: 'world' }.to_json
     }
@@ -121,6 +122,11 @@ class FlexChargeTest < Test::Unit::TestCase
         assert_equal request['transaction']['transactionType'], 'Purchase'
         assert_equal request['payer']['email'], @options[:email]
         assert_equal request['description'], @options[:description]
+
+        assert_equal request['billingInformation']['firstName'], 'Cure'
+        assert_equal request['billingInformation']['country'], 'CA'
+        assert_equal request['shippingInformation']['firstName'], 'Jhon'
+        assert_equal request['shippingInformation']['country'], 'US'
       end
     end.respond_with(successful_access_token_response, successful_purchase_response)
 
@@ -290,6 +296,14 @@ class FlexChargeTest < Test::Unit::TestCase
 
     assert_success response
     assert_equal 'ca7bb327-a750-412d-a9c3-050d72b3f0c5#USD', response.authorization
+  end
+
+  def test_add_base_data_without_idempotency_key
+    @options.delete(:idempotency_key)
+    post = {}
+    @gateway.send(:add_base_data, post, @options)
+
+    assert_equal 5, post[:idempotencyKey].split('-').size
   end
 
   private


### PR DESCRIPTION
## Summary:

Including shipping address if provided and fix idempotency key to default to random UUID.

[SER-1387](https://spreedly.atlassian.net/browse/SER-1387) 
[SER-1338](https://spreedly.atlassian.net/browse/SER-1338)

## Tests

### Remote Test:
Finished in 77.783815 seconds.
20 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 46.32943 seconds.
5963 tests, 79998 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
798 files inspected, no offenses detected