### PR TITLE
Rapyd: Add support for save_payment_method field

### DIFF
--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -243,6 +243,7 @@ module ActiveMerchant #:nodoc:
       def add_payment_fields(post, options)
         post[:description] = options[:description] if options[:description]
         post[:statement_descriptor] = options[:statement_descriptor] if options[:statement_descriptor]
+        post[:save_payment_method] = options[:save_payment_method] if options[:save_payment_method]
       end
 
       def add_payment_urls(post, options, action = '')

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -145,6 +145,14 @@ class RemoteRapydTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_purchase_with_save_payment_method
+    @options[:pm_type] = 'gb_visa_mo_card'
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(save_payment_method: true))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+    assert_equal true, response.params['data']['save_payment_method']
+  end
+
   def test_successful_purchase_with_address
     billing_address = address(name: 'Henry Winkler', address1: '123 Happy Days Lane')
 
@@ -182,7 +190,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Do Not Honor', response.message
+    assert_equal 'The request attempted an operation that requires a card number, but the number was not recognized. The request was rejected. Corrective action: Use the card number of a valid card.', response.message
   end
 
   def test_successful_authorize_and_capture
@@ -197,7 +205,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'Do Not Honor', response.message
+    assert_equal 'The request attempted an operation that requires a card number, but the number was not recognized. The request was rejected. Corrective action: Use the card number of a valid card.', response.message
   end
 
   def test_partial_capture
@@ -275,7 +283,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   def test_failed_void
     response = @gateway.void('')
     assert_failure response
-    assert_equal 'NOT_FOUND', response.message
+    assert_equal 'UNAUTHORIZED_API_CALL', response.message
   end
 
   def test_successful_verify
@@ -295,7 +303,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_equal 'Do Not Honor', response.message
+    assert_equal 'The request attempted an operation that requires a card number, but the number was not recognized. The request was rejected. Corrective action: Use the card number of a valid card.', response.message
   end
 
   def test_successful_store_and_purchase
@@ -334,7 +342,7 @@ class RemoteRapydTest < Test::Unit::TestCase
 
     unstore = @gateway.unstore('')
     assert_failure unstore
-    assert_equal 'NOT_FOUND', unstore.message
+    assert_equal 'UNAUTHORIZED_API_CALL', unstore.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/rapyd_test.rb
+++ b/test/unit/gateways/rapyd_test.rb
@@ -182,6 +182,16 @@ class RapydTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_save_payment_method
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({ save_payment_method: true }))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"save_payment_method":true/, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_3ds_global
     @options[:three_d_secure] = {
       required: true,


### PR DESCRIPTION
CER-1613

Top level boolean field that will trigger payment method to be saved.

Remote Tests:
54 tests, 152 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 94.4444% passed
* I fixed a few failing tests, so less failing on master.

Also, more of them seem fixable but I started to gown down a docs rabbit hole that is not in the scope of this ticket.