### PR TITLE
Decidir - Send extra fields for tokenized NT transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
 * Elavon: Remove old Stored Credential method [almalee24] #5219
 * PayTrace: Update MultiResponse for Capture [almalee24] #5203
 * Adyen: Add support for Pan Only GooglePay [almalee24] #5221
+* Decidir: Send extra fields for tokenized NT transactions [sinourain] #5224
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -203,6 +203,8 @@ module ActiveMerchant #:nodoc:
         post[:card_data][:security_code] = payment_method.verification_value if payment_method.verification_value? && options[:pass_cvv_for_nt]
 
         post[:token_card_data] = {
+          expiration_month: format(payment_method.month, :two_digits),
+          expiration_year: format(payment_method.year, :two_digits),
           token: payment_method.number,
           eci: payment_method.eci,
           cryptogram: payment_method.payment_cryptogram

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class DecidirTest < Test::Unit::TestCase
   include CommStub
+  include ActiveMerchant::Billing::CreditCardFormatting
 
   def setup
     @gateway_for_purchase = DecidirGateway.new(api_key: 'api_key')
@@ -414,6 +415,8 @@ class DecidirTest < Test::Unit::TestCase
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"cryptogram\":\"#{@network_token.payment_cryptogram}\"/, data)
       assert_match(/"security_code\":\"#{@network_token.verification_value}\"/, data)
+      assert_match(/"expiration_month\":\"#{format(@network_token.month, :two_digits)}\"/, data)
+      assert_match(/"expiration_year\":\"#{format(@network_token.year, :two_digits)}\"/, data)
     end.respond_with(successful_network_token_response)
 
     assert_success response


### PR DESCRIPTION
Summary:
------------------------------
Decidir - Send expiration_month and expiration_year fields in request for tokenized NT transactions.

Spreedly reference:
[ECS-3682](https://spreedly.atlassian.net/browse/ECS-3682)
[UBI-150](https://spreedly.atlassian.net/browse/UBI-150)

Remote Test:
------------------------------
Loaded suite test/remote/gateways/remote_decidir_test Started
Finished in 49.764098 seconds.
27 tests, 97 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
0.54 tests/s, 1.95 assertions/s

Unit Tests:
------------------------------
Finished in 32.823471 seconds.
5991 tests, 80194 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed
182.52 tests/s, 2443.19 assertions/s

RuboCop:
------------------------------
798 files inspected, no offenses detected