### PR TITLE
Enabling of recurring_detail_reference gateway specific field in other transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -69,6 +69,7 @@
 * Cybersource and Cybersource Rest: Add the MCC field [yunnydang] #5301
 * Adyen: Add the manual_capture field [yunnydang] #5310
 * Versapay: First Implementation [gasb150] #5288
+* Worldpay: Enable GSF recurring_detail_reference on other transactions [rubenmarindev] #5285
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -8,6 +8,8 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
     @bank_account = check(account_number: '123456789', routing_number: '121000358')
 
+    @adyen_bank_account = check(account_number: '9876543210', routing_number: '021000021')
+
     @declined_bank_account = check(account_number: '123456789', routing_number: '121000348')
 
     @general_bank_account = check(name: 'A. Klaassen', account_number: '123456789', routing_number: 'NL13TEST0123456789')
@@ -1036,7 +1038,6 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
   def test_successful_unstore
     assert response = @gateway.store(@credit_card, @options)
-
     assert !response.authorization.split('#')[2].nil?
     assert_equal 'Authorised', response.message
 
@@ -1051,7 +1052,7 @@ class RemoteAdyenTest < Test::Unit::TestCase
   end
 
   def test_successful_unstore_with_bank_account
-    assert response = @gateway.store(@bank_account, @options)
+    assert response = @gateway.store(@adyen_bank_account, @options)
 
     assert !response.authorization.split('#')[2].nil?
     assert_equal 'Authorised', response.message
@@ -1588,6 +1589,13 @@ class RemoteAdyenTest < Test::Unit::TestCase
       customer_reference: '101'
     }
     response = @gateway.purchase(@amount, @credit_card, @options.merge(level_2_data: level_2_data))
+    assert_success response
+    assert_equal '[capture-received]', response.message
+  end
+
+  def test_successful_response_with_recurring_detail_reference
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(recurring_detail_reference: '12345'))
+
     assert_success response
     assert_equal '[capture-received]', response.message
   end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -213,6 +213,15 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_successful_authorize_with_recurring_detail_reference
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(recurring_detail_reference: '12345'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'john.smith@test.com', JSON.parse(data)['shopperEmail']
+      assert_equal '12345', JSON.parse(data)['selectedRecurringDetailReference']
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_adds_3ds1_standalone_fields
     eci = '05'
     cavv = '3q2+78r+ur7erb7vyv66vv\/\/\/\/8='
@@ -1378,6 +1387,13 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_purchase_with_network_token
     response = stub_comms do
       @gateway.purchase(@amount, @nt_credit_card, @options)
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_recurring_detail_reference
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(recurring_detail_reference: '12345'))
     end.respond_with(successful_authorize_response, successful_capture_response)
     assert_success response
   end


### PR DESCRIPTION
### Summary:
Enabling of recurring_detail_reference gateway specific field in other transactions like purchase or refund for Adyen Gateway

### Spreedly reference:
[OPPS-9](https://spreedly.atlassian.net/browse/OPPS-9)

### Unit tests:
Finished in 0.118443 seconds.
130 tests, 701 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Remote tests:
Finished in 178.393637 seconds.
148 tests, 498 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.6216% passed

Failure tests not related to changes