### PR TITLE
Braintree: Account for BraintreeError

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -100,6 +100,7 @@
 * Nuvei: Fix send savePM in false by default [javierpedrozaing] #5353
 * Decidir and DecicirPlus: Add the wallet_id field [yunnydang] #5354
 * Worldpay: Update where to pass shopperIPAddress [almalee24] #5348
+* Braintree: Account for BraintreeError [almalee24] #5346
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).


### PR DESCRIPTION
Take into account Braintree::ErrorResult for add_bank_account_to_customer to prevent NoMethodError

Unit:
108 tests, 231 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed 
Remote:
123 tests, 662 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed