### PR TITLE
Airwallex: Support metadata for payment_intents

### DIFF
--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -168,12 +168,17 @@ module ActiveMerchant #:nodoc:
         post[:merchant_order_id] = merchant_order_id(options)
         add_referrer_data(post)
         add_descriptor(post, options)
+        add_metadata(post, options)
         post['payment_method_options'] = { 'card' => { 'risk_control' => { 'three_ds_action' => 'SKIP_3DS' } } } if options[:skip_3ds]
 
         response = commit(:setup, post)
         raise ArgumentError.new(response.message) unless response.success?
 
         response.params['id']
+      end
+
+      def add_metadata(post, options)
+        post[:metadata] = options[:metadata] if options[:metadata]
       end
 
       def add_billing(post, card, options = {})

--- a/test/unit/gateways/airwallex_test.rb
+++ b/test/unit/gateways/airwallex_test.rb
@@ -308,6 +308,15 @@ class AirwallexTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_purchase_passes_metadata
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(metadata: { some: 'value' }))
+    end.check_request do |_endpoint, data, _headers|
+      # only look for referrer data on the create_payment_intent request
+      assert_match(/\"metadata\":{\"some\":\"value\"}/, data) if data.include?('_setup')
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_purchase_passes_descriptor
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(description: 'a simple test'))


### PR DESCRIPTION
## Description

Allow the addition of metadata when creating a payment_intent using gateway options.

(See `metadata` property for creating a payment_intent at: https://www.airwallex.com/docs/api#/Payment_Acceptance/Payment_Intents/_api_v1_pa_payment_intents_create/post)

Local
6052 tests, 80574 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed