### PR TITLE
Stripe/StripePI: update add metadata for refund and void

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@
 * Elavon: Add updated stored credential version [almalee24] #5170
 * Adyen: Add header fields to response body [yunnydang] #5184
 * Stripe and Stripe PI: Add header fields to response body [yunnydang] #5185
+* Stripe and Stripe PI: Add metadata and order_id for refund and void [yunnydang] #5204
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -148,7 +148,7 @@ module ActiveMerchant #:nodoc:
       def void(identification, options = {})
         post = {}
         post[:reverse_transfer] = options[:reverse_transfer] if options[:reverse_transfer]
-        post[:metadata] = options[:metadata] if options[:metadata]
+        add_metadata(post, options)
         post[:reason] = options[:reason] if options[:reason]
         post[:expand] = [:charge]
         commit(:post, "charges/#{CGI.escape(identification)}/refunds", post, options)
@@ -159,7 +159,7 @@ module ActiveMerchant #:nodoc:
         add_amount(post, money, options)
         post[:refund_application_fee] = true if options[:refund_application_fee]
         post[:reverse_transfer] = options[:reverse_transfer] if options[:reverse_transfer]
-        post[:metadata] = options[:metadata] if options[:metadata]
+        add_metadata(post, options)
         post[:reason] = options[:reason] if options[:reason]
         post[:expand] = [:charge]
 

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -334,10 +334,18 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_success response
     assert response.authorization
 
-    assert void = @gateway.void(response.authorization, metadata: { test_metadata: 123 })
+    void_options = {
+      metadata: {
+        test_metadata: 123
+      },
+      order_id: '123445abcde'
+    }
+
+    assert void = @gateway.void(response.authorization, void_options)
     assert void.test?
     assert_success void
     assert_equal '123', void.params['metadata']['test_metadata']
+    assert_equal '123445abcde', void.params['metadata']['order_id']
   end
 
   def test_successful_void_with_reason
@@ -392,6 +400,27 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert_equal refund.authorization, refund_id
     assert_success refund
     assert_equal 'fraudulent', refund.params['reason']
+  end
+
+  def test_successful_refund_with_metada_and_order_id
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert response.authorization
+
+    refund_options = {
+      metadata: {
+        test_metadata: 123
+      },
+      order_id: '123445abcde'
+    }
+
+    assert refund = @gateway.refund(@amount - 20, response.authorization, refund_options)
+    assert refund.test?
+    refund_id = refund.params['id']
+    assert_equal refund.authorization, refund_id
+    assert_success refund
+    assert_equal '123445abcde', refund.params['metadata']['order_id']
+    assert_equal '123', refund.params['metadata']['test_metadata']
   end
 
   def test_successful_refund_on_verified_bank_account


### PR DESCRIPTION
This change swaps the add metadata line for refund and void with the add_metadata helper method. Before, we were just adding the entire options[:metadata] object but skipping the order_id. This corrects that to send order_id

Local:
5981 tests, 80146 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Stripe Unit:
147 tests, 777 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Stripe Remote:
78 tests, 333 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
87.1795% passed

Stripe PI Unit:
62 tests, 319 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Stripe PI Remote:
95 tests, 430 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.8421% passed