### PR TITLE
CyberSource and CyberSourceRest: update carnet card type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@
 * Decidir: Send extra fields for tokenized NT transactions [sinourain] #5224
 * StripePI: Skip add_network_token_cryptogram_and_eci method to accept ApplePay recurring payments [sinourain] #5212
 * Decidir: Fix scrub method after update NT fields [sinourain] #5241
+* Cybersource and Cybersource Rest: Update card type code for Carnet cards [rachelkirk] #5235
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -63,7 +63,7 @@ module ActiveMerchant #:nodoc:
         dankort: '034',
         maestro: '042',
         elo: '054',
-        carnet: '058'
+        carnet: '002'
       }
 
       @@decision_codes = {

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -29,7 +29,7 @@ module ActiveMerchant #:nodoc:
         master: '002',
         unionpay: '062',
         visa: '001',
-        carnet: '058'
+        carnet: '002'
       }
 
       WALLET_PAYMENT_SOLUTION = {

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -12,6 +12,7 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
 
     @master_card = credit_card('2222420000001113', brand: 'master')
     @discover_card = credit_card('6011111111111117', brand: 'discover')
+    @carnet_card = credit_card('5062280000000002', brand: 'carnet')
 
     @visa_network_token = network_tokenization_credit_card(
       '4111111111111111',
@@ -151,6 +152,15 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     assert_failure response
     assert_match %r{Invalid account}, response.message
     assert_equal 'INVALID_ACCOUNT', response.error_code
+  end
+
+  def test_successful_authorize_with_carnet_card
+    response = @gateway.authorize(@amount, @carnet_card, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_equal '002', response.params['paymentInformation']['card']['type']
+    refute_empty response.params['_links']['capture']
   end
 
   def test_successful_capture

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -76,6 +76,14 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
       source: :network_token
     )
 
+    @carnet_credit_card = credit_card(
+      '5062280000000002',
+      verification_value: '321',
+      month: '12',
+      year: (Time.now.year + 2).to_s,
+      brand: :carnet
+    )
+
     @amount = 100
 
     @options = {
@@ -439,6 +447,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_successful_response(response)
+  end
+
+  def test_successful_purchase_with_carnet_card
+    assert response = @gateway.purchase(@amount, @carnet_credit_card, @options)
+    assert_successful_response(response)
+    assert_equal '002', response.params['cardType']
   end
 
   def test_successful_purchase_with_bank_account

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -592,7 +592,7 @@ class CyberSourceRestTest < Test::Unit::TestCase
       @gateway.purchase(100, @carnet_card, @options)
     end.check_request do |_endpoint, data, _headers|
       request = JSON.parse(data)
-      assert_equal '058', request['paymentInformation']['card']['type']
+      assert_equal '002', request['paymentInformation']['card']['type']
     end.respond_with(successful_purchase_response)
   end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -2017,7 +2017,7 @@ class CyberSourceTest < Test::Unit::TestCase
     stub_comms do
       @gateway.purchase(100, @carnet_card, @options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<cardType>058<\/cardType>/, data)
+      assert_match(/<cardType>002<\/cardType>/, data)
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Update code sent for carnet card type

CER-1718

CyberSource

Unit
161 tests, 956 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote
137 tests, 681 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 94.8905% passed
*7 tests also failing on master

CyberSource REST

Unit
40 tests, 216 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote
53 tests, 176 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed