### PR TITLE
Decidir: Patagonia365 Card Type Mapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -76,8 +76,9 @@
 * Versapay: Store and Unstore transactions [gasb150] #5315
 * Nuvei: Add 3DS Global [javierpedrozaing] #5308
 * StripePI: Store the three_d_secure_usage field [yunnydang] #5321
-* StripePI: Last4 From Payment Method [nashton] #5322
+* StripePI: Last4 From Payment Method [naashton] #5322
 * New Card Type: Patagonia365 [gasb150] #5265
+* Decidir: Patagonia365 Card Type Mapping [naashton] #5324
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -156,6 +156,8 @@ module ActiveMerchant #:nodoc:
           63
         elsif CreditCard.brand?(credit_card.number) == 'naranja'
           24
+        elsif CreditCard.brand?(credit_card.number) == 'patagonia_365'
+          55
         else
           1
         end

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -204,6 +204,8 @@ module ActiveMerchant #:nodoc:
             63
           when 'diners_club'
             8
+          when 'patagonia_365'
+            55
           else
             1
           end

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -10,6 +10,7 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
     @credit_card = credit_card('4484590159923090')
     @american_express = credit_card('376414000000009')
     @cabal = credit_card('5896570000000008')
+    @patagonia_365 = credit_card('5046562602769006')
     @visa_debit = credit_card('4517721004856075')
     @declined_card = credit_card('4000300011112220')
     @options = {
@@ -229,6 +230,17 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
     response = @gateway_purchase.purchase(@amount, payment_reference, options)
     assert_success response
     assert_equal 63, response.params['payment_method_id']
+  end
+
+  def test_successful_purchase_with_card_brand_patagonia_365
+    options = @options.merge(card_brand: 'patagonia_365')
+
+    assert response = @gateway_purchase.store(@patagonia_365)
+    payment_reference = response.authorization
+
+    response = @gateway_purchase.purchase(@amount, payment_reference, options)
+    assert_success response
+    assert_equal 55, response.params['payment_method_id']
   end
 
   def test_successful_purchase_with_payment_method_id

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -9,6 +9,7 @@ class RemoteDecidirTest < Test::Unit::TestCase
     @credit_card = credit_card('4507990000004905')
     @master_card_credit_card = credit_card('5299910010000015')
     @amex_credit_card = credit_card('373953192351004')
+    @patagonia_365_card = credit_card('5046562602769006')
     @diners_club_credit_card = credit_card('36463664750005')
     @cabal_credit_card = credit_card('5896570000000008')
     @naranja_credit_card = credit_card('5895627823453005')
@@ -61,6 +62,14 @@ class RemoteDecidirTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_amex
     response = @gateway_for_purchase.purchase(@amount, @amex_credit_card, @options)
+    assert_success response
+    assert_equal 'approved', response.message
+    assert response.authorization
+  end
+
+  def test_successful_purchase_with_patagonia_365
+    @patagonia_365_card.brand = 'patagonia_365'
+    response = @gateway_for_purchase.purchase(@amount, @patagonia_365_card, @options)
     assert_success response
     assert_equal 'approved', response.message
     assert response.authorization


### PR DESCRIPTION
Add card map for patagonia_365 to pass payment id to gateway

Reference: https://developers.payway.com.ar/docs/gateway/3jw3eiapx1jwu-medios-de-pago