### PR TITLE
Validation added in Worldpay to avoid scheme transaction identifier when customer started transaction

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -798,7 +798,7 @@ module ActiveMerchant #:nodoc:
         stored_credential_params = generate_stored_credential_params(is_initial_transaction, reason, options[:stored_credential][:initiator])
 
         xml.storedCredentials stored_credential_params do
-          xml.schemeTransactionIdentifier network_transaction_id(options) if network_transaction_id(options) && !is_initial_transaction
+          xml.schemeTransactionIdentifier network_transaction_id(options) if network_transaction_id(options) && subsequent_non_cardholder_transaction?(options, is_initial_transaction)
         end
       end
 
@@ -809,8 +809,12 @@ module ActiveMerchant #:nodoc:
         stored_credential_params = generate_stored_credential_params(is_initial_transaction, options[:stored_credential_initiated_reason])
 
         xml.storedCredentials stored_credential_params do
-          xml.schemeTransactionIdentifier options[:stored_credential_transaction_id] if options[:stored_credential_transaction_id] && !is_initial_transaction
+          xml.schemeTransactionIdentifier options[:stored_credential_transaction_id] if options[:stored_credential_transaction_id] && subsequent_non_cardholder_transaction?(options, is_initial_transaction)
         end
+      end
+
+      def subsequent_non_cardholder_transaction?(options, is_initial_transaction)
+        !is_initial_transaction && options&.dig(:stored_credential, :initiator) != 'cardholder'
       end
 
       def add_shopper(xml, options)


### PR DESCRIPTION
### Summary
Fixing a problem when customer initiates transaction with master card and stored credentials, the schemeTransactionIdentifier must not retrieve a value avoiding a possible generated error for this reason

### Spreedly reference:
[OPPS-151](https://spreedly.atlassian.net/browse/OPPS-151)

### Unit tests:
Finished in 0.357197 seconds.
132 tests, 736 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Remote tests:
Finished in 250.382481 seconds.
114 tests, 489 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.3684% passed

Failure tests not related to changes