### PR TITLE
NMI: Add `industry_indicator` field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@
 * Checkout V2: Update stored credential options function [jherreraa] #5239
 * Ebanx: Add support for Stored Credentials [almalee24] #5243
 * Shift4: Update response parsing to account for hostresponse [jcreiff] #5261
+* NMI: Add `industry_indicator` field [naashton] #5264
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -158,6 +158,7 @@ module ActiveMerchant #:nodoc:
         post[:orderdescription] = options[:description]
         post[:currency] = options[:currency] || currency(money)
         post[:billing_method] = 'recurring' if options[:recurring]
+        post[:industry] = options[:industry_indicator] if options[:industry_indicator]
         if (dup_seconds = (options[:dup_seconds] || self.class.duplicate_window))
           post[:dup_seconds] = dup_seconds
         end

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -178,6 +178,15 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_apple_pay_and_industry_field
+    assert @gateway_secure.supports_network_tokenization?
+    assert response = @gateway_secure.purchase(@amount, @apple_pay, @options.merge(industry_indicator: 'ecommerce'))
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+    assert response.authorization
+  end
+
   def test_successful_purchase_with_google_pay
     assert @gateway_secure.supports_network_tokenization?
     assert response = @gateway_secure.purchase(@amount, @google_pay, @options)

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -638,6 +638,16 @@ class NmiTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_includes_industry_field
+    @transaction_options[:industry_indicator] = 'ecommerce'
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @transaction_options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r{ecommerce}, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_blank_cvv_not_sent
     @credit_card.verification_value = nil
     stub_comms do


### PR DESCRIPTION
Transactions on NMI could fail if this industry field is not provided. This field is not documented publicly on NMI.

Unit: 61 tests, 487 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 62 tests, 247 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.3871% passed