### PR TITLE
Worldpay: Support apple pay recurring

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@
 * CenPOS: Add test_url [jcreiff] #5274
 * Worldpay: Fix stored credentials issue [jherreraa] #5267
 * StripePI: Update authorization for failed Payment Intents [almalee24] #5260
+* Worldpay: Add support for recurring Apple Pay [kenderbolivart] #5628
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1597,6 +1597,23 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_authorize_recurring_apple_pay_with_ntid
+    stored_credential_params = stored_credential(:used, :recurring, :merchant, network_transaction_id: '3812908490218390214124')
+
+    @options.merge({
+      stored_credential: stored_credential_params,
+      stored_credential_transaction_id: '000000000000020005060720116005060',
+      wallet_type: :apple_pay
+    })
+    response = stub_comms do
+      @gateway.authorize(@amount, @apple_play_network_token, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<EMVCO_TOKEN-SSL type="APPLEPAY">), data
+      refute_match %r(<cryptogram>), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_successful_inquire_with_order_id
     response = stub_comms do
       @gateway.inquire(nil, { order_id: @options[:order_id].to_s })


### PR DESCRIPTION
[COMP-73](https://spreedly.atlassian.net/jira/software/projects/COMP/boards/195?selectedIssue=COMP-73)

Adds support for Apple Pay MIT recurring


**Unit:**

125 tests, 702 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

**Remote:**

111 tests, 479 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.1982% passed
