### PR TITLE
CyberSource Rest: Add the mcc field

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -1103,10 +1103,15 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_threeds_services(xml, options)
-        xml.tag! 'payerAuthEnrollService', { 'run' => 'true' } if options[:payer_auth_enroll_service]
+        if options[:payer_auth_enroll_service]
+          xml.tag! 'payerAuthEnrollService', { 'run' => 'true' } do
+            xml.tag! 'MCC', options[:mcc] if options[:mcc]
+          end
+        end
+
         if options[:payer_auth_validate_service]
           xml.tag! 'payerAuthValidateService', { 'run' => 'true' } do
-            xml.tag! 'signedPARes', options[:pares]
+            xml.tag! 'signedPARes', options[:pares] if options[:pares]
           end
         end
       end

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -138,6 +138,7 @@ module ActiveMerchant #:nodoc:
         post[:consumerAuthenticationInformation][:paSpecificationVersion] = three_d_secure[:version] if three_d_secure[:version]
         post[:consumerAuthenticationInformation][:directoryServerTransactionID] = three_d_secure[:ds_transaction_id] if three_d_secure[:ds_transaction_id]
         post[:consumerAuthenticationInformation][:eciRaw] = three_d_secure[:eci] if three_d_secure[:eci]
+        post[:consumerAuthenticationInformation][:mcc] = options[:mcc] if options[:mcc]
         if three_d_secure[:xid].present?
           post[:consumerAuthenticationInformation][:xid] = three_d_secure[:xid]
         else

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -569,6 +569,19 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     assert_success auth
   end
 
+  def test_successful_authorize_with_3ds2_mcc
+    @options[:three_d_secure] = {
+      version: '2.2.0',
+      cavv: '3q2+78r+ur7erb7vyv66vv\/\/\/\/8=',
+      eci: '05',
+      ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
+      enrolled: 'true',
+      authentication_response_status: 'Y'
+    }
+    auth = @gateway.authorize(@amount, @visa_card, @options.merge(mcc: '1234'))
+    assert_success auth
+  end
+
   def test_successful_authorize_with_3ds2_mastercard
     @options[:three_d_secure] = {
       version: '2.2.0',

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -1100,20 +1100,26 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
   def test_3ds_enroll_request_via_purchase
     assert response = @gateway.purchase(1202, @three_ds_enrolled_card, @options.merge(payer_auth_enroll_service: true))
-    assert_equal '475', response.params['reasonCode']
-    assert !response.params['acsURL'].blank?
-    assert !response.params['paReq'].blank?
-    assert !response.params['xid'].blank?
-    assert !response.success?
+    assert_equal '100', response.params['reasonCode']
+    assert response.success?
+  end
+
+  def test_3ds_enroll_and_mcc_request_via_purchase
+    assert response = @gateway.purchase(1202, @three_ds_enrolled_card, @options.merge(payer_auth_enroll_service: true, mcc: '1234'))
+    assert_equal '100', response.params['reasonCode']
+    assert response.success?
   end
 
   def test_3ds_enroll_request_via_authorize
-    assert response = @gateway.authorize(1202, @three_ds_enrolled_card, @options.merge(payer_auth_enroll_service: true))
-    assert_equal '475', response.params['reasonCode']
-    assert !response.params['acsURL'].blank?
-    assert !response.params['paReq'].blank?
-    assert !response.params['xid'].blank?
-    assert !response.success?
+    assert response = @gateway.authorize(1202, @three_ds_enrolled_card, @options.merge(payer_auth_enroll_service: true, mcc: '1234'))
+    assert_equal '100', response.params['reasonCode']
+    assert response.success?
+  end
+
+  def test_3ds_enroll_and_mcc_request_via_authorize
+    assert response = @gateway.authorize(1202, @three_ds_enrolled_card, @options.merge(payer_auth_enroll_service: true, mcc: '1234'))
+    assert_equal '100', response.params['reasonCode']
+    assert response.success?
   end
 
   def test_successful_3ds_requests_with_unenrolled_card

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -484,7 +484,7 @@ class CyberSourceRestTest < Test::Unit::TestCase
       cavv_algorithm: '2'
     }
     stub_comms do
-      @gateway.purchase(100, @master_card, @options)
+      @gateway.purchase(100, @master_card, @options.merge(mcc: '1234'))
     end.check_request do |_endpoint, data, _headers|
       json_data = JSON.parse(data)
       assert_equal json_data['consumerAuthenticationInformation']['ucafAuthenticationData'], '3q2+78r+ur7erb7vyv66vv\/\/\/\/8='
@@ -496,6 +496,7 @@ class CyberSourceRestTest < Test::Unit::TestCase
       assert_equal json_data['consumerAuthenticationInformation']['xid'], '3q2+78r+ur7erb7vyv66vv\/\/\/\/8='
       assert_equal json_data['consumerAuthenticationInformation']['veresEnrolled'], 'true'
       assert_equal json_data['consumerAuthenticationInformation']['paresStatus'], 'Y'
+      assert_equal json_data['consumerAuthenticationInformation']['mcc'], '1234'
     end.respond_with(successful_purchase_response)
   end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -1473,11 +1473,12 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_3ds_enroll_response
+  def test_3ds_enroll_and_mcc_response
     purchase = stub_comms do
-      @gateway.purchase(@amount, @credit_card, @options.merge(payer_auth_enroll_service: true))
+      @gateway.purchase(@amount, @credit_card, @options.merge(payer_auth_enroll_service: true, mcc: '1234'))
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/\<payerAuthEnrollService run=\"true\"\/\>/, data)
+      assert_match(/\<payerAuthEnrollService run=\"true\"\>/, data)
+      assert_match(/\<MCC\>1234\<\/MCC\>/, data)
     end.respond_with(threedeesecure_purchase_response)
 
     assert_failure purchase


### PR DESCRIPTION
Adds the optional mcc field

Local:
6016 tests, 80320 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
40 tests, 217 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
54 tests, 177 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed