### PR TITLE
StripePI: Update Stored Credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@
 * Adyen: Enable multiple legs within airline data [jcreiff] #5249
 * SafeCharge: Add card holder verification fields [yunnydang] #5252
 * Iveri: Add AuthorisationReversal for Auth Void [almalee24] #5233
+* Stripe PI: Update Stored Credentials [almalee24] #5236
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -586,7 +586,7 @@ module ActiveMerchant #:nodoc:
 
         card_options = post[:payment_method_options][:card]
         card_options[:stored_credential_transaction_type] = stored_credential_type
-        card_options[:mit_exemption].delete(:network_transaction_id) if stored_credential_type == 'setup_on_session'
+        card_options[:mit_exemption].delete(:network_transaction_id) if %w(setup_on_session stored_on_session).include?(stored_credential_type)
       end
 
       def initial_transaction_stored_credential(post, stored_credential)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -980,6 +980,25 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'requires_action', purchase.params['status']
   end
 
+  def test_succeeds_with_subsequent_cit_3ds_required
+    assert purchase = @gateway.purchase(@amount, @visa_card, {
+      currency: 'USD',
+      execute_threed: true,
+      confirm: true,
+      stored_credential_transaction_type: true,
+      stored_credential: {
+        initiator: 'cardholder',
+        reason_type: 'recurring',
+        initial_transaction: false,
+        network_transaction_id: '1098510912210968'
+      }
+    })
+    assert_success purchase
+    assert_equal 'succeeded', purchase.params['status']
+    assert purchase.params.dig('charges', 'data')[0]['captured']
+    assert purchase.params.dig('charges', 'data')[0]['payment_method_details']['card']['network_transaction_id']
+  end
+
   def test_succeeds_with_mit
     assert purchase = @gateway.purchase(@amount, @visa_card, {
       currency: 'USD',

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -913,11 +913,13 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         stored_credential: {
           initial_transaction: false,
           initiator: 'cardholder',
-          reason_type: 'installment'
+          reason_type: 'installment',
+          network_transaction_id: '1098510912210968'
         }
       })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match('payment_method_options[card][stored_credential_transaction_type]=stored_on_session', data)
+      assert_not_match('payment_method_options[card][mit_exemption][network_transaction_id]=1098510912210968', data)
     end.respond_with(successful_create_intent_response)
   end
 
@@ -930,11 +932,13 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         stored_credential: {
           initial_transaction: false,
           initiator: 'merchant',
-          reason_type: 'recurring'
+          reason_type: 'recurring',
+          network_transaction_id: '1098510912210968'
         }
       })
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match('payment_method_options[card][stored_credential_transaction_type]=stored_off_session_recurring', data)
+      assert_match('payment_method_options[card][mit_exemption][network_transaction_id]=1098510912210968', data)
     end.respond_with(successful_create_intent_response)
   end
 


### PR DESCRIPTION
Update Stored Credentials to only send NTID if
stored_credential_transaction_type is
setup_off_session_unscheduled or setup_off_session_recurring.

Remote:
96 tests, 457 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed