### PR TITLE
update active support version for rails master test

### DIFF
--- a/gemfiles/Gemfile.rails_master
+++ b/gemfiles/Gemfile.rails_master
@@ -1,3 +1,3 @@
 eval_gemfile '../Gemfile'
 
-gem 'activesupport', github: 'rails/rails'
+gem 'activesupport', '~>7.2.1'


### PR DESCRIPTION
This is a temporary fix to allow for our gha tests to run while we work on updating the ruby version of AM to >= 3.2.0.

Hopefully that version update will be fairly simple and we can get back to truly testing rails master shortly, but it doesn't make sense to let not run gha tests on pull requests while we work on that. 