### PR TITLE
Elavon: Remove old Stored Credential method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@
 * MercadoPago: Add idempotency key field [yunnydang] #5229
 * Adyen: Update split refund method [yunnydang] #5218
 * Adyen: Remove raw_error_message [almalee24] #5202
+* Elavon: Remove old Stored Credential method [almalee24] #5219
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_elavon_test.rb
+++ b/test/remote/gateways/remote_elavon_test.rb
@@ -210,7 +210,6 @@ class RemoteElavonTest < Test::Unit::TestCase
   def test_stored_credentials_with_pass_in_card
     # Initial CIT authorize
     initial_params = {
-      stored_cred_v2: true,
       stored_credential: {
         initial_transaction: true,
         reason_type: 'recurring',
@@ -275,7 +274,6 @@ class RemoteElavonTest < Test::Unit::TestCase
 
     # Initial CIT authorize
     initial_params = {
-      stored_cred_v2: true,
       stored_credential: {
         initial_transaction: true,
         reason_type: 'recurring',
@@ -330,7 +328,6 @@ class RemoteElavonTest < Test::Unit::TestCase
   def test_stored_credentials_with_manual_token
     # Initial CIT get token request
     get_token_params = {
-      stored_cred_v2: true,
       add_recurring_token: 'Y',
       stored_credential: {
         initial_transaction: true,

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -47,7 +47,7 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_successful_purchase
     response = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge!(stored_cred_v2: true))
+      @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<ssl_cvv2cvc2>123<\/ssl_cvv2cvc2>/, data)
     end.respond_with(successful_purchase_response)
@@ -409,7 +409,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_pass_in_initial_recurring_request
     recurring_params = {
-      stored_cred_v2: true,
       stored_credential: {
         initial_transaction: true,
         reason_type: 'recurring',
@@ -431,7 +430,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_pass_in_recurring_request
     recurring_params = {
-      stored_cred_v2: true,
       approval_code: '1234566',
       stored_credential: {
         reason_type: 'recurring',
@@ -454,7 +452,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_pass_in_installment_request
     installment_params = {
-      stored_cred_v2: true,
       installments: '4',
       payment_number: '2',
       approval_code: '1234566',
@@ -481,7 +478,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_pass_in_unscheduled_with_additional_data_request
     unscheduled_params = {
-      stored_cred_v2: true,
       approval_code: '1234566',
       par_value: '1234567890',
       association_token_data: '1',
@@ -508,7 +504,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_tokenized_card_initial_recurring_request
     recurring_params = {
-      stored_cred_v2: true,
       stored_credential: {
         initial_transaction: true,
         reason_type: 'recurring',
@@ -530,7 +525,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_tokenized_card_recurring_request
     recurring_params = {
-      stored_cred_v2: true,
       stored_credential: {
         reason_type: 'recurring',
         initiator: 'merchant',
@@ -551,7 +545,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_tokenized_card_installment_request
     installment_params = {
-      stored_cred_v2: true,
       installments: '4',
       payment_number: '2',
       stored_credential: {
@@ -576,7 +569,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_tokenized_card_unscheduled_with_additional_data_request
     unscheduled_params = {
-      stored_cred_v2: true,
       par_value: '1234567890',
       association_token_data: '1',
       stored_credential: {
@@ -601,7 +593,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_manual_token_recurring_request
     recurring_params = {
-      stored_cred_v2: true,
       ssl_token: '4421912014039990',
       stored_credential: {
         reason_type: 'recurring',
@@ -623,7 +614,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_manual_token_installment_request
     installment_params = {
-      stored_cred_v2: true,
       ssl_token: '4421912014039990',
       installments: '4',
       payment_number: '2',
@@ -649,7 +639,6 @@ class ElavonTest < Test::Unit::TestCase
 
   def test_stored_credential_manual_token_unscheduled_with_additional_data_request
     unscheduled_params = {
-      stored_cred_v2: true,
       ssl_token: '4421912014039990',
       par_value: '1234567890',
       association_token_data: '1',


### PR DESCRIPTION
Remote:
40 tests, 178 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95% passed