### PR TITLE
RedsysRest: add NetworToken

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -93,6 +93,7 @@
 * CommerceHub: Add Network Token support [almalee24] #5331
 * Worldpay: Update Stored Credentials [almalee24] #5330
 * Update Rubocop 1.26.0 [almalee24] #5325
+* RedsysREST: Add Network Tokens [gasb150] #5333
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/redsys_rest.rb
+++ b/lib/active_merchant/billing/gateways/redsys_rest.rb
@@ -280,7 +280,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def scrub(transcript)
+        merchant_parameters = filter_merchant_parameters(transcript)
+
         transcript.
+          gsub(%r((Ds_MerchantParameters=)(\w+)), '\1' + merchant_parameters.to_s + '\3').
           gsub(%r((PAN\"=>\")(\d+)), '\1[FILTERED]').
           gsub(%r((CVV2\"=>\")(\d+)), '\1[FILTERED]')
       end
@@ -338,14 +341,23 @@ module ActiveMerchant #:nodoc:
         post[:DS_MERCHANT_ORDER] = clean_order_id(order_id)
       end
 
-      def add_payment(post, card)
-        name = [card.first_name, card.last_name].join(' ').slice(0, 60)
-        year = sprintf('%.4i', card.year)
-        month = sprintf('%.2i', card.month)
-        post['DS_MERCHANT_TITULAR'] = CGI.escape(name)
-        post['DS_MERCHANT_PAN'] = card.number
-        post['DS_MERCHANT_EXPIRYDATE'] = "#{year[2..3]}#{month}"
-        post['DS_MERCHANT_CVV2'] = card.verification_value if card.verification_value.present?
+      def add_payment(post, payment_method)
+        year = sprintf('%.4i', payment_method.year)
+        month = sprintf('%.2i', payment_method.month)
+
+        if payment_method.is_a?(NetworkTokenizationCreditCard)
+          post[:Ds_Merchant_TokenData] = {
+            tokenCryptogram: payment_method.payment_cryptogram,
+            expirationDate: "#{year[2..3]}#{month}",
+            token: payment_method.number
+          }
+        else
+          name = [payment_method.first_name, payment_method.last_name].join(' ').slice(0, 60)
+          post['DS_MERCHANT_TITULAR'] = CGI.escape(name)
+          post['DS_MERCHANT_PAN'] = payment_method.number
+          post['DS_MERCHANT_EXPIRYDATE'] = "#{year[2..3]}#{month}"
+          post['DS_MERCHANT_CVV2'] = payment_method.verification_value if payment_method.verification_value.present?
+        end
       end
 
       def determine_action(options)
@@ -434,7 +446,7 @@ module ActiveMerchant #:nodoc:
 
         # Need to get updated for 3DS support
         if code = response[:ds_response]
-          (code.to_i < 100) || [400, 481, 500, 900].include?(code.to_i)
+          (code.to_i < 100) || [195, 400, 481, 500, 900].include?(code.to_i)
         else
           false
         end
@@ -506,6 +518,23 @@ module ActiveMerchant #:nodoc:
 
       def mac256(key, data)
         OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key, data)
+      end
+
+      def filter_merchant_parameters(transcript)
+        # Enhancement, the gateway response with base64 and it contians sensible data.
+        # Decode + Scrub + Encode the returned sensitive dat.
+        pre_filter_data =  transcript.match(%r(Ds_MerchantParameters=(\w+)))
+        return unless pre_filter_data
+
+        decoded_pre_filter_data = Base64.decode64(pre_filter_data[1])
+
+        filter_data = decoded_pre_filter_data.
+                      gsub(%r((PAN\":\")(\d+)), '\1[FILTERED]').
+                      gsub(%r((CVV2\":\")(\d+)), '\1[FILTERED]').
+                      gsub(%r((token\":\")(\d+)), '\1[FILTERED]').
+                      gsub(%r((tokenCryptogram\":\")([^*]*?")), '\1[FILTERED]"')
+
+        Base64.strict_encode64(filter_data)
       end
     end
   end

--- a/test/remote/gateways/remote_redsys_rest_test.rb
+++ b/test/remote/gateways/remote_redsys_rest_test.rb
@@ -9,6 +9,16 @@ class RemoteRedsysRestTest < Test::Unit::TestCase
     @declined_card = credit_card
     @threeds2_credit_card = credit_card('4918019199883839')
 
+    @network_tokenized_credit_card = network_tokenization_credit_card(
+      '4548812049400004',
+      payment_cryptogram: 'AOC/WIoqDoS3AdTkVpb5AAADFA==',
+      eci: '05',
+      source: :network_token,
+      brand: 'visa',
+      month: '04',
+      year: '26'
+    )
+
     @threeds2_credit_card_frictionless = credit_card('4548814479727229')
     @threeds2_credit_card_alt = credit_card('4548817212493017')
     @options = {
@@ -26,6 +36,12 @@ class RemoteRedsysRestTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, order_id: "a%4#{generate_order_id}")
     assert_success response
     assert_equal 'Transaction Approved', response.message
+  end
+
+  def test_successful_purchase_with_network_token
+    response = @gateway.purchase(100, @network_tokenized_credit_card, @options.merge(terminal: '001'))
+    assert_success response
+    assert_equal 'Requires SCA authentication', response.message
   end
 
   def test_failed_purchase
@@ -134,6 +150,35 @@ class RemoteRedsysRestTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
   end
 
+  def test_transcript_scrubbing_for_network_tokens
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @network_tokenized_credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@gateway.options[:secret_key], clean_transcript)
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+
+    # Ensure the encoded returned answer scrub the sensitive files.
+
+    decoded_merchant_params = Base64.decode64(transcript.match(%r(Ds_MerchantParameters=(\w+)))[1])
+    parsed_decoded_params = JSON.parse decoded_merchant_params
+    assert_equal parsed_decoded_params['Ds_Merchant_TokenData']['token'], @network_tokenized_credit_card.number
+    assert_equal parsed_decoded_params['Ds_Merchant_TokenData']['tokenCryptogram'], @network_tokenized_credit_card.payment_cryptogram
+
+    decoded_clean_merchant_params = Base64.decode64(clean_transcript.match(%r(Ds_MerchantParameters=(\w+)))[1])
+
+    parsed_clean_params = JSON.parse decoded_clean_merchant_params
+    assert_equal parsed_clean_params['Ds_Merchant_TokenData']['token'], '[FILTERED]'
+
+    assert_equal parsed_decoded_params['Ds_Merchant_TokenData']['token'], @network_tokenized_credit_card.number
+    assert_equal parsed_decoded_params['Ds_Merchant_TokenData']['tokenCryptogram'], @network_tokenized_credit_card.payment_cryptogram
+
+    assert_scrubbed(@network_tokenized_credit_card.number, decoded_clean_merchant_params)
+    assert_scrubbed(@network_tokenized_credit_card.payment_cryptogram, decoded_clean_merchant_params)
+  end
+
   def test_transcript_scrubbing_on_failed_transactions
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @declined_card, @options)
@@ -157,6 +202,16 @@ class RemoteRedsysRestTest < Test::Unit::TestCase
   def test_successful_authorize_3ds_setup
     options = @options.merge(execute_threed: true, terminal: 12)
     response = @gateway.authorize(@amount, @credit_card, options)
+    assert_success response
+    assert response.params['ds_emv3ds']
+    assert_equal '2.2.0', response.params['ds_emv3ds']['protocolVersion']
+    assert_equal 'CardConfiguration', response.message
+    assert response.authorization
+  end
+
+  def test_successful_authorize_3ds_setup_with_network_token
+    options = @options.merge(execute_threed: true, terminal: 12)
+    response = @gateway.authorize(@amount, @network_tokenized_credit_card, options)
     assert_success response
     assert response.params['ds_emv3ds']
     assert_equal '2.2.0', response.params['ds_emv3ds']['protocolVersion']


### PR DESCRIPTION
Summary
----------------
This add suppor for NetworkTokenizedCreditCard with redsys
Enhance Scrubbing method

Unit Tests
----------------
Finished in 0.029745 seconds.
28 tests, 124 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests
----------------
Finished in 34.288085 seconds.
29 tests, 108 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.5517% passed

Rubocop
----------------
803 files inspected, no offenses detected