### PR TITLE
Litle: Success codes added to valid responses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -88,6 +88,7 @@
 * MIT: Change test URL [Buitragox] #5335
 * Nuvei: Fix NTID stored credentials [javierpedrozaing] #5334
 * StripePI: Fix the store three_d_secure_usage field [yunnydang] #5338
+* Litle: Success codes added to valid responses [jherreraa] #5339
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -561,7 +561,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_from(kind, parsed)
-        return %w(000 001 010 141 142).any?(parsed[:response]) unless kind == :registerToken
+        return %w(000 001 010 136 141 142 470 473).any?(parsed[:response]) unless kind == :registerToken
 
         %w(000 801 802).include?(parsed[:response])
       end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -92,6 +92,21 @@ class LitleTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_alternate_response
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |endpoint, _data, _headers|
+      # Counterpoint to test_successful_postlive_url:
+      assert_match(/www\.testvantivcnp\.com/, endpoint)
+    end.respond_with(successful_purchase_alternate_response)
+
+    assert_success response
+    assert_equal '136', response.params['response']
+    assert_equal 'Approved', response.message
+    assert_equal '100000000000000006;sale;100', response.authorization
+    assert response.test?
+  end
+
   def test_successful_purchase_prepaid_card_141
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
@@ -825,6 +840,25 @@ class LitleTest < Test::Unit::TestCase
           <response>#{code}</response>
           <responseTime>2014-03-31T11:34:39</responseTime>
           <message>#{message}</message>
+          <authCode>11111 </authCode>
+          <fraudResult>
+            <avsResult>01</avsResult>
+            <cardValidationResult>M</cardValidationResult>
+          </fraudResult>
+        </saleResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_purchase_alternate_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <saleResponse id='1' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>100000000000000006</litleTxnId>
+          <orderId>1</orderId>
+          <response>136</response>
+          <responseTime>2014-03-31T11:34:39</responseTime>
+          <message>Approved</message>
           <authCode>11111 </authCode>
           <fraudResult>
             <avsResult>01</avsResult>


### PR DESCRIPTION
## Summary:

Add response codes to list of successful transactions

Remote tests
--------------------------------------------------------------------------
60 tests, 207 assertions, 21 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
65% passed --> Failures due to sandbox malfunction

unit tests
--------------------------------------------------------------------------
63 tests, 285 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed