### PR TITLE
StripePI: Update authorization for failed Payment Intents

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,7 @@
 * Adyen: Update shopperInteraction [almalee24] #5273
 * CenPOS: Add test_url [jcreiff] #5274
 * Worldpay: Fix stored credentials issue [jherreraa] #5267
+* StripePI: Update authorization for failed Payment Intents [almalee24] #5260
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -745,7 +745,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(success, url, method, response, options)
-        return response.dig('error', 'charge') || response.dig('error', 'setup_intent', 'id') || response['id'] unless success
+        return error_id(response, url) unless success
 
         if url == 'customers'
           [response['id'], response.dig('sources', 'data').first&.dig('id')].join('|')
@@ -755,6 +755,10 @@ module ActiveMerchant #:nodoc:
         else
           response['id']
         end
+      end
+
+      def error_id(response, url)
+        response.dig('error', 'charge') || response.dig('error', 'setup_intent', 'id') || response['id']
       end
 
       def message_from(success, response)

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -319,6 +319,14 @@ module ActiveMerchant #:nodoc:
 
       private
 
+      def error_id(response, url)
+        if url.end_with?('payment_intents')
+          response.dig('error', 'payment_intent', 'id') || super
+        else
+          super
+        end
+      end
+
       def digital_wallet_payment_method?(payment_method)
         payment_method.source == :google_pay || payment_method.source == :apple_pay
       end

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -227,7 +227,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert create = @gateway.create_intent(@amount, 'pm_card_chargeDeclined', @options.merge(confirm: true))
     assert_equal 'requires_payment_method', create.params.dig('error', 'payment_intent', 'status')
     assert_equal false, create.params.dig('error', 'payment_intent', 'charges', 'data')[0].dig('captured')
-    assert_equal 'ch_1F2MB6AWOtgoysogAIvNV32Z', create.authorization
+    assert_equal 'pi_1F2MB5AWOtgoysogCMt8BaxR', create.authorization
   end
 
   def test_failed_void_after_capture


### PR DESCRIPTION
If the transaction that failes was created through the create_intent or setup_purchase endpoint then we will grab response.dig('error', 'payment_intent', 'id') if present.

99 tests, 469 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed