### PR TITLE
Adyen: Update skip_mpi_data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -69,7 +69,8 @@
 * Cybersource and Cybersource Rest: Add the MCC field [yunnydang] #5301
 * Adyen: Add the manual_capture field [yunnydang] #5310
 * Versapay: First Implementation [gasb150] #5288
-* Worldpay: Enable GSF recurring_detail_reference on other transactions [rubenmarindev] #5285
+* Adyen: Enable GSF recurring_detail_reference on other transactions [rubenmarindev] #5285
+* Adyen: Update skip_mpi_data [almalee24] #5306
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1475,7 +1475,6 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
     used_options = options.merge(
       order_id: generate_unique_id,
-      skip_mpi_data: 'Y',
       shopper_interaction: 'ContAuth',
       recurring_processing_model: 'Subscription',
       network_transaction_id: auth.network_transaction_id

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -805,6 +805,25 @@ class AdyenTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_passing_shopper_interaction_moto
+    options = {
+      stored_credential: {
+        initiator: 'merchant',
+        recurring_type: 'unscheduled',
+        initial_transaction: true
+      },
+      shopper_interaction: 'Moto',
+      recurring_processing_model: nil,
+      order_id: '345123'
+    }
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/"shopperInteraction":"Moto"/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   def test_nonfractional_currency_handling
     stub_comms do
       @gateway.authorize(200, @credit_card, @options.merge(currency: 'JPY'))
@@ -1343,7 +1362,7 @@ class AdyenTest < Test::Unit::TestCase
       @gateway.authorize(@amount, @nt_credit_card, @options.merge(stored_credential: stored_credential))
     end.check_request do |_endpoint, data, _headers|
       parsed = JSON.parse(data)
-      assert_equal 'Ecommerce', parsed['shopperInteraction']
+      assert_equal 'ContAuth', parsed['shopperInteraction']
       assert_nil parsed['mpiData']
     end.respond_with(successful_authorize_response)
     assert_success response


### PR DESCRIPTION
Update skip_mpi_data to not pass MPI data if it's
a NetworkTokenizationCreditCard and stored_credential_initiator of merchant. It will also be skipped if shopper_interation is ContAuth and recurring_processing_model is Subscription.

Remote
147 tests, 470 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 91.8367% passed