### PR TITLE
Mercado Pago: add idempotency key field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 * Decidir & Braintree: Scrub cryptogram and card number [almalee24] #5220
 * Naranja: Update valid number check to include luhn10 [DustinHaefele] #5217
 * Cybersource: Add apple_pay with discover. [DustinHaefele] #5213
+* MercadoPago: Add idempotency key field [yunnydang] #5229
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -125,6 +125,12 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     assert_equal 'https://www.spreedly.com/', response.params['notification_url']
   end
 
+  def test_successful_purchase_with_idempotency_key
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(idempotency_key: '0d5020ed-1af6-469c-ae06-c3bec19954bb'))
+    assert_success response
+    assert_equal 'accredited', response.message
+  end
+
   def test_successful_purchase_with_payer
     response = @gateway.purchase(@amount, @credit_card, @options.merge({ payer: @payer }))
     assert_success response
@@ -155,6 +161,12 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     assert capture = @gateway.capture(@amount, auth.authorization)
     assert_success capture
     assert_equal 'accredited', capture.message
+  end
+
+  def test_successful_authorize_with_idempotency_key
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(idempotency_key: '0d5020ed-1af6-469c-ae06-c3bec19954bb'))
+    assert_success response
+    assert_equal 'accredited', response.message
   end
 
   def test_successful_authorize_and_capture_with_elo
@@ -308,6 +320,12 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
 
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
+    assert_success response
+    assert_match %r{pending_capture}, response.message
+  end
+
+  def test_successful_verify_with_idempotency_key
+    response = @gateway.verify(@credit_card, @options.merge(idempotency_key: '0d5020ed-1af6-469c-ae06-c3bec19954bb'))
     assert_success response
     assert_match %r{pending_capture}, response.message
   end

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -366,6 +366,23 @@ class MercadoPagoTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_includes_idempotency_key_header
+    @options[:idempotency_key] = '12345'
+    @gateway.expects(:ssl_post).with(anything, anything, { 'Content-Type' => 'application/json' }).returns(successful_purchase_response)
+    @gateway.expects(:ssl_post).with(anything, anything, { 'Content-Type' => 'application/json', 'X-Idempotency-Key' => '12345' }).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_includes_idempotency_key_header_for_refund
+    @options[:idempotency_key] = '12345'
+    @gateway.expects(:ssl_post).with(anything, anything, { 'Content-Type' => 'application/json', 'X-Idempotency-Key' => '12345' }).returns(successful_refund_response)
+
+    response = @gateway.refund(@amount, 'authorization|1.0', @options)
+    assert_success response
+  end
+
   def test_includes_additional_data
     @options[:additional_info] = { 'foo' => 'bar', 'baz' => 'quux' }
     response = stub_comms do


### PR DESCRIPTION
Adds the idempotency key to the headers of a request. Decided to use an instance variable to store the idempotency key (if provided) so that there is less wrangling of the options object and changes to the endpoint methods.

Local:
5995 tests, 80210 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
45 tests, 209 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
45 tests, 107 assertions, 17 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
62.2222% passed

Note: the tests failing are msotly due to payer email related issues. 