### PR TITLE
CybersourceRest: Update message and error_code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,7 @@
 * StripePI: Update authorization for failed Payment Intents [almalee24] #5260
 * Worldpay: Add support for recurring Apple Pay [kenderbolivart] #5628
 * Cybersource Rest: Add support for recurring Apple Pay [bdcano] #5270
+* Cybersource Rest: Update message and error_code [almalee24] #5276
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -415,21 +415,18 @@ module ActiveMerchant #:nodoc:
       def message_from(response)
         return response['status'] if success_from(response)
 
-        response['errorInformation']['message'] || response['message']
+        response.dig('errorInformation', 'message') || response['message']
       end
 
       def authorization_from(response)
         id = response['id']
-        has_amount = response['orderInformation'] && response['orderInformation']['amountDetails'] && response['orderInformation']['amountDetails']['authorizedAmount']
-        amount = response['orderInformation']['amountDetails']['authorizedAmount'].delete('.') if has_amount
+        amount = response.dig('orderInformation', 'amountDetails', 'authorizedAmount')&.delete('.')
 
-        return id if amount.blank?
-
-        [id, amount].join('|')
+        amount.present? ? [id, amount].join('|') : id
       end
 
       def error_code_from(response)
-        response['errorInformation']['reason'] unless success_from(response)
+        response.dig('errorInformation', 'reason') unless success_from(response)
       end
 
       # This implementation follows the Cybersource guide on how create the request signature, see:

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -613,6 +613,18 @@ class CyberSourceRestTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_failed_void
+    purchase = '1000|1842651133440156177166|AP4JY+Or4xRonEAOERAyMzQzOTEzMEM0MFZaNUZCBgDH3fgJ8AEGAMfd+AnwAwzRpAAA7RT/|purchase|100|USD|'
+
+    response = stub_comms do
+      @gateway.void(purchase, @options)
+    end.respond_with(successful_void_response)
+
+    assert_failure response
+    assert_equal nil, response.message
+    assert_equal nil, response.error_code
+  end
+
   private
 
   def parse_signature(signature)
@@ -840,6 +852,98 @@ class CyberSourceRestTest < Test::Unit::TestCase
       "status": "PENDING",
       "submitTimeUtc": "2023-03-27T20:45:09Z"
     }
+    RESPONSE
+  end
+
+  def successful_void_response
+    <<-RESPONSE
+      {
+        "_links":{
+          "void":{
+            "method": "POST",
+            "href": "/pts/v2/payments/123/voids"
+          },
+          "self":{
+            "method": "GET",
+            "href": "/pts/v2/payments/123"
+          }
+        },
+        "clientReferenceInformation":{
+          "code": "abcdefg",
+          "partner":  {
+            "solutionId": "HIJKLMN"
+          }
+        },
+        "consumerAuthenticationInformation": {
+          "token":  "token123"
+        },
+        "id": "64234623421",
+        "orderInformation": {
+          "amountDetails": {
+            "totalAmount":  "6.400",
+            "authorizedAmount": "6.400",
+            "currency": "JOD"
+          }
+        },
+        "paymentAccountInformation":{
+          "card": {
+            "type": "001"
+          }
+        },
+        "paymentInformation": {
+          "accountFeatures":  {
+            "group": "0"
+          },
+          "tokenizedCard":{
+            "type": "001"
+          },
+          "scheme": "VISA DEBIT",
+          "bin": "411111",
+          "accountType": "Visa Classic",
+          "issuer": "CONOTOXIA SP. Z O.O",
+          "card": {
+            "type": "001"
+          },
+          "binCountry": "PL"
+        },
+        "processorInformation": {
+          "systemTraceAuditNumber": "77788844",
+          "approvalCode": "7883243",
+          "networkTransactionId": "0972342342342353",
+          "retrievalReferenceNumber":"785652341",
+          "transactionId": "00012321324232",
+          "responseCode": "00",
+          "avs": {
+            "code": "Z",
+            "codeRaw": "Z"
+          }
+        },
+        "promotionInformation":{
+          "code": "ABC12345",
+          "description":  "percent discount",
+          "receiptData": "You have received a Visa Offer and saved 20% off your total (max discount for this offer is $20.00).",
+          "type": "V1"
+        },
+        "reconciliationId": "987552323786342334",
+        "riskInformation":  {
+          "localTime": "11:24:09",
+          "score": {
+            "result":"55",
+            "factorCodes":["B"],
+            "modelUsed":"default_uk"
+          },
+          "infoCodes": {
+            "address":["TOR-TA","TM-TTN"],
+            "velocity":["TTEL-T6","TTEL-T7"]
+          },
+          "profile": {
+            "earlyDecision": "ACCEPT"
+          },
+          "casePriority":"3"
+        },
+        "status": "ACCEPTED",
+        "submitTimeUtc": "2024-09-10T10:24:10Z"
+      }
     RESPONSE
   end
 end


### PR DESCRIPTION
Add dig to message_from and error_code_from to prevent NoMethod errors.

Remote
53 tests, 176 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed