### PR TITLE
Fatzebra: fix directory_server_transaction_id mapping

### DIFF
--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -151,7 +151,7 @@ module ActiveMerchant #:nodoc:
           par: three_d_secure[:authentication_response_status],
           ver: formatted_enrollment(three_d_secure[:enrolled]),
           threeds_version: three_d_secure[:version],
-          ds_transaction_id: three_d_secure[:ds_transaction_id]
+          directory_server_txn_id: three_d_secure[:ds_transaction_id]
         }.compact
       end
 

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -233,7 +233,7 @@ class RemoteFatZebraTest < Test::Unit::TestCase
       version: '2.0',
       cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
       eci: '05',
-      ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      ds_transaction_id: 'f25084f0-5b16-4c0a-ae5d-b24808a95e4b',
       enrolled: 'true',
       authentication_response_status: 'Y'
     }

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -25,6 +25,7 @@ class FatZebraTest < Test::Unit::TestCase
       eci: '05',
       xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
       enrolled: 'true',
+      ds_transaction_id: 'f25084f0-5b16-4c0a-ae5d-b24808a95e4b',
       authentication_response_status: 'Y'
     }
   end
@@ -235,7 +236,7 @@ class FatZebraTest < Test::Unit::TestCase
     assert_equal ds_options[:cavv], ds_data[:cavv]
     assert_equal ds_options[:eci], ds_data[:sli]
     assert_equal ds_options[:xid], ds_data[:xid]
-    assert_equal ds_options[:ds_transaction_id], ds_data[:ds_transaction_id]
+    assert_equal ds_options[:ds_transaction_id], ds_data[:directory_server_txn_id]
     assert_equal 'Y', ds_data[:ver]
     assert_equal ds_options[:authentication_response_status], ds_data[:par]
   end


### PR DESCRIPTION
Summary:
------------------------------
Rename the equivalent ds_transaction_id in fatzebra for directory_server_txn_id, to map it corrctly.

[ECS-3660](https://spreedly.atlassian.net/browse/ECS-3660) 
[UBI-132](https://spreedly.atlassian.net/browse/UBI-132)

Remote Tests:
------------------------------
Finished in 87.765183 seconds.
30 tests, 104 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 93.3333% passed

*Note Failing Test*: We have to remote tests failing because seems to be a change on the sandbox behavior when a transaction doesn't include a cvv

Unit Tests:
------------------------------
Finished in 0.073139 seconds.
23 tests, 130 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

RuboCop:
------------------------------
798 files inspected, no offenses detected