### PR TITLE
Worldpay: Fix stored credentials unscheduled reason type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -101,6 +101,7 @@
 * Decidir and DecicirPlus: Add the wallet_id field [yunnydang] #5354
 * Worldpay: Update where to pass shopperIPAddress [almalee24] #5348
 * Braintree: Account for BraintreeError [almalee24] #5346
+* Worldpay: Fix stored credentials unscheduled reason type [Buitragox] #5352 
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -1169,7 +1169,6 @@ module ActiveMerchant # :nodoc:
         stored_credential_params = {}
         stored_credential_params['usage'] = is_initial_transaction ? 'FIRST' : 'USED'
 
-        return stored_credential_params unless %w(RECURRING INSTALMENT).include?(reason)
         return stored_credential_params if customer_or_merchant == 'customerInitiatedReason' && stored_credential_params['usage'] == 'USED'
 
         stored_credential_params[customer_or_merchant] = reason if reason


### PR DESCRIPTION
Description
-------------------------
Unscheduled reason type should be sent in customer and merchant initiated transactions, except when it's a customer initiated transaction and usage=USED.

Unit tests
-------------------------
6119 tests, 80834 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote tests
-------------------------
114 tests, 489 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.3684% passed

Failures not related to changes.

Rubocop
-------------------------
803 files inspected, no offenses detected