### PR TITLE
CommerceHub - Update three_ds_server_trans_id assignation to serverTransactionId field for 3ds_global

### DIFF
--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -120,13 +120,13 @@ module ActiveMerchant #:nodoc:
 
       private
 
-      def add_three_d_secure(post, payment, options)
+      def add_three_d_secure(post, options)
         return unless three_d_secure = options[:three_d_secure]
 
         post[:additionalData3DS] = {
           dsTransactionId: three_d_secure[:ds_transaction_id],
           authenticationStatus: three_d_secure[:authentication_response_status],
-          serviceProviderTransactionId: three_d_secure[:three_ds_server_trans_id],
+          serverTransactionId: three_d_secure[:three_ds_server_trans_id],
           acsTransactionId: three_d_secure[:acs_transaction_id],
           mpiData: {
             cavv: three_d_secure[:cavv],
@@ -228,7 +228,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_purchase_and_auth_request(post, money, payment, options)
-        add_three_d_secure(post, payment, options)
+        add_three_d_secure(post, options)
         add_invoice(post, money, options)
         add_payment(post, payment, options)
         add_stored_credentials(post, options)

--- a/test/remote/gateways/remote_commerce_hub_test.rb
+++ b/test/remote/gateways/remote_commerce_hub_test.rb
@@ -46,7 +46,8 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
       cavv: 'AAABCZIhcQAAAABZlyFxAAAAAAA',
       eci: '05',
       xid: '&x_MD5_Hash=abfaf1d1df004e3c27d5d2e05929b529&x_state=BC&x_reference_3=&x_auth_code=ET141870&x_fp_timestamp=1231877695',
-      version: '2.2.0'
+      version: '2.2.0',
+      three_ds_server_trans_id: 'df8b9557-e41b-4e17-87e9-2328694a2ea0'
     }
     @dynamic_descriptors = {
       mcc: '1234',
@@ -118,6 +119,7 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'Approved', response.message
+    assert_equal response.params['additionalData3DS']['serverTransactionId'], @three_d_secure[:three_ds_server_trans_id]
   end
 
   def test_successful_purchase_whit_physical_goods_indicator


### PR DESCRIPTION
Making a mapping update mapping from to ~~serviceProviderTransactionId~~ to serverTransactionId

Spreedly reference: OPPS-192