### PR TITLE
StripePI: Last4 From Payment Method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -75,6 +75,7 @@
 * GlobalCollect: Add support for $0 Auth [almalee24] #5303
 * Versapay: Store and Unstore transactions [gasb150] #5315
 * Nuvei: Add 3DS Global [javierpedrozaing] #5308
+* StripePI: Last4 From Payment Method [nashton] #5322
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -426,7 +426,7 @@ module ActiveMerchant #:nodoc:
         return unless adding_network_token_card_data?(payment_method)
 
         post_data[:card] ||= {}
-        post_data[:card][:last4] = options[:last_4]
+        post_data[:card][:last4] = options[:last_4] || payment_method.number[-4..]
         post_data[:card][:network_token] = {}
         post_data[:card][:network_token][:number] = payment_method.number
         post_data[:card][:network_token][:exp_month] = payment_method.month

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -275,6 +275,17 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_not_nil(purchase.params.dig('charges', 'data')[0]['payment_method_details']['card']['network_token'])
   end
 
+  def test_successful_purchase_with_network_token_cc
+    options = {
+      currency: 'USD'
+    }
+
+    purchase = @gateway.purchase(@amount, @network_token_credit_card, options)
+    assert_equal(nil, purchase.responses.first.params.dig('token', 'card', 'tokenization_method'))
+    assert purchase.success?
+    assert_not_nil(purchase.params.dig('charges', 'data')[0]['payment_method_details']['card']['network_token'])
+  end
+
   def test_successful_purchase_with_google_pay_when_sending_the_billing_address
     options = {
       currency: 'GBP',

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -618,6 +618,22 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_create_intent_response_with_network_token_fields)
   end
 
+  def test_purchase_with_network_token_cc
+    options = {
+      currency: 'USD'
+    }
+
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @network_token_credit_card, options)
+    end.check_request do |_method, endpoint, data, _headers|
+      assert_match(%r{/payment_intents}, endpoint)
+      assert_match('confirm=true', data)
+      assert_match('payment_method_data[type]=card', data)
+      assert_match('[card][last4]=5556', data)
+      assert_match('[card][network_token][number]=4000056655665556', data)
+    end.respond_with(successful_create_intent_response_with_network_token_fields)
+  end
+
   def test_purchase_with_shipping_options
     options = {
       currency: 'GBP',


### PR DESCRIPTION
For some transactions and payment methods, the `options[:last_4]` will not be prepopluated, so we need to look in the `payment_method` to slice the last 4 from the number

Remote: 100 tests, 472 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit: 68 tests, 357 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
nick-mbp:active_merchant nick$ bundle exec rubocop
Inspecting 804 files
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

804 files inspected, no offenses detected