### PR TITLE
Shift4: Update response parsing to account for hostresponse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@
 * Stripe PI: Update Stored Credentials [almalee24] #5236
 * Checkout V2: Update stored credential options function [jherreraa] #5239
 * Ebanx: Add support for Stored Credentials [almalee24] #5243
+* Shift4: Update response parsing to account for hostresponse [jcreiff] #5261
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -269,7 +269,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(action, response)
-        success_from(action, response) ? 'Transaction successful' : (error(response)&.dig('longText') || response['result'].first&.dig('transaction', 'hostResponse', 'reasonDescription') || 'Transaction declined')
+        if success_from(action, response)
+          'Transaction successful'
+        else
+          error(response)&.dig('longText') ||
+            response['result'].first&.dig('transaction', 'hostresponse', 'reasonDescription') ||
+            response['result'].first&.dig('transaction', 'hostResponse', 'reasonDescription') ||
+            'Transaction declined'
+        end
       end
 
       def error_code_from(action, response)
@@ -277,7 +284,9 @@ module ActiveMerchant #:nodoc:
         primary_code = response['result'].first['error'].present?
         return unless code == 'D' || primary_code == true || success_from(action, response)
 
-        if response['result'].first&.dig('transaction', 'hostResponse')
+        if response['result'].first&.dig('transaction', 'hostresponse')
+          response['result'].first&.dig('transaction', 'hostresponse', 'reasonCode')
+        elsif response['result'].first&.dig('transaction', 'hostResponse')
           response['result'].first&.dig('transaction', 'hostResponse', 'reasonCode')
         elsif response['result'].first['error']
           response['result'].first&.dig('error', 'primaryCode')

--- a/test/remote/gateways/remote_shift4_test.rb
+++ b/test/remote/gateways/remote_shift4_test.rb
@@ -194,7 +194,7 @@ class RemoteShift4Test < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_include response.message, 'Card  for Merchant Id 0008628968 not found'
+    assert_include response.message, 'Unable to determine card type. Please check the number and re-enter.'
   end
 
   def test_failed_authorize_with_failure_amount
@@ -214,7 +214,7 @@ class RemoteShift4Test < Test::Unit::TestCase
   def test_failed_capture
     response = @gateway.capture(@amount, '', @options)
     assert_failure response
-    assert_include response.message, 'Card  for Merchant Id 0008628968 not found'
+    assert_include response.message, 'Unable to determine card type. Please check the number and re-enter.'
   end
 
   def test_failed_refund


### PR DESCRIPTION
The response object returned from the Shift4 gateway seems to have changed `hostResponse` to `hostresponse` around August 26th, which causes all failed auth/purchase transactions to default to the fallback message of "Transaction declined"

This commit corrects the parsing to account for this change but also leaves `hostResponse` as an option, in case the change is reverted by Shift4 in the future.

Assertions were added to show that the refactoring still provides correct values for both `message` and `error_code` for the various response structures we receive. Shift4 does not return a `host(r/R)esponse` object in sandbox testing, so we have to rely on unit tests here.

CER-1740

LOCAL
6018 tests, 80340 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

801 files inspected, no offenses detected

UNIT
29 tests, 190 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

REMOTE
29 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed