### PR TITLE
Nuvei: Fix send savePM in false by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -97,6 +97,7 @@
 * DLocal: Update the success_from for Void [almalee24] #5337
 * Braintree: Add support for stored credentials with Apple Pay [bdcano] #5336
 * FlexCharge: Update homePage url [javierpedrozaing] #5351
+* Nuvei: Fix send savePM in false by default [javierpedrozaing] #5353
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/nuvei.rb
+++ b/lib/active_merchant/billing/gateways/nuvei.rb
@@ -35,6 +35,7 @@ module ActiveMerchant
 
       def authorize(money, payment, options = {}, transaction_type = 'Auth')
         post = { transactionType: transaction_type }
+        post[:savePM] = options[:save_payment_method] ? options[:save_payment_method].to_s : 'false'
 
         build_post_data(post)
         add_amount(post, money, options)
@@ -94,6 +95,7 @@ module ActiveMerchant
       end
 
       def store(credit_card, options = {})
+        options[:save_payment_method] = true
         authorize(0, credit_card, options)
       end
 

--- a/test/remote/gateways/remote_nuvei_test.rb
+++ b/test/remote/gateways/remote_nuvei_test.rb
@@ -172,11 +172,11 @@ class RemoteNuveiTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase_with_invalid_cvv
-    @credit_card.verification_value = nil
+    @credit_card.verification_value = ''
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_match 'ERROR', response.params['transactionStatus']
-    assert_match 'Invalid CVV2', response.message
+    assert_match 'ERROR', response.params['status']
+    assert_match 'cardData.CVV is invalid', response.message
   end
 
   def test_failed_capture_invalid_transaction_id
@@ -218,6 +218,14 @@ class RemoteNuveiTest < Test::Unit::TestCase
     assert_success response
     assert_match 'SUCCESS', response.params['status']
     assert_match 'APPROVED', response.message
+  end
+
+  def test_successful_save_payment_method_override
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(save_payment_method: false))
+    assert_success response
+    assert_match 'SUCCESS', response.params['status']
+    assert_match 'APPROVED', response.message
+    assert_not_nil response.params[:paymentOption][:userPaymentOptionId]
   end
 
   def test_successful_verify_with_authentication_only_type

--- a/test/unit/gateways/nuvei_test.rb
+++ b/test/unit/gateways/nuvei_test.rb
@@ -133,6 +133,7 @@ class NuveiTest < Test::Unit::TestCase
     end.check_request do |_method, endpoint, data, _headers|
       if /payment/.match?(endpoint)
         json_data = JSON.parse(data)
+        assert_equal 'false', json_data['savePM']
         assert_match(/#{@amount}/, json_data['amount'])
         assert_match(/#{@credit_card.number}/, json_data['paymentOption']['card']['cardNumber'])
         assert_match(/#{@credit_card.verification_value}/, json_data['paymentOption']['card']['CVV'])
@@ -283,6 +284,7 @@ class NuveiTest < Test::Unit::TestCase
     end.check_request do |_method, endpoint, data, _headers|
       json_data = JSON.parse(data)
       if /payment/.match?(endpoint)
+        assert_equal 'true', json_data['savePM']
         assert_match(/#{@credit_card.number}/, json_data['paymentOption']['card']['cardNumber'])
         assert_equal '0', json_data['amount']
       end


### PR DESCRIPTION
Description
-------------------------
This commit send by default savePM in false if save_payment_method GSF is not included in the request, only we send true for store request.

[SER-1539](https://spreedly.atlassian.net/browse/SER-1539)

Unit test
-------------------------
28 tests, 143 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote test
-------------------------
42 tests, 136 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop
-------------------------
803 files inspected, no offenses detected