### PR TITLE
Paysafe: Add `external_initial_transaction_id`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,7 @@
 * Worldpay: Add support for recurring Apple Pay [kenderbolivart] #5628
 * Cybersource Rest: Add support for recurring Apple Pay [bdcano] #5270
 * Cybersource Rest: Update message and error_code [almalee24] #5276
+* Paysafe: Add support for `external_initial_transaction_id` [rachelkirk] #5291
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -321,6 +321,7 @@ module ActiveMerchant #:nodoc:
         end
 
         post[:storedCredential][:initialTransactionId] = options[:stored_credential][:network_transaction_id] if options[:stored_credential][:network_transaction_id]
+        post[:storedCredential][:externalInitialTransactionId] = options[:external_initial_transaction_id] if options[:external_initial_transaction_id]
       end
 
       def mastercard?(payment)


### PR DESCRIPTION
This allows a network transaction id obtained from a third party transaction to be passed in and maintain MIT transactions without interruptions.

Remote Tests:
35 tests, 86 assertions, 9 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 74.2857% passed
*I fixed one remote test that was failing due to changed error message, but the rest are failing on master as well

Unit Tests:
20 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed