### PR TITLE
Elavon: Update cvv for stored credential

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -247,7 +247,7 @@ module ActiveMerchant #:nodoc:
       def add_verification_value(xml, credit_card, options)
         return unless credit_card.verification_value?
         # Don't add cvv if this is a non-initial stored credential transaction
-        return if !options.dig(:stored_credential, :initial_transaction) && options[:stored_cred_v2]
+        return if options[:stored_credential] && !options.dig(:stored_credential, :initial_transaction) && options[:stored_cred_v2]
 
         xml.ssl_cvv2cvc2            credit_card.verification_value
         xml.ssl_cvv2cvc2_indicator  1

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -47,7 +47,7 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options)
+      @gateway.purchase(@amount, @credit_card, @options.merge!(stored_cred_v2: true))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<ssl_cvv2cvc2>123<\/ssl_cvv2cvc2>/, data)
     end.respond_with(successful_purchase_response)


### PR DESCRIPTION
Only skip CVV if stored credentials is being used and it's not an initial transaction.