### PR TITLE
Nuvei:  Add GSF for verify method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -64,6 +64,7 @@
 * Upgrade rexml to 3.3.8 [raymzag] #5245
 * Nuvei: Add partial approval feature [javierpedrozaing] #5250
 * Nuvei: Add ACH support [javierpedrozaing] #5269
+* Nuvei: Add GSF for verify method [javierpedrozaing] #5278
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/nuvei.rb
+++ b/lib/active_merchant/billing/gateways/nuvei.rb
@@ -39,7 +39,7 @@ module ActiveMerchant
         add_stored_credentials(post, payment, options)
         post[:userTokenId] = options[:user_token_id] if options[:user_token_id]
         post[:isPartialApproval] = options[:is_partial_approval] ? 1 : 0
-
+        post[:authenticationOnlyType] = options[:authentication_only_type] if options[:authentication_only_type]
         if options[:execute_threed]
           execute_3ds_flow(post, money, payment, transaction_type, options)
         else

--- a/test/remote/gateways/remote_nuvei_test.rb
+++ b/test/remote/gateways/remote_nuvei_test.rb
@@ -193,6 +193,12 @@ class RemoteNuveiTest < Test::Unit::TestCase
     assert_match 'APPROVED', response.message
   end
 
+  def test_successful_verify_with_authentication_only_type
+    response = @gateway.verify(@credit_card, @options.merge({ authentication_only_type: 'MAINTAINCARD' }))
+    assert_match 'SUCCESS', response.params['status']
+    assert_match 'APPROVED', response.message
+  end
+
   def test_successful_general_credit
     credit_response = @gateway.credit(@amount, @credit_card, @options)
     assert_success credit_response

--- a/test/unit/gateways/nuvei_test.rb
+++ b/test/unit/gateways/nuvei_test.rb
@@ -277,6 +277,20 @@ class NuveiTest < Test::Unit::TestCase
     end
   end
 
+  def test_successful_verify
+    @options.merge!(authentication_only_type: 'ACCOUNTVERIFICATION')
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.verify(@credit_card, @options)
+    end.check_request(skip_response: true) do |_method, endpoint, data, _headers|
+      if /payment/.match?(endpoint)
+        json_data = JSON.parse(data)
+        assert_match(/Auth/, json_data['transactionType'])
+        assert_match(/ACCOUNTVERIFICATION/, json_data['authenticationOnlyType'])
+        assert_equal '0', json_data['amount']
+      end
+    end
+  end
+
   private
 
   def three_ds_assertions(payment_option_card)


### PR DESCRIPTION
Description
-------------------------
[SER-1462](https://spreedly.atlassian.net/browse/SER-1462)

This commit add authenticationOnlyType as GSF for a verify request

Unit test
-------------------------
Finished in 0.009788 seconds.

18 tests, 99 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

1838.99 tests/s, 10114.43 assertions/s

Remote test
-------------------------
Finished in 121.496082 seconds.

28 tests, 87 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

0.23 tests/s, 0.72 assertions/s

Rubocop
-------------------------
801 files inspected, no offenses detected