### PR TITLE
DLocal: add country override optional field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -80,6 +80,7 @@
 * New Card Type: Patagonia365 [gasb150] #5265
 * Decidir: Patagonia365 Card Type Mapping [naashton] #5324
 * Ebanx: Add network token support [Buitragox] #5263
+* DLocal: Add the optional country field override [yunnydang] #5326
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -110,9 +110,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_country(post, card, options)
-        return unless address = options[:billing_address] || options[:address]
+        return unless (address = options[:billing_address] || options[:address]) || options[:country]
 
-        post[:country] = lookup_country_code(address[:country])
+        country = options[:country] ? lookup_country_code(options[:country]) : lookup_country_code(address[:country])
+        post[:country] = country
       end
 
       def lookup_country_code(country_field)

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -50,6 +50,20 @@ class RemoteDLocalTest < Test::Unit::TestCase
     assert_match 'The payment was paid', response.message
   end
 
+  def test_successful_purchase_with_country_override
+    options = {
+      billing_address: address(country: 'Mexico'),
+      document: '71575743221',
+      currency: 'BRL',
+      country: 'Brazil'
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_match 'The payment was paid', response.message
+    assert_match 'BR', response.params['card']['country']
+  end
+
   def test_successful_purchase_with_ip_and_phone
     response = @gateway.purchase(@amount, @credit_card, @options.merge(ip: '127.0.0.1'))
     assert_success response

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -176,6 +176,14 @@ class DLocalTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_country_overrride
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(country: 'Brazil'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'BR', JSON.parse(data)['country']
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_purchase_with_force_type
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge(force_type: 'debit'))


### PR DESCRIPTION
Adds the optional country field override

Local:
6104 tests, 80829 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
8 tests, 209 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
42 tests, 118 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed