### PR TITLE
Braintree: Support override_application_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 * Elavon: Update sending CVV for MIT transactions  [almalee24] #5210
 * Adyen: Fix NT integration [jherreraa] #5155
 * HPS: Update NetworkTokenizationCreditCard flow [almalee24] #5178
+* Braintree: Support override_application_id [aenand] #5194
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -815,7 +815,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_channel(parameters, options)
-        channel = @options[:channel] || application_id
+        channel = options[:override_application_id] || @options[:channel] || application_id
         parameters[:channel] = channel if channel
       end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -955,8 +955,6 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), {})[:channel], 'overidden-channel'
 
     assert_equal gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), { override_application_id: 'override-application-id' })[:channel], 'override-application-id'
-  ensure
-    ActiveMerchant::Billing::BraintreeBlueGateway.application_id = nil
   end
 
   def test_successful_purchase_with_descriptor

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -952,9 +952,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
 
   def test_override_application_id_is_sent_to_channel
     gateway = BraintreeBlueGateway.new(merchant_id: 'test', public_key: 'test', private_key: 'test', channel: 'overidden-channel')
-    assert_equal gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), {})[:channel], 'overidden-channel'
+    gateway_response = gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), {})
+    assert_equal gateway_response[:channel], 'overidden-channel'
 
-    assert_equal gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), { override_application_id: 'override-application-id' })[:channel], 'override-application-id'
+    gateway_response = gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), { override_application_id: 'override-application-id' })
+    assert_equal gateway_response[:channel], 'override-application-id'
   end
 
   def test_successful_purchase_with_descriptor

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -939,13 +939,22 @@ class BraintreeBlueTest < Test::Unit::TestCase
     end
   end
 
-  def test_solution_id_is_added_to_create_transaction_parameters
+  def test_channel_is_added_to_create_transaction_parameters
     assert_nil @gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), {})[:channel]
     ActiveMerchant::Billing::BraintreeBlueGateway.application_id = 'ABC123'
     assert_equal @gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), {})[:channel], 'ABC123'
 
     gateway = BraintreeBlueGateway.new(merchant_id: 'test', public_key: 'test', private_key: 'test', channel: 'overidden-channel')
     assert_equal gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), {})[:channel], 'overidden-channel'
+  ensure
+    ActiveMerchant::Billing::BraintreeBlueGateway.application_id = nil
+  end
+
+  def test_override_application_id_is_sent_to_channel
+    gateway = BraintreeBlueGateway.new(merchant_id: 'test', public_key: 'test', private_key: 'test', channel: 'overidden-channel')
+    assert_equal gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), {})[:channel], 'overidden-channel'
+
+    assert_equal gateway.send(:create_transaction_parameters, 100, credit_card('41111111111111111111'), { override_application_id: 'override-application-id' })[:channel], 'override-application-id'
   ensure
     ActiveMerchant::Billing::BraintreeBlueGateway.application_id = nil
   end


### PR DESCRIPTION
COMP-266

ActiveMerchant currently uses Class.application_id or @options[:channel] to let merchants pass platform BN codes to gateways to signify that a transaction may be going to one merchant's accounts but it originates from a platform or aggregator.

This poses a problem in that the Class value is assigned at compile time and the @options[:channel] refers to a static value used when initializing the class.

This commit adds support for `override_application_id` which is a way for aggregators to pass in a new BN code at transaction time alongside transaction parameters.

Test Summary
Remote:
123 tests, 661 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Cannot add a remote test because there is no generic `channel` value