### PR TITLE
CyberSource, CyberSource Rest: Add the MCC field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,7 @@
 * Nuvei: Add ACH support [javierpedrozaing] #5269
 * Nuvei: Add GSF for verify method [javierpedrozaing] #5278
 * Nuvei: Add Google and Apple pay [javierpedrozaing] #5289
+* Cybersource and Cybersource Rest: Add the MCC field [yunnydang] #5301
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -370,6 +370,7 @@ module ActiveMerchant #:nodoc:
         add_threeds_services(xml, options)
         add_business_rules_data(xml, creditcard_or_reference, options)
         add_airline_data(xml, options)
+        add_merchant_category_code(xml, options)
         add_sales_slip_number(xml, options)
         add_payment_network_token(xml, creditcard_or_reference, options)
         add_payment_solution(xml, creditcard_or_reference)
@@ -413,6 +414,7 @@ module ActiveMerchant #:nodoc:
         add_mdd_fields(xml, options)
         add_capture_service(xml, request_id, request_token, options)
         add_business_rules_data(xml, authorization, options)
+        add_merchant_category_code(xml, options)
         add_tax_management_indicator(xml, options)
         add_issuer_additional_data(xml, options)
         add_merchant_description(xml, options)
@@ -433,6 +435,7 @@ module ActiveMerchant #:nodoc:
         if (!payment_method_or_reference.is_a?(String) && card_brand(payment_method_or_reference) == 'check') || reference_is_a_check?(payment_method_or_reference)
           add_check_service(xml)
           add_airline_data(xml, options)
+          add_merchant_category_code(xml, options)
           add_sales_slip_number(xml, options)
           add_tax_management_indicator(xml, options)
           add_issuer_additional_data(xml, options)
@@ -443,6 +446,7 @@ module ActiveMerchant #:nodoc:
           add_threeds_services(xml, options)
           add_business_rules_data(xml, payment_method_or_reference, options)
           add_airline_data(xml, options)
+          add_merchant_category_code(xml, options)
           add_sales_slip_number(xml, options)
           add_payment_network_token(xml, payment_method_or_reference, options)
           add_payment_solution(xml, payment_method_or_reference)
@@ -477,6 +481,7 @@ module ActiveMerchant #:nodoc:
           add_mdd_fields(xml, options)
           add_auth_reversal_service(xml, request_id, request_token)
         end
+        add_merchant_category_code(xml, options)
         add_issuer_additional_data(xml, options)
         add_partner_solution_id(xml)
 
@@ -492,6 +497,7 @@ module ActiveMerchant #:nodoc:
         add_credit_service(xml, request_id: request_id,
                                 request_token: request_token,
                                 use_check_service: reference_is_a_check?(identification))
+        add_merchant_category_code(xml, options)
         add_partner_solution_id(xml)
 
         xml.target!
@@ -1033,6 +1039,10 @@ module ActiveMerchant #:nodoc:
 
       def add_subscription_retrieve_service(xml, options)
         xml.tag! 'paySubscriptionRetrieveService', { 'run' => 'true' }
+      end
+
+      def add_merchant_category_code(xml, options)
+        xml.tag! 'merchantCategoryCode', options[:merchant_category_code] if options[:merchant_category_code]
       end
 
       def add_subscription(xml, options, reference = nil)

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -242,6 +242,17 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     assert response.params['_links']['void'].present?
   end
 
+  def test_successful_refund_with_merchant_category_code
+    purchase = @gateway.purchase(@amount, @visa_card, @options)
+    response = @gateway.refund(@amount, purchase.authorization, @options.merge(merchant_category_code: '1111'))
+
+    assert_success response
+    assert response.test?
+    assert_equal 'PENDING', response.message
+    assert response.params['id'].present?
+    assert response.params['_links']['void'].present?
+  end
+
   def test_failure_refund
     purchase = @gateway.purchase(@amount, @card_without_funds, @options)
     response = @gateway.refund(@amount, purchase.authorization, @options)
@@ -293,6 +304,16 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     assert_nil response.params['_links']['capture']
   end
 
+  def test_successful_credit_with_merchant_category_code
+    response = @gateway.credit(@amount, @visa_card, @options.merge(merchant_category_code: '1111'))
+
+    assert_success response
+    assert response.test?
+    assert_equal 'PENDING', response.message
+    assert response.params['id'].present?
+    assert_nil response.params['_links']['capture']
+  end
+
   def test_failure_credit
     response = @gateway.credit(@amount, @card_without_funds, @options)
 
@@ -305,6 +326,15 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
   def test_successful_void
     authorize = @gateway.authorize(@amount, @visa_card, @options)
     response = @gateway.void(authorize.authorization, @options)
+    assert_success response
+    assert response.params['id'].present?
+    assert_equal 'REVERSED', response.message
+    assert_nil response.params['_links']['capture']
+  end
+
+  def test_successful_void_with_merchant_category_code
+    authorize = @gateway.authorize(@amount, @visa_card, @options)
+    response = @gateway.void(authorize.authorization, @options.merge(merchant_category_code: '1111'))
     assert_success response
     assert response.params['id'].present?
     assert_equal 'REVERSED', response.message
