### PR TITLE
Iveri: Add AuthorisationReversal for Auth Void

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@
 * Paypal: Add inquire method [almalee24] #5231
 * Adyen: Enable multiple legs within airline data [jcreiff] #5249
 * SafeCharge: Add card holder verification fields [yunnydang] #5252
+* Iveri: Add AuthorisationReversal for Auth Void [almalee24] #5233
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/iveri.rb
+++ b/lib/active_merchant/billing/gateways/iveri.rb
@@ -55,7 +55,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def void(authorization, options = {})
-        post = build_vxml_request('Void', options) do |xml|
+        txn_type = options[:reference_type] == :authorize ? 'AuthorisationReversal' : 'Void'
+        post = build_vxml_request(txn_type, options) do |xml|
           add_authorization(xml, authorization, options)
         end
 
@@ -65,7 +66,7 @@ module ActiveMerchant #:nodoc:
       def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
+          r.process(:ignore_result) { void(r.authorization, options.merge(reference_type: :authorize)) }
         end
       end
 

--- a/test/remote/gateways/remote_iveri_test.rb
+++ b/test/remote/gateways/remote_iveri_test.rb
@@ -133,17 +133,21 @@ class RemoteIveriTest < Test::Unit::TestCase
 
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
+    # authorization portion is successful since we use that as the main response
     assert_success response
     assert_equal 'Authorisation', response.responses[0].params['transaction_command']
     assert_equal '0', response.responses[0].params['result_status']
-    assert_equal 'Void', response.responses[1].params['transaction_command']
+    # authorizationreversal portion is successful
+    assert_success response.responses.last
+    assert_equal 'AuthorisationReversal', response.responses[1].params['transaction_command']
     assert_equal '0', response.responses[1].params['result_status']
     assert_equal 'Succeeded', response.message
   end
 
   def test_failed_verify
     response = @gateway.verify(@bad_card, @options)
-    assert_failure response
+    assert_failure response # assert failure of authorization portion
+    assert_failure response.responses.last # assert failure of authorisationvoid portion
     assert_includes ['Denied', 'Hot card', 'Please call'], response.message
   end
 


### PR DESCRIPTION
If a Authorization transaction needs to be voided then AuthorisationReversal needs to be used instead of Void.

22 tests, 58 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed