### PR TITLE
Decidir: Remove pass_cvv_for_nt

### DIFF
--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -200,7 +200,7 @@ module ActiveMerchant #:nodoc:
         post[:fraud_detection] ||= {}
         post[:fraud_detection][:sent_to_cs] = false
         post[:card_data][:last_four_digits] = options[:last_4]
-        post[:card_data][:security_code] = payment_method.verification_value if payment_method.verification_value? && options[:pass_cvv_for_nt]
+        post[:card_data][:security_code] = payment_method.verification_value if payment_method.verification_value?
 
         post[:token_card_data] = {
           expiration_month: format(payment_method.month, :two_digits),

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -33,9 +33,12 @@ class RemoteDecidirTest < Test::Unit::TestCase
     @network_token = network_tokenization_credit_card(
       '4012001037141112',
       brand: 'visa',
-      eci: '05',
-      payment_cryptogram: '000203016912340000000FA08400317500000000',
-      name: 'Tesest payway'
+      eci: '07',
+      payment_cryptogram: '060103078512340000000FA08400317400000000',
+      name: 'Tesest payway',
+      verification_value: '840',
+      month: '12',
+      year: '2027'
     )
 
     @failed_message = ['PEDIR AUTORIZACION | request_authorization_card', 'COMERCIO INVALIDO | invalid_card']
@@ -63,7 +66,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
     assert response.authorization
   end
 
-  def test_successful_purchase_with_network_token
+  def test_successful_purchase_with_network_token_visa
     options = {
       card_holder_door_number: 1234,
       card_holder_birthday: '200988',

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -411,7 +411,7 @@ class DecidirTest < Test::Unit::TestCase
     }
 
     response = stub_comms(@gateway_for_auth, :ssl_request) do
-      @gateway_for_auth.authorize(100, @network_token, options.merge(pass_cvv_for_nt: true))
+      @gateway_for_auth.authorize(100, @network_token, options)
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"cryptogram\":\"#{@network_token.payment_cryptogram}\"/, data)
       assert_match(/"security_code\":\"#{@network_token.verification_value}\"/, data)
@@ -432,7 +432,7 @@ class DecidirTest < Test::Unit::TestCase
       card_holder_identification_number: '44444444',
       last_4: @credit_card.last_digits
     }
-
+    @network_token.verification_value = nil
     response = stub_comms(@gateway_for_auth, :ssl_request) do
       @gateway_for_auth.authorize(100, @network_token, options)
     end.check_request do |_method, _endpoint, data, _headers|


### PR DESCRIPTION
This will allow all NT transactions to pass CVV if present.

Remote
27 tests, 97 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed