### PR TITLE
StripePI: Update to retrieve_setup_intent and headers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,7 @@
 * Adyen: Remove cryptogram flag [almalee24] #5300
 * Cecabank: Include Apple Pay and Google Pay for recurring payments [gasn150] #5295
 * DLocal: Add X-Dlocal-Payment-Source to header [almalee24] #5281
+* StripePI: Update to retrieve_setup_intent and headers [almalee24] #5283
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -673,7 +673,7 @@ module ActiveMerchant #:nodoc:
         options[:key] || @api_key
       end
 
-      def headers(options = {})
+      def headers(method = :post, options = {})
         headers = {
           'Authorization' => 'Basic ' + Base64.strict_encode64(key(options).to_s + ':').strip,
           'User-Agent' => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
@@ -681,7 +681,7 @@ module ActiveMerchant #:nodoc:
           'X-Stripe-Client-User-Agent' => stripe_client_user_agent(options),
           'X-Stripe-Client-User-Metadata' => { ip: options[:ip] }.to_json
         }
-        headers['Idempotency-Key'] = options[:idempotency_key] if options[:idempotency_key]
+        headers['Idempotency-Key'] = options[:idempotency_key] if options[:idempotency_key] && method != :get
         headers['Stripe-Account'] = options[:stripe_account] if options[:stripe_account]
         headers
       end
@@ -699,7 +699,7 @@ module ActiveMerchant #:nodoc:
       def api_request(method, endpoint, parameters = nil, options = {})
         raw_response = response = nil
         begin
-          raw_response = ssl_request(method, self.live_url + endpoint, post_data(parameters), headers(options))
+          raw_response = ssl_request(method, self.live_url + endpoint, post_data(parameters), headers(method, options))
           response = parse(raw_response)
         rescue ResponseError => e
           raw_response = e.response.body

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -196,9 +196,7 @@ module ActiveMerchant #:nodoc:
         # eg (latest_attempt -> payment_method_details -> card -> network_transaction_id)
         #
         # Being able to retrieve these fields enables payment flows that rely on MIT exemptions, e.g: off_session
-        commit(:post, "setup_intents/#{setup_intent_id}", {
-          'expand[]': 'latest_attempt'
-        }, options)
+        commit(:get, "setup_intents/#{setup_intent_id}?expand[]=latest_attempt", nil, options)
       end
 
       def authorize(money, payment_method, options = {})

--- a/lib/active_merchant/billing/gateways/webpay.rb
+++ b/lib/active_merchant/billing/gateways/webpay.rb
@@ -84,7 +84,7 @@ module ActiveMerchant #:nodoc:
         }
       end
 
-      def headers(options = {})
+      def headers(method = :post, options = {})
         {
           'Authorization' => 'Basic ' + Base64.encode64(@api_key.to_s + ':').strip,
           'User-Agent' => "Webpay/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",


### PR DESCRIPTION
Update retrieve_setup_intent to be a GET request and update idempotency_key to only be passed in headers if it for a POST request

Stripe PI
Remote:
99 tests, 469 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
67 tests, 350 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Stripe
Remote:
79 tests, 377 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
147 tests, 777 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed