### PR TITLE
StripePI: Skip add_network_token_cryptogram_and_eci method to accept ApplePay recurring payments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@
 * PayTrace: Update MultiResponse for Capture [almalee24] #5203
 * Adyen: Add support for Pan Only GooglePay [almalee24] #5221
 * Decidir: Send extra fields for tokenized NT transactions [sinourain] #5224
+* StripePI: Skip add_network_token_cryptogram_and_eci method to accept ApplePay recurring payments [sinourain] #5212
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -59,6 +59,8 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       first_name: 'Longbob',
       last_name: 'Longsen'
     )
+
+    @network_transaction_id = '1098510912210968'
   end
 
   def test_successful_create_and_confirm_intent
@@ -401,7 +403,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
   def test_succesful_purchase_with_stored_credentials_without_sending_ntid
     [@three_ds_off_session_credit_card, @three_ds_authentication_required_setup_for_off_session].each do |card_to_use|
-      network_transaction_id = '1098510912210968'
       stub_comms(@gateway, :ssl_request) do
         @gateway.purchase(@amount, card_to_use, {
           currency: 'USD',
@@ -413,7 +414,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
             initiator: 'cardholder',
             reason_type: 'installment',
             initial_transaction: true,
-            network_transaction_id: network_transaction_id, # TEST env seems happy with any value :/
+            network_transaction_id: @network_transaction_id, # TEST env seems happy with any value :/
             ds_transaction_id: 'null' # this is optional and can be null if not available.
           }
         })
@@ -427,7 +428,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
   def test_succesful_purchase_with_ntid_when_off_session
     # don't send NTID if setup_future_usage == off_session
     [@three_ds_off_session_credit_card, @three_ds_authentication_required_setup_for_off_session].each do |card_to_use|
-      network_transaction_id = '1098510912210968'
       stub_comms(@gateway, :ssl_request) do
         @gateway.purchase(@amount, card_to_use, {
           currency: 'USD',
@@ -439,7 +439,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
             initiator: 'cardholder',
             reason_type: 'installment',
             initial_transaction: true,
-            network_transaction_id: network_transaction_id, # TEST env seems happy with any value :/
+            network_transaction_id: @network_transaction_id, # TEST env seems happy with any value :/
             ds_transaction_id: 'null' # this is optional and can be null if not available.
           }
         })
@@ -452,7 +452,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
   def test_succesful_purchase_with_stored_credentials
     [@three_ds_off_session_credit_card, @three_ds_authentication_required_setup_for_off_session].each do |card_to_use|
-      network_transaction_id = '1098510912210968'
       stub_comms(@gateway, :ssl_request) do
         @gateway.purchase(@amount, card_to_use, {
           currency: 'USD',
@@ -460,12 +459,12 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
           confirm: true,
           off_session: true,
           stored_credential: {
-            network_transaction_id: network_transaction_id, # TEST env seems happy with any value :/
+            network_transaction_id: @network_transaction_id, # TEST env seems happy with any value :/
             ds_transaction_id: 'null' # this is optional and can be null if not available.
           }
         })
       end.check_request do |_method, _endpoint, data, _headers|
