### PR TITLE
CheckoutV2: Add metadata to Credit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -110,6 +110,7 @@
 * CommerceHub: Update merchantInvoiceNumber & merchantTransactionId [almalee24] #5374
 * VersaPay: refactor authorization from structure [gasb150] #5363
 * VersaPay: Improve Message Error and Error Mapping [gasb150] #5357
+* CheckoutV2: Add metadata to Credit [almalee24] #5328
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/response.rb
+++ b/lib/active_merchant/billing/response.rb
@@ -4,7 +4,7 @@ module ActiveMerchant # :nodoc:
     end
 
     class Response
-      attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result, :error_code, :emv_authorization, :network_transaction_id
+      attr_reader :params, :message, :test, :authorization, :avs_result, :cvv_result, :error_code, :emv_authorization, :network_transaction_id, :pending
 
       def success?
         @success
@@ -30,6 +30,7 @@ module ActiveMerchant # :nodoc:
         @error_code = options[:error_code]
         @emv_authorization = options[:emv_authorization]
         @network_transaction_id = options[:network_transaction_id]
+        @pending = options[:pending] || false
 
         @avs_result = if options[:avs_result].kind_of?(AVSResult)
                         options[:avs_result].to_hash

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -904,6 +904,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     response = @gateway_oauth.credit(@amount, @credit_card, @options.merge({ source_type: 'currency_account', source_id: 'ca_spwmped4qmqenai7hcghquqle4', account_holder_type: 'individual' }))
     assert_success response
     assert_equal 'Succeeded', response.message
+    assert_equal true, response.primary_response.pending
   end
 
   def test_successful_money_transfer_payout_via_credit_individual_account_holder_type
@@ -912,6 +913,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     response = @gateway_oauth.credit(@amount, @credit_card, @payout_options.merge(account_holder_type: 'individual', payout: true))
     assert_success response
     assert_equal 'Succeeded', response.message
+    assert_equal true, response.primary_response.pending
   end
 
   def test_successful_money_transfer_payout_via_credit_corporate_account_holder_type


### PR DESCRIPTION
Add metadata to Credit and pending as a field for response. Set pending to true for CheckoutV2 if a Credit returns status of Pending.

Remote 113 tests, 282 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Unit:
67 tests, 420 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed