### PR TITLE
Nuvei: Add card holder name verification params

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@
 * Ebanx: Add network token support [Buitragox] #5263
 * DLocal: Add the optional country field override [yunnydang] #5326
 * Nuvei: Adding account founding transaction  [javierpedrozaing] #5307
+* Nuvei: Add card holder name verification params [javierpedrozaing] #5312
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_nuvei_test.rb
+++ b/test/remote/gateways/remote_nuvei_test.rb
@@ -373,4 +373,10 @@ class RemoteNuveiTest < Test::Unit::TestCase
     assert_success refund_response
     assert_equal 'APPROVED', refund_response.message
   end
+
+  def test_successful_authorize_with_cardholder_name_verification
+    response = @gateway.authorize(0, @credit_card, @options.merge({ perform_name_verification: true }))
+    assert_success response
+    assert_match 'APPROVED', response.message
+  end
 end


### PR DESCRIPTION
Description
-------------------------
[SER-1456](https://spreedly.atlassian.net/browse/SER-1456)

This commit add Cardholder name verification for request with transation type "Auth"

Unit test
-------------------------
Finished in 0.082292 seconds.

23 tests, 123 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

279.49 tests/s, 1494.68 assertions/s

Remote test
-------------------------
Finished in 131.369427 seconds.

33 tests, 101 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

0.25 tests/s, 0.77 assertions/s

Rubocop
-------------------------
801 files inspected, no offenses detected