### PR TITLE
Adyen: Remove raw_error_message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@
 * Cybersource: Add apple_pay with discover. [DustinHaefele] #5213
 * MercadoPago: Add idempotency key field [yunnydang] #5229
 * Adyen: Update split refund method [yunnydang] #5218
+* Adyen: Remove raw_error_message [almalee24] #5202
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -904,18 +904,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorize_message_from(response, options = {})
-        return raw_authorize_error_message(response) if options[:raw_error_message]
-
         if response['refusalReason'] && response['additionalData'] && (response['additionalData']['merchantAdviceCode'] || response['additionalData']['refusalReasonRaw'])
           "#{response['refusalReason']} | #{response['additionalData']['merchantAdviceCode'] || response['additionalData']['refusalReasonRaw']}"
-        else
-          response['refusalReason'] || response['resultCode'] || response['message'] || response['result']
-        end
-      end
-
-      def raw_authorize_error_message(response)
-        if response['refusalReason'] && response['additionalData'] && response['additionalData']['refusalReasonRaw']
-          "#{response['refusalReason']} | #{response['additionalData']['refusalReasonRaw']}"
         else
           response['refusalReason'] || response['resultCode'] || response['message'] || response['result']
         end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -383,15 +383,6 @@ class AdyenTest < Test::Unit::TestCase
     assert_failure response
   end
 
-  def test_failed_authorise_mastercard_raw_error_message
-    @gateway.expects(:ssl_post).returns(failed_authorize_mastercard_response)
-
-    response = @gateway.send(:commit, 'authorise', {}, { raw_error_message: true })
-
-    assert_equal 'Refused | 01: Refer to card issuer', response.message
-    assert_failure response
-  end
-
   def test_successful_capture
     @gateway.expects(:ssl_post).returns(successful_capture_response)
     response = @gateway.capture(@amount, '7914775043909934')


### PR DESCRIPTION
Remote
143 tests, 464 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.3077% passed