### PR TITLE
Stripe PI: Add challenge as valid value for request_three_d_secure

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@
 * StripePI: Skip add_network_token_cryptogram_and_eci method to accept ApplePay recurring payments [sinourain] #5212
 * Decidir: Fix scrub method after update NT fields [sinourain] #5241
 * Cybersource and Cybersource Rest: Update card type code for Carnet cards [rachelkirk] #5235
+* Stripe PI: Add challenge as valid value for request_three_d_secure [jcreiff] #5238
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -645,7 +645,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def request_three_d_secure(post, options = {})
-        return unless options[:request_three_d_secure] && %w(any automatic).include?(options[:request_three_d_secure])
+        return unless options[:request_three_d_secure] && %w(any automatic challenge).include?(options[:request_three_d_secure])
 
         post[:payment_method_options] ||= {}
         post[:payment_method_options][:card] ||= {}

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1583,6 +1583,13 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'requires_action', purchase.params['status']
 
     options = {
+      currency: 'GBP',
+      request_three_d_secure: 'challenge'
+    }
+    assert purchase = @gateway.purchase(@amount, @three_ds_not_required_card, options)
+    assert_equal 'requires_action', purchase.params['status']
+
+    options = {
       currency: 'GBP'
     }
     assert purchase = @gateway.purchase(@amount, @three_ds_not_required_card, options)

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -163,6 +163,15 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       assert_match(/\[request_three_d_secure\]=automatic/, data)
     end.respond_with(successful_request_three_d_secure_response)
 
+    request_three_d_secure = 'challenge'
+    options = @options.merge(request_three_d_secure: request_three_d_secure)
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.create_intent(@amount, @visa_token, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/\[request_three_d_secure\]=challenge/, data)
+    end.respond_with(successful_request_three_d_secure_response)
+
     request_three_d_secure = true
     options = @options.merge(request_three_d_secure: request_three_d_secure)
 


### PR DESCRIPTION
[Stripe changelog entry announcing the new field](https://docs.stripe.com/changelog#december-20,-2023)

CER-1717

LOCAL
6007 tests, 80257 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed;

RUBOCOP
Inspecting 801 files
801 files inspected, no offenses detected

UNIT
62 tests, 321 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

REMOTE
95 tests, 454 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed