### PR TITLE
CecabankRest: Add AP/GP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,7 @@
 * DLocal: Add the description field for refund [yunnydang] #5296
 * Worldpay: Add support for Worldpay decrypted apple pay and google pay [dustinhaefele] #5271
 * Orbital: Update alternate_ucaf_flow [almalee24] #5282
+* Cecabank: Include Apple Pay and Google Pay for recurring payments [gasn150] #5295
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/cecabank/cecabank_json.rb
+++ b/lib/active_merchant/billing/gateways/cecabank/cecabank_json.rb
@@ -29,6 +29,11 @@ module ActiveMerchant
         transaction_risk_analysis_exemption: :TRA
       }.freeze
 
+      WALLET_PAYMENT_METHODS = {
+        apple_pay: 'A',
+        google_pay: 'G'
+      }
+
       self.test_url = 'https://tpv.ceca.es/tpvweb/rest/procesos/'
       self.live_url = 'https://pgw.ceca.es/tpvweb/rest/procesos/'
 
@@ -113,7 +118,7 @@ module ActiveMerchant
         post = { parametros: { accion: CECA_ACTIONS_DICTIONARY[action] } }
 
         add_invoice(post, money, options)
-        add_creditcard(post, creditcard)
+        add_payment_method(post, creditcard, options)
         add_stored_credentials(post, creditcard, options)
         add_three_d_secure(post, options)
 
@@ -159,20 +164,28 @@ module ActiveMerchant
         post[:parametros][:exponente] = 2.to_s
       end
 
-      def add_creditcard(post, creditcard)
+      def add_payment_method(post, payment_method, options)
         params = post[:parametros] ||= {}
+        three_d_secure = options.fetch(:three_d_secure, {})
 
-        payment_method = {
-          pan: creditcard.number,
-          caducidad: strftime_yyyymm(creditcard)
+        pm = {
+          pan: payment_method.number,
+          caducidad: strftime_yyyymm(payment_method)
         }
-        if CreditCard.brand?(creditcard.number) == 'american_express'
-          payment_method[:csc] = creditcard.verification_value
-        else
-          payment_method[:cvv2] = creditcard.verification_value
-        end
 
-        @options[:encryption_key] ? params[:encryptedData] = payment_method : params.merge!(payment_method)
+        if payment_method.is_a?(NetworkTokenizationCreditCard) && WALLET_PAYMENT_METHODS[payment_method.source.to_sym]
+          pm[:wallet] = {
+
+            # the authentication value should come nil (for recurring cases) or should I remove it?
+            authentication_value: (payment_method.payment_cryptogram unless options.dig(:stored_credential, :network_transaction_id)),
+            xid:  three_d_secure[:xid] || three_d_secure[:ds_transaction_id] || options[:xid],
+            walletType: WALLET_PAYMENT_METHODS[payment_method.source.to_sym],
+            eci: payment_method.eci || (three_d_secure[:eci] if three_d_secure) || '07'
+          }.compact.to_json
+        else
+          pm[CreditCard.brand?(payment_method.number) == 'american_express' ? :csc : :cvv2] = payment_method.verification_value
+        end
+        @options[:encryption_key] ? params[:encryptedData] = pm : params.merge!(pm)
       end
 
       def add_stored_credentials(post, creditcard, options)
@@ -233,7 +246,6 @@ module ActiveMerchant
 
         add_encryption(post)
         add_merchant_data(post)
-
         params_encoded = encode_post_parameters(post)
         add_signature(post, params_encoded, options)
 

--- a/test/remote/gateways/remote_cecabank_rest_json_test.rb
+++ b/test/remote/gateways/remote_cecabank_rest_json_test.rb
@@ -10,7 +10,8 @@ class RemoteCecabankTest < Test::Unit::TestCase
 
     @options = {
       order_id: generate_unique_id,
-      three_d_secure: three_d_secure
+      three_d_secure: three_d_secure,
+      exemption_type: 'transaction_risk_analysis_exemption'
     }
 
     @cit_options = @options.merge({
@@ -21,6 +22,26 @@ class RemoteCecabankTest < Test::Unit::TestCase
         initiator: 'cardholder'
       }
     })
+
+    @apple_pay_network_token = network_tokenization_credit_card(
+      '4507670001000009',
+      eci: '05',
+      payment_cryptogram: 'xgQAAAAAAAAAAAAAAAAAAAAAAAAA',
+      month: '12',
+      year: Time.now.year,
+      source: :apple_pay,
+      verification_value: '989'
+    )
+
+    @google_pay_network_token = network_tokenization_credit_card(
+      '4507670001000009',
+      eci: '05',
+      payment_cryptogram: 'AgAAAAAAAIR8CQrXcIhbQAAAAAA',
+      month: '10',
+      year: Time.now.year + 1,
+      source: :google_pay,
+      verification_value: nil
+    )
   end
 
   def test_successful_authorize
@@ -55,6 +76,24 @@ class RemoteCecabankTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, order_id: generate_unique_id)
     assert_success response
     assert_equal %i[codAut numAut referencia], JSON.parse(response.message).symbolize_keys.keys.sort
+  end
+
+  def test_successful_purchase_with_apple_pay
+    assert response = @gateway.purchase(@amount, @apple_pay_network_token, { order_id: generate_unique_id })
+    assert_success response
+    assert_equal %i[codAut numAut referencia], JSON.parse(response.message).symbolize_keys.keys.sort
+  end
+
+  def test_successful_purchase_with_google_pay
+    assert response = @gateway.purchase(@amount, @apple_pay_network_token, { order_id: generate_unique_id })
+    assert_success response
+    assert_equal %i[codAut numAut referencia], JSON.parse(response.message).symbolize_keys.keys.sort
+  end
+
+  def test_failed_purchase_with_apple_pay_sending_three_ds_data
+    assert response = @gateway.purchase(@amount, @apple_pay_network_token, @options)
+    assert_failure response
+    assert_equal response.error_code, '1061'
   end
 
   def test_unsuccessful_purchase
@@ -111,7 +150,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
 
   def test_purchase_stored_credential_with_network_transaction_id
     @cit_options.merge!({ network_transaction_id: '999999999999999' })
-    assert purchase = @gateway.purchase(@amount, @credit_card, @cit_options)
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_success purchase
   end
 
@@ -124,6 +163,21 @@ class RemoteCecabankTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_purchase_with_apple_pay_using_stored_credential_recurring_mit
+    @cit_options[:stored_credential][:reason_type] = 'installment'
+    assert purchase = @gateway.purchase(@amount, @apple_pay_network_token, @cit_options.except(:three_d_secure))
+    assert_success purchase
+
+    options = @cit_options.except(:three_d_secure, :extra_options_for_three_d_secure)
+    options[:stored_credential][:reason_type] = 'recurring'
+    options[:stored_credential][:initiator] = 'merchant'
+    options[:stored_credential][:network_transaction_id] = purchase.network_transaction_id
+    options[:order_id] = generate_unique_id
+
+    assert purchase2 = @gateway.purchase(@amount, @apple_pay_network_token, options)
+    assert_success purchase2
+  end
+
   def test_purchase_using_stored_credential_recurring_mit
     @cit_options[:stored_credential][:reason_type] = 'installment'
     assert purchase = @gateway.purchase(@amount, @credit_card, @cit_options)
@@ -133,6 +187,7 @@ class RemoteCecabankTest < Test::Unit::TestCase
     options[:stored_credential][:reason_type] = 'recurring'
     options[:stored_credential][:initiator] = 'merchant'
     options[:stored_credential][:network_transaction_id] = purchase.network_transaction_id
+    options[:order_id] = generate_unique_id
 
     assert purchase2 = @gateway.purchase(@amount, @credit_card, options)
     assert_success purchase2
@@ -170,12 +225,14 @@ class RemoteCecabankTest < Test::Unit::TestCase
   def three_d_secure
     {
       version: '2.2.0',
-      eci: '02',
-      cavv: '4F80DF50ADB0F9502B91618E9B704790EABA35FDFC972DDDD0BF498C6A75E492',
+      eci: '07',
       ds_transaction_id: 'a2bf089f-cefc-4d2c-850f-9153827fe070',
       acs_transaction_id: '18c353b0-76e3-4a4c-8033-f14fe9ce39dc',
-      authentication_response_status: 'Y',
-      three_ds_server_trans_id: '9bd9aa9c-3beb-4012-8e52-214cccb25ec5'
+      authentication_response_status: 'I',
+      three_ds_server_trans_id: '9bd9aa9c-3beb-4012-8e52-214cccb25ec5',
+      enrolled: 'true',
+      cavv: 'AJkCC1111111111122222222AAAA',
+      xid: '22222'
     }
   end
 end


### PR DESCRIPTION
Summary
----------------
This commit implement Apple Pay and Google Pay payment methods the unit and remote tests, and fix few faling tests in current implementation.

[SER-1431](https://spreedly.atlassian.net/browse/SER-1431)

Unit Tests:
----------------
Finished in 0.031554 seconds.
20 tests, 106 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests:
----------------
Finished in 20.386373 seconds.
20 tests, 69 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95% passed

Rubocop
----------------
801 files inspected, no offenses detected