### PR TITLE
NMI: Fix Decrypted indicator for Google/Apple pay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,10 +2,10 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
-* Mercury, TransFirst: Repair gateways following updates to `rexml` [aenand] #5206.
+* Mercury, TransFirst: Repair gateways following updates to `rexml` [aenand] #5206
+* NMI: Fix Decrypted indicator for Google/Apple pay [javierpedrozaing] #5196
 
-= Version 1.137.0 (August 2, 2024)
-
+== Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).
 * Bump Ruby version to 3.1 [dustinhaefele] #5104
 * FlexCharge: Update inquire method to use the new orders end-point

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -192,8 +192,8 @@ module ActiveMerchant #:nodoc:
         if payment_method.source == :apple_pay || payment_method.source == :google_pay
           post[:cavv] = payment_method.payment_cryptogram
           post[:eci] = payment_method.eci
-          post[:decrypted_applepay_data] = 1
-          post[:decrypted_googlepay_data] = 1
+          post[:decrypted_applepay_data] = 1 if payment_method.source == :apple_pay
+          post[:decrypted_googlepay_data] = 1 if payment_method.source == :google_pay
         else
           post[:token_cryptogram] = payment_method.payment_cryptogram
         end

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -159,6 +159,28 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_google_pay_without_billing_address
+    assert @gateway_secure.supports_network_tokenization?
+    @options.delete(:billing_address)
+
+    assert response = @gateway_secure.purchase(@amount, @google_pay, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_apple_pay_without_billing_address
+    assert @gateway_secure.supports_network_tokenization?
+    @options.delete(:billing_address)
+
+    assert response = @gateway_secure.purchase(@amount, @apple_pay, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+    assert response.authorization
+  end
+
   def test_failed_purchase_with_apple_pay
     assert response = @gateway_secure.purchase(1, @apple_pay, @options)
     assert_failure response

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -62,6 +62,8 @@ class NmiTest < Test::Unit::TestCase
       assert_match(/ccexp=#{sprintf("%.2i", @apple_pay.month)}#{@apple_pay.year.to_s[-2..-1]}/, data)
       assert_match(/cavv=EHuWW9PiBkWvqE5juRwDzAUFBAk%3D/, data)
       assert_match(/eci=05/, data)
+      assert_match(/decrypted_applepay_data/, data)
+      assert_nil data['decrypted_googlepay_data']
     end.respond_with(successful_purchase_response)
   end
 
@@ -74,6 +76,8 @@ class NmiTest < Test::Unit::TestCase
       assert_match(/ccexp=#{sprintf("%.2i", @google_pay.month)}#{@google_pay.year.to_s[-2..-1]}/, data)
       assert_match(/cavv=EHuWW9PiBkWvqE5juRwDzAUFBAk%3D/, data)
       assert_match(/eci=05/, data)
+      assert_match(/decrypted_googlepay_data/, data)
+      assert_nil data['decrypted_applepay_data']
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Description
-------------------------
[SER-1402](https://spreedly.atlassian.net/browse/SER-1402)

This commit adds a small fix to send the proper decrypted indicator respectively for Apple Pay and Google Pay.
Additionally, adds some remote tests for successful Apple/Google transactions without sending the billing address.

Unit test
-------------------------
Finished in 0.017629 seconds.

6 tests, 21 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

340.35 tests/s, 1191.22 assertions/s

Remote test
-------------------------
Finished in 30.626119 seconds.

19 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

0.62 tests/s, 1.63 assertions/s

Rubocop
-------------------------
801 files inspected, no offenses detected