### PR TITLE
This grabs and sets the 3d secured supported field when running a verify

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -75,6 +75,7 @@
 * GlobalCollect: Add support for $0 Auth [almalee24] #5303
 * Versapay: Store and Unstore transactions [gasb150] #5315
 * Nuvei: Add 3DS Global [javierpedrozaing] #5308
+* StripePI: Store the three_d_secure_usage field [yunnydang] #5321
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -628,9 +628,20 @@ module ActiveMerchant #:nodoc:
         response.merge!(headers)
       end
 
+      def add_card_response_field(response)
+        return unless @card_3d_supported.present?
+
+        card_details = {}
+        card_details['three_d_secure_usage_supported'] = @card_3d_supported if @card_3d_supported
+
+        response.merge!(card_details)
+      end
+
       def parse(body)
         response = JSON.parse(body)
         add_header_fields(response)
+        add_card_response_field(response)
+
         response
       end
 

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -529,6 +529,8 @@ module ActiveMerchant #:nodoc:
         payment_method_response = create_payment_method(payment_method, options)
         return payment_method_response if payment_method_response.failure?
 
+        add_card_3d_secure_usage_supported(payment_method_response)
+
         responses << payment_method_response
         add_payment_method_token(post, payment_method_response.params['id'], options)
       end
@@ -731,6 +733,13 @@ module ActiveMerchant #:nodoc:
 
         name = [payment_method.first_name, payment_method.last_name].compact.join(' ')
         post[:billing_details][:name] = name
+      end
+
+      # This surfaces the three_d_secure_usage.supported field and saves it as an instance variable so that we can access it later on in the response
+      def add_card_3d_secure_usage_supported(response)
+        return unless response.params['card'] && response.params['card']['three_d_secure_usage']
+
+        @card_3d_supported = response.params['card']['three_d_secure_usage']['supported'] if response.params['card']['three_d_secure_usage']['supported']
       end
 
       def format_idempotency_key(options, suffix)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1549,6 +1549,15 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'M', verify.cvv_result['code']
   end
 
+  def test_successful_verify_returns_card_three_3d_supported
+    options = {
+      customer: @customer,
+      billing_address: address
+    }
+    assert verify = @gateway.verify(@visa_card, options)
+    assert_equal true, verify.params.dig('three_d_secure_usage_supported')
+  end
+
   def test_failed_verify
     options = {
       customer: @customer

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -373,6 +373,16 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     assert_equal 'succeeded', verify.params['status']
   end
 
+  def test_successful_verify_returns_card_three_3d_supported
+    @gateway.instance_variable_set(:@card_3d_supported, true)
+    @gateway.expects(:ssl_request).returns(successful_verify_response)
+
+    assert verify = @gateway.verify(@visa_token)
+    assert_success verify
+    assert_equal 'succeeded', verify.params['status']
+    assert_equal true, verify.params['three_d_secure_usage_supported']
+  end
+
   def test_successful_verify_google_pay
     stub_comms(@gateway, :ssl_request) do
       @gateway.verify(@google_pay, @options.merge(new_ap_gp_route: true))


### PR DESCRIPTION
This makes it easier to return the 3d secured supported filed especially during multi requests to stripe PI

Local:
6064 tests, 80619 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
68 tests, 356 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
100 tests, 448 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97% passed