### PR TITLE
Credorax: Add support for gateway card validation

### DIFF
--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -165,6 +165,7 @@ module ActiveMerchant # :nodoc:
         add_echo(post, options)
         add_submerchant_id(post, options)
         add_stored_credential(post, options)
+        add_account_name_inquiry(post, options)
         add_processor(post, options)
         add_authorization_details(post, options)
 
@@ -282,7 +283,7 @@ module ActiveMerchant # :nodoc:
       }
 
       def add_payment_method(post, payment_method, options)
-        post[:c1] = payment_method&.name || ''
+        post[:c1] = payment_method&.name || '' unless options[:account_name_inquiry].to_s == 'true'
         add_network_tokenization_card(post, payment_method, options) if payment_method.is_a? NetworkTokenizationCreditCard
         post[:b2] = CARD_TYPES[payment_method.brand] || ''
         post[:b1] = payment_method.number
@@ -353,6 +354,14 @@ module ActiveMerchant # :nodoc:
       def add_customer_name(post, options)
         post[:j5] = options[:first_name] if options[:first_name]
         post[:j13] = options[:last_name] if options[:last_name]
+      end
+
+      def add_account_name_inquiry(post, options)
+        return unless options[:account_name_inquiry].to_s == 'true'
+
+        post[:c22] = options[:first_name] if options[:first_name]
+        post[:c23] = options[:last_name] if options[:last_name]
+        post[:a9] = '5'
       end
 
       def add_3d_secure(post, options)

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -10,6 +10,9 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     @fully_auth_card = credit_card('5223450000000007', brand: 'mastercard', verification_value: '090', month: '12')
     @declined_card = credit_card('4176661000001111', verification_value: '681', month: '12')
     @three_ds_card = credit_card('5455330200000016', verification_value: '737', month: '10', year: Time.now.year + 2)
+    @inquiry_match_card = credit_card('4123560000000072')
+    @inquiry_no_match_card = credit_card('4123560000000429')
+    @inquiry_unverified_card = credit_card('4176660000000266')
     @address = {
       name:     'Jon Smith',
       address1: '123 Your Street',
@@ -306,6 +309,40 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, options_with_auth_details)
     assert_success response
     assert_equal 'Succeeded', response.message
+    assert response.authorization
+  end
+
+  def test_successful_zero_authorize_with_name_inquiry_match
+    extra_options = @options.merge({ account_name_inquiry: true, first_name: 'Art', last_name: 'Vandelay' })
+    response = @gateway.authorize(0, @inquiry_match_card, extra_options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal '2', response.params['O']
+    assert_equal 'A', response.params['Z26']
+    assert_equal 'A', response.params['Z27']
+    assert_equal 'A', response.params['Z28']
+    assert response.authorization
+  end
+
+  def test_successful_zero_authorize_with_name_inquiry_no_match
+    extra_options = @options.merge({ account_name_inquiry: true, first_name: 'Art', last_name: 'Vandelay' })
+    response = @gateway.authorize(0, @inquiry_no_match_card, extra_options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal '2', response.params['O']
+    assert_equal 'C', response.params['Z26']
+    assert_equal 'C', response.params['Z27']
+    assert_equal 'C', response.params['Z28']
+    assert response.authorization
+  end
+
+  def test_successful_zero_authorize_with_name_inquiry_unverified
+    extra_options = @options.merge({ account_name_inquiry: true, first_name: 'Art', last_name: 'Vandelay' })
+    response = @gateway.authorize(0, @inquiry_unverified_card, extra_options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal '2', response.params['O']
+    assert_equal 'U', response.params['Z26']
     assert response.authorization
   end
 

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -840,6 +840,20 @@ class CredoraxTest < Test::Unit::TestCase
     end.respond_with(successful_credit_response)
   end
 
+  def test_authorize_adds_cardholder_name_inquiry
+    @options[:account_name_inquiry] = true
+    @options[:first_name] = 'Art'
+    @options[:last_name] = 'Vandelay'
+    stub_comms do
+      @gateway.authorize(0, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/c22=Art/, data)
+      assert_match(/c23=Vandelay/, data)
+      assert_match(/a9=5/, data)
+      assert_not_match(/c1=/, data)
+    end.respond_with(successful_credit_response)
+  end
+
   def test_purchase_omits_phone_when_nil
     # purchase passes the phone number when provided
     @options[:billing_address][:phone] = '555-444-3333'


### PR DESCRIPTION
This change allows the `cardholder_name_inquiry` flag to be sent. If set to true, it will trigger first and last name data to be sent for c22, and c23. $0 auth transactions to validate cards also require the value for a9 to be set to 5.

Remote Tests:
52 tests, 176 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 88.4615% passed
*6 failing tests also failing on master

Unit Tests
83 tests, 399 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed