### PR TITLE
Iveri: Add AuthReversal for Authorizations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@
 * Decidir: Pass CVV for NT [almalee24] #5205
 * NMI: Add customer vault fields [yunnydang] #5215
 * CheckoutV2: Add inquire method [almalee24] #5209
+* Iveri: Add AuthReversal for Authorizations [almalee24] #5201
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/iveri.rb
+++ b/lib/active_merchant/billing/gateways/iveri.rb
@@ -55,7 +55,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def void(authorization, options = {})
-        post = build_vxml_request('Void', options) do |xml|
+        txn_type = options[:reference_type] == :authorize ? 'AuthReversal' : 'Void'
+        post = build_vxml_request(txn_type, options) do |xml|
           add_authorization(xml, authorization, options)
         end
 
@@ -65,7 +66,7 @@ module ActiveMerchant #:nodoc:
       def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
+          r.process(:ignore_result) { void(r.authorization, options.merge(reference_type: :authorize)) }
         end
       end
 

--- a/test/remote/gateways/remote_iveri_test.rb
+++ b/test/remote/gateways/remote_iveri_test.rb
@@ -136,8 +136,8 @@ class RemoteIveriTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Authorisation', response.responses[0].params['transaction_command']
     assert_equal '0', response.responses[0].params['result_status']
-    assert_equal 'Void', response.responses[1].params['transaction_command']
-    assert_equal '0', response.responses[1].params['result_status']
+    assert_equal 'AuthReversal', response.responses[1].params['transaction_command']
+    assert_equal '-1', response.responses[1].params['result_status']
     assert_equal 'Succeeded', response.message
   end
 


### PR DESCRIPTION
If the transaction to be voided is an Authorization then use AuthReversal instead of Void.

Remote
22 tests, 56 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95.4545% passed

Unit
16 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed