### PR TITLE
Datatrans: Modify authorization_from string for store

### DIFF
--- a/lib/active_merchant/billing/gateways/datatrans.rb
+++ b/lib/active_merchant/billing/gateways/datatrans.rb
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def unstore(authorization, options = {})
-        data_alias = authorization.split('|')[2].split('-')[0]
+        data_alias = authorization.split('|')[2]
         commit('delete_alias', {}, { alias_id: data_alias }, :delete)
       end
 
@@ -110,7 +110,7 @@ module ActiveMerchant #:nodoc:
       def add_payment_method(post, payment_method)
         case payment_method
         when String
-          token, exp_month, exp_year = payment_method.split('|')[2].split('-')
+          token, exp_month, exp_year = payment_method.split('|')[2..4]
           card = {
             type: 'ALIAS',
             alias: token,
@@ -250,9 +250,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(response, action, options)
-        string = [response.dig('responses', 0, 'alias'), options[:expiry_month], options[:expiry_year]].join('-') if action == 'tokenize'
+        token_array = [response.dig('responses', 0, 'alias'), options[:expiry_month], options[:expiry_year]].join('|') if action == 'tokenize'
 
-        auth = [response['transactionId'], response['acquirerAuthorizationCode'], string].join('|')
+        auth = [response['transactionId'], response['acquirerAuthorizationCode'], token_array].join('|')
         return auth unless auth == '||'
       end
 

--- a/test/unit/gateways/datatrans_test.rb
+++ b/test/unit/gateways/datatrans_test.rb
@@ -325,9 +325,9 @@ class DatatransTest < Test::Unit::TestCase
     assert_equal '|9248|', @gateway.send(:authorization_from, { 'acquirerAuthorizationCode' => '9248' }, '', {})
     assert_equal nil, @gateway.send(:authorization_from, {}, '', {})
     # tes for store
-    assert_equal '||any_alias-any_month-any_year', @gateway.send(:authorization_from, { 'responses' => [{ 'alias' => 'any_alias' }] }, 'tokenize', { expiry_month: 'any_month', expiry_year: 'any_year' })
+    assert_equal '||any_alias|any_month|any_year', @gateway.send(:authorization_from, { 'responses' => [{ 'alias' => 'any_alias' }] }, 'tokenize', { expiry_month: 'any_month', expiry_year: 'any_year' })
     # handle nil responses or missing keys
-    assert_equal '||-any_month-any_year', @gateway.send(:authorization_from, {}, 'tokenize', { expiry_month: 'any_month', expiry_year: 'any_year' })
+    assert_equal '|||any_month|any_year', @gateway.send(:authorization_from, {}, 'tokenize', { expiry_month: 'any_month', expiry_year: 'any_year' })
   end
 
   def test_parse


### PR DESCRIPTION
Summary:
Modify the string for store to be separated by '|' instead of '-'.

SER-1395

Tests
Remote Test:
Finished in 31.477035 seconds.
25 tests, 72 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications 100% passed

Unit Tests:
Finished in 0.115603 seconds.
29 tests, 165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop
798 files inspected, no offenses detected