### PR TITLE
NMI: add customer vault fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,12 +6,15 @@
 * NMI: Fix Decrypted indicator for Google/Apple pay [javierpedrozaing] #5196
 * FlexCharge: add more descriptives error messages [gasb150] #5199
 * Braintree: Updates to Paypal Integration [almalee24] #5190
+* Stripe and Stripe PI: Add metadata and order_id for refund and void [yunnydang] #5204
 * CommerceHub: Update test url [DustinHaefele] #5211
+* Adyen: Fix billing address empty string error [yunnydang] #5208
 * Elavon: Update sending CVV for MIT transactions  [almalee24] #5210
 * Adyen: Fix NT integration [jherreraa] #5155
 * HPS: Update NetworkTokenizationCreditCard flow [almalee24] #5178
 * Braintree: Support override_application_id [aenand] #5194
 * Decidir: Pass CVV for NT [almalee24] #5205
+* NMI: Add customer vault fields [yunnydang] #5215
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).
@@ -43,8 +46,6 @@
 * Elavon: Add updated stored credential version [almalee24] #5170
 * Adyen: Add header fields to response body [yunnydang] #5184
 * Stripe and Stripe PI: Add header fields to response body [yunnydang] #5185
-* Stripe and Stripe PI: Add metadata and order_id for refund and void [yunnydang] #5204
-* Adyen: Fix billing address empty string error [yunnydang] #5208
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -34,6 +34,7 @@ module ActiveMerchant #:nodoc:
       def purchase(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
+        add_customer_vault_data(post, options)
         add_payment_method(post, payment_method, options)
         add_stored_credential(post, options)
         add_customer_data(post, options)
@@ -48,6 +49,7 @@ module ActiveMerchant #:nodoc:
       def authorize(amount, payment_method, options = {})
         post = {}
         add_invoice(post, amount, options)
+        add_customer_vault_data(post, options)
         add_payment_method(post, payment_method, options)
         add_stored_credential(post, options)
         add_customer_data(post, options)
@@ -97,6 +99,7 @@ module ActiveMerchant #:nodoc:
 
       def verify(payment_method, options = {})
         post = {}
+        add_customer_vault_data(post, options)
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)
         add_vendor_data(post, options)
@@ -277,6 +280,11 @@ module ActiveMerchant #:nodoc:
       def add_vendor_data(post, options)
         post[:vendor_id] = options[:vendor_id] if options[:vendor_id]
         post[:processor_id] = options[:processor_id] if options[:processor_id]
+      end
+
+      def add_customer_vault_data(post, options)
+        post[:customer_vault] = options[:customer_vault] if options[:customer_vault]
+        post[:customer_vault_id] = options[:customer_vault_id] if options[:customer_vault_id]
       end
 
       def add_merchant_defined_fields(post, options)

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -110,6 +110,34 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_customer_vault_data
+    vault_id = SecureRandom.hex(16)
+
+    options = {
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store purchase',
+      customer_vault: 'add_customer'
+    }
+
+    assert response = @gateway.purchase(@amount, @credit_card, options.merge(customer_vault_id: vault_id))
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+    assert_equal vault_id, response.params['customer_vault_id']
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_customer_vault_and_auto_generate_customer_vault_id
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(customer_vault: 'add_customer'))
+    assert_success response
+    assert response.test?
+
+    assert_equal 'Succeeded', response.message
+    assert response.params.include?('customer_vault_id')
+    assert response.authorization
+  end
+
   def test_successful_purchase_sans_cvv
     @credit_card.verification_value = nil
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -351,6 +379,34 @@ class RemoteNmiTest < Test::Unit::TestCase
     response = @gateway.verify(@credit_card, options)
     assert_success response
     assert_match 'Succeeded', response.message
+  end
+
+  def test_successful_verify_with_customer_vault_data
+    vault_id = SecureRandom.hex(16)
+
+    options = {
+      order_id: generate_unique_id,
+      billing_address: address,
+      description: 'Store purchase',
+      customer_vault: 'add_customer'
+    }
+
+    assert response = @gateway.verify(@credit_card, options.merge(customer_vault_id: vault_id))
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+    assert_equal vault_id, response.params['customer_vault_id']
+    assert response.authorization
+  end
+
+  def test_successful_verify_with_customer_vault_and_auto_generate_customer_vault_id
+    assert response = @gateway.verify(@credit_card, @options.merge(customer_vault: 'add_customer'))
+    assert_success response
+    assert response.test?
+
+    assert_equal 'Succeeded', response.message
+    assert response.params.include?('customer_vault_id')
+    assert response.authorization
   end
 
   def test_failed_verify

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -210,6 +210,23 @@ class NmiTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_purchase_with_customer_vault_options
+    options = {
+      description: 'Store purchase',
+      customer_vault: 'add_customer',
+      customer_vault_id: '12345abcde'
+    }
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/customer_vault=add_customer/, data)
+      assert_match(/customer_vault_id=12345abcde/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_purchase_with_shipping_fields_omits_blank_name
     options = @transaction_options.merge({ shipping_address: shipping_address(name: nil) })
 


### PR DESCRIPTION
This allows us to send customer vault fields on purchase, authorize, and verify endpoints for securely storing customer's payment information for later use. If customer_vault field is sent with 'add_customer' and no customer_vault_id is present, NMI will auto generate one and echo it back in the response.

Local:
5986 tests, 80170 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
60 tests, 484 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
61 tests, 241 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.3607% passed