### PR TITLE
StripePI: Add metadata for GooglePay FPAN

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@
 * Decidir: Fix scrub method after update NT fields [sinourain] #5241
 * Cybersource and Cybersource Rest: Update card type code for Carnet cards [rachelkirk] #5235
 * Stripe PI: Add challenge as valid value for request_three_d_secure [jcreiff] #5238
+* StripePI: Add metadata for GooglePay FPAN [almalee24] #5242
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -126,6 +126,15 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert purchase.params.dig('charges', 'data')[0]['balance_transaction']
   end
 
+  def test_successful_purchase_google_pay_fpan
+    options = {
+      currency: 'GBP',
+      customer: @customer
+    }
+    assert purchase = @gateway.purchase(@amount, @visa_payment_method, options.merge(wallet_type: :non_tokenized_google_pay))
+    assert_equal 'succeeded', purchase.params['status']
+  end
+
   def test_successful_purchase_with_card_brand
     options = {
       currency: 'USD',


### PR DESCRIPTION
Remote:
98 tests, 462 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

If the payment methods is GooglePay FPAN which would be treated as a CreditCard then add metadata.input_method as GooglePay.