### PR TITLE
Repair Mecury and TransFirst

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 = ActiveMerchant CHANGELOG
 
 == HEAD
+* Mercury, TransFirst: Repair gateways following updates to `rexml` [aenand] #5206.
 
 = Version 1.137.0 (August 2, 2024)
 

--- a/lib/active_merchant/billing/gateways/mercury.rb
+++ b/lib/active_merchant/billing/gateways/mercury.rb
@@ -349,7 +349,9 @@ module ActiveMerchant #:nodoc:
       end
 
       def unescape_xml(escaped_xml)
-        escaped_xml.gsub(/\&gt;/, '>').gsub(/\&lt;/, '<')
+        xml = escaped_xml.gsub(/\&gt;/, '>')
+        xml.slice! "<?xml version=\"1.0\"?>" # rubocop:disable Style/StringLiterals
+        xml
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/trans_first.rb
+++ b/lib/active_merchant/billing/gateways/trans_first.rb
@@ -167,6 +167,9 @@ module ActiveMerchant #:nodoc:
         end
 
         response
+      rescue StandardError
+        response[:message] = data&.to_s&.strip
+        response
       end
 
       def commit(action, params)

--- a/test/unit/gateways/mercury_test.rb
+++ b/test/unit/gateways/mercury_test.rb
@@ -126,7 +126,7 @@ class MercuryTest < Test::Unit::TestCase
 
   def successful_purchase_response
     <<~RESPONSE
-      <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CreditTransactionResponse xmlns="http://www.mercurypay.com"><CreditTransactionResult>
+      <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CreditTransactionResponse xmlns="http://www.mercurypay.com"><CreditTransactionResult><?xml version="1.0"?>
       <RStream>
         <CmdResponse>
           <ResponseOrigin>Processor</ResponseOrigin>
@@ -163,7 +163,7 @@ class MercuryTest < Test::Unit::TestCase
 
   def failed_purchase_response
     <<~RESPONSE
-      <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CreditTransactionResponse xmlns="http://www.mercurypay.com"><CreditTransactionResult>
+      <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CreditTransactionResponse xmlns="http://www.mercurypay.com"><CreditTransactionResult><?xml version="1.0"?>
       <RStream>
         <CmdResponse>
           <ResponseOrigin>Server</ResponseOrigin>
@@ -179,7 +179,7 @@ class MercuryTest < Test::Unit::TestCase
 
   def successful_refund_response
     <<~RESPONSE
-      <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CreditTransactionResponse xmlns="http://www.mercurypay.com"><CreditTransactionResult>
+      <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CreditTransactionResponse xmlns="http://www.mercurypay.com"><CreditTransactionResult><?xml version="1.0"?>
       <RStream>
         <CmdResponse>
           <ResponseOrigin>Processor</ResponseOrigin>

--- a/test/unit/gateways/trans_first_test.rb
+++ b/test/unit/gateways/trans_first_test.rb
@@ -15,6 +15,16 @@ class TransFirstTest < Test::Unit::TestCase
     @amount = 100
   end
 
+  def test_missing_field_response
+    @gateway.stubs(:ssl_post).returns(missing_field_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_failure response
+    assert response.test?
+    assert_equal 'Missing parameter: UserId.', response.message
+  end
+
   def test_successful_purchase
     @gateway.stubs(:ssl_post).returns(successful_purchase_response)
 


### PR DESCRIPTION
A previous commit broke these gateways after updating REXML. This commit updates the two gateways so that they can process the XML like it used to.

Test Summary
Remote:
No credentials available for Mercury
Could not reach the test server for TransFirst