### PR TITLE
StripePI: Update version to 2022-11-15

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -101,7 +101,8 @@
 * Decidir and DecicirPlus: Add the wallet_id field [yunnydang] #5354
 * Worldpay: Update where to pass shopperIPAddress [almalee24] #5348
 * Braintree: Account for BraintreeError [almalee24] #5346
-* Worldpay: Fix stored credentials unscheduled reason type [Buitragox] #5352 
+* Worldpay: Fix stored credentials unscheduled reason type [Buitragox] #5352
+* StripePI: Update version to 2022-11-15 [almalee24] #5314
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -403,7 +403,7 @@ module ActiveMerchant # :nodoc:
         post[:level3] = level_three unless level_three.empty?
       end
 
-      def add_expand_parameters(post, options)
+      def add_expand_parameters(method, url, post, options)
         post[:expand] ||= []
         post[:expand].concat(Array.wrap(options[:expand]).map(&:to_sym)).uniq!
       end
@@ -681,7 +681,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def commit(method, url, parameters = nil, options = {})
-        add_expand_parameters(parameters, options) if parameters
+        add_expand_parameters(method, url, parameters, options) if parameters
         return Response.new(false, 'Invalid API Key provided') unless key_valid?(options)
 
         response = api_request(method, url, parameters, options)
@@ -786,10 +786,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def card_from_response(response)
-        # StripePI puts the AVS and CVC check significantly deeper into the response object
-        response['card'] || response['active_card'] || response['source'] ||
-          response.dig('charges', 'data', 0, 'payment_method_details', 'card', 'checks') ||
-          response.dig('latest_attempt', 'payment_method_details', 'card', 'checks') || {}
+        response['card'] || response['active_card'] || response['source'] || {}
       end
 
       def emv_authorization_from_response(response)

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-
+require 'pry'
 class StripePaymentIntentsTest < Test::Unit::TestCase
   include CommStub
 
@@ -89,7 +89,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert capture = @gateway.capture(@amount, create.params['id'], options)
     assert_success capture
     assert_equal 'succeeded', capture.params['status']
-    assert_equal 'Payment complete.', capture.params.dig('charges', 'data')[0].dig('outcome', 'seller_message')
+    assert_equal 'Payment complete.', capture.params.dig('latest_charge', 'outcome', 'seller_message')
   end
 
   def test_successful_create_and_capture_intent_with_network_token
@@ -102,7 +102,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert capture = @gateway.capture(@amount, create.params['id'], options)
     assert_success capture
     assert_equal 'succeeded', capture.params['status']
-    assert_equal 'Payment complete.', capture.params.dig('charges', 'data')[0].dig('outcome', 'seller_message')
+    assert_equal 'Payment complete.', capture.params.dig('latest_charge', 'outcome', 'seller_message')
   end
 
   def test_successful_create_and_update_intent
@@ -129,7 +129,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert create = @gateway.create_intent(@amount, @visa_token, @options.merge(capture_method: 'manual', confirm: true))
 
     assert cancel = @gateway.void(create.params['id'])
-    assert_equal @amount, cancel.params.dig('charges', 'data')[0].dig('amount_refunded')
+    assert_equal @amount, cancel.params.dig('latest_charge', 'amount_refunded')
     assert_equal 'canceled', cancel.params['status']
   end
 
@@ -232,7 +232,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
     assert create = @gateway.create_intent(@amount, 'pm_card_chargeDeclined', @options.merge(confirm: true))
     assert_equal 'requires_payment_method', create.params.dig('error', 'payment_intent', 'status')
-    assert_equal false, create.params.dig('error', 'payment_intent', 'charges', 'data')[0].dig('captured')
+    assert_equal false, create.params.dig('error', 'payment_intent', 'latest_charge', 'captured')
     assert_equal 'pi_1F2MB5AWOtgoysogCMt8BaxR', create.authorization
   end
 
@@ -558,7 +558,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @visa_token)
     end.check_request do |_method, _endpoint, data, _headers|
-      assert_match('expand[0]=charges.data.balance_transaction', data)
+      assert_match('expand[1]=latest_charge.balance_transaction', data)
     end.respond_with(successful_create_intent_response)
   end
 
@@ -1086,11 +1086,8 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       "canceled_at": null,
       "cancellation_reason": null,
       "capture_method": "automatic",
