### PR TITLE
Adyen: Enable multiple legs within airline data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@
 * Stripe PI: Add challenge as valid value for request_three_d_secure [jcreiff] #5238
 * StripePI: Add metadata for GooglePay FPAN [almalee24] #5242
 * Paypal: Add inquire method [almalee24] #5231
+* Adyen: Enable multiple legs within airline data [jcreiff] #5249
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -360,6 +360,26 @@ module ActiveMerchant #:nodoc:
           post[:additionalData].merge!(extract_and_transform(leg_data, options[:additional_data_airline][:leg]))
         end
 
+        # temporary duplication with minor modification (:legs array with nested hashes instead of a single :leg hash)
+        # this should preserve backward-compatibility with :leg logic above until it is deprecated/removed
+        if options[:additional_data_airline][:legs].present?
+          options[:additional_data_airline][:legs].each_with_index do |leg, number|
+            leg_data = %w[
+              carrier_code
+              class_of_travel
+              date_of_travel
+              depart_airport
+              depart_tax
+              destination_code
+              fare_base_code
+              flight_number
+              stop_over_code
+            ].each_with_object({}) { |value, hash| hash["airline.leg#{number + 1}.#{value}"] = value }
+
+            post[:additionalData].merge!(extract_and_transform(leg_data, leg))
+          end
+        end
+
         if options[:additional_data_airline][:passenger].present?
           passenger_data = %w[
             date_of_birth

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1684,6 +1684,38 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_succesful_purchase_with_airline_data_with_legs
+    airline_data = {
+      agency_invoice_number: 'BAC123',
+      agency_plan_name: 'plan name',
+      airline_code: '434234',
+      airline_designator_code: '1234',
+      boarding_fee: '100',
+      computerized_reservation_system: 'abcd',
+      customer_reference_number: 'asdf1234',
+      document_type: 'cc',
+      flight_date: '2023-09-08',
+      ticket_issue_address: 'abcqwer',
+      ticket_number: 'ABCASDF',
+      travel_agency_code: 'ASDF',
+      travel_agency_name: 'hopper',
+      passenger_name: 'Joe Doe',
+      legs: [{
+        carrier_code: 'KL',
+        class_of_travel: 'F'
+      }],
+      passenger: {
+        first_name: 'Joe',
+        last_name: 'Doe',
+        telephone_number: '432211111'
+      }
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(additional_data_airline: airline_data))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
   def test_succesful_purchase_with_lodging_data
     lodging_data = {
       check_in_date: '20230822',

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -1599,6 +1599,62 @@ class AdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_succesful_additional_airline_data_with_legs
+    airline_data = {
+      agency_invoice_number: 'BAC123',
+      agency_plan_name: 'plan name',
+      airline_code: '434234',
+      airline_designator_code: '1234',
+      boarding_fee: '100',
+      computerized_reservation_system: 'abcd',
+      customer_reference_number: 'asdf1234',
+      document_type: 'cc',
+      legs: [
+        {
+          carrier_code: 'KL',
+          date_of_travel: '2024-10-10'
+        },
+        {
+          carrier_code: 'KL',
+          date_of_travel: '2024-10-11'
+        }
+      ],
+      passenger: {
+        first_name: 'Joe',
+        last_name: 'Doe'
+      }
+    }
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(additional_data_airline: airline_data))
+    end.check_request do |_endpoint, data, _headers|
+      parsed = JSON.parse(data)
+      additional_data = parsed['additionalData']
+      assert_equal additional_data['airline.agency_invoice_number'], airline_data[:agency_invoice_number]
+      assert_equal additional_data['airline.agency_plan_name'], airline_data[:agency_plan_name]
+      assert_equal additional_data['airline.airline_code'], airline_data[:airline_code]
+      assert_equal additional_data['airline.airline_designator_code'], airline_data[:airline_designator_code]
+      assert_equal additional_data['airline.boarding_fee'], airline_data[:boarding_fee]
+      assert_equal additional_data['airline.computerized_reservation_system'], airline_data[:computerized_reservation_system]
+      assert_equal additional_data['airline.customer_reference_number'], airline_data[:customer_reference_number]
+      assert_equal additional_data['airline.document_type'], airline_data[:document_type]
+      assert_equal additional_data['airline.flight_date'], airline_data[:flight_date]
+      assert_equal additional_data['airline.ticket_issue_address'], airline_data[:abcqwer]
+      assert_equal additional_data['airline.ticket_number'], airline_data[:ticket_number]
+      assert_equal additional_data['airline.travel_agency_code'], airline_data[:travel_agency_code]
+      assert_equal additional_data['airline.travel_agency_name'], airline_data[:travel_agency_name]
+      assert_equal additional_data['airline.passenger_name'], airline_data[:passenger_name]
+      assert_equal additional_data['airline.leg1.carrier_code'], airline_data[:legs][0][:carrier_code]
+      assert_equal additional_data['airline.leg1.date_of_travel'], airline_data[:legs][0][:date_of_travel]
+      assert_equal additional_data['airline.leg2.carrier_code'], airline_data[:legs][1][:carrier_code]
+      assert_equal additional_data['airline.leg2.date_of_travel'], airline_data[:legs][1][:date_of_travel]
+      assert_equal additional_data['airline.passenger.first_name'], airline_data[:passenger][:first_name]
+      assert_equal additional_data['airline.passenger.last_name'], airline_data[:passenger][:last_name]
+      assert_equal additional_data['airline.passenger.telephone_number'], airline_data[:passenger][:telephone_number]
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_additional_data_lodging
     lodging_data = {
       check_in_date: '20230822',


### PR DESCRIPTION
The original implementation of the `leg` field assumes that there will be one `leg` hash provided, but based on [Adyen's documentation](https://docs.adyen.com/payment-methods/cards/enhanced-scheme-data/airline/), the flexibility to send multiple legs (leg1, leg2, etc.) is required

CER-1738

LOCAL
6016 tests, 80319 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

RUBOCOP
801 files inspected, no offenses detected

UNIT
127 tests, 691 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

REMOTE
147 tests, 471 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 91.8367% passed