### PR TITLE
BraintreeBlue: Updates to Paypal integration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
 * Mercury, TransFirst: Repair gateways following updates to `rexml` [aenand] #5206
 * NMI: Fix Decrypted indicator for Google/Apple pay [javierpedrozaing] #5196
 * FlexCharge: add more descriptives error messages [gasb150] #5199
+* Braintree: Updates to Paypal Integration [almalee24] #5190
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1330,6 +1330,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal '1000 Approved', response.message
     assert_equal 'paypal_payer_id', response.params['braintree_transaction']['paypal_details']['payer_id']
     assert_equal 'payer@example.com', response.params['braintree_transaction']['paypal_details']['payer_email']
+    assert_equal nil, response.params['braintree_transaction']['paypal_details']['paypal_payment_token']
   end
 
   def test_successful_credit_card_purchase_with_prepaid_debit_issuing_bank

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -253,6 +253,24 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.authorize(100, 'fake-paypal-future-nonce', options)
   end
 
+  def test_not_adding_default_payment_method_to_customer
+    options = {
+      prevent_default_payment_method: true,
+      payment_method_nonce: 'fake-paypal-future-nonce',
+      store: true,
+      device_data: 'device_data',
+      paypal: {
+        paypal_flow_type: 'checkout_with_vault'
+      }
+    }
+
+    Braintree::TransactionGateway.any_instance.expects(:sale).returns(braintree_result(paypal: { implicitly_vaulted_payment_method_token: 'abc123' }))
+
+    Braintree::CustomerGateway.any_instance.expects(:update).with(nil, { default_payment_method_token: 'abc123' }).never
+
+    @gateway.authorize(100, 'fake-paypal-future-nonce', options)
+  end
+
   def test_risk_data_can_be_specified
     risk_data = {
       customer_browser: 'User-Agent Header',


### PR DESCRIPTION
Do not add default payment method to customer if prevent_default_payment_method is true. Add paypal_payment_token to transaction_hash.

123 tests, 662 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed