### PR TITLE
MercadoPago: Adding 3DS gateway specific fields

### DIFF
--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -105,7 +105,8 @@ module ActiveMerchant #:nodoc:
         add_net_amount(post, options)
         add_taxes(post, options)
         add_notification_url(post, options)
-        post[:binary_mode] = (options[:binary_mode].nil? ? true : options[:binary_mode])
+        add_3ds(post, options)
+        post[:binary_mode] = options.fetch(:binary_mode, true) unless options[:execute_threed]
         post
       end
 
@@ -287,7 +288,7 @@ module ActiveMerchant #:nodoc:
         if action == 'refund'
           response['status'] != 404 && response['error'].nil?
         else
-          %w[active approved authorized cancelled in_process].include?(response['status'])
+          %w[active approved authorized cancelled in_process pending].include?(response['status'])
         end
       end
 
@@ -320,6 +321,13 @@ module ActiveMerchant #:nodoc:
             response['status']
           end
         end
+      end
+
+      def add_3ds(post, options)
+        return unless options[:execute_threed]
+
+        post[:three_d_secure_mode] = options[:three_ds_mode] == 'mandatory' ? 'mandatory' : 'optional'
+        post[:notification_url] = options[:notification_url] if options[:notification_url]
       end
 
       def url(action)


### PR DESCRIPTION
## Summary:
MercadoPago adding needed fields to mark a transaction to request 3DS flow.

[SER-1226](https://spreedly.atlassian.net/browse/SER-1226)

## Tests

###  Remote Test:
Finished in 79.263845 seconds.
20 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 43.253318 seconds.
5981 tests, 80141 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
798 files inspected, no offenses detected