-        assert_match(%r{payment_method_options\[card\]\[mit_exemption\]\[network_transaction_id\]=#{network_transaction_id}}, data)
+        assert_match(%r{payment_method_options\[card\]\[mit_exemption\]\[network_transaction_id\]=#{@network_transaction_id}}, data)
         assert_match(%r{payment_method_options\[card\]\[mit_exemption\]\[ds_transaction_id\]=null}, data)
       end.respond_with(successful_create_intent_response)
     end
@@ -473,7 +472,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
   def test_succesful_purchase_with_stored_credentials_without_optional_ds_transaction_id
     [@three_ds_off_session_credit_card, @three_ds_authentication_required_setup_for_off_session].each do |card_to_use|
-      network_transaction_id = '1098510912210968'
       stub_comms(@gateway, :ssl_request) do
         @gateway.purchase(@amount, card_to_use, {
           currency: 'USD',
@@ -481,11 +479,11 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
           confirm: true,
           off_session: true,
           stored_credential: {
-            network_transaction_id: network_transaction_id # TEST env seems happy with any value :/
+            network_transaction_id: @network_transaction_id # TEST env seems happy with any value :/
           }
         })
       end.check_request do |_method, _endpoint, data, _headers|
-        assert_match(%r{payment_method_options\[card\]\[mit_exemption\]\[network_transaction_id\]=#{network_transaction_id}}, data)
+        assert_match(%r{payment_method_options\[card\]\[mit_exemption\]\[network_transaction_id\]=#{@network_transaction_id}}, data)
         assert_no_match(%r{payment_method_options\[card\]\[mit_exemption\]\[ds_transaction_id\]=null}, data)
       end.respond_with(successful_create_intent_response)
     end
@@ -505,15 +503,12 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
   end
 
   def test_sends_network_transaction_id_separate_from_stored_creds
-    network_transaction_id = '1098510912210968'
-    options = @options.merge(
-      network_transaction_id: network_transaction_id
-    )
+    options = @options.merge(network_transaction_id: @network_transaction_id)
 
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @visa_token, options)
     end.check_request do |_method, _endpoint, data, _headers|
-      assert_match(%r{payment_method_options\[card\]\[mit_exemption\]\[network_transaction_id\]=#{network_transaction_id}}, data)
+      assert_match(%r{payment_method_options\[card\]\[mit_exemption\]\[network_transaction_id\]=#{@network_transaction_id}}, data)
     end.respond_with(successful_create_intent_response)
   end
 
@@ -661,10 +656,9 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
   end
 
   def test_stored_credentials_does_not_override_ntid_field
-    network_transaction_id = '1098510912210968'
     sc_network_transaction_id = '1078784111114777'
     options = @options.merge(
-      network_transaction_id: network_transaction_id,
+      network_transaction_id: @network_transaction_id,
       stored_credential: {
         network_transaction_id: sc_network_transaction_id,
         ds_transaction_id: 'null'
@@ -674,7 +668,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @visa_token, options)
     end.check_request do |_method, _endpoint, data, _headers|
-      assert_match(%r{payment_method_options\[card\]\[mit_exemption\]\[network_transaction_id\]=#{network_transaction_id}}, data)
+      assert_match(%r{payment_method_options\[card\]\[mit_exemption\]\[network_transaction_id\]=#{@network_transaction_id}}, data)
     end.respond_with(successful_create_intent_response)
   end
 
@@ -942,6 +936,59 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       @gateway.create_setup_intent(@visa_token, options)
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/\[moto\]=true/, data)
+    end.respond_with(successful_verify_response)
+  end
+
+  def test_add_network_token_cryptogram_and_eci_for_apple_pay_cit
+    options = {
+      currency: 'USD',
+      execute_threed: true,
+      confirm: true,
+      off_session: true,
+      stored_credential_transaction_type: true,
+      stored_credential: {
+        initiator: 'cardholder',
+        reason_type: 'installment',
+        initial_transaction: true,
+        network_transaction_id: @network_transaction_id, # TEST env seems happy with any value :/
+        ds_transaction_id: 'null' # this is optional and can be null if not available.
+      }
+    }
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_intent(@amount, @apple_pay, options)
+    end.check_request do |_method, endpoint, data, _headers|
+      if /payment_intents/.match?(endpoint)
+        assert_match(/payment_method_options\[card\]\[stored_credential_transaction_type\]=setup_on_session/, data)
+        assert_match(/card\[eci\]=05/, data)
+        assert_match(/card\[cryptogram\]=dGVzdGNyeXB0b2dyYW1YWFhYWFhYWFhYWFg9PQ%3D%3D/, data)
+      end
+    end.respond_with(successful_create_intent_response_with_apple_pay_and_billing_address)
+  end
+
+  def test_skip_network_token_cryptogram_and_eci_for_apple_pay_mit
+    options = {
+      currency: 'USD',
+      execute_threed: true,
+      confirm: true,
+      stored_credential_transaction_type: true,
+      stored_credential: {
+        initiator: 'merchant',
+        reason_type: 'recurring',
+        initial_transaction: false,
+        network_transaction_id: @network_transaction_id,
+        off_session: 'true'
+      }
+    }
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_intent(@amount, @apple_pay, options)
+    end.check_request do |_method, endpoint, data, _headers|
+      if /payment_intents/.match?(endpoint)
+        assert_match(/payment_method_options\[card\]\[stored_credential_transaction_type\]=stored_off_session_recurring/, data)
+        assert_not_match(/card\[eci\]/, data)
+        assert_not_match(/card\[cryptogram\]/, data)
+      end
     end.respond_with(successful_verify_response)
   end
 


### PR DESCRIPTION
Summary:
------------------------------
StripePI: Skip add_network_token_cryptogram_and_eci method to accept ApplePay recurring payments and add unit/remote tests

[SER-3618](https://spreedly.atlassian.net/browse/ECS-3618)

Remote Test:
------------------------------
Loaded suite test/remote/gateways/remote_stripe_payment_intents_test
Started
Finished in 255.69074 seconds.
97 tests, 460 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
0.38 tests/s, 1.80 assertions/s

Unit Tests:
------------------------------
Finished in 29.539052 seconds.
5993 tests, 80199 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
202.88 tests/s, 2715.02 assertions/s

RuboCop:
------------------------------
798 files inspected, no offenses detected