### PR TITLE
Worldpay: Update where to pass shopperIPAddress

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -99,6 +99,7 @@
 * FlexCharge: Update homePage url [javierpedrozaing] #5351
 * Nuvei: Fix send savePM in false by default [javierpedrozaing] #5353
 * Decidir and DecicirPlus: Add the wallet_id field [yunnydang] #5354
+* Worldpay: Update where to pass shopperIPAddress [almalee24] #5348
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -402,7 +402,12 @@ module ActiveMerchant # :nodoc:
               add_amount(xml, money, options)
               add_order_content(xml, options)
               add_payment_details_for_ff_credit(xml, payment_method, options)
-              add_shopper_id(xml, options)
+
+              if options[:email]
+                xml.shopper do
+                  xml.shopperEmailAddress options[:email]
+                end
+              end
             end
           end
         end
@@ -477,6 +482,7 @@ module ActiveMerchant # :nodoc:
               add_token_for_ff_credit(xml, payment_method, options)
             end
           end
+          add_shopper_id(xml, options)
         end
       end
 
@@ -670,8 +676,8 @@ module ActiveMerchant # :nodoc:
             eci = eci_value(payment_method, options)
             xml.eciIndicator eci if eci.present?
           end
-          add_shopper_id(xml, options, false)
           add_stored_credential_options(xml, options)
+          add_shopper_id(xml, options, false)
         end
       end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -51,7 +51,8 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
     @options = {
       order_id: generate_unique_id,
-      email: 'wow@example.com'
+      email: 'wow@example.com',
+      ip: '127.0.0.1'
     }
 
     @level_two_data = {
@@ -1037,35 +1038,32 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal '20', credit.error_code
   end
 
-  # These three fast_fund_credit tests are currently failing with the message: Disbursement transaction not supported
-  # It seems that the current sandbox setup does not support testing this.
+  def test_successful_fast_fund_credit_on_cft_gateway
+    options = @options.merge({ fast_fund_credit: true })
 
-  # def test_successful_fast_fund_credit_on_cft_gateway
-  #   options = @options.merge({ fast_fund_credit: true })
+    credit = @cftgateway.credit(@amount, @credit_card, options)
+    assert_success credit
+    assert_equal 'SUCCESS', credit.message
+  end
 
-  #   credit = @cftgateway.credit(@amount, @credit_card, options)
-  #   assert_success credit
-  #   assert_equal 'SUCCESS', credit.message
-  # end
+  def test_successful_fast_fund_credit_with_token_on_cft_gateway
+    assert store = @gateway.store(@credit_card, @store_options)
+    assert_success store
 
-  # def test_successful_fast_fund_credit_with_token_on_cft_gateway
-  #   assert store = @gateway.store(@credit_card, @store_options)
-  #   assert_success store
+    options = @options.merge({ fast_fund_credit: true })
+    assert credit = @cftgateway.credit(@amount, store.authorization, options)
+    assert_success credit
+  end
 
-  #   options = @options.merge({ fast_fund_credit: true })
-  #   assert credit = @cftgateway.credit(@amount, store.authorization, options)
-  #   assert_success credit
-  # end
+  def test_failed_fast_fund_credit_on_cft_gateway
+    options = @options.merge({ fast_fund_credit: true })
+    refused_card = credit_card('4444333322221111', name: 'REFUSED') # 'magic' value for testing failures, provided by Worldpay
 
-  # def test_failed_fast_fund_credit_on_cft_gateway
-  #   options = @options.merge({ fast_fund_credit: true })
-  #   refused_card = credit_card('4444333322221111', name: 'REFUSED') # 'magic' value for testing failures, provided by Worldpay
-
-  #   credit = @cftgateway.credit(@amount, refused_card, options)
-  #   assert_failure credit
-  #   assert_equal '01', credit.params['action_code']
-  #   assert_equal "A transaction status of 'ok' or 'PUSH_APPROVED' is required.", credit.message
-  # end
+    credit = @cftgateway.credit(@amount, refused_card, options)
+    assert_failure credit
+    assert_equal '01', credit.params['action_code']
+    assert_equal "A transaction status of 'ok' or 'PUSH_APPROVED' is required.", credit.message
+  end
 
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -838,6 +838,17 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_fast_fund_credit
+    options = @options.merge({ fast_fund_credit: true, email: 'test@email.com' })
+
+    stub_comms do
+      @gateway.credit(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<FF_DISBURSE-SSL>/, data)
+      assert_match(/<shopperEmailAddress>/, data)
+    end.respond_with(successful_visa_credit_response)
+  end
+
   def test_successful_visa_credit
     response = stub_comms do
       @gateway.credit(@amount, @credit_card, @options)


### PR DESCRIPTION
For NetworkTokens shopperIPAddress should be passed after the stored credentials fields. And for Fast Access transactions shopperIPAddress should be passed within paymentDetails

Remote
117 tests, 498 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 98.2906% passed

Unit
134 tests, 743 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed