### PR TITLE
Decidir: Pass CVV for NT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Adyen: Fix NT integration [jherreraa] #5155
 * HPS: Update NetworkTokenizationCreditCard flow [almalee24] #5178
 * Braintree: Support override_application_id [aenand] #5194
+* Decidir: Pass CVV for NT [almalee24] #5205
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -198,6 +198,7 @@ module ActiveMerchant #:nodoc:
         post[:fraud_detection] ||= {}
         post[:fraud_detection][:sent_to_cs] = false
         post[:card_data][:last_four_digits] = options[:last_4]
+        post[:card_data][:security_code] = payment_method.verification_value if payment_method.verification_value? && options[:pass_cvv_for_nt]
 
         post[:token_card_data] = {
           token: payment_method.number,


### PR DESCRIPTION
This changes will allow CVV, card number, exp month and exp year.

Remote
27 tests, 97 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed