### PR TITLE
Adyen: Fix billing address empty string error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@
 * Adyen: Add header fields to response body [yunnydang] #5184
 * Stripe and Stripe PI: Add header fields to response body [yunnydang] #5185
 * Stripe and Stripe PI: Add metadata and order_id for refund and void [yunnydang] #5204
+* Adyen: Fix billing address empty string error [yunnydang] #5208
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -510,9 +510,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_billing_address(post, options, address)
+        address[:address1] = 'NA' if address[:address1].blank?
+        address[:address2] = 'NA' if address[:address2].blank?
+
         post[:billingAddress] = {}
-        post[:billingAddress][:street] = options[:address_override] == true ? address[:address2] : address[:address1] || 'NA'
-        post[:billingAddress][:houseNumberOrName] = options[:address_override] == true ? address[:address1] : address[:address2] || 'NA'
+        post[:billingAddress][:street] = options[:address_override] == true ? address[:address2] : address[:address1]
+        post[:billingAddress][:houseNumberOrName] = options[:address_override] == true ? address[:address1] : address[:address2]
         post[:billingAddress][:postalCode] = address[:zip] if address[:zip]
         post[:billingAddress][:city] = address[:city] || 'NA'
         post[:billingAddress][:stateOrProvince] = get_state(address)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -585,6 +585,30 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_successful_purchase_with_google_pay_without_billing_address_and_address_override
+    options = {
+      reference: '345123',
+      email: 'john.smith@test.com',
+      ip: '77.110.174.153',
+      shopper_reference: 'John Smith',
+      billing_address: {
+        address1: '',
+        address2: '',
+        country: 'US',
+        city: 'Beverly Hills',
+        state: 'CA',
+        zip: '90210'
+      },
+      order_id: '123',
+      stored_credential: { reason_type: 'unscheduled' },
+      address_override: true
+    }
+
+    response = @gateway.purchase(@amount, @google_pay_card, options)
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
   def test_successful_purchase_with_google_pay_and_truncate_order_id
     response = @gateway.purchase(@amount, @google_pay_card, @options.merge(order_id: @long_order_id))
     assert_success response


### PR DESCRIPTION
This change allows us to return "NA" instead of nil for street address and house or number address if address_override is set to true.

Local:
5985 tests, 80165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
121 tests, 635 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
144 tests, 465 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.6667% passed