### PR TITLE
Adyen: Add support for Pan Only GooglePay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 * Adyen: Remove raw_error_message [almalee24] #5202
 * Elavon: Remove old Stored Credential method [almalee24] #5219
 * PayTrace: Update MultiResponse for Capture [almalee24] #5203
+* Adyen: Add support for Pan Only GooglePay [almalee24] #5221
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -591,6 +591,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_successful_purchase_with_google_pay_pan_only
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(wallet_type: :google_pay))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
   def test_successful_purchase_with_google_pay_without_billing_address_and_address_override
     options = {
       reference: '345123',


### PR DESCRIPTION
Remote
146 tests, 469 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 91.7808% passed

If it is a Pan Only GooglePay then pass 'paymentdatasource.type and selectedBrand as googlepay and paymentdatasource.tokenized as false