### PR TITLE
SumUp: Append partner_id to checkout_reference

### DIFF
--- a/lib/active_merchant/billing/gateways/sum_up.rb
+++ b/lib/active_merchant/billing/gateways/sum_up.rb
@@ -101,7 +101,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_invoice(post, money, options)
-        post[:checkout_reference] = options[:order_id]
+        post[:checkout_reference] = options[:partner_id] && options[:order_id] ? "#{options[:partner_id]}-#{options[:order_id]}" : options[:order_id]
         post[:amount]             = amount(money)
         post[:currency]           = options[:currency] || currency(money)
         post[:description]        = options[:description]

--- a/test/remote/gateways/remote_sum_up_test.rb
+++ b/test/remote/gateways/remote_sum_up_test.rb
@@ -51,6 +51,16 @@ class RemoteSumUpTest < Test::Unit::TestCase
     assert_equal 'PAID', response.message
   end
 
+  def test_successful_purchase_with_partner_id
+    options = {
+      partner_id: 'PartnerId',
+      order_id: SecureRandom.uuid
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_equal "#{options[:partner_id]}-#{options[:order_id]}", response.params['checkout_reference']
+  end
+
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/remote/gateways/remote_sum_up_test.rb
+++ b/test/remote/gateways/remote_sum_up_test.rb
@@ -58,6 +58,7 @@ class RemoteSumUpTest < Test::Unit::TestCase
     }
 
     response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
     assert_equal "#{options[:partner_id]}-#{options[:order_id]}", response.params['checkout_reference']
   end
 

--- a/test/unit/gateways/sum_up_test.rb
+++ b/test/unit/gateways/sum_up_test.rb
@@ -43,6 +43,18 @@ class SumUpTest < Test::Unit::TestCase
     end.respond_with(successful_create_checkout_response)
   end
 
+  def test_successful_purchase_without_partner_id
+    @options.delete(:partner_id)
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      if checkout_ref = json_data['checkout_reference']
+        assert_match /#{@options[:order_id]}/, checkout_ref
+      end
+    end.respond_with(successful_create_checkout_response)
+  end
+
   def test_failed_purchase
     @gateway.expects(:ssl_request).returns(failed_complete_checkout_array_response)
     response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
For merchants that need to pass an identifier that the source of the transaction originates from their platform, they can pass this value which will be prepended to the `order_id` and passed along as the `checkout_reference`

Unit: 10 tests, 32 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 11 tests, 20 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
54.5455% passed

Note: Some of the remote tests are failing, unrelated to changes in this PR. SumUP echo's back the `checkout_reference` so we can easily validate that the one we pass in the request by checking the response.