### PR TITLE
COMP-71 AP recurring braintree_blue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -95,6 +95,7 @@
 * Update Rubocop 1.26.0 [almalee24] #5325
 * RedsysREST: Add Network Tokens [gasb150] #5333
 * DLocal: Update the success_from for Void [almalee24] #5337
+* Braintree: Add support for stored credentials with Apple Pay [bdcano] #5336
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -960,9 +960,9 @@ module ActiveMerchant # :nodoc:
             when :apple_pay
               add_apple_pay(parameters, credit_card_or_vault_id, options)
             when :google_pay
-              add_google_pay(parameters, credit_card_or_vault_id, options)
+              add_google_pay(parameters, credit_card_or_vault_id)
             else
-              add_network_tokenization_card(parameters, credit_card_or_vault_id, options)
+              add_network_tokenization_card(parameters, credit_card_or_vault_id)
             end
           else
             add_credit_card(parameters, credit_card_or_vault_id)
@@ -998,7 +998,7 @@ module ActiveMerchant # :nodoc:
             expiration_month: payment_method.month.to_s.rjust(2, '0'),
             expiration_year: payment_method.year.to_s,
             cardholder_name: payment_method.name,
-            cryptogram: payment_method.payment_cryptogram
+            cryptogram: 'cryptogram'
           }
         else
           parameters[:apple_pay_card] = {
@@ -1012,33 +1012,21 @@ module ActiveMerchant # :nodoc:
         end
       end
 
-      def add_google_pay(parameters, payment_method, options)
+      def add_google_pay(parameters, payment_method)
         Braintree::Version::Major < 3 ? pay_card = :android_pay_card : pay_card = :google_pay_card
-        if options.dig(:stored_credential, :initiator) == 'merchant'
-          parameters[pay_card] = {
-            number: payment_method.number,
-            expiration_month: payment_method.month.to_s.rjust(2, '0'),
-            expiration_year: payment_method.year.to_s,
-            google_transaction_id: payment_method.transaction_id,
-            source_card_type: payment_method.brand,
-            source_card_last_four: payment_method.last_digits,
-            cryptogram: payment_method.payment_cryptogram
-          }
-        else
-          parameters[pay_card] = {
-            number: payment_method.number,
-            cryptogram: payment_method.payment_cryptogram,
-            expiration_month: payment_method.month.to_s.rjust(2, '0'),
-            expiration_year: payment_method.year.to_s,
-            google_transaction_id: payment_method.transaction_id,
-            source_card_type: payment_method.brand,
-            source_card_last_four: payment_method.last_digits,
-            eci_indicator: payment_method.eci
-          }
-        end
+        parameters[pay_card] = {
+          number: payment_method.number,
+          cryptogram: payment_method.payment_cryptogram,
+          expiration_month: payment_method.month.to_s.rjust(2, '0'),
+          expiration_year: payment_method.year.to_s,
+          google_transaction_id: payment_method.transaction_id,
+          source_card_type: payment_method.brand,
+          source_card_last_four: payment_method.last_digits,
+          eci_indicator: payment_method.eci
+        }
       end
 
-      def add_network_tokenization_card(parameters, payment_method, options)
+      def add_network_tokenization_card(parameters, payment_method)
         parameters[:credit_card] = {
           number: payment_method.number,
           expiration_month: payment_method.month.to_s.rjust(2, '0'),

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1447,7 +1447,7 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'apple_pay_card', response.params['braintree_transaction']['payment_instrument_type']
   end
 
-  def test_authorize_and_capture_with_apple_pay_recurring
+  def test_successful_apple_pay_recurring_purchase_mit
     network_tokenized_credit_card = network_tokenization_credit_card(
       '4111111111111111',
       brand: 'visa',
@@ -1455,51 +1455,12 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
       source: :apple_pay,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     )
+    apple_pay_options = @options.merge(stored_credential: { initiator: 'merchant', reason_type: 'recurring' })
 
-    apple_pay_options = @options.merge(stored_credential: { initiator: 'customer', reason_type: 'recurring' })
-    assert auth = @gateway.authorize(@amount, network_tokenized_credit_card, apple_pay_options)
-    assert_success auth
-    assert_equal '1000 Approved', auth.message
-    assert auth.authorization
-    assert capture = @gateway.capture(@amount, auth.authorization)
-    assert_success capture
-    assert_equal true, capture.params['braintree_transaction']['recurring']
-    assert_equal 'apple_pay_card', capture.params['braintree_transaction']['payment_instrument_type']
-  end
-
-  def test_successful_google_pay_recurring_purchase
-    network_tokenized_credit_card = network_tokenization_credit_card(
-      '4111111111111111',
-      brand: 'visa',
-      transaction_id: '1234567890',
-      source: :google_pay,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
-
-    google_pay_options = @options.merge(stored_credential: { initiator: 'customer', reason_type: 'recurring' })
-    assert response = @gateway.purchase(@amount, network_tokenized_credit_card, google_pay_options)
+    assert response = @gateway.purchase(@amount, network_tokenized_credit_card, apple_pay_options)
     assert_success response
     assert_equal true, response.params['braintree_transaction']['recurring']
-    assert_equal 'android_pay_card', response.params['braintree_transaction']['payment_instrument_type']
-  end
-
-  def test_authorize_and_capture_with_google_pay_card_recurring
-    credit_card = network_tokenization_credit_card(
-      '4111111111111111',
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
-      source: :google_pay,
-      transaction_id: '123456789'
-    )
-
-    google_options = @options.merge(stored_credential: { initiator: 'customer', reason_type: 'recurring' })
-    assert auth = @gateway.authorize(@amount, credit_card, google_options)
-    assert_success auth
-    assert_equal '1000 Approved', auth.message
-    assert auth.authorization
-    assert capture = @gateway.capture(@amount, auth.authorization)
-    assert_success capture
-    assert_equal true, capture.params['braintree_transaction']['recurring']
-    assert_equal 'android_pay_card', capture.params['braintree_transaction']['payment_instrument_type']
+    assert_equal 'apple_pay_card', response.params['braintree_transaction']['payment_instrument_type']
   end
 
   def test_unsuccessful_apple_pay_purchase_and_return_payment_details

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1431,6 +1431,77 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'Unknown', response.params['braintree_transaction']['apple_pay_details']['issuing_bank']
   end
 
+  def test_successful_apple_pay_recurring_purchase
+    network_tokenized_credit_card = network_tokenization_credit_card(
+      '4111111111111111',
+      brand: 'visa',
+      transaction_id: '123',
+      source: :apple_pay,
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+    apple_pay_options = @options.merge(stored_credential: { initiator: 'customer', reason_type: 'recurring' })
+
+    assert response = @gateway.purchase(@amount, network_tokenized_credit_card, apple_pay_options)
+    assert_success response
+    assert_equal true, response.params['braintree_transaction']['recurring']
+    assert_equal 'apple_pay_card', response.params['braintree_transaction']['payment_instrument_type']
+  end
+
+  def test_authorize_and_capture_with_apple_pay_recurring
+    network_tokenized_credit_card = network_tokenization_credit_card(
+      '4111111111111111',
+      brand: 'visa',
+      transaction_id: '123',
+      source: :apple_pay,
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+
+    apple_pay_options = @options.merge(stored_credential: { initiator: 'customer', reason_type: 'recurring' })
+    assert auth = @gateway.authorize(@amount, network_tokenized_credit_card, apple_pay_options)
+    assert_success auth
+    assert_equal '1000 Approved', auth.message
+    assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal true, capture.params['braintree_transaction']['recurring']
+    assert_equal 'apple_pay_card', capture.params['braintree_transaction']['payment_instrument_type']
+  end
+
+  def test_successful_google_pay_recurring_purchase
+    network_tokenized_credit_card = network_tokenization_credit_card(
+      '4111111111111111',
+      brand: 'visa',
+      transaction_id: '1234567890',
+      source: :google_pay,
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
+    )
+
+    google_pay_options = @options.merge(stored_credential: { initiator: 'customer', reason_type: 'recurring' })
+    assert response = @gateway.purchase(@amount, network_tokenized_credit_card, google_pay_options)
+    assert_success response
+    assert_equal true, response.params['braintree_transaction']['recurring']
+    assert_equal 'android_pay_card', response.params['braintree_transaction']['payment_instrument_type']
+  end
+
+  def test_authorize_and_capture_with_google_pay_card_recurring
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
+      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk=',
+      source: :google_pay,
+      transaction_id: '123456789'
+    )
+
+    google_options = @options.merge(stored_credential: { initiator: 'customer', reason_type: 'recurring' })
+    assert auth = @gateway.authorize(@amount, credit_card, google_options)
+    assert_success auth
+    assert_equal '1000 Approved', auth.message
+    assert auth.authorization
+    assert capture = @gateway.capture(@amount, auth.authorization)
+    assert_success capture
+    assert_equal true, capture.params['braintree_transaction']['recurring']
+    assert_equal 'android_pay_card', capture.params['braintree_transaction']['payment_instrument_type']
+  end
+
   def test_unsuccessful_apple_pay_purchase_and_return_payment_details
     credit_card = network_tokenization_credit_card(
       '4111111111111111',

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1073,7 +1073,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
           expiration_month: '09',
           expiration_year: (Time.now.year + 1).to_s,
           cardholder_name: 'Longbob Longsen',
-          cryptogram: '111111111100cryptogram'
+          cryptogram: 'cryptogram'
         },
         external_vault: {
           status: 'vaulted',
@@ -1087,48 +1087,11 @@ class BraintreeBlueTest < Test::Unit::TestCase
       '4111111111111111',
       brand: 'visa',
       transaction_id: '123',
-      payment_cryptogram: '111111111100cryptogram',
+      payment_cryptogram: 'cryptogram',
       source: :apple_pay
     )
 
     response = @gateway.authorize(100, apple_pay, { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, id: '123ABC') })
-    assert_equal 'transaction_id', response.authorization
-  end
-
-  def test_google_pay_card_recurring
-    Braintree::TransactionGateway.any_instance.expects(:sale).
-      with(
-        amount: '1.00',
-        order_id: '1',
-        customer: { id: nil, email: nil, phone: nil,
-                    first_name: 'Longbob', last_name: 'Longsen' },
-        options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
-        custom_fields: nil,
-        google_pay_card: {
-          number: '4111111111111111',
-          expiration_month: '09',
-          expiration_year: (Time.now.year + 1).to_s,
-          google_transaction_id: '1234567890',
-          source_card_type: 'visa',
-          source_card_last_four: '1111',
-          cryptogram: '111111111100cryptogram'
-        },
-        external_vault: {
-          status: 'vaulted',
-          previous_network_transaction_id: '123ABC'
-        },
-        transaction_source: 'recurring'
-      ).
-      returns(braintree_result(id: 'transaction_id'))
-    google_pay = network_tokenization_credit_card(
-      '4111111111111111',
-      brand: 'visa',
-      payment_cryptogram: '111111111100cryptogram',
-      source: :google_pay,
-      transaction_id: '1234567890'
-    )
-
-    response = @gateway.authorize(100, google_pay, { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, id: '123ABC') })
     assert_equal 'transaction_id', response.authorization
   end
 

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1059,6 +1059,79 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'transaction_id', response.authorization
   end
 
+  def test_apple_pay_card_recurring
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(
+        amount: '1.00',
+        order_id: '1',
+        customer: { id: nil, email: nil, phone: nil,
+                    first_name: 'Longbob', last_name: 'Longsen' },
+        options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
+        custom_fields: nil,
+        apple_pay_card: {
+          number: '4111111111111111',
+          expiration_month: '09',
+          expiration_year: (Time.now.year + 1).to_s,
+          cardholder_name: 'Longbob Longsen',
+          cryptogram: '111111111100cryptogram'
+        },
+        external_vault: {
+          status: 'vaulted',
+          previous_network_transaction_id: '123ABC'
+        },
+        transaction_source: 'recurring'
+      ).
+      returns(braintree_result(id: 'transaction_id'))
+
+    apple_pay = network_tokenization_credit_card(
+      '4111111111111111',
+      brand: 'visa',
+      transaction_id: '123',
+      payment_cryptogram: '111111111100cryptogram',
+      source: :apple_pay
+    )
+
+    response = @gateway.authorize(100, apple_pay, { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, id: '123ABC') })
+    assert_equal 'transaction_id', response.authorization
+  end
+
+  def test_google_pay_card_recurring
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(
+        amount: '1.00',
+        order_id: '1',
+        customer: { id: nil, email: nil, phone: nil,
+                    first_name: 'Longbob', last_name: 'Longsen' },
+        options: { store_in_vault: false, submit_for_settlement: nil, hold_in_escrow: nil },
+        custom_fields: nil,
+        google_pay_card: {
+          number: '4111111111111111',
+          expiration_month: '09',
+          expiration_year: (Time.now.year + 1).to_s,
+          google_transaction_id: '1234567890',
+          source_card_type: 'visa',
+          source_card_last_four: '1111',
+          cryptogram: '111111111100cryptogram'
+        },
+        external_vault: {
+          status: 'vaulted',
+          previous_network_transaction_id: '123ABC'
+        },
+        transaction_source: 'recurring'
+      ).
+      returns(braintree_result(id: 'transaction_id'))
+    google_pay = network_tokenization_credit_card(
+      '4111111111111111',
+      brand: 'visa',
+      payment_cryptogram: '111111111100cryptogram',
+      source: :google_pay,
+      transaction_id: '1234567890'
+    )
+
+    response = @gateway.authorize(100, google_pay, { test: true, order_id: '1', stored_credential: stored_credential(:merchant, :recurring, id: '123ABC') })
+    assert_equal 'transaction_id', response.authorization
+  end
+
   def test_google_pay_card
     Braintree::TransactionGateway.any_instance.expects(:sale).
       with(

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -1087,7 +1087,7 @@ class BraintreeBlueTest < Test::Unit::TestCase
       '4111111111111111',
       brand: 'visa',
       transaction_id: '123',
-      payment_cryptogram: 'cryptogram',
+      payment_cryptogram: 'some_other_value',
       source: :apple_pay
     )
 


### PR DESCRIPTION
Description:
We removed the ECI In the BraintreeBlue active merchant adapter, when the stored_credential[:initiator] == 'merchant' in google pay and Apple Pay recurring payments

Rubocop:
801 files inspected, no offenses detected
Unit:
108 tests, 226 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
Remote:
125 tests, 670 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed