### PR TITLE
Worldpay: Fix stored credentials issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@
 * SumUp: Append partner_id to checkout_reference [naashton] #5272
 * Adyen: Update shopperInteraction [almalee24] #5273
 * CenPOS: Add test_url [jcreiff] #5274
+* Worldpay: Fix stored credentials issue [jherreraa] #5267
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -751,7 +751,7 @@ module ActiveMerchant #:nodoc:
                  when 'unscheduled' then 'UNSCHEDULED'
                  end
         is_initial_transaction = options[:stored_credential][:initial_transaction]
-        stored_credential_params = generate_stored_credential_params(is_initial_transaction, reason)
+        stored_credential_params = generate_stored_credential_params(is_initial_transaction, reason, options[:stored_credential][:initiator])
 
         xml.storedCredentials stored_credential_params do
           xml.schemeTransactionIdentifier network_transaction_id(options) if network_transaction_id(options) && !is_initial_transaction
@@ -1086,8 +1086,8 @@ module ActiveMerchant #:nodoc:
         test? && options[:execute_threed] && !options[:three_ds_version]&.start_with?('2') ? '3D' : payment_method.name
       end
 
-      def generate_stored_credential_params(is_initial_transaction, reason = nil)
-        customer_or_merchant = reason == 'RECURRING' && is_initial_transaction ? 'customerInitiatedReason' : 'merchantInitiatedReason'
+      def generate_stored_credential_params(is_initial_transaction, reason = nil, initiator = nil)
+        customer_or_merchant = initiator == 'cardholder' ? 'customerInitiatedReason' : 'merchantInitiatedReason'
 
         stored_credential_params = {}
         stored_credential_params['usage'] = is_initial_transaction ? 'FIRST' : 'USED'

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -388,7 +388,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<storedCredentials usage\=\"FIRST\" customerInitiatedReason\=\"RECURRING\"\>/, data)
+      assert_match(/<storedCredentials usage\=\"FIRST\" merchantInitiatedReason\=\"RECURRING\"\>/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
   end


### PR DESCRIPTION
[OPPS-8](https://spreedly.atlassian.net/browse/OPPS-8)

## Summary:

Update generate_stored_credential_params function to fix issue on stored credentials reason

Unit tests
----------------
Finished in 0.562645 seconds
124 tests, 698 assertions, 0 failures, 
0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed 

220.39 tests/s, 1240.57 assertions/s


Remote tests
----------------
Finished in 113.845584 seconds
110 tests, 466 assertions, 2 failures, 
0 errors, 0 pendings, 0 omissions, 0 notifications 98.1818% passed

0.97 tests/s, 4.09 assertions/s

-> failure not related to change