### PR TITLE
Worldpay: Update Stored Credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -91,6 +91,7 @@
 * Litle: Success codes added to valid responses [jherreraa] #5339
 * CommerceHub: Update Production URL [almalee24] #5340
 * CommerceHub: Add Network Token support [almalee24] #5331
+* Worldpay: Update Stored Credentials [almalee24] #5330
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -783,7 +783,7 @@ module ActiveMerchant #:nodoc:
       def add_stored_credential_options(xml, options = {})
         if options[:stored_credential]
           add_stored_credential_using_normalized_fields(xml, options)
-        else
+        elsif options[:stored_credential_usage]
           add_stored_credential_using_gateway_specific_fields(xml, options)
         end
       end
@@ -798,23 +798,21 @@ module ActiveMerchant #:nodoc:
         stored_credential_params = generate_stored_credential_params(is_initial_transaction, reason, options[:stored_credential][:initiator])
 
         xml.storedCredentials stored_credential_params do
-          xml.schemeTransactionIdentifier network_transaction_id(options) if network_transaction_id(options) && subsequent_non_cardholder_transaction?(options, is_initial_transaction)
+          xml.schemeTransactionIdentifier network_transaction_id(options) if send_network_transaction_id?(options)
         end
       end
 
       def add_stored_credential_using_gateway_specific_fields(xml, options)
-        return unless options[:stored_credential_usage]
-
         is_initial_transaction = options[:stored_credential_usage] == 'FIRST'
         stored_credential_params = generate_stored_credential_params(is_initial_transaction, options[:stored_credential_initiated_reason])
 
         xml.storedCredentials stored_credential_params do
-          xml.schemeTransactionIdentifier options[:stored_credential_transaction_id] if options[:stored_credential_transaction_id] && subsequent_non_cardholder_transaction?(options, is_initial_transaction)
+          xml.schemeTransactionIdentifier options[:stored_credential_transaction_id] if options[:stored_credential_transaction_id] && !is_initial_transaction
         end
       end
 
-      def subsequent_non_cardholder_transaction?(options, is_initial_transaction)
-        !is_initial_transaction && options&.dig(:stored_credential, :initiator) != 'cardholder'
+      def send_network_transaction_id?(options)
+        network_transaction_id(options) && !options.dig(:stored_credential, :initial_transaction) && options.dig(:stored_credential, :initiator) != 'cardholder'
       end
 
       def add_shopper(xml, options)
@@ -1164,6 +1162,10 @@ module ActiveMerchant #:nodoc:
 
         stored_credential_params = {}
         stored_credential_params['usage'] = is_initial_transaction ? 'FIRST' : 'USED'
+
+        return stored_credential_params unless %w(RECURRING INSTALMENT).include?(reason)
+        return stored_credential_params if customer_or_merchant == 'customerInitiatedReason' && stored_credential_params['usage'] == 'USED'
+
         stored_credential_params[customer_or_merchant] = reason if reason
         stored_credential_params
       end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -422,7 +422,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"UNSCHEDULED\"\>/, data)
+      assert_match(/<storedCredentials usage\=\"USED\"\>/, data)
       assert_match(/<schemeTransactionIdentifier\>000000000000020005060720116005060\<\/schemeTransactionIdentifier\>/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
@@ -437,7 +437,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @nt_credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"UNSCHEDULED\"\>/, data)
+      assert_match(/<storedCredentials usage\=\"USED\"\>/, data)
       assert_match(/<schemeTransactionIdentifier\>000000000000020005060720116005060\<\/schemeTransactionIdentifier\>/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
@@ -448,7 +448,7 @@ class WorldpayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @nt_credit_card, @options.merge({ stored_credential: stored_credential_params }))
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"UNSCHEDULED\"\>/, data)
+      assert_match(/<storedCredentials usage\=\"USED\"\>/, data)
       assert_match(/<schemeTransactionIdentifier\>20005060720116005060\<\/schemeTransactionIdentifier\>/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
@@ -1700,6 +1700,25 @@ class WorldpayTest < Test::Unit::TestCase
     end.check_request do |_endpoint, data, _headers|
       assert_match(/<storedCredentials usage\=\"USED\" merchantInitiatedReason\=\"RECURRING\"\>/, data)
       assert_match(/<schemeTransactionIdentifier\>000000000000020005060720116005060\<\/schemeTransactionIdentifier\>/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
+  def test_authorize_stored_credentials_for_subsequent_customer_transaction
+    options = @options.merge!({
+      stored_credential: {
+        network_transaction_id: '3812908490218390214124',
+        initial_transaction: false,
+        reason_type: 'recurring',
+        initiator: 'cardholder'
+      }
+    })
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<storedCredentials usage\=\"USED\"\>/, data)
+      assert_not_match(/<schemeTransactionIdentifier\>000000000000020005060720116005060\<\/schemeTransactionIdentifier\>/, data)
     end.respond_with(successful_authorize_response)
     assert_success response
   end


### PR DESCRIPTION
    Update add_stored_credential_using_normalized_fields to
    only send usage: 'USED' with merchantInitiatedReason and
    only send reason if it's recurring or installment.

    Unit:
    133 tests, 741 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed

    Remote:
    114 tests, 489 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    97.3684% passed