### PR TITLE
Plexo: remove Bin and Last4 fields from NetworkToken

### DIFF
--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -212,8 +212,6 @@ module ActiveMerchant #:nodoc:
             id: payment.brand,
             NetworkToken: {
               Number: payment.number,
-              Bin: get_last_eight_digits(payment.number),
-              Last4: get_last_four_digits(payment.number),
               ExpMonth: (format(payment.month, :two_digits) if payment.month),
               ExpYear: (format(payment.year, :two_digits) if payment.year),
               Cryptogram: payment.payment_cryptogram
@@ -230,14 +228,6 @@ module ActiveMerchant #:nodoc:
             }
           }
         end
-      end
-
-      def get_last_eight_digits(number)
-        number[-8..-1]
-      end
-
-      def get_last_four_digits(number)
-        number[-4..-1]
       end
 
       def add_card_holder(card, payment, options)

--- a/test/remote/gateways/remote_plexo_test.rb
+++ b/test/remote/gateways/remote_plexo_test.rb
@@ -182,6 +182,9 @@ class RemotePlexoTest < Test::Unit::TestCase
     assert_equal 'The selected payment state is not valid.', response.message
   end
 
+  # for verify tests: sometimes those fails but re-running after
+  # few seconds they can works
+
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response

--- a/test/unit/gateways/plexo_test.rb
+++ b/test/unit/gateways/plexo_test.rb
@@ -346,9 +346,12 @@ class PlexoTest < Test::Unit::TestCase
       assert_equal request['Amount']['Currency'], 'UYU'
       assert_equal request['Amount']['Details']['TipAmount'], '5'
       assert_equal request['Flow'], 'direct'
+      assert_equal request['paymentMethod']['source'], 'network-token'
       assert_equal @network_token_credit_card.number, request['paymentMethod']['NetworkToken']['Number']
       assert_equal @network_token_credit_card.payment_cryptogram, request['paymentMethod']['NetworkToken']['Cryptogram']
       assert_equal @network_token_credit_card.first_name, request['paymentMethod']['NetworkToken']['Cardholder']['FirstName']
+      assert_equal request['paymentMethod']['NetworkToken']['ExpMonth'], '12'
+      assert_equal request['paymentMethod']['NetworkToken']['ExpYear'], '20'
     end.respond_with(successful_network_token_response)
 
     assert_success purchase


### PR DESCRIPTION
Summary:
------------------------------

For NT transactions we must pass the Bin and the last4 digits of the underlying PAN, otherwise we can't pass it currently we where passing those values based in the NT number instead of PAN ones, and due we don't have the underlying PAN, those lines are unnecesary.

Remote Tests:
------------------------------
Finished in 44.017128 seconds.
32 tests, 65 assertions, 0 failures, 0 errors, 0 pendings, 3 omissions, 0 notifications 100% passed

Unit Tests:
------------------------------
Finished in 0.040727 seconds.
25 tests, 140 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop
------------------------------
798 files, no offenses detected