### PR TITLE
Adyen: add the manual_capture field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,7 @@
 * Nuvei: Add GSF for verify method [javierpedrozaing] #5278
 * Nuvei: Add Google and Apple pay [javierpedrozaing] #5289
 * Cybersource and Cybersource Rest: Add the MCC field [yunnydang] #5301
+* Adyen: Add the manual_capture field [yunnydang] #5310
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -278,6 +278,7 @@ module ActiveMerchant #:nodoc:
         post[:additionalData][:industryUsage] = options[:industry_usage] if options[:industry_usage]
         post[:additionalData][:RequestedTestAcquirerResponseCode] = options[:requested_test_acquirer_response_code] if options[:requested_test_acquirer_response_code] && test?
         post[:additionalData][:updateShopperStatement] = options[:update_shopper_statement] if options[:update_shopper_statement]
+        post[:additionalData][:manualCapture] = options[:manual_capture] if options[:manual_capture]
       end
 
       def extract_and_transform(mapper, from)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -567,6 +567,12 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal '[capture-received]', response.message
   end
 
+  def test_succesful_authorize_with_manual_capture
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(manual_capture: 'true'))
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
   def test_succesful_purchase_with_brand_override
     response = @gateway.purchase(@amount, @improperly_branded_maestro, @options.merge({ overwrite_brand: true, selected_brand: 'maestro' }))
     assert_success response

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -648,6 +648,14 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_manual_capture_sent
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(manual_capture: 'true'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'true', JSON.parse(data)['additionalData']['manualCapture']
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_risk_data_complex_data
     stub_comms do
       risk_data = {


### PR DESCRIPTION
This adds the optional manual_capture field for auth and capture

Local:
6063 tests, 80613 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
129 tests, 697 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
147 tests, 470 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.8367% passed