-      "charges": {
+      "latest_charge": {
         "object": "list",
-        "data": [
-
-        ],
         "has_more": false,
         "total_count": 0,
         "url": "/v1/charges?payment_intent=pi_3Jr0wXAWOtgoysog2Sp0iKjo"
@@ -1139,7 +1136,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
   def successful_create_intent_response
     <<-RESPONSE
-      {"id":"pi_1F1xauAWOtgoysogIfHO8jGi","object":"payment_intent","amount":2020,"amount_capturable":2020,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"manual","charges":{"object":"list","data":[{"id":"ch_1F1xavAWOtgoysogxrtSiCu4","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564501833,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":58,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F1xauAWOtgoysogIfHO8jGi","payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1xavAWOtgoysogxrtSiCu4/rcpt_FX1eGdFRi8ssOY8Fqk4X6nEjNeGV5PG","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F1xavAWOtgoysogxrtSiCu4/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F1xauAWOtgoysogIfHO8jGi"},"client_secret":"pi_1F1xauAWOtgoysogIfHO8jGi_secret_ZrXvfydFv0BelaMQJgHxjts5b","confirmation_method":"manual","created":1564501832,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_capture","transfer_data":null,"transfer_group":null}
+      {"id":"pi_1F1xauAWOtgoysogIfHO8jGi","object":"payment_intent","amount":2020,"amount_capturable":2020,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"manual","latest_charge":{"object":"list","id":"ch_1F1xavAWOtgoysogxrtSiCu4","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564501833,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":58,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F1xauAWOtgoysogIfHO8jGi","payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1xavAWOtgoysogxrtSiCu4/rcpt_FX1eGdFRi8ssOY8Fqk4X6nEjNeGV5PG","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F1xavAWOtgoysogxrtSiCu4/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null,"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F1xauAWOtgoysogIfHO8jGi"},"client_secret":"pi_1F1xauAWOtgoysogIfHO8jGi_secret_ZrXvfydFv0BelaMQJgHxjts5b","confirmation_method":"manual","created":1564501832,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_capture","transfer_data":null,"transfer_group":null}
     RESPONSE
   end
 
@@ -1161,118 +1158,114 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "canceled_at": null,
         "cancellation_reason": null,
         "capture_method": "automatic",
-        "charges": {
+        "latest_charge": {
           "object": "list",
-          "data": [
-            {
-              "id": "ch_3NfRruAWOtgoysog1ptwVNHx",
-              "object": "charge",
-              "amount": 2000,
-              "amount_captured": 2000,
-              "amount_refunded": 0,
-              "application": null,
-              "application_fee": null,
-              "application_fee_amount": null,
-              "balance_transaction": "txn_3NfRruAWOtgoysog1mtFHzZr",
-              "billing_details": {
-                "address": {
-                  "city": null,
-                  "country": null,
-                  "line1": null,
-                  "line2": null,
-                  "postal_code": null,
-                  "state": null
-                },
-                "email": null,
-                "name": "Longbob Longsen",
-                "phone": null
+          "id": "ch_3NfRruAWOtgoysog1ptwVNHx",
+          "object": "charge",
+          "amount": 2000,
+          "amount_captured": 2000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3NfRruAWOtgoysog1mtFHzZr",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1692123686,
+          "currency": "usd",
+          "customer": null,
+          "description": null,
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 34,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3NfRruAWOtgoysog1FxgDwtf",
+          "payment_method": "pm_1NfRruAWOtgoysogjdx336vt",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
               },
-              "calculated_statement_descriptor": "SPREEDLY",
-              "captured": true,
-              "created": 1692123686,
-              "currency": "usd",
-              "customer": null,
-              "description": null,
-              "destination": null,
-              "dispute": null,
-              "disputed": false,
-              "failure_balance_transaction": null,
-              "failure_code": null,
-              "failure_message": null,
-              "fraud_details": {
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2030,
+              "fingerprint": null,
+              "funding": "debit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_token": {
+                "exp_month": 9,
+                "exp_year": 2030,
+                "fingerprint": "OdTRtGskBulROtqa",
+                "last4": "5556",
+                "used": false
               },
-              "invoice": null,
-              "livemode": false,
-              "metadata": {
-              },
-              "on_behalf_of": null,
-              "order": null,
-              "outcome": {
-                "network_status": "approved_by_network",
-                "reason": null,
-                "risk_level": "normal",
-                "risk_score": 34,
-                "seller_message": "Payment complete.",
-                "type": "authorized"
-              },
-              "paid": true,
-              "payment_intent": "pi_3NfRruAWOtgoysog1FxgDwtf",
-              "payment_method": "pm_1NfRruAWOtgoysogjdx336vt",
-              "payment_method_details": {
-                "card": {
-                  "brand": "visa",
-                  "checks": {
-                    "address_line1_check": null,
-                    "address_postal_code_check": null,
-                    "cvc_check": "pass"
-                  },
-                  "country": "US",
-                  "ds_transaction_id": null,
-                  "exp_month": 9,
-                  "exp_year": 2030,
-                  "fingerprint": null,
-                  "funding": "debit",
-                  "installments": null,
-                  "last4": "4242",
-                  "mandate": null,
-                  "moto": null,
-                  "network": "visa",
-                  "network_token": {
-                    "exp_month": 9,
-                    "exp_year": 2030,
-                    "fingerprint": "OdTRtGskBulROtqa",
-                    "last4": "5556",
-                    "used": false
-                  },
-                  "network_transaction_id": "791008482116711",
-                  "three_d_secure": null,
-                  "wallet": null
-                },
-                "type": "card"
-              },
-              "receipt_email": null,
-              "receipt_number": null,
-              "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKKeE76YGMgbjse9I0TM6LBZ6z9Y1XXMETb-LDQ5oyLVXQhIMltBU0qwDkNKpNvrIGvXOhYmhorDkkE36",
-              "refunded": false,
-              "refunds": {
-                "object": "list",
-                "data": [
-                ],
-                "has_more": false,
-                "total_count": 0,
-                "url": "/v1/charges/ch_3NfRruAWOtgoysog1ptwVNHx/refunds"
-              },
-              "review": null,
-              "shipping": null,
-              "source": null,
-              "source_transfer": null,
-              "statement_descriptor": null,
-              "statement_descriptor_suffix": null,
-              "status": "succeeded",
-              "transfer_data": null,
-              "transfer_group": null
-            }
-          ],
+              "network_transaction_id": "791008482116711",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKKeE76YGMgbjse9I0TM6LBZ6z9Y1XXMETb-LDQ5oyLVXQhIMltBU0qwDkNKpNvrIGvXOhYmhorDkkE36",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3NfRruAWOtgoysog1ptwVNHx/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null,
           "has_more": false,
           "total_count": 1,
           "url": "/v1/charges?payment_intent=pi_3NfRruAWOtgoysog1FxgDwtf"
@@ -1285,7 +1278,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "description": null,
         "invoice": null,
         "last_payment_error": null,
-        "latest_charge": "ch_3NfRruAWOtgoysog1ptwVNHx",
         "level3": null,
         "livemode": false,
         "metadata": {
@@ -1337,118 +1329,114 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "canceled_at": null,
         "cancellation_reason": null,
         "capture_method": "manual",
-        "charges": {
+        "latest_charge": {
           "object": "list",
-          "data": [
-            {
-              "id": "ch_3NfTpgAWOtgoysog1ZcuSdwZ",
-              "object": "charge",
-              "amount": 2000,
-              "amount_captured": 0,
-              "amount_refunded": 0,
-              "application": null,
-              "application_fee": null,
-              "application_fee_amount": null,
-              "balance_transaction": null,
-              "billing_details": {
-                "address": {
-                  "city": null,
-                  "country": null,
-                  "line1": null,
-                  "line2": null,
-                  "postal_code": null,
-                  "state": null
-                },
-                "email": null,
-                "name": "Longbob Longsen",
-                "phone": null
+          "id": "ch_3NfTpgAWOtgoysog1ZcuSdwZ",
+          "object": "charge",
+          "amount": 2000,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1692131237,
+          "currency": "gbp",
+          "customer": "cus_OSOcijtQkDdBbF",
+          "description": null,
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 24,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3NfTpgAWOtgoysog1SqST5dL",
+          "payment_method": "pm_1NfTpgAWOtgoysogHnl1rNCf",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
               },
-              "calculated_statement_descriptor": "SPREEDLY",
-              "captured": false,
-              "created": 1692131237,
-              "currency": "gbp",
-              "customer": "cus_OSOcijtQkDdBbF",
-              "description": null,
-              "destination": null,
-              "dispute": null,
-              "disputed": false,
-              "failure_balance_transaction": null,
-              "failure_code": null,
-              "failure_message": null,
-              "fraud_details": {
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2030,
+              "fingerprint": null,
+              "funding": "debit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_token": {
+                "exp_month": 9,
+                "exp_year": 2030,
+                "fingerprint": "OdTRtGskBulROtqa",
+                "last4": "5556",
+                "used": false
               },
-              "invoice": null,
-              "livemode": false,
-              "metadata": {
-              },
-              "on_behalf_of": null,
-              "order": null,
-              "outcome": {
-                "network_status": "approved_by_network",
-                "reason": null,
-                "risk_level": "normal",
-                "risk_score": 24,
-                "seller_message": "Payment complete.",
-                "type": "authorized"
-              },
-              "paid": true,
-              "payment_intent": "pi_3NfTpgAWOtgoysog1SqST5dL",
-              "payment_method": "pm_1NfTpgAWOtgoysogHnl1rNCf",
-              "payment_method_details": {
-                "card": {
-                  "brand": "visa",
-                  "checks": {
-                    "address_line1_check": null,
-                    "address_postal_code_check": null,
-                    "cvc_check": "pass"
-                  },
-                  "country": "US",
-                  "ds_transaction_id": null,
-                  "exp_month": 9,
-                  "exp_year": 2030,
-                  "fingerprint": null,
-                  "funding": "debit",
-                  "installments": null,
-                  "last4": "4242",
-                  "mandate": null,
-                  "moto": null,
-                  "network": "visa",
-                  "network_token": {
-                    "exp_month": 9,
-                    "exp_year": 2030,
-                    "fingerprint": "OdTRtGskBulROtqa",
-                    "last4": "5556",
-                    "used": false
-                  },
-                  "network_transaction_id": "791008482116711",
-                  "three_d_secure": null,
-                  "wallet": null
-                },
-                "type": "card"
-              },
-              "receipt_email": null,
-              "receipt_number": null,
-              "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKKW_76YGMgZFk46uT_Y6LBZ51LZOrwdCQ0w176ShWIhNs2CXEh-L6A9pDYW33I_z6C6SenKNrWasw9Ie",
-              "refunded": false,
-              "refunds": {
-                "object": "list",
-                "data": [
-                ],
-                "has_more": false,
-                "total_count": 0,
-                "url": "/v1/charges/ch_3NfTpgAWOtgoysog1ZcuSdwZ/refunds"
-              },
-              "review": null,
-              "shipping": null,
-              "source": null,
-              "source_transfer": null,
-              "statement_descriptor": null,
-              "statement_descriptor_suffix": null,
-              "status": "succeeded",
-              "transfer_data": null,
-              "transfer_group": null
-            }
-          ],
+              "network_transaction_id": "791008482116711",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKKW_76YGMgZFk46uT_Y6LBZ51LZOrwdCQ0w176ShWIhNs2CXEh-L6A9pDYW33I_z6C6SenKNrWasw9Ie",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3NfTpgAWOtgoysog1ZcuSdwZ/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null,
           "has_more": false,
           "total_count": 1,
           "url": "/v1/charges?payment_intent=pi_3NfTpgAWOtgoysog1SqST5dL"
@@ -1461,7 +1449,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "description": null,
         "invoice": null,
         "last_payment_error": null,
-        "latest_charge": "ch_3NfTpgAWOtgoysog1ZcuSdwZ",
         "level3": null,
         "livemode": false,
         "metadata": {
@@ -1513,123 +1500,119 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "canceled_at": null,
         "cancellation_reason": null,
         "capture_method": "manual",
-        "charges": {
+        "latest_charge": {
           "object": "list",
-          "data": [
-            {
-              "id": "ch_3NfTpgAWOtgoysog1ZcuSdwZ",
-              "object": "charge",
-              "amount": 2000,
-              "amount_captured": 2000,
-              "amount_refunded": 0,
-              "application": null,
-              "application_fee": null,
-              "application_fee_amount": null,
-              "balance_transaction": "txn_3NfTpgAWOtgoysog1ZTZXCvO",
-              "billing_details": {
-                "address": {
-                  "city": null,
-                  "country": null,
-                  "line1": null,
-                  "line2": null,
-                  "postal_code": null,
-                  "state": null
-                },
-                "email": null,
-                "name": "Longbob Longsen",
-                "phone": null
+          "id": "ch_3NfTpgAWOtgoysog1ZcuSdwZ",
+          "object": "charge",
+          "amount": 2000,
+          "amount_captured": 2000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3NfTpgAWOtgoysog1ZTZXCvO",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1692131237,
+          "currency": "gbp",
+          "customer": "cus_OSOcijtQkDdBbF",
+          "description": null,
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 24,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3NfTpgAWOtgoysog1SqST5dL",
+          "payment_method": "pm_1NfTpgAWOtgoysogHnl1rNCf",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
               },
-              "calculated_statement_descriptor": "SPREEDLY",
-              "captured": true,
-              "created": 1692131237,
-              "currency": "gbp",
-              "customer": "cus_OSOcijtQkDdBbF",
-              "description": null,
-              "destination": null,
-              "dispute": null,
-              "disputed": false,
-              "failure_balance_transaction": null,
-              "failure_code": null,
-              "failure_message": null,
-              "fraud_details": {
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2030,
+              "fingerprint": null,
+              "funding": "debit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_token": {
+                "exp_month": 9,
+                "exp_year": 2030,
+                "fingerprint": "OdTRtGskBulROtqa",
+                "last4": "5556",
+                "used": false
               },
-              "invoice": null,
-              "livemode": false,
-              "metadata": {
-              },
-              "on_behalf_of": null,
-              "order": null,
-              "outcome": {
-                "network_status": "approved_by_network",
-                "reason": null,
-                "risk_level": "normal",
-                "risk_score": 24,
-                "seller_message": "Payment complete.",
-                "type": "authorized"
-              },
-              "paid": true,
-              "payment_intent": "pi_3NfTpgAWOtgoysog1SqST5dL",
-              "payment_method": "pm_1NfTpgAWOtgoysogHnl1rNCf",
-              "payment_method_details": {
-                "card": {
-                  "brand": "visa",
-                  "checks": {
-                    "address_line1_check": null,
-                    "address_postal_code_check": null,
-                    "cvc_check": "pass"
-                  },
-                  "country": "US",
-                  "ds_transaction_id": null,
-                  "exp_month": 9,
-                  "exp_year": 2030,
-                  "fingerprint": null,
-                  "funding": "debit",
-                  "installments": null,
-                  "last4": "4242",
-                  "mandate": null,
-                  "moto": null,
-                  "network": "visa",
-                  "network_token": {
-                    "exp_month": 9,
-                    "exp_year": 2030,
-                    "fingerprint": "OdTRtGskBulROtqa",
-                    "last4": "5556",
-                    "used": false
-                  },
-                  "network_transaction_id": "791008482116711",
-                  "three_d_secure": null,
-                  "wallet": null
-                },
-                "type": "card"
-              },
-              "receipt_email": null,
-              "receipt_number": null,
-              "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKKa_76YGMgZZ4Fl_Etg6LBYGcD6D2xFTlgp69zLDZz1ZToBrKKjxhRCpYcnLWInSmJZHcjcBdrhyAKGv",
-              "refunded": false,
-              "refunds": {
-                "object": "list",
-                "data": [
-                ],
-                "has_more": false,
-                "total_count": 0,
-                "url": "/v1/charges/ch_3NfTpgAWOtgoysog1ZcuSdwZ/refunds"
-              },
-              "review": null,
-              "shipping": null,
-              "source": null,
-              "source_transfer": null,
-              "statement_descriptor": null,
-              "statement_descriptor_suffix": null,
-              "status": "succeeded",
-              "transfer_data": null,
-              "transfer_group": null
-            }
-          ],
+              "network_transaction_id": "791008482116711",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKKa_76YGMgZZ4Fl_Etg6LBYGcD6D2xFTlgp69zLDZz1ZToBrKKjxhRCpYcnLWInSmJZHcjcBdrhyAKGv",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3NfTpgAWOtgoysog1ZcuSdwZ/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null,
           "has_more": false,
           "total_count": 1,
           "url": "/v1/charges?payment_intent=pi_3NfTpgAWOtgoysog1SqST5dL"
         },
-         "client_secret": "pi_3NfRruAWOtgoysog1FxgDwtf_secret_f4ke",
+        "client_secret": "pi_3NfRruAWOtgoysog1FxgDwtf_secret_f4ke",
         "confirmation_method": "manual",
         "created": 1692131236,
         "currency": "gbp",
@@ -1637,7 +1620,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "description": null,
         "invoice": null,
         "last_payment_error": null,
-        "latest_charge": "ch_3NfTpgAWOtgoysog1ZcuSdwZ",
         "level3": null,
         "livemode": false,
         "metadata": {
@@ -1673,31 +1655,297 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
   def successful_create_intent_response_with_apple_pay_and_billing_address
     <<-RESPONSE
-      {"id"=>"pi_3N0mqdAWOtgoysog1IQeiLiz", "object"=>"payment_intent", "amount"=>2000, "amount_capturable"=>0, "amount_details"=>{"tip"=>{}}, "amount_received"=>2000, "application"=>nil, "application_fee_amount"=>nil, "automatic_payment_methods"=>nil, "canceled_at"=>nil, "cancellation_reason"=>nil, "capture_method"=>"automatic", "charges"=>{"object"=>"list", "data"=>[{"id"=>"ch_3N0mqdAWOtgoysog1HddFSKg", "object"=>"charge", "amount"=>2000, "amount_captured"=>2000, "amount_refunded"=>0, "application"=>nil, "application_fee"=>nil, "application_fee_amount"=>nil, "balance_transaction"=>"txn_3N0mqdAWOtgoysog1EpiFDCD", "billing_details"=>{"address"=>{"city"=>"Ottawa", "country"=>"CA", "line1"=>"456 My Street", "line2"=>"Apt 1", "postal_code"=>"K1C2N6", "state"=>"ON"}, "email"=>nil, "name"=>nil, "phone"=>nil}, "calculated_statement_descriptor"=>"SPREEDLY", "captured"=>true, "created"=>1682432883, "currency"=>"gbp", "customer"=>nil, "description"=>nil, "destination"=>nil, "dispute"=>nil, "disputed"=>false, "failure_balance_transaction"=>nil, "failure_code"=>nil, "failure_message"=>nil, "fraud_details"=>{}, "invoice"=>nil, "livemode"=>false, "metadata"=>{}, "on_behalf_of"=>nil, "order"=>nil, "outcome"=>{"network_status"=>"approved_by_network", "reason"=>nil, "risk_level"=>"normal", "risk_score"=>15, "seller_message"=>"Payment complete.", "type"=>"authorized"}, "paid"=>true, "payment_intent"=>"pi_3N0mqdAWOtgoysog1IQeiLiz", "payment_method"=>"pm_1N0mqdAWOtgoysogloANIhUF", "payment_method_details"=>{"card"=>{"brand"=>"visa", "checks"=>{"address_line1_check"=>"pass", "address_postal_code_check"=>"pass", "cvc_check"=>nil}, "country"=>"US", "ds_transaction_id"=>nil, "exp_month"=>9, "exp_year"=>2030, "fingerprint"=>"hfaVNMiXc0dYSiC5", "funding"=>"credit", "installments"=>nil, "last4"=>"0000", "mandate"=>nil, "moto"=>nil, "network"=>"visa", "network_token"=>{"used"=>false}, "network_transaction_id"=>"104102978678771", "three_d_secure"=>nil, "wallet"=>{"apple_pay"=>{"type"=>"apple_pay"}, "dynamic_last4"=>"4242", "type"=>"apple_pay"}}, "type"=>"card"}, "receipt_email"=>nil, "receipt_number"=>nil, "receipt_url"=>"https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKPTGn6IGMgZMGrHHLa46LBY0n2_9_Yar0wPTNukle4t28eKG0ZDZnxGYr6GyKn8VsKIEVjU4NkW8NHTL", "refunded"=>false, "refunds"=>{"object"=>"list", "data"=>[], "has_more"=>false, "total_count"=>0, "url"=>"/v1/charges/ch_3N0mqdAWOtgoysog1HddFSKg/refunds"}, "review"=>nil, "shipping"=>nil, "source"=>nil, "source_transfer"=>nil, "statement_descriptor"=>nil, "statement_descriptor_suffix"=>nil, "status"=>"succeeded", "transfer_data"=>nil, "transfer_group"=>nil}], "has_more"=>false, "total_count"=>1, "url"=>"/v1/charges?payment_intent=pi_3N0mqdAWOtgoysog1IQeiLiz"}, "client_secret"=>"pi_3N0mqdAWOtgoysog1IQeiLiz_secret_laDLUM6rVleLRqz0nMus9HktB", "confirmation_method"=>"automatic", "created"=>1682432883, "currency"=>"gbp", "customer"=>nil, "description"=>nil, "invoice"=>nil, "last_payment_error"=>nil, "latest_charge"=>"ch_3N0mqdAWOtgoysog1HddFSKg", "level3"=>nil, "livemode"=>false, "metadata"=>{}, "next_action"=>nil, "on_behalf_of"=>nil, "payment_method"=>"pm_1N0mqdAWOtgoysogloANIhUF", "payment_method_options"=>{"card"=>{"installments"=>nil, "mandate_options"=>nil, "network"=>nil, "request_three_d_secure"=>"automatic"}}, "payment_method_types"=>["card"], "processing"=>nil, "receipt_email"=>nil, "review"=>nil, "setup_future_usage"=>nil, "shipping"=>nil, "source"=>nil, "statement_descriptor"=>nil, "statement_descriptor_suffix"=>nil, "status"=>"succeeded", "transfer_data"=>nil, "transfer_group"=>nil}
+      {"id"=>"pi_3N0mqdAWOtgoysog1IQeiLiz", "object"=>"payment_intent", "amount"=>2000, "amount_capturable"=>0, "amount_details"=>{"tip"=>{}}, "amount_received"=>2000, "application"=>nil, "application_fee_amount"=>nil, "automatic_payment_methods"=>nil, "canceled_at"=>nil, "cancellation_reason"=>nil, "capture_method"=>"automatic", "latest_charge"=>{"object"=>"list", "id"=>"ch_3N0mqdAWOtgoysog1HddFSKg", "object"=>"charge", "amount"=>2000, "amount_captured"=>2000, "amount_refunded"=>0, "application"=>nil, "application_fee"=>nil, "application_fee_amount"=>nil, "balance_transaction"=>"txn_3N0mqdAWOtgoysog1EpiFDCD", "billing_details"=>{"address"=>{"city"=>"Ottawa", "country"=>"CA", "line1"=>"456 My Street", "line2"=>"Apt 1", "postal_code"=>"K1C2N6", "state"=>"ON"}, "email"=>nil, "name"=>nil, "phone"=>nil}, "calculated_statement_descriptor"=>"SPREEDLY", "captured"=>true, "created"=>1682432883, "currency"=>"gbp", "customer"=>nil, "description"=>nil, "destination"=>nil, "dispute"=>nil, "disputed"=>false, "failure_balance_transaction"=>nil, "failure_code"=>nil, "failure_message"=>nil, "fraud_details"=>{}, "invoice"=>nil, "livemode"=>false, "metadata"=>{}, "on_behalf_of"=>nil, "order"=>nil, "outcome"=>{"network_status"=>"approved_by_network", "reason"=>nil, "risk_level"=>"normal", "risk_score"=>15, "seller_message"=>"Payment complete.", "type"=>"authorized"}, "paid"=>true, "payment_intent"=>"pi_3N0mqdAWOtgoysog1IQeiLiz", "payment_method"=>"pm_1N0mqdAWOtgoysogloANIhUF", "payment_method_details"=>{"card"=>{"brand"=>"visa", "checks"=>{"address_line1_check"=>"pass", "address_postal_code_check"=>"pass", "cvc_check"=>nil}, "country"=>"US", "ds_transaction_id"=>nil, "exp_month"=>9, "exp_year"=>2030, "fingerprint"=>"hfaVNMiXc0dYSiC5", "funding"=>"credit", "installments"=>nil, "last4"=>"0000", "mandate"=>nil, "moto"=>nil, "network"=>"visa", "network_token"=>{"used"=>false}, "network_transaction_id"=>"104102978678771", "three_d_secure"=>nil, "wallet"=>{"apple_pay"=>{"type"=>"apple_pay"}, "dynamic_last4"=>"4242", "type"=>"apple_pay"}}, "type"=>"card"}, "receipt_email"=>nil, "receipt_number"=>nil, "receipt_url"=>"https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKPTGn6IGMgZMGrHHLa46LBY0n2_9_Yar0wPTNukle4t28eKG0ZDZnxGYr6GyKn8VsKIEVjU4NkW8NHTL", "refunded"=>false, "refunds"=>{"object"=>"list", "data"=>[], "has_more"=>false, "total_count"=>0, "url"=>"/v1/charges/ch_3N0mqdAWOtgoysog1HddFSKg/refunds"}, "review"=>nil, "shipping"=>nil, "source"=>nil, "source_transfer"=>nil, "statement_descriptor"=>nil, "statement_descriptor_suffix"=>nil, "status"=>"succeeded", "transfer_data"=>nil, "transfer_group"=>nil, "has_more"=>false, "total_count"=>1, "url"=>"/v1/charges?payment_intent=pi_3N0mqdAWOtgoysog1IQeiLiz"}, "client_secret"=>"pi_3N0mqdAWOtgoysog1IQeiLiz_secret_laDLUM6rVleLRqz0nMus9HktB", "confirmation_method"=>"automatic", "created"=>1682432883, "currency"=>"gbp", "customer"=>nil, "description"=>nil, "invoice"=>nil, "last_payment_error"=>nil, "level3"=>nil, "livemode"=>false, "metadata"=>{}, "next_action"=>nil, "on_behalf_of"=>nil, "payment_method"=>"pm_1N0mqdAWOtgoysogloANIhUF", "payment_method_options"=>{"card"=>{"installments"=>nil, "mandate_options"=>nil, "network"=>nil, "request_three_d_secure"=>"automatic"}}, "payment_method_types"=>["card"], "processing"=>nil, "receipt_email"=>nil, "review"=>nil, "setup_future_usage"=>nil, "shipping"=>nil, "source"=>nil, "statement_descriptor"=>nil, "statement_descriptor_suffix"=>nil, "status"=>"succeeded", "transfer_data"=>nil, "transfer_group"=>nil}
     RESPONSE
   end
 
   def successful_create_intent_response_with_google_pay_and_billing_address
     <<-RESPONSE
-      {"id"=>"pi_3N0nKLAWOtgoysog3cRTGUqD", "object"=>"payment_intent", "amount"=>2000, "amount_capturable"=>0, "amount_details"=>{"tip"=>{}}, "amount_received"=>2000, "application"=>nil, "application_fee_amount"=>nil, "automatic_payment_methods"=>nil, "canceled_at"=>nil, "cancellation_reason"=>nil, "capture_method"=>"automatic", "charges"=>{"object"=>"list", "data"=>[{"id"=>"ch_3N0nKLAWOtgoysog3npJdWNI", "object"=>"charge", "amount"=>2000, "amount_captured"=>2000, "amount_refunded"=>0, "application"=>nil, "application_fee"=>nil, "application_fee_amount"=>nil, "balance_transaction"=>"txn_3N0nKLAWOtgoysog3ZAmtAMT", "billing_details"=>{"address"=>{"city"=>"Ottawa", "country"=>"CA", "line1"=>"456 My Street", "line2"=>"Apt 1", "postal_code"=>"K1C2N6", "state"=>"ON"}, "email"=>nil, "name"=>nil, "phone"=>nil}, "calculated_statement_descriptor"=>"SPREEDLY", "captured"=>true, "created"=>1682434726, "currency"=>"gbp", "customer"=>nil, "description"=>nil, "destination"=>nil, "dispute"=>nil, "disputed"=>false, "failure_balance_transaction"=>nil, "failure_code"=>nil, "failure_message"=>nil, "fraud_details"=>{}, "invoice"=>nil, "livemode"=>false, "metadata"=>{}, "on_behalf_of"=>nil, "order"=>nil, "outcome"=>{"network_status"=>"approved_by_network", "reason"=>nil, "risk_level"=>"normal", "risk_score"=>61, "seller_message"=>"Payment complete.", "type"=>"authorized"}, "paid"=>true, "payment_intent"=>"pi_3N0nKLAWOtgoysog3cRTGUqD", "payment_method"=>"pm_1N0nKLAWOtgoysoglKSvcZz9", "payment_method_details"=>{"card"=>{"brand"=>"visa", "checks"=>{"address_line1_check"=>"pass", "address_postal_code_check"=>"pass", "cvc_check"=>nil}, "country"=>"US", "ds_transaction_id"=>nil, "exp_month"=>9, "exp_year"=>2030, "fingerprint"=>"hfaVNMiXc0dYSiC5", "funding"=>"credit", "installments"=>nil, "last4"=>"0000", "mandate"=>nil, "moto"=>nil, "network"=>"visa", "network_token"=>{"used"=>false}, "network_transaction_id"=>"104102978678771", "three_d_secure"=>nil, "wallet"=>{"dynamic_last4"=>"4242", "google_pay"=>{}, "type"=>"google_pay"}}, "type"=>"card"}, "receipt_email"=>nil, "receipt_number"=>nil, "receipt_url"=>"https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKKbVn6IGMgbEjx6eavI6LBZciyBuj3wwsvIi6Fdr1gNyM807fxUBTGDg2j_1c42EB8vLZl4KcSJA0otk", "refunded"=>false, "refunds"=>{"object"=>"list", "data"=>[], "has_more"=>false, "total_count"=>0, "url"=>"/v1/charges/ch_3N0nKLAWOtgoysog3npJdWNI/refunds"}, "review"=>nil, "shipping"=>nil, "source"=>nil, "source_transfer"=>nil, "statement_descriptor"=>nil, "statement_descriptor_suffix"=>nil, "status"=>"succeeded", "transfer_data"=>nil, "transfer_group"=>nil}], "has_more"=>false, "total_count"=>1, "url"=>"/v1/charges?payment_intent=pi_3N0nKLAWOtgoysog3cRTGUqD"}, "client_secret"=>"pi_3N0nKLAWOtgoysog3cRTGUqD_secret_L4UFErMf6H4itOcZrZRqTwsuA", "confirmation_method"=>"automatic", "created"=>1682434725, "currency"=>"gbp", "customer"=>nil, "description"=>nil, "invoice"=>nil, "last_payment_error"=>nil, "latest_charge"=>"ch_3N0nKLAWOtgoysog3npJdWNI", "level3"=>nil, "livemode"=>false, "metadata"=>{}, "next_action"=>nil, "on_behalf_of"=>nil, "payment_method"=>"pm_1N0nKLAWOtgoysoglKSvcZz9", "payment_method_options"=>{"card"=>{"installments"=>nil, "mandate_options"=>nil, "network"=>nil, "request_three_d_secure"=>"automatic"}}, "payment_method_types"=>["card"], "processing"=>nil, "receipt_email"=>nil, "review"=>nil, "setup_future_usage"=>nil, "shipping"=>nil, "source"=>nil, "statement_descriptor"=>nil, "statement_descriptor_suffix"=>nil, "status"=>"succeeded", "transfer_data"=>nil, "transfer_group"=>nil}
+      {"id"=>"pi_3N0nKLAWOtgoysog3cRTGUqD", "object"=>"payment_intent", "amount"=>2000, "amount_capturable"=>0, "amount_details"=>{"tip"=>{}}, "amount_received"=>2000, "application"=>nil, "application_fee_amount"=>nil, "automatic_payment_methods"=>nil, "canceled_at"=>nil, "cancellation_reason"=>nil, "capture_method"=>"automatic", "latest_charge"=>{"object"=>"list", "id"=>"ch_3N0nKLAWOtgoysog3npJdWNI", "object"=>"charge", "amount"=>2000, "amount_captured"=>2000, "amount_refunded"=>0, "application"=>nil, "application_fee"=>nil, "application_fee_amount"=>nil, "balance_transaction"=>"txn_3N0nKLAWOtgoysog3ZAmtAMT", "billing_details"=>{"address"=>{"city"=>"Ottawa", "country"=>"CA", "line1"=>"456 My Street", "line2"=>"Apt 1", "postal_code"=>"K1C2N6", "state"=>"ON"}, "email"=>nil, "name"=>nil, "phone"=>nil}, "calculated_statement_descriptor"=>"SPREEDLY", "captured"=>true, "created"=>1682434726, "currency"=>"gbp", "customer"=>nil, "description"=>nil, "destination"=>nil, "dispute"=>nil, "disputed"=>false, "failure_balance_transaction"=>nil, "failure_code"=>nil, "failure_message"=>nil, "fraud_details"=>{}, "invoice"=>nil, "livemode"=>false, "metadata"=>{}, "on_behalf_of"=>nil, "order"=>nil, "outcome"=>{"network_status"=>"approved_by_network", "reason"=>nil, "risk_level"=>"normal", "risk_score"=>61, "seller_message"=>"Payment complete.", "type"=>"authorized"}, "paid"=>true, "payment_intent"=>"pi_3N0nKLAWOtgoysog3cRTGUqD", "payment_method"=>"pm_1N0nKLAWOtgoysoglKSvcZz9", "payment_method_details"=>{"card"=>{"brand"=>"visa", "checks"=>{"address_line1_check"=>"pass", "address_postal_code_check"=>"pass", "cvc_check"=>nil}, "country"=>"US", "ds_transaction_id"=>nil, "exp_month"=>9, "exp_year"=>2030, "fingerprint"=>"hfaVNMiXc0dYSiC5", "funding"=>"credit", "installments"=>nil, "last4"=>"0000", "mandate"=>nil, "moto"=>nil, "network"=>"visa", "network_token"=>{"used"=>false}, "network_transaction_id"=>"104102978678771", "three_d_secure"=>nil, "wallet"=>{"dynamic_last4"=>"4242", "google_pay"=>{}, "type"=>"google_pay"}}, "type"=>"card"}, "receipt_email"=>nil, "receipt_number"=>nil, "receipt_url"=>"https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKKbVn6IGMgbEjx6eavI6LBZciyBuj3wwsvIi6Fdr1gNyM807fxUBTGDg2j_1c42EB8vLZl4KcSJA0otk", "refunded"=>false, "refunds"=>{"object"=>"list", "data"=>[], "has_more"=>false, "total_count"=>0, "url"=>"/v1/charges/ch_3N0nKLAWOtgoysog3npJdWNI/refunds"}, "review"=>nil, "shipping"=>nil, "source"=>nil, "source_transfer"=>nil, "statement_descriptor"=>nil, "statement_descriptor_suffix"=>nil, "status"=>"succeeded", "transfer_data"=>nil, "transfer_group"=>nil, "has_more"=>false, "total_count"=>1, "url"=>"/v1/charges?payment_intent=pi_3N0nKLAWOtgoysog3cRTGUqD"}, "client_secret"=>"pi_3N0nKLAWOtgoysog3cRTGUqD_secret_L4UFErMf6H4itOcZrZRqTwsuA", "confirmation_method"=>"automatic", "created"=>1682434725, "currency"=>"gbp", "customer"=>nil, "description"=>nil, "invoice"=>nil, "last_payment_error"=>nil, "level3"=>nil, "livemode"=>false, "metadata"=>{}, "next_action"=>nil, "on_behalf_of"=>nil, "payment_method"=>"pm_1N0nKLAWOtgoysoglKSvcZz9", "payment_method_options"=>{"card"=>{"installments"=>nil, "mandate_options"=>nil, "network"=>nil, "request_three_d_secure"=>"automatic"}}, "payment_method_types"=>["card"], "processing"=>nil, "receipt_email"=>nil, "review"=>nil, "setup_future_usage"=>nil, "shipping"=>nil, "source"=>nil, "statement_descriptor"=>nil, "statement_descriptor_suffix"=>nil, "status"=>"succeeded", "transfer_data"=>nil, "transfer_group"=>nil}
     RESPONSE
   end
 
   def successful_capture_response
     <<-RESPONSE
-      {"id":"pi_1F1xauAWOtgoysogIfHO8jGi","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":2020,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"manual","charges":{"object":"list","data":[{"id":"ch_1F1xavAWOtgoysogxrtSiCu4","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":"txn_1F1xawAWOtgoysog27xGBjM6","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":true,"created":1564501833,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":58,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F1xauAWOtgoysogIfHO8jGi","payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1xavAWOtgoysogxrtSiCu4/rcpt_FX1eGdFRi8ssOY8Fqk4X6nEjNeGV5PG","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F1xavAWOtgoysogxrtSiCu4/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F1xauAWOtgoysogIfHO8jGi"},"client_secret":"pi_1F1xauAWOtgoysogIfHO8jGi_secret_ZrXvfydFv0BelaMQJgHxjts5b","confirmation_method":"manual","created":1564501832,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1xauAWOtgoysog00COoKIU","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}
+      {
+        "id":"pi_1F1xauAWOtgoysogIfHO8jGi",
+        "object":"payment_intent",
+        "amount":2020,
+        "amount_capturable":0,
+        "amount_received":2020,
+        "application":null,
+        "application_fee_amount":null,
+        "canceled_at":null,
+        "cancellation_reason":null,
+        "capture_method":"manual",
+        "latest_charge":{
+          "object":"list",
+          "id":"ch_1F1xavAWOtgoysogxrtSiCu4",
+          "object":"charge",
+          "amount":2020,
+          "amount_refunded":0,
+          "application":null,
+          "application_fee":null,
+          "application_fee_amount":null,
+          "balance_transaction":"txn_1F1xawAWOtgoysog27xGBjM6",
+          "billing_details":{
+            "address":{
+              "city":null,
+              "country":null,
+              "line1":null,
+              "line2":null,
+              "postal_code":null,
+              "state":null
+            },
+            "email":null,
+            "name":null,
+            "phone":null
+          },
+          "captured":true,
+          "created":1564501833,
+          "currency":"gbp",
+          "customer":"cus_7s22nNueP2Hjj6",
+          "description":null,
+          "destination":null,
+          "dispute":null,
+          "failure_code":null,
+          "failure_message":null,
+          "fraud_details":{},
+          "invoice":null,
+          "livemode":false,
+          "metadata":{},
+          "on_behalf_of":null,
+          "order":null,
+          "outcome":{
+            "network_status":"approved_by_network",
+            "reason":null,
+            "risk_level":"normal",
+            "risk_score":58,
+            "seller_message":"Payment complete.",
+            "type":"authorized"
+          },
+          "paid":true,
+          "payment_intent":"pi_1F1xauAWOtgoysogIfHO8jGi",
+          "payment_method":"pm_1F1xauAWOtgoysog00COoKIU",
+          "payment_method_details":{
+            "card":{
+              "brand":"visa",
+              "checks":{
+                "address_line1_check":null,
+                "address_postal_code_check":null,
+                "cvc_check":null
+              },
+              "country":"US",
+              "exp_month":7,
+              "exp_year":2020,
+              "fingerprint":"hfaVNMiXc0dYSiC5",
+              "funding":"credit",
+              "last4":"4242",
+              "three_d_secure":null,
+              "wallet":null
+            },
+            "type":"card"
+          },
+          "receipt_email":null,
+          "receipt_number":null,
+          "receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1xavAWOtgoysogxrtSiCu4/rcpt_FX1eGdFRi8ssOY8Fqk4X6nEjNeGV5PG",
+          "refunded":false,
+          "refunds":{
+            "object":"list",
+            "data":[],
+            "has_more":false,
+            "total_count":0,
+            "url":"/v1/charges/ch_1F1xavAWOtgoysogxrtSiCu4/refunds"
+          },
+          "review":null,
+          "shipping":null,
+          "source":null,
+          "source_transfer":null,
+          "statement_descriptor":null,
+          "status":"succeeded",
+          "transfer_data":null,
+          "transfer_group":null,
+          "has_more":false,
+          "total_count":1,
+          "url":"/v1/charges?payment_intent=pi_1F1xauAWOtgoysogIfHO8jGi"
+        },
+        "client_secret":"pi_1F1xauAWOtgoysogIfHO8jGi_secret_ZrXvfydFv0BelaMQJgHxjts5b",
+        "confirmation_method":"manual",
+        "created":1564501832,
+        "currency":"gbp",
+        "customer":"cus_7s22nNueP2Hjj6",
+        "description":null,
+        "invoice":null,
+        "last_payment_error":null,
+        "livemode":false,
+        "metadata":{},
+        "next_action":null,
+        "on_behalf_of":null,
+        "payment_method":"pm_1F1xauAWOtgoysog00COoKIU",
+        "payment_method_options":{
+          "card":{
+            "request_three_d_secure":"automatic"
+          }
+        },
+        "payment_method_types":["card"],
+        "receipt_email":null,
+        "review":null,
+        "setup_future_usage":null,
+        "shipping":null,
+        "source":null,
+        "statement_descriptor":null,
+        "status":"succeeded",
+        "transfer_data":null,
+        "transfer_group":null
+      }
     RESPONSE
   end
 
   def successful_void_response
     <<-RESPONSE
-      {"id":"pi_1F1yBVAWOtgoysogearamRvl","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":1564504103,"cancellation_reason":"requested_by_customer","capture_method":"manual","charges":{"object":"list","data":[{"id":"ch_1F1yBWAWOtgoysog1MQfDpJH","object":"charge","amount":2020,"amount_refunded":2020,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564504102,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":46,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F1yBVAWOtgoysogearamRvl","payment_method":"pm_1F1yBVAWOtgoysogddy4E3hL","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1yBWAWOtgoysog1MQfDpJH/rcpt_FX2Go3YHBqAYQPJuKGMeab3nyCU0Kks","refunded":true,"refunds":{"object":"list","data":[{"id":"re_1F1yBXAWOtgoysog0PU371Yz","object":"refund","amount":2020,"balance_transaction":null,"charge":"ch_1F1yBWAWOtgoysog1MQfDpJH","created":1564504103,"currency":"gbp","metadata":{},"reason":"requested_by_customer","receipt_number":null,"source_transfer_reversal":null,"status":"succeeded","transfer_reversal":null}],"has_more":false,"total_count":1,"url":"/v1/charges/ch_1F1yBWAWOtgoysog1MQfDpJH/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F1yBVAWOtgoysogearamRvl"},"client_secret":"pi_1F1yBVAWOtgoysogearamRvl_secret_oCnlR2t0GPclqACgHt2rst4gM","confirmation_method":"manual","created":1564504101,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1yBVAWOtgoysogddy4E3hL","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"canceled","transfer_data":null,"transfer_group":null}
+      {
+        "id":"pi_1F1yBVAWOtgoysogearamRvl",
+        "object":"payment_intent",
+        "amount":2020,
+        "amount_capturable":0,
+        "amount_received":0,
+        "application":null,
+        "application_fee_amount":null,
+        "canceled_at":1564504103,
+        "cancellation_reason":"requested_by_customer",
+        "capture_method":"manual",
+        "latest_charge":{
+          "object":"list",
+          "id":"ch_1F1yBWAWOtgoysog1MQfDpJH",
+          "object":"charge",
+          "amount":2020,
+          "amount_refunded":2020,
+          "application":null,
+          "application_fee":null,
+          "application_fee_amount":null,
+          "balance_transaction":null,
+          "billing_details":{
+            "address":{
+              "city":null,
+              "country":null,
+              "line1":null,
+              "line2":null,
+              "postal_code":null,
+              "state":null
+            },
+            "email":null,
+            "name":null,
+            "phone":null
+          },
+          "captured":false,
+          "created":1564504102,
+          "currency":"gbp",
+          "customer":"cus_7s22nNueP2Hjj6",
+          "description":null,
+          "destination":null,
+          "dispute":null,
+          "failure_code":null,
+          "failure_message":null,
+          "fraud_details":{},
+          "invoice":null,
+          "livemode":false,
+          "metadata":{},
+          "on_behalf_of":null,
+          "order":null,
+          "outcome":{
+            "network_status":"approved_by_network",
+            "reason":null,
+            "risk_level":"normal",
+            "risk_score":46,
+            "seller_message":"Payment complete.",
+            "type":"authorized"
+          },
+          "paid":true,
+          "payment_intent":"pi_1F1yBVAWOtgoysogearamRvl",
+          "payment_method":"pm_1F1yBVAWOtgoysogddy4E3hL",
+          "payment_method_details":{
+            "card":{
+              "brand":"visa",
+              "checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},
+              "country":"US",
+              "exp_month":7,
+              "exp_year":2020,
+              "fingerprint":"hfaVNMiXc0dYSiC5",
+              "funding":"credit",
+              "last4":"4242",
+              "three_d_secure":null,
+              "wallet":null
+            },
+            "type":"card"
+          },
+          "receipt_email":null,
+          "receipt_number":null,
+          "receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F1yBWAWOtgoysog1MQfDpJH/rcpt_FX2Go3YHBqAYQPJuKGMeab3nyCU0Kks",
+          "refunded":true,
+          "refunds":{
+            "object":"list",
+            "data":[{
+              "id":"re_1F1yBXAWOtgoysog0PU371Yz",
+              "object":"refund",
+              "amount":2020,
+              "balance_transaction":null,
+              "charge":"ch_1F1yBWAWOtgoysog1MQfDpJH",
+              "created":1564504103,
+              "currency":"gbp",
+              "metadata":{},
+              "reason":"requested_by_customer",
+              "receipt_number":null,
+              "source_transfer_reversal":null,
+              "status":"succeeded",
+              "transfer_reversal":null
+            }],
+            "has_more":false,
+            "total_count":1,
+            "url":"/v1/charges/ch_1F1yBWAWOtgoysog1MQfDpJH/refunds"
+          },
+          "review":null,
+          "shipping":null,
+          "source":null,
+          "source_transfer":null,
+          "statement_descriptor":null,
+          "status":"succeeded",
+          "transfer_data":null,
+          "transfer_group":null,
+          "has_more":false,
+          "total_count":1,
+          "url":"/v1/charges?payment_intent=pi_1F1yBVAWOtgoysogearamRvl"
+        },
+        "client_secret":"pi_1F1yBVAWOtgoysogearamRvl_secret_oCnlR2t0GPclqACgHt2rst4gM",
+        "confirmation_method":"manual",
+        "created":1564504101,
+        "currency":"gbp",
+        "customer":"cus_7s22nNueP2Hjj6",
+        "description":null,
+        "invoice":null,
+        "last_payment_error":null,
+        "livemode":false,
+        "metadata":{},
+        "next_action":null,
+        "on_behalf_of":null,
+        "payment_method":"pm_1F1yBVAWOtgoysogddy4E3hL",
+        "payment_method_options":{"card":{"request_three_d_secure":"automatic"}},
+        "payment_method_types":["card"],
+        "receipt_email":null,
+        "review":null,
+        "setup_future_usage":null,
+        "shipping":null,
+        "source":null,
+        "statement_descriptor":null,
+        "status":"canceled",
+        "transfer_data":null,
+        "transfer_group":null
+      }
     RESPONSE
   end
 
   def successful_update_intent_response
     <<-RESPONSE
-      {"id":"pi_1F1yBbAWOtgoysog52J88BuO","object":"payment_intent","amount":2050,"amount_capturable":0,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"manual","charges":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges?payment_intent=pi_1F1yBbAWOtgoysog52J88BuO"},"client_secret":"pi_1F1yBbAWOtgoysog52J88BuO_secret_olw5rmbtm7cd72S9JfbKjTJJv","confirmation_method":"manual","created":1564504107,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1yBbAWOtgoysoguJQsDdYj","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_confirmation","transfer_data":null,"transfer_group":null}
+      {"id":"pi_1F1yBbAWOtgoysog52J88BuO","object":"payment_intent","amount":2050,"amount_capturable":0,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"manual","latest_charge":{"object":"list","has_more":false,"total_count":0,"url":"/v1/charges?payment_intent=pi_1F1yBbAWOtgoysog52J88BuO"},"client_secret":"pi_1F1yBbAWOtgoysog52J88BuO_secret_olw5rmbtm7cd72S9JfbKjTJJv","confirmation_method":"manual","created":1564504107,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F1yBbAWOtgoysoguJQsDdYj","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_confirmation","transfer_data":null,"transfer_group":null}
     RESPONSE
   end
 
@@ -1752,9 +2000,8 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "canceled_at": null,
         "cancellation_reason": null,
         "capture_method": "manual",
-        "charges": {
+        "latest_charge": {
           "object": "list",
-          "data": [],
           "has_more": false,
           "total_count": 0,
           "url": "/v1/charges?payment_intent=pi_1F1wpFAWOtgoysog8nTulYGk"
@@ -1802,9 +2049,8 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "canceled_at": null,
         "cancellation_reason": null,
         "capture_method": "manual",
-        "charges": {
+        "latest_charge": {
           "object": "list",
-          "data": [],
           "has_more": false,
           "total_count": 0,
           "url": "/v1/charges?payment_intent=pi_1F1wpFAWOtgoysog8nTulYGk"},
@@ -1854,87 +2100,86 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       "canceled_at"=>nil,
       "cancellation_reason"=>nil,
       "capture_method"=>"automatic",
-      "charges"=>
+      "latest_charge"=>
        {"object"=>"list",
-        "data"=>
-         [{"id"=>"ch_1HZJGQAWOtgoysogEpbZTGIl",
-           "object"=>"charge",
-           "amount"=>2000,
-           "amount_captured"=>2000,
-           "amount_refunded"=>0,
-           "application"=>nil,
-           "application_fee"=>nil,
-           "application_fee_amount"=>nil,
-           "balance_transaction"=>"txn_1HZJGQAWOtgoysogEKwV2r5N",
-           "billing_details"=>
-            {"address"=>{"city"=>nil, "country"=>nil, "line1"=>nil, "line2"=>nil, "postal_code"=>nil, "state"=>nil}, "email"=>nil, "name"=>nil, "phone"=>nil},
-           "calculated_statement_descriptor"=>"SPREEDLY",
-           "captured"=>true,
-           "created"=>1602002626,
-           "currency"=>"gbp",
-           "customer"=>nil,
-           "description"=>nil,
-           "destination"=>nil,
-           "dispute"=>nil,
-           "disputed"=>false,
-           "failure_code"=>nil,
-           "failure_message"=>nil,
-           "fraud_details"=>{},
-           "invoice"=>nil,
-           "livemode"=>false,
-           "metadata"=>{},
-           "on_behalf_of"=>nil,
-           "order"=>nil,
-           "outcome"=>
-            {"network_status"=>"approved_by_network",
-             "reason"=>nil,
-             "risk_level"=>"normal",
-             "risk_score"=>16,
-             "seller_message"=>"Payment complete.",
-             "type"=>"authorized"},
-           "paid"=>true,
-           "payment_intent"=>"pi_1HZJGPAWOtgoysogrKURP11Q",
-           "payment_method"=>"pm_1HZJGOAWOtgoysogvnMsnnG1",
-           "payment_method_details"=>
-            {"card"=>
-              {"brand"=>"visa",
-               "checks"=>{"address_line1_check"=>nil, "address_postal_code_check"=>nil, "cvc_check"=>"pass"},
-               "country"=>"US",
-               "ds_transaction_id"=>nil,
-               "exp_month"=>10,
-               "exp_year"=>2020,
-               "fingerprint"=>"hfaVNMiXc0dYSiC5",
-               "funding"=>"credit",
-               "installments"=>nil,
-               "last4"=>"4242",
-               "moto"=>nil,
-               "network"=>"visa",
-               "network_transaction_id"=>"1041029786787710",
-               "three_d_secure"=>
-                {"authenticated"=>false,
-                 "authentication_flow"=>nil,
-                 "electronic_commerce_indicator"=>"06",
-                 "result"=>"attempt_acknowledged",
-                 "result_reason"=>nil,
-                 "succeeded"=>true,
-                 "transaction_id"=>"d1VlRVF6a1BVNXN1cjMzZVl0RU0=",
-                 "version"=>"1.0.2"},
-               "wallet"=>nil},
-             "type"=>"card"},
-           "receipt_email"=>nil,
-           "receipt_number"=>nil,
-           "receipt_url"=>"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1HZJGQAWOtgoysogEpbZTGIl/rcpt_I9cVpN9xAeS39FhMqTS33Fj8gHsjjuX",
-           "refunded"=>false,
-           "refunds"=>{"object"=>"list", "data"=>[], "has_more"=>false, "total_count"=>0, "url"=>"/v1/charges/ch_1HZJGQAWOtgoysogEpbZTGIl/refunds"},
-           "review"=>nil,
-           "shipping"=>nil,
-           "source"=>nil,
-           "source_transfer"=>nil,
-           "statement_descriptor"=>nil,
-           "statement_descriptor_suffix"=>nil,
-           "status"=>"succeeded",
-           "transfer_data"=>nil,
-           "transfer_group"=>nil}],
+        "id"=>"ch_1HZJGQAWOtgoysogEpbZTGIl",
+        "object"=>"charge",
+        "amount"=>2000,
+        "amount_captured"=>2000,
+        "amount_refunded"=>0,
+        "application"=>nil,
+        "application_fee"=>nil,
+        "application_fee_amount"=>nil,
+        "balance_transaction"=>"txn_1HZJGQAWOtgoysogEKwV2r5N",
+        "billing_details"=>
+        {"address"=>{"city"=>nil, "country"=>nil, "line1"=>nil, "line2"=>nil, "postal_code"=>nil, "state"=>nil}, "email"=>nil, "name"=>nil, "phone"=>nil},
+        "calculated_statement_descriptor"=>"SPREEDLY",
+        "captured"=>true,
+        "created"=>1602002626,
+        "currency"=>"gbp",
+        "customer"=>nil,
+        "description"=>nil,
+        "destination"=>nil,
+        "dispute"=>nil,
+        "disputed"=>false,
+        "failure_code"=>nil,
+        "failure_message"=>nil,
+        "fraud_details"=>{},
+        "invoice"=>nil,
+        "livemode"=>false,
+        "metadata"=>{},
+        "on_behalf_of"=>nil,
+        "order"=>nil,
+        "outcome"=>
+        {"network_status"=>"approved_by_network",
+          "reason"=>nil,
+          "risk_level"=>"normal",
+          "risk_score"=>16,
+          "seller_message"=>"Payment complete.",
+          "type"=>"authorized"},
+        "paid"=>true,
+        "payment_intent"=>"pi_1HZJGPAWOtgoysogrKURP11Q",
+        "payment_method"=>"pm_1HZJGOAWOtgoysogvnMsnnG1",
+        "payment_method_details"=>
+        {"card"=>
+          {"brand"=>"visa",
+            "checks"=>{"address_line1_check"=>nil, "address_postal_code_check"=>nil, "cvc_check"=>"pass"},
+            "country"=>"US",
+            "ds_transaction_id"=>nil,
+            "exp_month"=>10,
+            "exp_year"=>2020,
+            "fingerprint"=>"hfaVNMiXc0dYSiC5",
+            "funding"=>"credit",
+            "installments"=>nil,
+            "last4"=>"4242",
+            "moto"=>nil,
+            "network"=>"visa",
+            "network_transaction_id"=>"1041029786787710",
+            "three_d_secure"=>
+            {"authenticated"=>false,
+              "authentication_flow"=>nil,
+              "electronic_commerce_indicator"=>"06",
+              "result"=>"attempt_acknowledged",
+              "result_reason"=>nil,
+              "succeeded"=>true,
+              "transaction_id"=>"d1VlRVF6a1BVNXN1cjMzZVl0RU0=",
+              "version"=>"1.0.2"},
+            "wallet"=>nil},
+          "type"=>"card"},
+        "receipt_email"=>nil,
+        "receipt_number"=>nil,
+        "receipt_url"=>"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1HZJGQAWOtgoysogEpbZTGIl/rcpt_I9cVpN9xAeS39FhMqTS33Fj8gHsjjuX",
+        "refunded"=>false,
+        "refunds"=>{"object"=>"list", "data"=>[], "has_more"=>false, "total_count"=>0, "url"=>"/v1/charges/ch_1HZJGQAWOtgoysogEpbZTGIl/refunds"},
+        "review"=>nil,
+        "shipping"=>nil,
+        "source"=>nil,
+        "source_transfer"=>nil,
+        "statement_descriptor"=>nil,
+        "statement_descriptor_suffix"=>nil,
+        "status"=>"succeeded",
+        "transfer_data"=>nil,
+        "transfer_group"=>nil,
         "has_more"=>false,
         "total_count"=>1,
         "url"=>"/v1/charges?payment_intent=pi_1HZJGPAWOtgoysogrKURP11Q"},
@@ -1969,13 +2214,13 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
 
   def failed_capture_response
     <<-RESPONSE
-      {"error":{"charge":"ch_1F2MB6AWOtgoysogAIvNV32Z","code":"card_declined","decline_code":"generic_decline","doc_url":"https://stripe.com/docs/error-codes/card-declined","message":"Your card was declined.","payment_intent":{"id":"pi_1F2MB5AWOtgoysogCMt8BaxR","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"automatic","charges":{"object":"list","data":[{"id":"ch_1F2MB6AWOtgoysogAIvNV32Z","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564596332,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":"card_declined","failure_message":"Your card was declined.","fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"declined_by_network","reason":"generic_decline","risk_level":"normal","risk_score":41,"seller_message":"The bank did not return any further details with this decline.","type":"issuer_declined"},"paid":false,"payment_intent":"pi_1F2MB5AWOtgoysogCMt8BaxR","payment_method":"pm_1F2MB5AWOtgoysogq3yXZ98h","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"1VUoWMvHnqtngyrD","funding":"credit","last4":"0002","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F2MB6AWOtgoysogAIvNV32Z/rcpt_FXR3PjBGluHmHsnLmp0S2KQiHl3yg6W","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F2MB6AWOtgoysogAIvNV32Z/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"failed","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F2MB5AWOtgoysogCMt8BaxR"},"client_secret":"pi_1F2MB5AWOtgoysogCMt8BaxR_secret_fOHryjtjBE4gACiHTcREraXSQ","confirmation_method":"manual","created":1564596331,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":{"charge":"ch_1F2MB6AWOtgoysogAIvNV32Z","code":"card_declined","decline_code":"generic_decline","doc_url":"https://stripe.com/docs/error-codes/card-declined","message":"Your card was declined.","payment_method":{"id":"pm_1F2MB5AWOtgoysogq3yXZ98h","object":"payment_method","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"1VUoWMvHnqtngyrD","funding":"credit","generated_from":null,"last4":"0002","three_d_secure_usage":{"supported":true},"wallet":null},"created":1564596331,"customer":null,"livemode":false,"metadata":{},"type":"card"},"type":"card_error"},"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":null,"payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_payment_method","transfer_data":null,"transfer_group":null},"payment_method":{"id":"pm_1F2MB5AWOtgoysogq3yXZ98h","object":"payment_method","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"1VUoWMvHnqtngyrD","funding":"credit","generated_from":null,"last4":"0002","three_d_secure_usage":{"supported":true},"wallet":null},"created":1564596331,"customer":null,"livemode":false,"metadata":{},"type":"card"},"type":"card_error"}}
+      {"error":{"charge":"ch_1F2MB6AWOtgoysogAIvNV32Z","code":"card_declined","decline_code":"generic_decline","doc_url":"https://stripe.com/docs/error-codes/card-declined","message":"Your card was declined.","payment_intent":{"id":"pi_1F2MB5AWOtgoysogCMt8BaxR","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":0,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"automatic","latest_charge":{"object":"list","id":"ch_1F2MB6AWOtgoysogAIvNV32Z","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":null,"billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":false,"created":1564596332,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":"card_declined","failure_message":"Your card was declined.","fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"declined_by_network","reason":"generic_decline","risk_level":"normal","risk_score":41,"seller_message":"The bank did not return any further details with this decline.","type":"issuer_declined"},"paid":false,"payment_intent":"pi_1F2MB5AWOtgoysogCMt8BaxR","payment_method":"pm_1F2MB5AWOtgoysogq3yXZ98h","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"1VUoWMvHnqtngyrD","funding":"credit","last4":"0002","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F2MB6AWOtgoysogAIvNV32Z/rcpt_FXR3PjBGluHmHsnLmp0S2KQiHl3yg6W","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F2MB6AWOtgoysogAIvNV32Z/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"failed","transfer_data":null,"transfer_group":null,"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F2MB5AWOtgoysogCMt8BaxR"},"client_secret":"pi_1F2MB5AWOtgoysogCMt8BaxR_secret_fOHryjtjBE4gACiHTcREraXSQ","confirmation_method":"manual","created":1564596331,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":{"charge":"ch_1F2MB6AWOtgoysogAIvNV32Z","code":"card_declined","decline_code":"generic_decline","doc_url":"https://stripe.com/docs/error-codes/card-declined","message":"Your card was declined.","payment_method":{"id":"pm_1F2MB5AWOtgoysogq3yXZ98h","object":"payment_method","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"1VUoWMvHnqtngyrD","funding":"credit","generated_from":null,"last4":"0002","three_d_secure_usage":{"supported":true},"wallet":null},"created":1564596331,"customer":null,"livemode":false,"metadata":{},"type":"card"},"type":"card_error"},"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":null,"payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"requires_payment_method","transfer_data":null,"transfer_group":null},"payment_method":{"id":"pm_1F2MB5AWOtgoysogq3yXZ98h","object":"payment_method","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"1VUoWMvHnqtngyrD","funding":"credit","generated_from":null,"last4":"0002","three_d_secure_usage":{"supported":true},"wallet":null},"created":1564596331,"customer":null,"livemode":false,"metadata":{},"type":"card"},"type":"card_error"}}
     RESPONSE
   end
 
   def failed_cancel_response
     <<-RESPONSE
-      {"error":{"code":"payment_intent_unexpected_state","doc_url":"https://stripe.com/docs/error-codes/payment-intent-unexpected-state","message":"You cannot cancel this PaymentIntent because it has a status of succeeded. Only a PaymentIntent with one of the following statuses may be canceled: requires_payment_method, requires_capture, requires_confirmation, requires_action.","payment_intent":{"id":"pi_1F2McmAWOtgoysoglFLDRWab","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":2020,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"automatic","charges":{"object":"list","data":[{"id":"ch_1F2McmAWOtgoysogQgUS1YtH","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":"txn_1F2McmAWOtgoysog8uxBEJ30","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":true,"created":1564598048,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":53,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F2McmAWOtgoysoglFLDRWab","payment_method":"pm_1F2MclAWOtgoysogq80GBBMO","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F2McmAWOtgoysogQgUS1YtH/rcpt_FXRVzyFnf7aCS1r13N3uym1u8AaboOJ","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F2McmAWOtgoysogQgUS1YtH/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null}],"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F2McmAWOtgoysoglFLDRWab"},"client_secret":"pi_1F2McmAWOtgoysoglFLDRWab_secret_z4faDF0Cv0JZJ6pxK3bdIodkD","confirmation_method":"manual","created":1564598048,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F2MclAWOtgoysogq80GBBMO","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null},"type":"invalid_request_error"}}
+      {"error":{"code":"payment_intent_unexpected_state","doc_url":"https://stripe.com/docs/error-codes/payment-intent-unexpected-state","message":"You cannot cancel this PaymentIntent because it has a status of succeeded. Only a PaymentIntent with one of the following statuses may be canceled: requires_payment_method, requires_capture, requires_confirmation, requires_action.","payment_intent":{"id":"pi_1F2McmAWOtgoysoglFLDRWab","object":"payment_intent","amount":2020,"amount_capturable":0,"amount_received":2020,"application":null,"application_fee_amount":null,"canceled_at":null,"cancellation_reason":null,"capture_method":"automatic","latest_charge":{"object":"list","id":"ch_1F2McmAWOtgoysogQgUS1YtH","object":"charge","amount":2020,"amount_refunded":0,"application":null,"application_fee":null,"application_fee_amount":null,"balance_transaction":"txn_1F2McmAWOtgoysog8uxBEJ30","billing_details":{"address":{"city":null,"country":null,"line1":null,"line2":null,"postal_code":null,"state":null},"email":null,"name":null,"phone":null},"captured":true,"created":1564598048,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"destination":null,"dispute":null,"failure_code":null,"failure_message":null,"fraud_details":{},"invoice":null,"livemode":false,"metadata":{},"on_behalf_of":null,"order":null,"outcome":{"network_status":"approved_by_network","reason":null,"risk_level":"normal","risk_score":53,"seller_message":"Payment complete.","type":"authorized"},"paid":true,"payment_intent":"pi_1F2McmAWOtgoysoglFLDRWab","payment_method":"pm_1F2MclAWOtgoysogq80GBBMO","payment_method_details":{"card":{"brand":"visa","checks":{"address_line1_check":null,"address_postal_code_check":null,"cvc_check":null},"country":"US","exp_month":7,"exp_year":2020,"fingerprint":"hfaVNMiXc0dYSiC5","funding":"credit","last4":"4242","three_d_secure":null,"wallet":null},"type":"card"},"receipt_email":null,"receipt_number":null,"receipt_url":"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_1F2McmAWOtgoysogQgUS1YtH/rcpt_FXRVzyFnf7aCS1r13N3uym1u8AaboOJ","refunded":false,"refunds":{"object":"list","data":[],"has_more":false,"total_count":0,"url":"/v1/charges/ch_1F2McmAWOtgoysogQgUS1YtH/refunds"},"review":null,"shipping":null,"source":null,"source_transfer":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null,"has_more":false,"total_count":1,"url":"/v1/charges?payment_intent=pi_1F2McmAWOtgoysoglFLDRWab"},"client_secret":"pi_1F2McmAWOtgoysoglFLDRWab_secret_z4faDF0Cv0JZJ6pxK3bdIodkD","confirmation_method":"manual","created":1564598048,"currency":"gbp","customer":"cus_7s22nNueP2Hjj6","description":null,"invoice":null,"last_payment_error":null,"livemode":false,"metadata":{},"next_action":null,"on_behalf_of":null,"payment_method":"pm_1F2MclAWOtgoysogq80GBBMO","payment_method_options":{"card":{"request_three_d_secure":"automatic"}},"payment_method_types":["card"],"receipt_email":null,"review":null,"setup_future_usage":null,"shipping":null,"source":null,"statement_descriptor":null,"status":"succeeded","transfer_data":null,"transfer_group":null},"type":"invalid_request_error"}}
     RESPONSE
   end
 
@@ -2228,7 +2473,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       -> "Strict-Transport-Security: max-age=31556926; includeSubDomains; preload\r\n"
       -> "\r\n"
       reading 5204 bytes...
-      -> "{\n  \"id\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc\",\n  \"object\": \"payment_intent\",\n  \"amount\": 100,\n  \"amount_capturable\": 0,\n  \"amount_received\": 100,\n  \"application\": null,\n  \"application_fee_amount\": null,\n  \"automatic_payment_methods\": null,\n  \"canceled_at\": null,\n  \"cancellation_reason\": null,\n  \"capture_method\": \"automatic\",\n  \"charges\": {\n    \"object\": \"list\",\n    \"data\": [\n      {\n        \"id\": \"ch_3KHrnWAWOtgoysog1noj1iU9\",\n        \"object\": \"charge\",\n        \"amount\": 100,\n        \"amount_captured\": 100,\n        \"amount_refunded\": 0,\n        \"application\": null,\n        \"application_fee\": null,\n        \"application_fee_amount\": null,\n        \"balance_transaction\": \"txn_3KHrnWAWOtgoysog1vy6pmxk\",\n        \"billing_details\": {\n          \"address\": {\n            \"city\": null,\n            \"country\": null,\n            \"line1\": null,\n            \"line2\": null,\n            \"postal_code\": null,\n            \"state\": null\n          },\n          \"email\": null,\n          \"name\": null,\n          \"phone\": null\n        },\n        \"calculated_statement_descriptor\": \"SPREEDLY\",\n        \"captured\": true,\n        \"created\": 1642174478,\n        \"currency\": \"usd\",\n        \"customer\": null,\n        \"description\": null,\n        \"destination\": null,\n        \"dispute\": null,\n        \"disputed\": false,\n        \"failure_code\": null,\n        \"failure_message\": null,\n        \"fraud_details\": {\n        },\n        \"invoice\": null,\n        \"livemode\": false,\n        \"metadata\": {\n          \"connect_agent\": \"placeholder\",\n          \"transaction_token\": \"Coe7nlopnvhfcNRXhJMH5DTVusU\",\n          \"email\": \"john.smith@example.com\",\n          \"order_id\": \"AH2EjtfMGoZkWNEwLU90sq7VzcDlzWH_KugIYT4aVWEtJF9AwmqiXqsBs2l9q6F2Ruq9WKkUBbuLWNmA3P22ShFXFCZosTwkoflaDeTD2xeiMvmYv29VPINEDtLdSAoJ-DDlRKnsxa-n\"\n        },\n        \"on_behalf_of\": null,\n        \"order\": null,\n        \"outcome\": {\n          \"network_status\": \"approved_by_network\",\n          \"reason\": null,\n          \"risk_level\": \"normal\",\n          \"risk_score\": 36,\n          \"seller_message\": \"Payment complete.\",\n          \"type\": \"authorized\"\n        },\n        \"paid\": true,\n        \"payment_intent\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc\",\n        \"payment_method\": \"pm_1KHrnWAWOtgoysogqXkTXrCb\",\n        \"payment_method_details\": {\n          \"card\": {\n            \"brand\": \"visa\",\n            \"checks\": {\n              \"address_line1_check\": null,\n              \"address_postal_code_check\": null,\n              \"cvc_check\": null\n            },\n            \"country\": \"US\",\n            \"ds_transaction_id\": null,\n            \"exp_month\": 12,\n            \"exp_year\": 2027,\n            \"fingerprint\": \"sUdMrygQwzOKqwSm\",\n            \"funding\": \"debit\",\n            \"installments\": null,\n            \"last4\": \"0000\",\n            \"mandate\": null,\n            \"moto\": null,\n            \"network\": \"visa\",\n            \"network_transaction_id\": \"1158510077114121\",\n            \"three_d_secure\": null,\n            \"wallet\": {\n              \"dynamic_last4\": \"3478\",\n              \"google_pay\": {\n              },\n              \"type\": \"google_pay\"\n            }\n          },\n          \"type\": \"card\"\n        },\n        \"receipt_email\": null,\n        \"receipt_number\": null,\n        \"receipt_url\": \"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3KHrnWAWOtgoysog1noj1iU9/rcpt_KxnOefAivglRgWZmxp0PLOJUQg0VhS9\",\n        \"refunded\": false,\n        \"refunds\": {\n          \"object\": \"list\",\n          \"data\": [\n\n          ],\n          \"has_more\": false,\n          \"total_count\": 0,\n          \"url\": \"/v1/charges/ch_3KHrnWAWOtgoysog1noj1iU9/refunds\"\n        },\n        \"review\": null,\n        \"shipping\": null,\n        \"source\": null,\n        \"source_transfer\": null,\n        \"statement_descriptor\": null,\n        \"statement_descriptor_suffix\": null,\n        \"status\": \"succeeded\",\n        \"transfer_data\": null,\n        \"transfer_group\": null\n      }\n    ],\n    \"has_more\": false,\n    \"total_count\": 1,\n    \"url\": \"/v1/charges?payment_intent=pi_3KHrnWAWOtgoysog1Y5qMLqc\"\n  },\n  \"client_secret\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc_secret_5ZEt4fzM7YCi1zdMzs4iQXLjC\",\n  \"confirmation_method\": \"automatic\",\n  \"created\": 1642174478,\n  \"currency\": \"usd\",\n  \"customer\": null,\n  \"description\": null,\n  \"invoice\": null,\n  \"last_payment_error\": null,\n  \"livemode\": false,\n  \"metadata\": {\n    \"connect_agent\": \"placeholder\",\n    \"transaction_token\": \"Coe7nlopnvhfcNRXhJMH5DTVusU\",\n    \"email\": \"john.smith@example.com\",\n    \"order_id\": \"AH2EjtfMGoZkWNEwLU90sq7VzcDlzWH_KugIYT4aVWEtJF9AwmqiXqsBs2l9q6F2Ruq9WKkUBbuLWNmA3P22ShFXFCZosTwkoflaDeTD2xeiMvmYv29VPINEDtLdSAoJ-DDlRKnsxa-n\"\n  },\n  \"next_action\": null,\n  \"on_behalf_of\": null,\n  \"payment_method\": \"pm_1KHrnWAWOtgoysogqXkTXrCb\",\n  \"payment_method_options\": {\n    \"card\": {\n      \"installments\": null,\n      \"mandate_options\": null,\n      \"network\": null,\n      \"request_three_d_secure\": \"automatic\"\n    }\n  },\n  \"payment_method_types\": [\n    \"card\"\n  ],\n  \"processing\": null,\n  \"receipt_email\": null,\n  \"review\": null,\n  \"setup_future_usage\": null,\n  \"shipping\": null,\n  \"source\": null,\n  \"statement_descriptor\": null,\n  \"statement_descriptor_suffix\": null,\n  \"status\": \"succeeded\",\n  \"transfer_data\": null,\n  \"transfer_group\": null\n}\n"
+      -> "{\n  \"id\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc\",\n  \"object\": \"payment_intent\",\n  \"amount\": 100,\n  \"amount_capturable\": 0,\n  \"amount_received\": 100,\n  \"application\": null,\n  \"application_fee_amount\": null,\n  \"automatic_payment_methods\": null,\n  \"canceled_at\": null,\n  \"cancellation_reason\": null,\n  \"capture_method\": \"automatic\",\n  \"latest_charge\": {\n    \"object\": \"list\",\n    \"id\": \"ch_3KHrnWAWOtgoysog1noj1iU9\",\n        \"object\": \"charge\",\n        \"amount\": 100,\n        \"amount_captured\": 100,\n        \"amount_refunded\": 0,\n        \"application\": null,\n        \"application_fee\": null,\n        \"application_fee_amount\": null,\n        \"balance_transaction\": \"txn_3KHrnWAWOtgoysog1vy6pmxk\",\n        \"billing_details\": {\n          \"address\": {\n            \"city\": null,\n            \"country\": null,\n            \"line1\": null,\n            \"line2\": null,\n            \"postal_code\": null,\n            \"state\": null\n          },\n          \"email\": null,\n          \"name\": null,\n          \"phone\": null\n        },\n        \"calculated_statement_descriptor\": \"SPREEDLY\",\n        \"captured\": true,\n        \"created\": 1642174478,\n        \"currency\": \"usd\",\n        \"customer\": null,\n        \"description\": null,\n        \"destination\": null,\n        \"dispute\": null,\n        \"disputed\": false,\n        \"failure_code\": null,\n        \"failure_message\": null,\n        \"fraud_details\": {\n        },\n        \"invoice\": null,\n        \"livemode\": false,\n        \"metadata\": {\n          \"connect_agent\": \"placeholder\",\n          \"transaction_token\": \"Coe7nlopnvhfcNRXhJMH5DTVusU\",\n          \"email\": \"john.smith@example.com\",\n          \"order_id\": \"AH2EjtfMGoZkWNEwLU90sq7VzcDlzWH_KugIYT4aVWEtJF9AwmqiXqsBs2l9q6F2Ruq9WKkUBbuLWNmA3P22ShFXFCZosTwkoflaDeTD2xeiMvmYv29VPINEDtLdSAoJ-DDlRKnsxa-n\"\n        },\n        \"on_behalf_of\": null,\n        \"order\": null,\n        \"outcome\": {\n          \"network_status\": \"approved_by_network\",\n          \"reason\": null,\n          \"risk_level\": \"normal\",\n          \"risk_score\": 36,\n          \"seller_message\": \"Payment complete.\",\n          \"type\": \"authorized\"\n        },\n        \"paid\": true,\n        \"payment_intent\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc\",\n        \"payment_method\": \"pm_1KHrnWAWOtgoysogqXkTXrCb\",\n        \"payment_method_details\": {\n          \"card\": {\n            \"brand\": \"visa\",\n            \"checks\": {\n              \"address_line1_check\": null,\n              \"address_postal_code_check\": null,\n              \"cvc_check\": null\n            },\n            \"country\": \"US\",\n            \"ds_transaction_id\": null,\n            \"exp_month\": 12,\n            \"exp_year\": 2027,\n            \"fingerprint\": \"sUdMrygQwzOKqwSm\",\n            \"funding\": \"debit\",\n            \"installments\": null,\n            \"last4\": \"0000\",\n            \"mandate\": null,\n            \"moto\": null,\n            \"network\": \"visa\",\n            \"network_transaction_id\": \"1158510077114121\",\n            \"three_d_secure\": null,\n            \"wallet\": {\n              \"dynamic_last4\": \"3478\",\n              \"google_pay\": {\n              },\n              \"type\": \"google_pay\"\n            }\n          },\n          \"type\": \"card\"\n        },\n        \"receipt_email\": null,\n        \"receipt_number\": null,\n        \"receipt_url\": \"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3KHrnWAWOtgoysog1noj1iU9/rcpt_KxnOefAivglRgWZmxp0PLOJUQg0VhS9\",\n        \"refunded\": false,\n        \"refunds\": {\n          \"object\": \"list\",\n          \"data\": [\n\n          ],\n          \"has_more\": false,\n          \"total_count\": 0,\n          \"url\": \"/v1/charges/ch_3KHrnWAWOtgoysog1noj1iU9/refunds\"\n        },\n        \"review\": null,\n        \"shipping\": null,\n        \"source\": null,\n        \"source_transfer\": null,\n        \"statement_descriptor\": null,\n        \"statement_descriptor_suffix\": null,\n        \"status\": \"succeeded\",\n        \"transfer_data\": null,\n        \"transfer_group\": null,\n    \"has_more\": false,\n    \"total_count\": 1,\n    \"url\": \"/v1/charges?payment_intent=pi_3KHrnWAWOtgoysog1Y5qMLqc\"\n  },\n  \"client_secret\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc_secret_5ZEt4fzM7YCi1zdMzs4iQXLjC\",\n  \"confirmation_method\": \"automatic\",\n  \"created\": 1642174478,\n  \"currency\": \"usd\",\n  \"customer\": null,\n  \"description\": null,\n  \"invoice\": null,\n  \"last_payment_error\": null,\n  \"livemode\": false,\n  \"metadata\": {\n    \"connect_agent\": \"placeholder\",\n    \"transaction_token\": \"Coe7nlopnvhfcNRXhJMH5DTVusU\",\n    \"email\": \"john.smith@example.com\",\n    \"order_id\": \"AH2EjtfMGoZkWNEwLU90sq7VzcDlzWH_KugIYT4aVWEtJF9AwmqiXqsBs2l9q6F2Ruq9WKkUBbuLWNmA3P22ShFXFCZosTwkoflaDeTD2xeiMvmYv29VPINEDtLdSAoJ-DDlRKnsxa-n\"\n  },\n  \"next_action\": null,\n  \"on_behalf_of\": null,\n  \"payment_method\": \"pm_1KHrnWAWOtgoysogqXkTXrCb\",\n  \"payment_method_options\": {\n    \"card\": {\n      \"installments\": null,\n      \"mandate_options\": null,\n      \"network\": null,\n      \"request_three_d_secure\": \"automatic\"\n    }\n  },\n  \"payment_method_types\": [\n    \"card\"\n  ],\n  \"processing\": null,\n  \"receipt_email\": null,\n  \"review\": null,\n  \"setup_future_usage\": null,\n  \"shipping\": null,\n  \"source\": null,\n  \"statement_descriptor\": null,\n  \"statement_descriptor_suffix\": null,\n  \"status\": \"succeeded\",\n  \"transfer_data\": null,\n  \"transfer_group\": null\n}\n"
       read 5204 bytes
       Conn close
     PRE_SCRUBBED
@@ -2262,7 +2507,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       -> "Strict-Transport-Security: max-age=31556926; includeSubDomains; preload\r\n"
       -> "\r\n"
       reading 5204 bytes...
-      -> "{\n  \"id\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc\",\n  \"object\": \"payment_intent\",\n  \"amount\": 100,\n  \"amount_capturable\": 0,\n  \"amount_received\": 100,\n  \"application\": null,\n  \"application_fee_amount\": null,\n  \"automatic_payment_methods\": null,\n  \"canceled_at\": null,\n  \"cancellation_reason\": null,\n  \"capture_method\": \"automatic\",\n  \"charges\": {\n    \"object\": \"list\",\n    \"data\": [\n      {\n        \"id\": \"ch_3KHrnWAWOtgoysog1noj1iU9\",\n        \"object\": \"charge\",\n        \"amount\": 100,\n        \"amount_captured\": 100,\n        \"amount_refunded\": 0,\n        \"application\": null,\n        \"application_fee\": null,\n        \"application_fee_amount\": null,\n        \"balance_transaction\": \"txn_3KHrnWAWOtgoysog1vy6pmxk\",\n        \"billing_details\": {\n          \"address\": {\n            \"city\": null,\n            \"country\": null,\n            \"line1\": null,\n            \"line2\": null,\n            \"postal_code\": null,\n            \"state\": null\n          },\n          \"email\": null,\n          \"name\": null,\n          \"phone\": null\n        },\n        \"calculated_statement_descriptor\": \"SPREEDLY\",\n        \"captured\": true,\n        \"created\": 1642174478,\n        \"currency\": \"usd\",\n        \"customer\": null,\n        \"description\": null,\n        \"destination\": null,\n        \"dispute\": null,\n        \"disputed\": false,\n        \"failure_code\": null,\n        \"failure_message\": null,\n        \"fraud_details\": {\n        },\n        \"invoice\": null,\n        \"livemode\": false,\n        \"metadata\": {\n          \"connect_agent\": \"placeholder\",\n          \"transaction_token\": \"Coe7nlopnvhfcNRXhJMH5DTVusU\",\n          \"email\": \"john.smith@example.com\",\n          \"order_id\": \"AH2EjtfMGoZkWNEwLU90sq7VzcDlzWH_KugIYT4aVWEtJF9AwmqiXqsBs2l9q6F2Ruq9WKkUBbuLWNmA3P22ShFXFCZosTwkoflaDeTD2xeiMvmYv29VPINEDtLdSAoJ-DDlRKnsxa-n\"\n        },\n        \"on_behalf_of\": null,\n        \"order\": null,\n        \"outcome\": {\n          \"network_status\": \"approved_by_network\",\n          \"reason\": null,\n          \"risk_level\": \"normal\",\n          \"risk_score\": 36,\n          \"seller_message\": \"Payment complete.\",\n          \"type\": \"authorized\"\n        },\n        \"paid\": true,\n        \"payment_intent\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc\",\n        \"payment_method\": \"pm_1KHrnWAWOtgoysogqXkTXrCb\",\n        \"payment_method_details\": {\n          \"card\": {\n            \"brand\": \"visa\",\n            \"checks\": {\n              \"address_line1_check\": null,\n              \"address_postal_code_check\": null,\n              \"cvc_check\": null\n            },\n            \"country\": \"US\",\n            \"ds_transaction_id\": null,\n            \"exp_month\": 12,\n            \"exp_year\": 2027,\n            \"fingerprint\": \"sUdMrygQwzOKqwSm\",\n            \"funding\": \"debit\",\n            \"installments\": null,\n            \"last4\": \"0000\",\n            \"mandate\": null,\n            \"moto\": null,\n            \"network\": \"visa\",\n            \"network_transaction_id\": \"1158510077114121\",\n            \"three_d_secure\": null,\n            \"wallet\": {\n              \"dynamic_last4\": \"3478\",\n              \"google_pay\": {\n              },\n              \"type\": \"google_pay\"\n            }\n          },\n          \"type\": \"card\"\n        },\n        \"receipt_email\": null,\n        \"receipt_number\": null,\n        \"receipt_url\": \"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3KHrnWAWOtgoysog1noj1iU9/rcpt_KxnOefAivglRgWZmxp0PLOJUQg0VhS9\",\n        \"refunded\": false,\n        \"refunds\": {\n          \"object\": \"list\",\n          \"data\": [\n\n          ],\n          \"has_more\": false,\n          \"total_count\": 0,\n          \"url\": \"/v1/charges/ch_3KHrnWAWOtgoysog1noj1iU9/refunds\"\n        },\n        \"review\": null,\n        \"shipping\": null,\n        \"source\": null,\n        \"source_transfer\": null,\n        \"statement_descriptor\": null,\n        \"statement_descriptor_suffix\": null,\n        \"status\": \"succeeded\",\n        \"transfer_data\": null,\n        \"transfer_group\": null\n      }\n    ],\n    \"has_more\": false,\n    \"total_count\": 1,\n    \"url\": \"/v1/charges?payment_intent=pi_3KHrnWAWOtgoysog1Y5qMLqc\"\n  },\n  \"client_secret\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc_secret_5ZEt4fzM7YCi1zdMzs4iQXLjC\",\n  \"confirmation_method\": \"automatic\",\n  \"created\": 1642174478,\n  \"currency\": \"usd\",\n  \"customer\": null,\n  \"description\": null,\n  \"invoice\": null,\n  \"last_payment_error\": null,\n  \"livemode\": false,\n  \"metadata\": {\n    \"connect_agent\": \"placeholder\",\n    \"transaction_token\": \"Coe7nlopnvhfcNRXhJMH5DTVusU\",\n    \"email\": \"john.smith@example.com\",\n    \"order_id\": \"AH2EjtfMGoZkWNEwLU90sq7VzcDlzWH_KugIYT4aVWEtJF9AwmqiXqsBs2l9q6F2Ruq9WKkUBbuLWNmA3P22ShFXFCZosTwkoflaDeTD2xeiMvmYv29VPINEDtLdSAoJ-DDlRKnsxa-n\"\n  },\n  \"next_action\": null,\n  \"on_behalf_of\": null,\n  \"payment_method\": \"pm_1KHrnWAWOtgoysogqXkTXrCb\",\n  \"payment_method_options\": {\n    \"card\": {\n      \"installments\": null,\n      \"mandate_options\": null,\n      \"network\": null,\n      \"request_three_d_secure\": \"automatic\"\n    }\n  },\n  \"payment_method_types\": [\n    \"card\"\n  ],\n  \"processing\": null,\n  \"receipt_email\": null,\n  \"review\": null,\n  \"setup_future_usage\": null,\n  \"shipping\": null,\n  \"source\": null,\n  \"statement_descriptor\": null,\n  \"statement_descriptor_suffix\": null,\n  \"status\": \"succeeded\",\n  \"transfer_data\": null,\n  \"transfer_group\": null\n}\n"
+      -> "{\n  \"id\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc\",\n  \"object\": \"payment_intent\",\n  \"amount\": 100,\n  \"amount_capturable\": 0,\n  \"amount_received\": 100,\n  \"application\": null,\n  \"application_fee_amount\": null,\n  \"automatic_payment_methods\": null,\n  \"canceled_at\": null,\n  \"cancellation_reason\": null,\n  \"capture_method\": \"automatic\",\n  \"latest_charge\": {\n    \"object\": \"list\",\n    \"id\": \"ch_3KHrnWAWOtgoysog1noj1iU9\",\n        \"object\": \"charge\",\n        \"amount\": 100,\n        \"amount_captured\": 100,\n        \"amount_refunded\": 0,\n        \"application\": null,\n        \"application_fee\": null,\n        \"application_fee_amount\": null,\n        \"balance_transaction\": \"txn_3KHrnWAWOtgoysog1vy6pmxk\",\n        \"billing_details\": {\n          \"address\": {\n            \"city\": null,\n            \"country\": null,\n            \"line1\": null,\n            \"line2\": null,\n            \"postal_code\": null,\n            \"state\": null\n          },\n          \"email\": null,\n          \"name\": null,\n          \"phone\": null\n        },\n        \"calculated_statement_descriptor\": \"SPREEDLY\",\n        \"captured\": true,\n        \"created\": 1642174478,\n        \"currency\": \"usd\",\n        \"customer\": null,\n        \"description\": null,\n        \"destination\": null,\n        \"dispute\": null,\n        \"disputed\": false,\n        \"failure_code\": null,\n        \"failure_message\": null,\n        \"fraud_details\": {\n        },\n        \"invoice\": null,\n        \"livemode\": false,\n        \"metadata\": {\n          \"connect_agent\": \"placeholder\",\n          \"transaction_token\": \"Coe7nlopnvhfcNRXhJMH5DTVusU\",\n          \"email\": \"john.smith@example.com\",\n          \"order_id\": \"AH2EjtfMGoZkWNEwLU90sq7VzcDlzWH_KugIYT4aVWEtJF9AwmqiXqsBs2l9q6F2Ruq9WKkUBbuLWNmA3P22ShFXFCZosTwkoflaDeTD2xeiMvmYv29VPINEDtLdSAoJ-DDlRKnsxa-n\"\n        },\n        \"on_behalf_of\": null,\n        \"order\": null,\n        \"outcome\": {\n          \"network_status\": \"approved_by_network\",\n          \"reason\": null,\n          \"risk_level\": \"normal\",\n          \"risk_score\": 36,\n          \"seller_message\": \"Payment complete.\",\n          \"type\": \"authorized\"\n        },\n        \"paid\": true,\n        \"payment_intent\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc\",\n        \"payment_method\": \"pm_1KHrnWAWOtgoysogqXkTXrCb\",\n        \"payment_method_details\": {\n          \"card\": {\n            \"brand\": \"visa\",\n            \"checks\": {\n              \"address_line1_check\": null,\n              \"address_postal_code_check\": null,\n              \"cvc_check\": null\n            },\n            \"country\": \"US\",\n            \"ds_transaction_id\": null,\n            \"exp_month\": 12,\n            \"exp_year\": 2027,\n            \"fingerprint\": \"sUdMrygQwzOKqwSm\",\n            \"funding\": \"debit\",\n            \"installments\": null,\n            \"last4\": \"0000\",\n            \"mandate\": null,\n            \"moto\": null,\n            \"network\": \"visa\",\n            \"network_transaction_id\": \"1158510077114121\",\n            \"three_d_secure\": null,\n            \"wallet\": {\n              \"dynamic_last4\": \"3478\",\n              \"google_pay\": {\n              },\n              \"type\": \"google_pay\"\n            }\n          },\n          \"type\": \"card\"\n        },\n        \"receipt_email\": null,\n        \"receipt_number\": null,\n        \"receipt_url\": \"https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3KHrnWAWOtgoysog1noj1iU9/rcpt_KxnOefAivglRgWZmxp0PLOJUQg0VhS9\",\n        \"refunded\": false,\n        \"refunds\": {\n          \"object\": \"list\",\n          \"data\": [\n\n          ],\n          \"has_more\": false,\n          \"total_count\": 0,\n          \"url\": \"/v1/charges/ch_3KHrnWAWOtgoysog1noj1iU9/refunds\"\n        },\n        \"review\": null,\n        \"shipping\": null,\n        \"source\": null,\n        \"source_transfer\": null,\n        \"statement_descriptor\": null,\n        \"statement_descriptor_suffix\": null,\n        \"status\": \"succeeded\",\n        \"transfer_data\": null,\n        \"transfer_group\": null,\n    \"has_more\": false,\n    \"total_count\": 1,\n    \"url\": \"/v1/charges?payment_intent=pi_3KHrnWAWOtgoysog1Y5qMLqc\"\n  },\n  \"client_secret\": \"pi_3KHrnWAWOtgoysog1Y5qMLqc_secret_5ZEt4fzM7YCi1zdMzs4iQXLjC\",\n  \"confirmation_method\": \"automatic\",\n  \"created\": 1642174478,\n  \"currency\": \"usd\",\n  \"customer\": null,\n  \"description\": null,\n  \"invoice\": null,\n  \"last_payment_error\": null,\n  \"livemode\": false,\n  \"metadata\": {\n    \"connect_agent\": \"placeholder\",\n    \"transaction_token\": \"Coe7nlopnvhfcNRXhJMH5DTVusU\",\n    \"email\": \"john.smith@example.com\",\n    \"order_id\": \"AH2EjtfMGoZkWNEwLU90sq7VzcDlzWH_KugIYT4aVWEtJF9AwmqiXqsBs2l9q6F2Ruq9WKkUBbuLWNmA3P22ShFXFCZosTwkoflaDeTD2xeiMvmYv29VPINEDtLdSAoJ-DDlRKnsxa-n\"\n  },\n  \"next_action\": null,\n  \"on_behalf_of\": null,\n  \"payment_method\": \"pm_1KHrnWAWOtgoysogqXkTXrCb\",\n  \"payment_method_options\": {\n    \"card\": {\n      \"installments\": null,\n      \"mandate_options\": null,\n      \"network\": null,\n      \"request_three_d_secure\": \"automatic\"\n    }\n  },\n  \"payment_method_types\": [\n    \"card\"\n  ],\n  \"processing\": null,\n  \"receipt_email\": null,\n  \"review\": null,\n  \"setup_future_usage\": null,\n  \"shipping\": null,\n  \"source\": null,\n  \"statement_descriptor\": null,\n  \"statement_descriptor_suffix\": null,\n  \"status\": \"succeeded\",\n  \"transfer_data\": null,\n  \"transfer_group\": null\n}\n"
       read 5204 bytes
       Conn close
     SCRUBBED
@@ -2275,7 +2520,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       starting SSL for api.stripe.com:443...
       SSL established, protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384
       <- \"POST /v1/payment_intents HTTP/1.1\\r\\nContent-Type: application/x-www-form-urlencoded\\r\\nAuthorization: Basic c2tfdGVzdF81MTYwRFg2QVdPdGdveXNvZ0JvcHRXN2xpeEtFeHozNlJ1bnRlaHU4WUw4RWRZT2dqaXlkaFpVTEMzaEJzdmQ0Rk90d1RtNTd3WjRRNVZtTkY5enJJV0tvRzAwOFQxNzZHOG46\\r\\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.135.0\\r\\nStripe-Version: 2020-08-27\\r\\nX-Stripe-Client-User-Agent: {\\\"bindings_version\\\":\\\"1.135.0\\\",\\\"lang\\\":\\\"ruby\\\",\\\"lang_version\\\":\\\"3.1.3 p185 (2022-11-24)\\\",\\\"platform\\\":\\\"arm64-darwin22\\\",\\\"publisher\\\":\\\"active_merchant\\\",\\\"application\\\":{\\\"name\\\":\\\"Spreedly/ActiveMerchant\\\",\\\"version\\\":\\\"1.0/1.135.0\\\",\\\"url\\\":\\\"https://spreedly.com\\\"}}\\r\\nX-Stripe-Client-User-Metadata: {\\\"ip\\\":\\\"127.0.0.1\\\"}\\r\\nX-Transaction-Powered-By: Spreedly\\r\\nConnection: close\\r\\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\\r\\nAccept: */*\\r\\nHost: api.stripe.com\\r\\nContent-Length: 838\\r\\n\\r\\n\"
-      <- \"amount=50&currency=usd&capture_method=automatic&payment_method_data[type]=card&payment_method_data[card][last4]=4242&payment_method_data[card][exp_month]=9&payment_method_data[card][exp_year]=2024&payment_method_data[card][network_token][number]=4242424242424242&payment_method_data[card][network_token][exp_month]=9&payment_method_data[card][network_token][exp_year]=2024&payment_method_data[card][network_token][tokenization_method]=apple_pay&payment_method_options[card][network_token][cryptogram]=AMwBRjPWDnAgAA7Rls7mAoABFA%3D%3D&metadata[connect_agent]=placeholder&metadata[transaction_token]=WmaAqGg0LW0ahLEvwIkMMCAKHKe&metadata[order_id]=9900a089-9ce6-4158-9605-10b5633d1d57&confirm=true&return_url=http%3A%2F%2Fcore.spreedly.invalid%2Ftransaction%2FWmaAqGg0LW0ahLEvwIkMMCAKHKe%2Fredirect&expand[0]=charges.data.balance_transaction\"
+      <- \"amount=50&currency=usd&capture_method=automatic&payment_method_data[type]=card&payment_method_data[card][last4]=4242&payment_method_data[card][exp_month]=9&payment_method_data[card][exp_year]=2024&payment_method_data[card][network_token][number]=4242424242424242&payment_method_data[card][network_token][exp_month]=9&payment_method_data[card][network_token][exp_year]=2024&payment_method_data[card][network_token][tokenization_method]=apple_pay&payment_method_options[card][network_token][cryptogram]=AMwBRjPWDnAgAA7Rls7mAoABFA%3D%3D&metadata[connect_agent]=placeholder&metadata[transaction_token]=WmaAqGg0LW0ahLEvwIkMMCAKHKe&metadata[order_id]=9900a089-9ce6-4158-9605-10b5633d1d57&confirm=true&return_url=http%3A%2F%2Fcore.spreedly.invalid%2Ftransaction%2FWmaAqGg0LW0ahLEvwIkMMCAKHKe%2Fredirect&expand[0]=latest_charge&expand[1]=latest_charge.balance_transaction\"
       -> "HTTP/1.1 200 OK\r\n"
       -> "Server: nginx\r\n"
       -> "Date: Fri, 14 Jan 2022 15:34:39 GMT\r\n"
@@ -2293,7 +2538,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       -> "request-id: req_VkIqZgctQBI9yo\r\n"
       -> "stripe-should-retry: false\r\n"
       -> "stripe-version: 2020-08-27\r\n"
-      -> \"{\\n  \\\"id\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie\\\",\\n  \\\"object\\\": \\\"payment_intent\\\",\\n  \\\"amount\\\": 50,\\n  \\\"amount_capturable\\\": 0,\\n  \\\"amount_details\\\": {\\n    \\\"tip\\\": {}\\n  },\\n  \\\"amount_received\\\": 50,\\n  \\\"application\\\": null,\\n  \\\"application_fee_amount\\\": null,\\n  \\\"automatic_payment_methods\\\": null,\\n  \\\"canceled_at\\\": null,\\n  \\\"cancellation_reason\\\": null,\\n  \\\"capture_method\\\": \\\"automatic\\\",\\n  \\\"charges\\\": {\\n    \\\"object\\\": \\\"list\\\",\\n    \\\"data\\\": [\\n      {\\n        \\\"id\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n        \\\"object\\\": \\\"charge\\\",\\n        \\\"amount\\\": 50,\\n        \\\"amount_captured\\\": 50,\\n        \\\"amount_refunded\\\": 0,\\n        \\\"application\\\": null,\\n        \\\"application_fee\\\": null,\\n        \\\"application_fee_amount\\\": null,\\n        \\\"balance_transaction\\\": {\\n          \\\"id\\\": \\\"txn_3P1UIQAWOtgoysog26U2VWBy\\\",\\n          \\\"object\\\": \\\"balance_transaction\\\",\\n          \\\"amount\\\": 50,\\n          \\\"available_on\\\": 1712707200,\\n          \\\"created\\\": 1712152571,\\n          \\\"currency\\\": \\\"usd\\\",\\n          \\\"description\\\": null,\\n          \\\"exchange_rate\\\": null,\\n          \\\"fee\\\": 31,\\n          \\\"fee_details\\\": [\\n            {\\n              \\\"amount\\\": 31,\\n              \\\"application\\\": null,\\n              \\\"currency\\\": \\\"usd\\\",\\n              \\\"description\\\": \\\"Stripe processing fees\\\",\\n              \\\"type\\\": \\\"stripe_fee\\\"\\n            }\\n          ],\\n          \\\"net\\\": 19,\\n          \\\"reporting_category\\\": \\\"charge\\\",\\n          \\\"source\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n          \\\"status\\\": \\\"pending\\\",\\n          \\\"type\\\": \\\"charge\\\"\\n        },\\n        \\\"billing_details\\\": {\\n          \\\"address\\\": {\\n            \\\"city\\\": null,\\n            \\\"country\\\": null,\\n            \\\"line1\\\": null,\\n            \\\"line2\\\": null,\\n            \\\"postal_code\\\": null,\\n            \\\"state\\\": null\\n          },\\n          \\\"email\\\": null,\\n          \\\"name\\\": null,\\n          \\\"phone\\\": null\\n        },\\n        \\\"calculated_statement_descriptor\\\": \\\"TEST\\\",\\n        \\\"captured\\\": true,\\n        \\\"created\\\": 1712152571,\\n        \\\"currency\\\": \\\"usd\\\",\\n        \\\"customer\\\": null,\\n        \\\"description\\\": null,\\n        \\\"destination\\\": null,\\n        \\\"dispute\\\": null,\\n        \\\"disputed\\\": false,\\n        \\\"failure_balance_transaction\\\": null,\\n        \\\"failure_code\\\": null,\\n        \\\"failure_message\\\": null,\\n        \\\"fraud_details\\\": {},\\n        \\\"invoice\\\": null,\\n        \\\"livemode\\\": false,\\n        \\\"metadata\\\": {\\n          \\\"connect_agent\\\": \\\"placeholder\\\",\\n          \\\"order_id\\\": \\\"9900a089-9ce6-4158-9605-10b5633d1d57\\\",\\n          \\\"transaction_token\\\": \\\"WmaAqGg0LW0ahLEvwIkMMCAKHKe\\\"\\n        },\\n        \\\"on_behalf_of\\\": null,\\n        \\\"order\\\": null,\\n        \\\"outcome\\\": {\\n          \\\"network_status\\\": \\\"approved_by_network\\\",\\n          \\\"reason\\\": null,\\n          \\\"risk_level\\\": \\\"normal\\\",\\n          \\\"risk_score\\\": 2,\\n          \\\"seller_message\\\": \\\"Payment complete.\\\",\\n          \\\"type\\\": \\\"authorized\\\"\\n        },\\n        \\\"paid\\\": true,\\n        \\\"payment_intent\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie\\\",\\n        \\\"payment_method\\\": \\\"pm_1P1UIQAWOtgoysogLERqyfg0\\\",\\n        \\\"payment_method_details\\\": {\\n          \\\"card\\\": {\\n            \\\"amount_authorized\\\": 50,\\n            \\\"brand\\\": \\\"visa\\\",\\n            \\\"checks\\\": {\\n              \\\"address_line1_check\\\": null,\\n              \\\"address_postal_code_check\\\": null,\\n              \\\"cvc_check\\\": null\\n            },\\n            \\\"country\\\": \\\"US\\\",\\n            \\\"ds_transaction_id\\\": null,\\n            \\\"exp_month\\\": 9,\\n            \\\"exp_year\\\": 2024,\\n            \\\"extended_authorization\\\": {\\n              \\\"status\\\": \\\"disabled\\\"\\n            },\\n            \\\"fingerprint\\\": null,\\n            \\\"funding\\\": \\\"credit\\\",\\n            \\\"incremental_authorization\\\": {\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"installments\\\": null,\\n            \\\"last4\\\": \\\"4242\\\",\\n            \\\"mandate\\\": null,\\n            \\\"moto\\\": null,\\n            \\\"multicapture\\\": {\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"network\\\": \\\"visa\\\",\\n            \\\"network_token\\\": {\\n              \\\"exp_month\\\": 9,\\n              \\\"exp_year\\\": 2024,\\n              \\\"fingerprint\\\": \\\"hfaVNMiXc0dYSiC5\\\",\\n              \\\"last4\\\": \\\"4242\\\",\\n              \\\"tokenization_method\\\": \\\"apple_pay\\\",\\n              \\\"used\\\": false\\n            },\\n            \\\"network_transaction_id\\\": \\\"104102978678771\\\",\\n            \\\"overcapture\\\": {\\n              \\\"maximum_amount_capturable\\\": 50,\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"three_d_secure\\\": null,\\n            \\\"wallet\\\": {\\n              \\\"apple_pay\\\": {\\n                \\\"type\\\": \\\"apple_pay\\\"\\n              },\\n              \\\"dynamic_last4\\\": \\\"4242\\\",\\n              \\\"type\\\": \\\"apple_pay\\\"\\n            }\\n          },\\n          \\\"type\\\": \\\"card\\\"\\n        },\\n        \\\"radar_options\\\": {},\\n        \\\"receipt_email\\\": null,\\n        \\\"receipt_number\\\": null,\\n        \\\"receipt_url\\\": \\\"https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKPu_tbAGMgb1i-5uogg6LBYtHz5nv48TLnQFKbUhbQOjDLetYGrcnmnG64XzKTY69nso826Kd0cANL-w\\\",\\n        \\\"refunded\\\": false,\\n        \\\"refunds\\\": {\\n          \\\"object\\\": \\\"list\\\",\\n          \\\"data\\\": [],\\n          \\\"has_more\\\": false,\\n          \\\"total_count\\\": 0,\\n          \\\"url\\\": \\\"/v1/charges/ch_3P1UIQAWOtgoysog2zDy9BAh/refunds\\\"\\n        },\\n        \\\"review\\\": null,\\n        \\\"shipping\\\": null,\\n        \\\"source\\\": null,\\n        \\\"source_transfer\\\": null,\\n        \\\"statement_descriptor\\\": null,\\n        \\\"statement_descriptor_suffix\\\": null,\\n        \\\"status\\\": \\\"succeeded\\\",\\n        \\\"transfer_data\\\": null,\\n        \\\"transfer_group\\\": null\\n      }\\n    ],\\n    \\\"has_more\\\": false,\\n    \\\"total_count\\\": 1,\\n    \\\"url\\\": \\\"/v1/charges?payment_intent=pi_3P1UIQAWOtgoysog22LYv5Ie\\\"\\n  },\\n  \\\"client_secret\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie_secret_BXrSnt0ALWlIKXABbi8BoFJm0\\\",\\n  \\\"confirmation_method\\\": \\\"automatic\\\",\\n  \\\"created\\\": 1712152570,\\n  \\\"currency\\\": \\\"usd\\\",\\n  \\\"customer\\\": null,\\n  \\\"description\\\": null,\\n  \\\"invoice\\\": null,\\n  \\\"last_payment_error\\\": null,\\n  \\\"latest_charge\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n  \\\"level3\\\": null,\\n  \\\"livemode\\\": false,\\n  \\\"metadata\\\": {\\n    \\\"connect_agent\\\": \\\"placeholder\\\",\\n    \\\"order_id\\\": \\\"9900a089-9ce6-4158-9605-10b5633d1d57\\\",\\n    \\\"transaction_token\\\": \\\"WmaAqGg0LW0ahLEvwIkMMCAKHKe\\\"\\n  },\\n  \\\"next_action\\\": null,\\n  \\\"on_behalf_of\\\": null,\\n  \\\"payment_method\\\": \\\"pm_1P1UIQAWOtgoysogLERqyfg0\\\",\\n  \\\"payment_method_configuration_details\\\": null,\\n  \\\"payment_method_options\\\": {\\n    \\\"card\\\": {\\n      \\\"installments\\\": null,\\n      \\\"mandate_options\\\": null,\\n      \\\"network\\\": null,\\n      \\\"request_three_d_secure\\\": \\\"automatic\\\"\\n    }\\n  },\\n  \\\"payment_method_types\\\": [\\n    \\\"card\\\"\\n  ],\\n  \\\"processing\\\": null,\\n  \\\"receipt_email\\\": null,\\n  \\\"review\\\": null,\\n  \\\"setup_future_usage\\\": null,\\n  \\\"shipping\\\": null,\\n  \\\"source\\\": null,\\n  \\\"statement_descriptor\\\": null,\\n  \\\"statement_descriptor_suffix\\\": null,\\n  \\\"status\\\": \\\"succeeded\\\",\\n  \\\"transfer_data\\\": null,\\n  \\\"transfer_group\\\": null\\n}\"
+      -> \"{\\n  \\\"id\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie\\\",\\n  \\\"object\\\": \\\"payment_intent\\\",\\n  \\\"amount\\\": 50,\\n  \\\"amount_capturable\\\": 0,\\n  \\\"amount_details\\\": {\\n    \\\"tip\\\": {}\\n  },\\n  \\\"amount_received\\\": 50,\\n  \\\"application\\\": null,\\n  \\\"application_fee_amount\\\": null,\\n  \\\"automatic_payment_methods\\\": null,\\n  \\\"canceled_at\\\": null,\\n  \\\"cancellation_reason\\\": null,\\n  \\\"capture_method\\\": \\\"automatic\\\",\\n  \\\"latest_charge\\\": {\\n    \\\"object\\\": \\\"list\\\",\\n    \\\"id\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n        \\\"object\\\": \\\"charge\\\",\\n        \\\"amount\\\": 50,\\n        \\\"amount_captured\\\": 50,\\n        \\\"amount_refunded\\\": 0,\\n        \\\"application\\\": null,\\n        \\\"application_fee\\\": null,\\n        \\\"application_fee_amount\\\": null,\\n        \\\"balance_transaction\\\": {\\n          \\\"id\\\": \\\"txn_3P1UIQAWOtgoysog26U2VWBy\\\",\\n          \\\"object\\\": \\\"balance_transaction\\\",\\n          \\\"amount\\\": 50,\\n          \\\"available_on\\\": 1712707200,\\n          \\\"created\\\": 1712152571,\\n          \\\"currency\\\": \\\"usd\\\",\\n          \\\"description\\\": null,\\n          \\\"exchange_rate\\\": null,\\n          \\\"fee\\\": 31,\\n          \\\"fee_details\\\": [\\n            {\\n              \\\"amount\\\": 31,\\n              \\\"application\\\": null,\\n              \\\"currency\\\": \\\"usd\\\",\\n              \\\"description\\\": \\\"Stripe processing fees\\\",\\n              \\\"type\\\": \\\"stripe_fee\\\"\\n            }\\n          ],\\n          \\\"net\\\": 19,\\n          \\\"reporting_category\\\": \\\"charge\\\",\\n          \\\"source\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n          \\\"status\\\": \\\"pending\\\",\\n          \\\"type\\\": \\\"charge\\\"\\n        },\\n        \\\"billing_details\\\": {\\n          \\\"address\\\": {\\n            \\\"city\\\": null,\\n            \\\"country\\\": null,\\n            \\\"line1\\\": null,\\n            \\\"line2\\\": null,\\n            \\\"postal_code\\\": null,\\n            \\\"state\\\": null\\n          },\\n          \\\"email\\\": null,\\n          \\\"name\\\": null,\\n          \\\"phone\\\": null\\n        },\\n        \\\"calculated_statement_descriptor\\\": \\\"TEST\\\",\\n        \\\"captured\\\": true,\\n        \\\"created\\\": 1712152571,\\n        \\\"currency\\\": \\\"usd\\\",\\n        \\\"customer\\\": null,\\n        \\\"description\\\": null,\\n        \\\"destination\\\": null,\\n        \\\"dispute\\\": null,\\n        \\\"disputed\\\": false,\\n        \\\"failure_balance_transaction\\\": null,\\n        \\\"failure_code\\\": null,\\n        \\\"failure_message\\\": null,\\n        \\\"fraud_details\\\": {},\\n        \\\"invoice\\\": null,\\n        \\\"livemode\\\": false,\\n        \\\"metadata\\\": {\\n          \\\"connect_agent\\\": \\\"placeholder\\\",\\n          \\\"order_id\\\": \\\"9900a089-9ce6-4158-9605-10b5633d1d57\\\",\\n          \\\"transaction_token\\\": \\\"WmaAqGg0LW0ahLEvwIkMMCAKHKe\\\"\\n        },\\n        \\\"on_behalf_of\\\": null,\\n        \\\"order\\\": null,\\n        \\\"outcome\\\": {\\n          \\\"network_status\\\": \\\"approved_by_network\\\",\\n          \\\"reason\\\": null,\\n          \\\"risk_level\\\": \\\"normal\\\",\\n          \\\"risk_score\\\": 2,\\n          \\\"seller_message\\\": \\\"Payment complete.\\\",\\n          \\\"type\\\": \\\"authorized\\\"\\n        },\\n        \\\"paid\\\": true,\\n        \\\"payment_intent\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie\\\",\\n        \\\"payment_method\\\": \\\"pm_1P1UIQAWOtgoysogLERqyfg0\\\",\\n        \\\"payment_method_details\\\": {\\n          \\\"card\\\": {\\n            \\\"amount_authorized\\\": 50,\\n            \\\"brand\\\": \\\"visa\\\",\\n            \\\"checks\\\": {\\n              \\\"address_line1_check\\\": null,\\n              \\\"address_postal_code_check\\\": null,\\n              \\\"cvc_check\\\": null\\n            },\\n            \\\"country\\\": \\\"US\\\",\\n            \\\"ds_transaction_id\\\": null,\\n            \\\"exp_month\\\": 9,\\n            \\\"exp_year\\\": 2024,\\n            \\\"extended_authorization\\\": {\\n              \\\"status\\\": \\\"disabled\\\"\\n            },\\n            \\\"fingerprint\\\": null,\\n            \\\"funding\\\": \\\"credit\\\",\\n            \\\"incremental_authorization\\\": {\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"installments\\\": null,\\n            \\\"last4\\\": \\\"4242\\\",\\n            \\\"mandate\\\": null,\\n            \\\"moto\\\": null,\\n            \\\"multicapture\\\": {\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"network\\\": \\\"visa\\\",\\n            \\\"network_token\\\": {\\n              \\\"exp_month\\\": 9,\\n              \\\"exp_year\\\": 2024,\\n              \\\"fingerprint\\\": \\\"hfaVNMiXc0dYSiC5\\\",\\n              \\\"last4\\\": \\\"4242\\\",\\n              \\\"tokenization_method\\\": \\\"apple_pay\\\",\\n              \\\"used\\\": false\\n            },\\n            \\\"network_transaction_id\\\": \\\"104102978678771\\\",\\n            \\\"overcapture\\\": {\\n              \\\"maximum_amount_capturable\\\": 50,\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"three_d_secure\\\": null,\\n            \\\"wallet\\\": {\\n              \\\"apple_pay\\\": {\\n                \\\"type\\\": \\\"apple_pay\\\"\\n              },\\n              \\\"dynamic_last4\\\": \\\"4242\\\",\\n              \\\"type\\\": \\\"apple_pay\\\"\\n            }\\n          },\\n          \\\"type\\\": \\\"card\\\"\\n        },\\n        \\\"radar_options\\\": {},\\n        \\\"receipt_email\\\": null,\\n        \\\"receipt_number\\\": null,\\n        \\\"receipt_url\\\": \\\"https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKPu_tbAGMgb1i-5uogg6LBYtHz5nv48TLnQFKbUhbQOjDLetYGrcnmnG64XzKTY69nso826Kd0cANL-w\\\",\\n        \\\"refunded\\\": false,\\n        \\\"refunds\\\": {\\n          \\\"object\\\": \\\"list\\\",\\n          \\\"data\\\": [],\\n          \\\"has_more\\\": false,\\n          \\\"total_count\\\": 0,\\n          \\\"url\\\": \\\"/v1/charges/ch_3P1UIQAWOtgoysog2zDy9BAh/refunds\\\"\\n        },\\n        \\\"review\\\": null,\\n        \\\"shipping\\\": null,\\n        \\\"source\\\": null,\\n        \\\"source_transfer\\\": null,\\n        \\\"statement_descriptor\\\": null,\\n        \\\"statement_descriptor_suffix\\\": null,\\n        \\\"status\\\": \\\"succeeded\\\",\\n        \\\"transfer_data\\\": null,\\n        \\\"transfer_group\\\": null,\\n    \\\"has_more\\\": false,\\n    \\\"total_count\\\": 1,\\n    \\\"url\\\": \\\"/v1/charges?payment_intent=pi_3P1UIQAWOtgoysog22LYv5Ie\\\"\\n  },\\n  \\\"client_secret\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie_secret_BXrSnt0ALWlIKXABbi8BoFJm0\\\",\\n  \\\"confirmation_method\\\": \\\"automatic\\\",\\n  \\\"created\\\": 1712152570,\\n  \\\"currency\\\": \\\"usd\\\",\\n  \\\"customer\\\": null,\\n  \\\"description\\\": null,\\n  \\\"invoice\\\": null,\\n  \\\"last_payment_error\\\": null,\\n  \\\"level3\\\": null,\\n  \\\"livemode\\\": false,\\n  \\\"metadata\\\": {\\n    \\\"connect_agent\\\": \\\"placeholder\\\",\\n    \\\"order_id\\\": \\\"9900a089-9ce6-4158-9605-10b5633d1d57\\\",\\n    \\\"transaction_token\\\": \\\"WmaAqGg0LW0ahLEvwIkMMCAKHKe\\\"\\n  },\\n  \\\"next_action\\\": null,\\n  \\\"on_behalf_of\\\": null,\\n  \\\"payment_method\\\": \\\"pm_1P1UIQAWOtgoysogLERqyfg0\\\",\\n  \\\"payment_method_configuration_details\\\": null,\\n  \\\"payment_method_options\\\": {\\n    \\\"card\\\": {\\n      \\\"installments\\\": null,\\n      \\\"mandate_options\\\": null,\\n      \\\"network\\\": null,\\n      \\\"request_three_d_secure\\\": \\\"automatic\\\"\\n    }\\n  },\\n  \\\"payment_method_types\\\": [\\n    \\\"card\\\"\\n  ],\\n  \\\"processing\\\": null,\\n  \\\"receipt_email\\\": null,\\n  \\\"review\\\": null,\\n  \\\"setup_future_usage\\\": null,\\n  \\\"shipping\\\": null,\\n  \\\"source\\\": null,\\n  \\\"statement_descriptor\\\": null,\\n  \\\"statement_descriptor_suffix\\\": null,\\n  \\\"status\\\": \\\"succeeded\\\",\\n  \\\"transfer_data\\\": null,\\n  \\\"transfer_group\\\": null\\n}\"
       read 6581 bytes
       Conn close\n"
     PRE_SCRUBBED
@@ -2306,7 +2551,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       starting SSL for api.stripe.com:443...
       SSL established, protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384
       <- \"POST /v1/payment_intents HTTP/1.1\\r\\nContent-Type: application/x-www-form-urlencoded\\r\\nAuthorization: Basic [FILTERED]\\r\\nUser-Agent: Stripe/v1 ActiveMerchantBindings/1.135.0\\r\\nStripe-Version: 2020-08-27\\r\\nX-Stripe-Client-User-Agent: {\\\"bindings_version\\\":\\\"1.135.0\\\",\\\"lang\\\":\\\"ruby\\\",\\\"lang_version\\\":\\\"3.1.3 p185 (2022-11-24)\\\",\\\"platform\\\":\\\"arm64-darwin22\\\",\\\"publisher\\\":\\\"active_merchant\\\",\\\"application\\\":{\\\"name\\\":\\\"Spreedly/ActiveMerchant\\\",\\\"version\\\":\\\"1.0/1.135.0\\\",\\\"url\\\":\\\"https://spreedly.com\\\"}}\\r\\nX-Stripe-Client-User-Metadata: {\\\"ip\\\":\\\"127.0.0.1\\\"}\\r\\nX-Transaction-Powered-By: Spreedly\\r\\nConnection: close\\r\\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\\r\\nAccept: */*\\r\\nHost: api.stripe.com\\r\\nContent-Length: 838\\r\\n\\r\\n\"
-      <- \"amount=50&currency=usd&capture_method=automatic&payment_method_data[type]=card&payment_method_data[card][last4]=4242&payment_method_data[card][exp_month]=9&payment_method_data[card][exp_year]=2024&payment_method_data[card][network_token][number]=[FILTERED]&payment_method_data[card][network_token][exp_month]=9&payment_method_data[card][network_token][exp_year]=2024&payment_method_data[card][network_token][tokenization_method]=apple_pay&payment_method_options[card][network_token][cryptogram]=[FILTERED]metadata[connect_agent]=placeholder&metadata[transaction_token]=WmaAqGg0LW0ahLEvwIkMMCAKHKe&metadata[order_id]=9900a089-9ce6-4158-9605-10b5633d1d57&confirm=true&return_url=http%3A%2F%2Fcore.spreedly.invalid%2Ftransaction%2FWmaAqGg0LW0ahLEvwIkMMCAKHKe%2Fredirect&expand[0]=charges.data.balance_transaction\"
+      <- \"amount=50&currency=usd&capture_method=automatic&payment_method_data[type]=card&payment_method_data[card][last4]=4242&payment_method_data[card][exp_month]=9&payment_method_data[card][exp_year]=2024&payment_method_data[card][network_token][number]=[FILTERED]&payment_method_data[card][network_token][exp_month]=9&payment_method_data[card][network_token][exp_year]=2024&payment_method_data[card][network_token][tokenization_method]=apple_pay&payment_method_options[card][network_token][cryptogram]=[FILTERED]metadata[connect_agent]=placeholder&metadata[transaction_token]=WmaAqGg0LW0ahLEvwIkMMCAKHKe&metadata[order_id]=9900a089-9ce6-4158-9605-10b5633d1d57&confirm=true&return_url=http%3A%2F%2Fcore.spreedly.invalid%2Ftransaction%2FWmaAqGg0LW0ahLEvwIkMMCAKHKe%2Fredirect&expand[0]=latest_charge&expand[1]=latest_charge.balance_transaction\"
       -> "HTTP/1.1 200 OK\r\n"
       -> "Server: nginx\r\n"
       -> "Date: Fri, 14 Jan 2022 15:34:39 GMT\r\n"
@@ -2324,7 +2569,7 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       -> "request-id: req_VkIqZgctQBI9yo\r\n"
       -> "stripe-should-retry: false\r\n"
       -> "stripe-version: 2020-08-27\r\n"
-      -> \"{\\n  \\\"id\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie\\\",\\n  \\\"object\\\": \\\"payment_intent\\\",\\n  \\\"amount\\\": 50,\\n  \\\"amount_capturable\\\": 0,\\n  \\\"amount_details\\\": {\\n    \\\"tip\\\": {}\\n  },\\n  \\\"amount_received\\\": 50,\\n  \\\"application\\\": null,\\n  \\\"application_fee_amount\\\": null,\\n  \\\"automatic_payment_methods\\\": null,\\n  \\\"canceled_at\\\": null,\\n  \\\"cancellation_reason\\\": null,\\n  \\\"capture_method\\\": \\\"automatic\\\",\\n  \\\"charges\\\": {\\n    \\\"object\\\": \\\"list\\\",\\n    \\\"data\\\": [\\n      {\\n        \\\"id\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n        \\\"object\\\": \\\"charge\\\",\\n        \\\"amount\\\": 50,\\n        \\\"amount_captured\\\": 50,\\n        \\\"amount_refunded\\\": 0,\\n        \\\"application\\\": null,\\n        \\\"application_fee\\\": null,\\n        \\\"application_fee_amount\\\": null,\\n        \\\"balance_transaction\\\": {\\n          \\\"id\\\": \\\"txn_3P1UIQAWOtgoysog26U2VWBy\\\",\\n          \\\"object\\\": \\\"balance_transaction\\\",\\n          \\\"amount\\\": 50,\\n          \\\"available_on\\\": 1712707200,\\n          \\\"created\\\": 1712152571,\\n          \\\"currency\\\": \\\"usd\\\",\\n          \\\"description\\\": null,\\n          \\\"exchange_rate\\\": null,\\n          \\\"fee\\\": 31,\\n          \\\"fee_details\\\": [\\n            {\\n              \\\"amount\\\": 31,\\n              \\\"application\\\": null,\\n              \\\"currency\\\": \\\"usd\\\",\\n              \\\"description\\\": \\\"Stripe processing fees\\\",\\n              \\\"type\\\": \\\"stripe_fee\\\"\\n            }\\n          ],\\n          \\\"net\\\": 19,\\n          \\\"reporting_category\\\": \\\"charge\\\",\\n          \\\"source\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n          \\\"status\\\": \\\"pending\\\",\\n          \\\"type\\\": \\\"charge\\\"\\n        },\\n        \\\"billing_details\\\": {\\n          \\\"address\\\": {\\n            \\\"city\\\": null,\\n            \\\"country\\\": null,\\n            \\\"line1\\\": null,\\n            \\\"line2\\\": null,\\n            \\\"postal_code\\\": null,\\n            \\\"state\\\": null\\n          },\\n          \\\"email\\\": null,\\n          \\\"name\\\": null,\\n          \\\"phone\\\": null\\n        },\\n        \\\"calculated_statement_descriptor\\\": \\\"TEST\\\",\\n        \\\"captured\\\": true,\\n        \\\"created\\\": 1712152571,\\n        \\\"currency\\\": \\\"usd\\\",\\n        \\\"customer\\\": null,\\n        \\\"description\\\": null,\\n        \\\"destination\\\": null,\\n        \\\"dispute\\\": null,\\n        \\\"disputed\\\": false,\\n        \\\"failure_balance_transaction\\\": null,\\n        \\\"failure_code\\\": null,\\n        \\\"failure_message\\\": null,\\n        \\\"fraud_details\\\": {},\\n        \\\"invoice\\\": null,\\n        \\\"livemode\\\": false,\\n        \\\"metadata\\\": {\\n          \\\"connect_agent\\\": \\\"placeholder\\\",\\n          \\\"order_id\\\": \\\"9900a089-9ce6-4158-9605-10b5633d1d57\\\",\\n          \\\"transaction_token\\\": \\\"WmaAqGg0LW0ahLEvwIkMMCAKHKe\\\"\\n        },\\n        \\\"on_behalf_of\\\": null,\\n        \\\"order\\\": null,\\n        \\\"outcome\\\": {\\n          \\\"network_status\\\": \\\"approved_by_network\\\",\\n          \\\"reason\\\": null,\\n          \\\"risk_level\\\": \\\"normal\\\",\\n          \\\"risk_score\\\": 2,\\n          \\\"seller_message\\\": \\\"Payment complete.\\\",\\n          \\\"type\\\": \\\"authorized\\\"\\n        },\\n        \\\"paid\\\": true,\\n        \\\"payment_intent\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie\\\",\\n        \\\"payment_method\\\": \\\"pm_1P1UIQAWOtgoysogLERqyfg0\\\",\\n        \\\"payment_method_details\\\": {\\n          \\\"card\\\": {\\n            \\\"amount_authorized\\\": 50,\\n            \\\"brand\\\": \\\"visa\\\",\\n            \\\"checks\\\": {\\n              \\\"address_line1_check\\\": null,\\n              \\\"address_postal_code_check\\\": null,\\n              \\\"cvc_check\\\": null\\n            },\\n            \\\"country\\\": \\\"US\\\",\\n            \\\"ds_transaction_id\\\": null,\\n            \\\"exp_month\\\": 9,\\n            \\\"exp_year\\\": 2024,\\n            \\\"extended_authorization\\\": {\\n              \\\"status\\\": \\\"disabled\\\"\\n            },\\n            \\\"fingerprint\\\": null,\\n            \\\"funding\\\": \\\"credit\\\",\\n            \\\"incremental_authorization\\\": {\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"installments\\\": null,\\n            \\\"last4\\\": \\\"4242\\\",\\n            \\\"mandate\\\": null,\\n            \\\"moto\\\": null,\\n            \\\"multicapture\\\": {\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"network\\\": \\\"visa\\\",\\n            \\\"network_token\\\": {\\n              \\\"exp_month\\\": 9,\\n              \\\"exp_year\\\": 2024,\\n              \\\"fingerprint\\\": \\\"hfaVNMiXc0dYSiC5\\\",\\n              \\\"last4\\\": \\\"4242\\\",\\n              \\\"tokenization_method\\\": \\\"apple_pay\\\",\\n              \\\"used\\\": false\\n            },\\n            \\\"network_transaction_id\\\": \\\"104102978678771\\\",\\n            \\\"overcapture\\\": {\\n              \\\"maximum_amount_capturable\\\": 50,\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"three_d_secure\\\": null,\\n            \\\"wallet\\\": {\\n              \\\"apple_pay\\\": {\\n                \\\"type\\\": \\\"apple_pay\\\"\\n              },\\n              \\\"dynamic_last4\\\": \\\"4242\\\",\\n              \\\"type\\\": \\\"apple_pay\\\"\\n            }\\n          },\\n          \\\"type\\\": \\\"card\\\"\\n        },\\n        \\\"radar_options\\\": {},\\n        \\\"receipt_email\\\": null,\\n        \\\"receipt_number\\\": null,\\n        \\\"receipt_url\\\": \\\"https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKPu_tbAGMgb1i-5uogg6LBYtHz5nv48TLnQFKbUhbQOjDLetYGrcnmnG64XzKTY69nso826Kd0cANL-w\\\",\\n        \\\"refunded\\\": false,\\n        \\\"refunds\\\": {\\n          \\\"object\\\": \\\"list\\\",\\n          \\\"data\\\": [],\\n          \\\"has_more\\\": false,\\n          \\\"total_count\\\": 0,\\n          \\\"url\\\": \\\"/v1/charges/ch_3P1UIQAWOtgoysog2zDy9BAh/refunds\\\"\\n        },\\n        \\\"review\\\": null,\\n        \\\"shipping\\\": null,\\n        \\\"source\\\": null,\\n        \\\"source_transfer\\\": null,\\n        \\\"statement_descriptor\\\": null,\\n        \\\"statement_descriptor_suffix\\\": null,\\n        \\\"status\\\": \\\"succeeded\\\",\\n        \\\"transfer_data\\\": null,\\n        \\\"transfer_group\\\": null\\n      }\\n    ],\\n    \\\"has_more\\\": false,\\n    \\\"total_count\\\": 1,\\n    \\\"url\\\": \\\"/v1/charges?payment_intent=pi_3P1UIQAWOtgoysog22LYv5Ie\\\"\\n  },\\n  \\\"client_secret\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie_secret_BXrSnt0ALWlIKXABbi8BoFJm0\\\",\\n  \\\"confirmation_method\\\": \\\"automatic\\\",\\n  \\\"created\\\": 1712152570,\\n  \\\"currency\\\": \\\"usd\\\",\\n  \\\"customer\\\": null,\\n  \\\"description\\\": null,\\n  \\\"invoice\\\": null,\\n  \\\"last_payment_error\\\": null,\\n  \\\"latest_charge\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n  \\\"level3\\\": null,\\n  \\\"livemode\\\": false,\\n  \\\"metadata\\\": {\\n    \\\"connect_agent\\\": \\\"placeholder\\\",\\n    \\\"order_id\\\": \\\"9900a089-9ce6-4158-9605-10b5633d1d57\\\",\\n    \\\"transaction_token\\\": \\\"WmaAqGg0LW0ahLEvwIkMMCAKHKe\\\"\\n  },\\n  \\\"next_action\\\": null,\\n  \\\"on_behalf_of\\\": null,\\n  \\\"payment_method\\\": \\\"pm_1P1UIQAWOtgoysogLERqyfg0\\\",\\n  \\\"payment_method_configuration_details\\\": null,\\n  \\\"payment_method_options\\\": {\\n    \\\"card\\\": {\\n      \\\"installments\\\": null,\\n      \\\"mandate_options\\\": null,\\n      \\\"network\\\": null,\\n      \\\"request_three_d_secure\\\": \\\"automatic\\\"\\n    }\\n  },\\n  \\\"payment_method_types\\\": [\\n    \\\"card\\\"\\n  ],\\n  \\\"processing\\\": null,\\n  \\\"receipt_email\\\": null,\\n  \\\"review\\\": null,\\n  \\\"setup_future_usage\\\": null,\\n  \\\"shipping\\\": null,\\n  \\\"source\\\": null,\\n  \\\"statement_descriptor\\\": null,\\n  \\\"statement_descriptor_suffix\\\": null,\\n  \\\"status\\\": \\\"succeeded\\\",\\n  \\\"transfer_data\\\": null,\\n  \\\"transfer_group\\\": null\\n}\"
+      -> \"{\\n  \\\"id\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie\\\",\\n  \\\"object\\\": \\\"payment_intent\\\",\\n  \\\"amount\\\": 50,\\n  \\\"amount_capturable\\\": 0,\\n  \\\"amount_details\\\": {\\n    \\\"tip\\\": {}\\n  },\\n  \\\"amount_received\\\": 50,\\n  \\\"application\\\": null,\\n  \\\"application_fee_amount\\\": null,\\n  \\\"automatic_payment_methods\\\": null,\\n  \\\"canceled_at\\\": null,\\n  \\\"cancellation_reason\\\": null,\\n  \\\"capture_method\\\": \\\"automatic\\\",\\n  \\\"latest_charge\\\": {\\n    \\\"object\\\": \\\"list\\\",\\n    \\\"id\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n        \\\"object\\\": \\\"charge\\\",\\n        \\\"amount\\\": 50,\\n        \\\"amount_captured\\\": 50,\\n        \\\"amount_refunded\\\": 0,\\n        \\\"application\\\": null,\\n        \\\"application_fee\\\": null,\\n        \\\"application_fee_amount\\\": null,\\n        \\\"balance_transaction\\\": {\\n          \\\"id\\\": \\\"txn_3P1UIQAWOtgoysog26U2VWBy\\\",\\n          \\\"object\\\": \\\"balance_transaction\\\",\\n          \\\"amount\\\": 50,\\n          \\\"available_on\\\": 1712707200,\\n          \\\"created\\\": 1712152571,\\n          \\\"currency\\\": \\\"usd\\\",\\n          \\\"description\\\": null,\\n          \\\"exchange_rate\\\": null,\\n          \\\"fee\\\": 31,\\n          \\\"fee_details\\\": [\\n            {\\n              \\\"amount\\\": 31,\\n              \\\"application\\\": null,\\n              \\\"currency\\\": \\\"usd\\\",\\n              \\\"description\\\": \\\"Stripe processing fees\\\",\\n              \\\"type\\\": \\\"stripe_fee\\\"\\n            }\\n          ],\\n          \\\"net\\\": 19,\\n          \\\"reporting_category\\\": \\\"charge\\\",\\n          \\\"source\\\": \\\"ch_3P1UIQAWOtgoysog2zDy9BAh\\\",\\n          \\\"status\\\": \\\"pending\\\",\\n          \\\"type\\\": \\\"charge\\\"\\n        },\\n        \\\"billing_details\\\": {\\n          \\\"address\\\": {\\n            \\\"city\\\": null,\\n            \\\"country\\\": null,\\n            \\\"line1\\\": null,\\n            \\\"line2\\\": null,\\n            \\\"postal_code\\\": null,\\n            \\\"state\\\": null\\n          },\\n          \\\"email\\\": null,\\n          \\\"name\\\": null,\\n          \\\"phone\\\": null\\n        },\\n        \\\"calculated_statement_descriptor\\\": \\\"TEST\\\",\\n        \\\"captured\\\": true,\\n        \\\"created\\\": 1712152571,\\n        \\\"currency\\\": \\\"usd\\\",\\n        \\\"customer\\\": null,\\n        \\\"description\\\": null,\\n        \\\"destination\\\": null,\\n        \\\"dispute\\\": null,\\n        \\\"disputed\\\": false,\\n        \\\"failure_balance_transaction\\\": null,\\n        \\\"failure_code\\\": null,\\n        \\\"failure_message\\\": null,\\n        \\\"fraud_details\\\": {},\\n        \\\"invoice\\\": null,\\n        \\\"livemode\\\": false,\\n        \\\"metadata\\\": {\\n          \\\"connect_agent\\\": \\\"placeholder\\\",\\n          \\\"order_id\\\": \\\"9900a089-9ce6-4158-9605-10b5633d1d57\\\",\\n          \\\"transaction_token\\\": \\\"WmaAqGg0LW0ahLEvwIkMMCAKHKe\\\"\\n        },\\n        \\\"on_behalf_of\\\": null,\\n        \\\"order\\\": null,\\n        \\\"outcome\\\": {\\n          \\\"network_status\\\": \\\"approved_by_network\\\",\\n          \\\"reason\\\": null,\\n          \\\"risk_level\\\": \\\"normal\\\",\\n          \\\"risk_score\\\": 2,\\n          \\\"seller_message\\\": \\\"Payment complete.\\\",\\n          \\\"type\\\": \\\"authorized\\\"\\n        },\\n        \\\"paid\\\": true,\\n        \\\"payment_intent\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie\\\",\\n        \\\"payment_method\\\": \\\"pm_1P1UIQAWOtgoysogLERqyfg0\\\",\\n        \\\"payment_method_details\\\": {\\n          \\\"card\\\": {\\n            \\\"amount_authorized\\\": 50,\\n            \\\"brand\\\": \\\"visa\\\",\\n            \\\"checks\\\": {\\n              \\\"address_line1_check\\\": null,\\n              \\\"address_postal_code_check\\\": null,\\n              \\\"cvc_check\\\": null\\n            },\\n            \\\"country\\\": \\\"US\\\",\\n            \\\"ds_transaction_id\\\": null,\\n            \\\"exp_month\\\": 9,\\n            \\\"exp_year\\\": 2024,\\n            \\\"extended_authorization\\\": {\\n              \\\"status\\\": \\\"disabled\\\"\\n            },\\n            \\\"fingerprint\\\": null,\\n            \\\"funding\\\": \\\"credit\\\",\\n            \\\"incremental_authorization\\\": {\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"installments\\\": null,\\n            \\\"last4\\\": \\\"4242\\\",\\n            \\\"mandate\\\": null,\\n            \\\"moto\\\": null,\\n            \\\"multicapture\\\": {\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"network\\\": \\\"visa\\\",\\n            \\\"network_token\\\": {\\n              \\\"exp_month\\\": 9,\\n              \\\"exp_year\\\": 2024,\\n              \\\"fingerprint\\\": \\\"hfaVNMiXc0dYSiC5\\\",\\n              \\\"last4\\\": \\\"4242\\\",\\n              \\\"tokenization_method\\\": \\\"apple_pay\\\",\\n              \\\"used\\\": false\\n            },\\n            \\\"network_transaction_id\\\": \\\"104102978678771\\\",\\n            \\\"overcapture\\\": {\\n              \\\"maximum_amount_capturable\\\": 50,\\n              \\\"status\\\": \\\"unavailable\\\"\\n            },\\n            \\\"three_d_secure\\\": null,\\n            \\\"wallet\\\": {\\n              \\\"apple_pay\\\": {\\n                \\\"type\\\": \\\"apple_pay\\\"\\n              },\\n              \\\"dynamic_last4\\\": \\\"4242\\\",\\n              \\\"type\\\": \\\"apple_pay\\\"\\n            }\\n          },\\n          \\\"type\\\": \\\"card\\\"\\n        },\\n        \\\"radar_options\\\": {},\\n        \\\"receipt_email\\\": null,\\n        \\\"receipt_number\\\": null,\\n        \\\"receipt_url\\\": \\\"https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKPu_tbAGMgb1i-5uogg6LBYtHz5nv48TLnQFKbUhbQOjDLetYGrcnmnG64XzKTY69nso826Kd0cANL-w\\\",\\n        \\\"refunded\\\": false,\\n        \\\"refunds\\\": {\\n          \\\"object\\\": \\\"list\\\",\\n          \\\"data\\\": [],\\n          \\\"has_more\\\": false,\\n          \\\"total_count\\\": 0,\\n          \\\"url\\\": \\\"/v1/charges/ch_3P1UIQAWOtgoysog2zDy9BAh/refunds\\\"\\n        },\\n        \\\"review\\\": null,\\n        \\\"shipping\\\": null,\\n        \\\"source\\\": null,\\n        \\\"source_transfer\\\": null,\\n        \\\"statement_descriptor\\\": null,\\n        \\\"statement_descriptor_suffix\\\": null,\\n        \\\"status\\\": \\\"succeeded\\\",\\n        \\\"transfer_data\\\": null,\\n        \\\"transfer_group\\\": null,\\n    \\\"has_more\\\": false,\\n    \\\"total_count\\\": 1,\\n    \\\"url\\\": \\\"/v1/charges?payment_intent=pi_3P1UIQAWOtgoysog22LYv5Ie\\\"\\n  },\\n  \\\"client_secret\\\": \\\"pi_3P1UIQAWOtgoysog22LYv5Ie_secret_BXrSnt0ALWlIKXABbi8BoFJm0\\\",\\n  \\\"confirmation_method\\\": \\\"automatic\\\",\\n  \\\"created\\\": 1712152570,\\n  \\\"currency\\\": \\\"usd\\\",\\n  \\\"customer\\\": null,\\n  \\\"description\\\": null,\\n  \\\"invoice\\\": null,\\n  \\\"last_payment_error\\\": null,\\n  \\\"level3\\\": null,\\n  \\\"livemode\\\": false,\\n  \\\"metadata\\\": {\\n    \\\"connect_agent\\\": \\\"placeholder\\\",\\n    \\\"order_id\\\": \\\"9900a089-9ce6-4158-9605-10b5633d1d57\\\",\\n    \\\"transaction_token\\\": \\\"WmaAqGg0LW0ahLEvwIkMMCAKHKe\\\"\\n  },\\n  \\\"next_action\\\": null,\\n  \\\"on_behalf_of\\\": null,\\n  \\\"payment_method\\\": \\\"pm_1P1UIQAWOtgoysogLERqyfg0\\\",\\n  \\\"payment_method_configuration_details\\\": null,\\n  \\\"payment_method_options\\\": {\\n    \\\"card\\\": {\\n      \\\"installments\\\": null,\\n      \\\"mandate_options\\\": null,\\n      \\\"network\\\": null,\\n      \\\"request_three_d_secure\\\": \\\"automatic\\\"\\n    }\\n  },\\n  \\\"payment_method_types\\\": [\\n    \\\"card\\\"\\n  ],\\n  \\\"processing\\\": null,\\n  \\\"receipt_email\\\": null,\\n  \\\"review\\\": null,\\n  \\\"setup_future_usage\\\": null,\\n  \\\"shipping\\\": null,\\n  \\\"source\\\": null,\\n  \\\"statement_descriptor\\\": null,\\n  \\\"statement_descriptor_suffix\\\": null,\\n  \\\"status\\\": \\\"succeeded\\\",\\n  \\\"transfer_data\\\": null,\\n  \\\"transfer_group\\\": null\\n}\"
       read 6581 bytes
       Conn close\n"
     SCRUBBED
@@ -2339,78 +2584,74 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "amount_capturable": 0,
         "amount_received": 2000,
         "capture_method": "automatic",
-        "charges": {
+        "latest_charge": {
           "object": "list",
-          "data": [
-            {
-              "id": "ch_3OAbBTAWOtgoysog3eoQxrT9",
-              "object": "charge",
-              "amount": 2000,
-              "amount_captured": 2000,
-              "outcome": {
-                "network_status": "approved_by_network",
-                "reason": null,
-                "risk_level": "normal",
-                "risk_score": 37,
-                "seller_message": "Payment complete.",
-                "type": "authorized"
+          "id": "ch_3OAbBTAWOtgoysog3eoQxrT9",
+          "object": "charge",
+          "amount": 2000,
+          "amount_captured": 2000,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 37,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3OAbBTAWOtgoysog36MuKzzw",
+          "payment_method": "pm_1OAbBTAWOtgoysogVf7KTk4H",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 2000,
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": "pass",
+                "address_postal_code_check": "pass",
+                "cvc_check": "pass"
               },
-              "paid": true,
-              "payment_intent": "pi_3OAbBTAWOtgoysog36MuKzzw",
-              "payment_method": "pm_1OAbBTAWOtgoysogVf7KTk4H",
-              "payment_method_details": {
-                "card": {
-                  "amount_authorized": 2000,
-                  "brand": "visa",
-                  "checks": {
-                    "address_line1_check": "pass",
-                    "address_postal_code_check": "pass",
-                    "cvc_check": "pass"
-                  },
-                  "country": "US",
-                  "ds_transaction_id": null,
-                  "exp_month": 10,
-                  "exp_year": 2028,
-                  "extended_authorization": {
-                    "status": "disabled"
-                  },
-                  "fingerprint": "hfaVNMiXc0dYSiC5",
-                  "funding": "credit",
-                  "incremental_authorization": {
-                    "status": "unavailable"
-                  },
-                  "installments": null,
-                  "last4": "4242",
-                  "mandate": null,
-                  "moto": null,
-                  "multicapture": {
-                    "status": "unavailable"
-                  },
-                  "network": "visa",
-                  "network_token": {
-                    "used": false
-                  },
-                  "network_transaction_id": "104102978678771",
-                  "overcapture": {
-                    "maximum_amount_capturable": 2000,
-                    "status": "unavailable"
-                  },
-                  "three_d_secure": null,
-                  "wallet": null
-                },
-                "type": "card"
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 10,
+              "exp_year": 2028,
+              "extended_authorization": {
+                "status": "disabled"
               },
-              "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKJCUtKoGMgYHwo4IbXs6LBbLMStawAC9eTsIUAmLDXw4dZNPmxzC6ds3zZxb-WVIVBJi_F4M59cPA3fR",
-              "refunded": false,
-              "refunds": {
-                "object": "list",
-                "data": [],
-                "has_more": false,
-                "total_count": 0,
-                "url": "/v1/charges/ch_3OAbBTAWOtgoysog3eoQxrT9/refunds"
-              }
-            }
-          ],
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104102978678771",
+              "overcapture": {
+                "maximum_amount_capturable": 2000,
+                "status": "unavailable"
+              },
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xNjBEWDZBV090Z295c29nKJCUtKoGMgYHwo4IbXs6LBbLMStawAC9eTsIUAmLDXw4dZNPmxzC6ds3zZxb-WVIVBJi_F4M59cPA3fR",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3OAbBTAWOtgoysog3eoQxrT9/refunds"
+          },
           "has_more": false,
           "total_count": 1,
           "url": "/v1/charges?payment_intent=pi_3OAbBTAWOtgoysog36MuKzzw"
@@ -2419,7 +2660,6 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
         "confirmation_method": "automatic",
         "created": 1699547663,
         "currency": "usd",
-        "latest_charge": "ch_3OAbBTAWOtgoysog3eoQxrT9",
         "payment_method": "pm_1OAbBTAWOtgoysogVf7KTk4H",
         "payment_method_types": [
           "card"


### PR DESCRIPTION
Update version to 2022-11-15 and charges to be
latest_charge. latest_charge is no longer
automatically expanded andwill only be expanded
if the repsonse is succesful.

Remote
99 tests, 463 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.9899% passed