### PR TITLE
CyberSourceRest: Support Apple Pay recurring

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@
 * Worldpay: Fix stored credentials issue [jherreraa] #5267
 * StripePI: Update authorization for failed Payment Intents [almalee24] #5260
 * Worldpay: Add support for recurring Apple Pay [kenderbolivart] #5628
+* Cybersource Rest: Add support for recurring Apple Pay [bdcano] #5270
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -366,6 +366,15 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     refute_empty response.params['_links']['capture']
   end
 
+  def test_successful_authorize_with_apple_pay_recurring
+    auth = @gateway.authorize(@amount, @apple_pay, @options)
+    response = @gateway.authorize(@amount, @apple_pay, @options.merge(stored_credential: stored_credential_options(:merchant, :recurring, ntid: auth.network_transaction_id)))
+
+    assert_success response
+    assert_equal 'AUTHORIZED', response.message
+    refute_empty response.params['_links']['capture']
+  end
+
   def test_successful_authorize_with_google_pay
     response = @gateway.authorize(@amount, @apple_pay, @options)
 


### PR DESCRIPTION
[COMP-72](https://spreedly.atlassian.net/browse/COMP-72)

Adds support for Apple Pay recurring

Test Summary
Remote Test:
------------------------------
Finished in 28.189687 seconds.
6030 tests, 80342 assertions, 0 failures, 23 errors, 0 pendings, 0 omissions, 0 notifications
99.6186% passed

Unit Tests:
------------------------------
Finished in 0.670757 seconds.
41 tests, 223 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
------------------------------
801 files inspected, no offenses detected