### PR TITLE
PayTrace: Update MultiResponse for Capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
 * Adyen: Update split refund method [yunnydang] #5218
 * Adyen: Remove raw_error_message [almalee24] #5202
 * Elavon: Remove old Stored Credential method [almalee24] #5219
+* PayTrace: Update MultiResponse for Capture [almalee24] #5203
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/pay_trace.rb
+++ b/lib/active_merchant/billing/gateways/pay_trace.rb
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
 
       def capture(money, authorization, options = {})
         if visa_or_mastercard?(options)
-          MultiResponse.run do |r|
+          MultiResponse.run(:use_first_response) do |r|
             r.process { commit(ENDPOINTS[:capture], build_capture_request(money, authorization, options)) }
             r.process { commit(ENDPOINTS[:"level_3_#{options[:visa_or_mastercard]}"], send_level_3_data(r, options)) }
           end

--- a/test/remote/gateways/remote_pay_trace_test.rb
+++ b/test/remote/gateways/remote_pay_trace_test.rb
@@ -263,7 +263,8 @@ class RemotePayTraceTest < Test::Unit::TestCase
     assert_success capture
 
     transaction_id = auth.authorization
-    assert_equal "Visa/MasterCard enhanced data was successfully added to Transaction ID #{transaction_id}. 2 line item records were created.", capture.message
+    assert_equal capture.authorization, transaction_id
+    assert_equal 'Your transaction was successfully captured.', capture.message
   end
 
   def test_failed_authorize


### PR DESCRIPTION
Update MulitResponse for Capture to pass
:use_first_response. This will correctly
populate authorization.