### PR TITLE
Worldpay: Add customStringFields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@
 * Cybersource Rest: Add support for recurring Apple Pay [bdcano] #5270
 * Cybersource Rest: Update message and error_code [almalee24] #5276
 * Paysafe: Add support for `external_initial_transaction_id` [rachelkirk] #5291
+* Worldpay: Add customStringFields [jcreiff] #5284
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -237,6 +237,7 @@ module ActiveMerchant #:nodoc:
               add_order_content(xml, options)
               add_payment_method(xml, money, payment_method, options)
               add_shopper(xml, options)
+              add_fraud_sight_data(xml, options)
               add_statement_narrative(xml, options)
               add_risk_data(xml, options[:risk_data]) if options[:risk_data]
               add_sub_merchant_data(xml, options[:sub_merchant_data]) if options[:sub_merchant_data]
@@ -788,6 +789,20 @@ module ActiveMerchant #:nodoc:
           xml.browser do
             xml.acceptHeader options[:accept_header]
             xml.userAgentHeader options[:user_agent]
+          end
+        end
+      end
+
+      def add_fraud_sight_data(xml, options)
+        return unless options[:custom_string_fields].is_a?(Hash)
+
+        xml.tag! 'FraudSightData' do
+          xml.tag! 'customStringFields' do
+            options[:custom_string_fields].each do |key, value|
+              # transform custom_string_field_1 into customStringField1, etc.
+              formatted_key = key.to_s.camelize(:lower).to_sym
+              xml.tag! formatted_key, value
+            end
           end
         end
       end

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -781,6 +781,20 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_purchase_with_custom_string_fields
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(custom_string_fields: { custom_string_field_1: 'testvalue1', custom_string_field_2: 'testvalue2' }))
+    assert_success response
+    assert_equal true, response.params['ok']
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_failed_purchase_with_blank_custom_string_field
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(custom_string_fields: { custom_string_field_1: '' }))
+    assert_failure response
+
+    assert_equal "The tag 'customStringField1' cannot be empty", response.message
+  end
+
   # Fails currently because the sandbox doesn't actually validate the stored_credential options
   # def test_failed_authorize_with_bad_stored_cred_options
   #   assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(stored_credential_usage: 'FIRST'))

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -502,6 +502,19 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_custom_string_fields
+    options = @options.merge(custom_string_fields: { custom_string_field_1: 'testvalue1', custom_string_field_2: 'testvalue2' })
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<FraudSightData>\n), data
+      assert_match %r(<customStringFields>\n), data
+      assert_match %r(<customStringField1>testvalue1</customStringField1>), data
+      assert_match %r(<customStringField2>testvalue2</customStringField2>), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_successful_purchase_with_sub_merchant_data
     options = @options.merge(@sub_merchant_options)
     response = stub_comms do


### PR DESCRIPTION
These fields are included as part of FraudSightData in auth/purchase requests https://docs.worldpay.com/apis/wpg/fraudsightglobal/fraudsightdirect

CER-1766

LOCAL
6040 tests, 80501 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

801 files inspected, no offenses detected

UNIT
125 tests, 705 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

REMOTE
112 tests, 473 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.3214% passed