@@ -593,6 +623,14 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_level_2_data
     response = @gateway.purchase(@amount, @visa_card, @options.merge({ purchase_order_number: '13829012412' }))
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_nil response.params['_links']['capture']
+  end
+
+  def test_successful_purchase_with_merchant_catefory_code
+    response = @gateway.purchase(@amount, @visa_card, @options.merge(merchant_category_code: '1111'))
     assert_success response
     assert response.test?
     assert_equal 'AUTHORIZED', response.message

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -171,6 +171,13 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
+  def test_successful_authorization_with_merchant_catefory_code
+    options = @options.merge(merchant_category_code: '1111')
+    assert response = @gateway.authorize(@amount, @credit_card, options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  end
+
   def test_successful_authorization_with_reconciliation_id
     options = @options.merge(reconciliation_id: '1936831')
     assert response = @gateway.authorize(@amount, @credit_card, options)
@@ -316,6 +323,13 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
+  def test_successful_purchase_with_merchant_catefory_code
+    options = @options.merge(merchant_category_code: '1111')
+    assert response = @gateway.purchase(@amount, @credit_card, options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  end
+
   def test_successful_auth_with_gratuity_amount
     options = @options.merge(gratuity_amount: '7.50')
 
@@ -368,6 +382,15 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_successful_response(purchase)
     assert void = @gateway.void(purchase.authorization, @options)
+    assert_successful_response(void)
+  end
+
+  def test_purchase_and_void_with_merchant_category_code
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(purchase)
+
+    void_options = @options.merge(merchant_category_code: '1111')
+    assert void = @gateway.void(purchase.authorization, void_options)
     assert_successful_response(void)
   end
 
@@ -694,6 +717,16 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
+  def test_successful_capture_with_merchant_category_code
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+
+    capture_options = @options.merge(merchant_category_code: '1111')
+    assert response = @gateway.capture(@amount, auth.authorization, capture_options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+  end
+
   def test_successful_capture_with_solution_id
     ActiveMerchant::Billing::CyberSourceGateway.application_id = 'A1000000'
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
@@ -750,6 +783,15 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(refund)
   ensure
     ActiveMerchant::Billing::CyberSourceGateway.application_id = nil
+  end
+
+  def test_successful_refund_with_merchant_category_code
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_successful_response(response)
+
+    refund_options = @options.merge(merchant_category_code: '1111')
+    assert response = @gateway.refund(@amount, response.authorization, refund_options)
+    assert_successful_response(response)
   end
 
   def test_successful_refund_with_bank_account_follow_on

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -463,6 +463,15 @@ class CyberSourceRestTest < Test::Unit::TestCase
     end.respond_with(successful_credit_response)
   end
 
+  def test_successful_credit_with_merchant_category_code
+    stub_comms do
+      @gateway.credit(@amount, @credit_card, @options.merge(merchant_category_code: '1111'))
+    end.check_request do |_endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      assert_equal json_data['merchantInformation']['categoryCode'], '1111'
+    end.respond_with(successful_credit_response)
+  end
+
   def test_authorize_includes_reconciliation_id
     stub_comms do
       @gateway.authorize(100, @credit_card, order_id: '1', reconciliation_id: '181537')
@@ -487,6 +496,15 @@ class CyberSourceRestTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       json_data = JSON.parse(data)
       assert_equal json_data['orderInformation']['invoiceDetails']['invoiceNumber'], '1234567'
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_successful_purchase_with_merchant_category_code
+    stub_comms do
+      @gateway.purchase(100, @credit_card, @options.merge(merchant_category_code: '1111'))
+    end.check_request do |_endpoint, data, _headers|
+      json_data = JSON.parse(data)
+      assert_equal json_data['merchantInformation']['categoryCode'], '1111'
     end.respond_with(successful_purchase_response)
   end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -105,6 +105,14 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_merchant_category_code
+    stub_comms do
+      @gateway.purchase(100, @credit_card, @options.merge!(merchant_category_code: '1111'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<merchantCategoryCode>1111<\/merchantCategoryCode>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_purchase_with_purchase_totals_data
     stub_comms do
       @gateway.purchase(100, @credit_card, @options.merge(discount_management_indicator: 'T', purchase_tax_amount: 7.89, original_amount: 1.23, invoice_amount: 1.23))
@@ -119,6 +127,14 @@ class CyberSourceTest < Test::Unit::TestCase
       @gateway.authorize(100, @credit_card, @options.merge(national_tax_indicator: national_tax_indicator))
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<otherTax>\s+<nationalTaxIndicator>#{national_tax_indicator}<\/nationalTaxIndicator>\s+<\/otherTax>/m, data)
+    end.respond_with(successful_authorization_response)
+  end
+
+  def test_successful_authorize_with_merchant_category_code
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(merchant_category_code: '1111'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<merchantCategoryCode>1111<\/merchantCategoryCode>/, data)
     end.respond_with(successful_authorization_response)
   end
 
@@ -739,6 +755,14 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
   end
 
+  def test_successful_capture_with_merchant_category_code
+    stub_comms do
+      @gateway.capture(100, '1846925324700976124593', @options.merge!(merchant_category_code: '1111'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<merchantCategoryCode>1111<\/merchantCategoryCode>/, data)
+    end.respond_with(successful_capture_response)
+  end
+
   def test_successful_credit_card_purchase_request
     @gateway.stubs(:ssl_post).returns(successful_capture_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -844,6 +868,14 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_success(response = @gateway.purchase(@amount, @elo_credit_card, @options))
 
     assert_success(@gateway.refund(@amount, response.authorization))
+  end
+
+  def test_successful_refund_with_merchant_category_code
+    stub_comms do
+      @gateway.refund(100, 'test;12345', @options.merge!(merchant_category_code: '1111'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<merchantCategoryCode>1111<\/merchantCategoryCode>/, data)
+    end.respond_with(successful_refund_response)
   end
 
   def test_successful_credit_to_card_request


### PR DESCRIPTION
Local:
6053 tests, 80556 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

CyberSource:
Unit:
165 tests, 968 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
142 tests, 716 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.0704% passed

CyberSource Rest:
Unit:
44 tests, 235 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
58 tests, 197 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed