### PR TITLE
MercadoPago: Sending sponsor_id only on production

### DIFF
--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -137,7 +137,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_additional_data(post, options)
-        post[:sponsor_id] = options[:sponsor_id]
+        post[:sponsor_id] = options[:sponsor_id] unless test?
         post[:metadata] = options[:metadata] if options[:metadata]
         post[:device_id] = options[:device_id] if options[:device_id]
         post[:additional_info] = {

--- a/test/remote/gateways/remote_mercado_pago_test.rb
+++ b/test/remote/gateways/remote_mercado_pago_test.rb
@@ -394,4 +394,18 @@ class RemoteMercadoPagoTest < Test::Unit::TestCase
     assert_equal response.params['three_ds_info']['external_resource_url'], 'https://api.mercadopago.com/cardholder_authenticator/v2/prod/browser-challenges'
     assert_include response.params['three_ds_info'], 'creq'
   end
+
+  def test_successful_purchase_with_3ds_mandatory
+    three_ds_cc = credit_card('5031755734530604', verification_value: '123', month: 11, year: 2025)
+    @options[:execute_threed] = true
+    @options[:three_ds_mode] = 'mandatory'
+
+    response = @gateway.purchase(290, three_ds_cc, @options)
+
+    assert_success response
+    assert_equal 'pending_challenge', response.message
+    assert_include response.params, 'three_ds_info'
+    assert_equal response.params['three_ds_info']['external_resource_url'], 'https://api.mercadopago.com/cardholder_authenticator/v2/prod/browser-challenges'
+    assert_include response.params['three_ds_info'], 'creq'
+  end
 end


### PR DESCRIPTION
### Summary:
MercadoPago only sending platform/partnership info on production.

## Tests

### Remote Test:
Finished in 79.263845 seconds.
20 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications
100% passed

### Unit Tests:
Finished in 68.455283 seconds.
6012 tests, 80277 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
801 files inspected, no offenses detected