### PR TITLE
SafeCharge: add card holder verification fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@
 * StripePI: Add metadata for GooglePay FPAN [almalee24] #5242
 * Paypal: Add inquire method [almalee24] #5231
 * Adyen: Enable multiple legs within airline data [jcreiff] #5249
+* SafeCharge: Add card holder verification fields [yunnydang] #5252
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -195,6 +195,8 @@ module ActiveMerchant #:nodoc:
           post[:sg_Zip] = address[:zip] if address[:zip]
           post[:sg_Country] = address[:country] if address[:country]
           post[:sg_Phone] = address[:phone] if address[:phone]
+          post[:sg_middleName] = options[:middle_name] if options[:middle_name]
+          post[:sg_doCardHolderNameVerification] = options[:card_holder_verification] if options[:card_holder_verification]
         end
 
         post[:sg_Email] = options[:email]

--- a/test/remote/gateways/remote_safe_charge_test.rb
+++ b/test/remote/gateways/remote_safe_charge_test.rb
@@ -63,6 +63,13 @@ class RemoteSafeChargeTest < Test::Unit::TestCase
     assert_equal 'Success', response.message
   end
 
+  def test_successful_purchase_with_card_holder_verification
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(middle_name: 'middle', card_holder_verification: 1))
+    assert_success response
+    assert_equal 'Success', response.message
+    assert_equal '', response.params['cardholdernameverification']
+  end
+
   def test_successful_purchase_with_token
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -94,6 +94,21 @@ class SafeChargeTest < Test::Unit::TestCase
     assert purchase.test?
   end
 
+  def test_successful_purchase_with_card_holder_verification
+    purchase = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(middle_name: 'middle', card_holder_verification: 1))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/sg_middleName=middle/, data)
+      assert_match(/sg_doCardHolderNameVerification=1/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success purchase
+    assert_equal '111951|101508189567|ZQBpAFAASABGAHAAVgBPAFUAMABiADMAewBtAGsAd' \
+                 'AAvAFIAQQBrAGoAYwBxACoAXABHAEEAOgA3ACsAMgA4AD0AOABDAG4AbQAzAF' \
+                 'UAbQBYAFIAMwA=|%02d|%d|1.00|USD' % [@credit_card.month, @credit_card.year.to_s[-2..-1]], purchase.authorization
+    assert purchase.test?
+  end
+
   def test_successful_purchase_with_falsey_stored_credential_mode
     purchase = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential_mode: false))


### PR DESCRIPTION
This change adds the optional middle_name and card_holder_verification fields
Local:
6017 tests, 80326 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
31 tests, 176 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
35 tests, 93 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.2857% passed