### PR TITLE
Addition of shopper ip address when a network token transaction occurs

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -700,9 +700,13 @@ module ActiveMerchant #:nodoc:
         if options[:ip] && options[:session_id]
           xml.session 'shopperIPAddress' => options[:ip], 'id' => options[:session_id]
         else
-          xml.session 'shopperIPAddress' => options[:ip] if options[:ip]
+          add_shopper_ip_address(xml, options)
           xml.session 'id' => options[:session_id] if options[:session_id]
         end
+      end
+
+      def add_shopper_ip_address(xml, options)
+        xml.session 'shopperIPAddress' => options[:ip] if options[:ip]
       end
 
       def add_three_d_secure(xml, options)
@@ -778,6 +782,7 @@ module ActiveMerchant #:nodoc:
             xml.acceptHeader options[:accept_header]
             xml.userAgentHeader options[:user_agent]
           end
+          add_shopper_ip_address(xml, options)
         end
       end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -205,6 +205,12 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_purchase_with_network_token_with_shopper_ip_address
+    assert response = @gateway.purchase(@amount, @nt_credit_card, @options.merge(ip: '127.0.0.1'))
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_successful_purchase_with_network_token_and_stored_credentials
     stored_credential_params = stored_credential(:initial, :unscheduled, :merchant)
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -534,6 +534,16 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_authorize_with_network_token_with_shopper_ip_address
+    response = stub_comms do
+      @gateway.authorize(@amount, @nt_credit_card, @options.merge(ip: '127.0.0.1', email: 'wow@example.com'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<session shopperIPAddress=\"127.0.0.1\"\/>/, data)
+      #assert_match %r(<eciIndicator>05</eciIndicator>), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_successful_purchase_with_elo
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(currency: 'BRL'))


### PR DESCRIPTION
**Summary:**
Addition of shopper ip address when a network token transaction occurs

**Unit tests**
Finished in 0.384488 seconds.

125 tests, 702 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
325.11 tests/s, 1825.80 assertions/s

**Remote tests**
Finished in 149.317889 seconds.

111 tests, 469 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.1982% passed

0.74 tests/s, 3.14 assertions/s

-> failure not related to changes