### PR TITLE
Nuvei: Add partial approval feature

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,7 @@
 * DLocal: Add X-Dlocal-Payment-Source to header [almalee24] #5281
 * StripePI: Update to retrieve_setup_intent and headers [almalee24] #5283
 * Upgrade rexml to 3.3.8 [raymzag] #5245
+* Nuvei: Add partial approval feature [javierpedrozaing] #5250
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/nuvei.rb
+++ b/lib/active_merchant/billing/gateways/nuvei.rb
@@ -38,6 +38,7 @@ module ActiveMerchant
         add_customer_ip(post, options)
         add_stored_credentials(post, payment, options)
         post[:userTokenId] = options[:user_token_id] if options[:user_token_id]
+        post[:isPartialApproval] = options[:is_partial_approval] ? 1 : 0
 
         if options[:execute_threed]
           execute_3ds_flow(post, money, payment, transaction_type, options)

--- a/test/remote/gateways/remote_nuvei_test.rb
+++ b/test/remote/gateways/remote_nuvei_test.rb
@@ -269,4 +269,12 @@ class RemoteNuveiTest < Test::Unit::TestCase
     assert_success recurring_response
     assert_match 'SUCCESS', recurring_response.params['status']
   end
+
+  def test_successful_partial_approval
+    response = @gateway.authorize(55, @credit_card, @options.merge(is_partial_approval: true))
+    assert_success response
+    assert_equal '55', response.params['partialApproval']['requestedAmount']
+    assert_equal '55', response.params['partialApproval']['processedAmount']
+    assert_match 'APPROVED', response.message
+  end
 end

--- a/test/unit/gateways/nuvei_test.rb
+++ b/test/unit/gateways/nuvei_test.rb
@@ -205,6 +205,17 @@ class NuveiTest < Test::Unit::TestCase
     end
   end
 
+  def test_successful_partial_approval
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(55, @credit_card, @options.merge(is_partial_approval: true))
+    end.check_request(skip_response: true) do |_method, endpoint, data, _headers|
+      if /payment/.match?(endpoint)
+        json_data = JSON.parse(data)
+        assert_equal 1, json_data['isPartialApproval']
+      end
+    end
+  end
+
   def test_successful_credit
     stub_comms(@gateway, :ssl_request) do
       @gateway.credit(@amount, @credit_card, @options)


### PR DESCRIPTION
Description
-------------------------
[SER-1356](https://spreedly.atlassian.net/browse/SER-1356)

This commit enable partial approval for payment sending a GSF flag

Unit test
-------------------------
Finished in 0.010615 seconds.

1 tests, 3 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

94.21 tests/s, 282.62 assertions/s

Remote test
-------------------------
Finished in 37.737084 seconds.

18 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

0.48 tests/s, 1.32 assertions/s

Rubocop
-------------------------
801 files inspected, no offenses detected