### PR TITLE
Paypal: Add inquire method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@
 * Cybersource and Cybersource Rest: Update card type code for Carnet cards [rachelkirk] #5235
 * Stripe PI: Add challenge as valid value for request_three_d_secure [jcreiff] #5238
 * StripePI: Add metadata for GooglePay FPAN [almalee24] #5242
+* Paypal: Add inquire method [almalee24] #5231
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -179,6 +179,11 @@ module ActiveMerchant #:nodoc:
       #     . (period)
       #     {space}
       #
+
+      def inquire(authorization, options = {})
+        transaction_details(authorization)
+      end
+
       def reference_transaction(money, options = {})
         requires!(options, :reference_id)
         commit 'DoReferenceTransaction', build_reference_transaction_request(money, options)

--- a/test/remote/gateways/remote_paypal_test.rb
+++ b/test/remote/gateways/remote_paypal_test.rb
@@ -172,6 +172,16 @@ class PaypalTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_purchase_and_inquire
+    purchase_response = @gateway.purchase(@amount, @credit_card, @params)
+    assert_success purchase_response
+    assert purchase_response.params['transaction_id']
+
+    response = @gateway.inquire(purchase_response.authorization, {})
+    assert_success response
+    assert_equal 'Success', response.message
+  end
+
   def test_purchase_and_full_credit
     purchase = @gateway.purchase(@amount, @credit_card, @params)
     assert_success purchase


### PR DESCRIPTION
Add inquire method to get the latest status
on a transaction.

Remote
31 tests, 87 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed