### PR TITLE
DLocal: add the description field for refund

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@
 * Paysafe: Add support for `external_initial_transaction_id` [rachelkirk] #5291
 * Worldpay: Add customStringFields [jcreiff] #5284
 * Airwallex: truncate descriptor field to 32 characters [jcreiff] #5292
+* DLocal: Add the description field for refund [yunnydang] #5296
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -42,6 +42,7 @@ module ActiveMerchant #:nodoc:
 
       def refund(money, authorization, options = {})
         post = {}
+        add_description(post, options)
         post[:payment_id] = authorization
         post[:notification_url] = options[:notification_url]
         add_invoice(post, money, options) if money
@@ -90,14 +91,18 @@ module ActiveMerchant #:nodoc:
         add_payer(post, card, options)
         add_card(post, card, action, options)
         add_additional_data(post, options)
+        add_description(post, options)
         post[:order_id] = options[:order_id] || generate_unique_id
         post[:original_order_id] = options[:original_order_id] if options[:original_order_id]
-        post[:description] = options[:description] if options[:description]
       end
 
       def add_invoice(post, money, options)
         post[:amount] = amount(money)
         post[:currency] = (options[:currency] || currency(money))
+      end
+
+      def add_description(post, options)
+        post[:description] = options[:description] if options[:description]
       end
 
       def add_additional_data(post, options)

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -297,6 +297,16 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_match 'Amount exceeded', response.message
   end
 
+  def test_successful_refund_with_description
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @options.merge(notification_url: 'http://example.com', description: 'test'))
+    assert_success refund
+    assert_match 'The refund was paid', refund.message
+    assert_match 'test', refund.params['description']
+  end
+
   def test_successful_void
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -320,6 +320,14 @@ class DLocalTest < Test::Unit::TestCase
     assert_equal '5007', response.error_code
   end
 
+  def test_successful_refund_with_description
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.refund(@amount, @credit_card, @options.merge(description: 'test'))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"description\":\"test\"/, data)
+    end.respond_with(successful_refund_response)
+  end
+
   def test_successful_void
     @gateway.expects(:ssl_post).returns(successful_void_response)
 


### PR DESCRIPTION
Opens up the description field to be also be available on refund as it was only used for auth and purchase

Local:
6046 tests, 80532 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
47 tests, 205 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
41 tests, 115 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed