### PR TITLE
Add the wallet_id field for decidir gateways

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -98,6 +98,7 @@
 * Braintree: Add support for stored credentials with Apple Pay [bdcano] #5336
 * FlexCharge: Update homePage url [javierpedrozaing] #5351
 * Nuvei: Fix send savePM in false by default [javierpedrozaing] #5353
+* Decidir and DecicirPlus: Add the wallet_id field [yunnydang] #5354
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -119,6 +119,7 @@ module ActiveMerchant # :nodoc:
         post[:site_transaction_id] = options[:order_id]
         post[:bin] = credit_card.number[0..5]
         post[:payment_type] = options[:payment_type] || 'single'
+        post[:wallet_id] = options[:wallet_id] if options[:wallet_id]
         post[:installments] = options[:installments] ? options[:installments].to_i : 1
         post[:description] = options[:description] if options[:description]
         post[:email] = options[:email] if options[:email]

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -93,6 +93,12 @@ module ActiveMerchant # :nodoc:
         authorization.split('|')[0]
       end
 
+      def add_wallet_id(post, options)
+        return unless options[:wallet_id]
+
+        post[:wallet_id] = options[:wallet_id]
+      end
+
       def add_payment(post, payment, options = {})
         if payment.is_a?(String)
           token, bin = payment.split('|')
@@ -133,6 +139,7 @@ module ActiveMerchant # :nodoc:
 
         add_aggregate_data(post, options) if options[:aggregate_data]
         add_sub_payments(post, options)
+        add_wallet_id(post, options)
       end
 
       def add_aggregate_data(post, options)

--- a/test/remote/gateways/remote_decidir_plus_test.rb
+++ b/test/remote/gateways/remote_decidir_plus_test.rb
@@ -221,6 +221,17 @@ class RemoteDecidirPlusTest < Test::Unit::TestCase
     assert_equal({ 'send_to_cs' => false, 'status' => nil }, response.params['fraud_detection'])
   end
 
+  def test_successful_purchase_with_wallet_id
+    options = @options.merge(wallet_id: 'moto')
+
+    assert response = @gateway_purchase.store(@credit_card)
+    payment_reference = response.authorization
+
+    response = @gateway_purchase.purchase(@amount, payment_reference, options)
+    assert_success response
+    assert_equal 1, response.params['payment_method_id']
+  end
+
   def test_successful_purchase_with_card_brand
     options = @options.merge(card_brand: 'cabal')
 

--- a/test/remote/gateways/remote_decidir_test.rb
+++ b/test/remote/gateways/remote_decidir_test.rb
@@ -183,6 +183,15 @@ class RemoteDecidirTest < Test::Unit::TestCase
     assert_equal 'approved', response.message
   end
 
+  def test_successful_purchase_wallet_id
+    options = @options.merge(wallet_id: 'moto')
+
+    response = @gateway_for_purchase.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'approved', response.message
+    assert response.authorization
+  end
+
   def test_successful_purchase_with_customer_object
     customer_options = {
       customer_id: 'John',

--- a/test/unit/gateways/decidir_plus_test.rb
+++ b/test/unit/gateways/decidir_plus_test.rb
@@ -202,6 +202,19 @@ class DecidirPlusTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_wallet_id
+    wallet_id = 'moto'
+    options = @options.merge(wallet_id:)
+
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @payment_reference, options)
+    end.check_request do |_action, _endpoint, data, _headers|
+      assert_equal(wallet_id, JSON.parse(data)['wallet_id'])
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_aggregate_data
     aggregate_data = {
       indicator: '1',

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -156,6 +156,19 @@ class DecidirTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_wallet_id
+    options = @options.merge(wallet_id: 'moto')
+
+    response = stub_comms(@gateway_for_purchase, :ssl_request) do
+      @gateway_for_purchase.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_equal('moto', JSON.parse(data, symbolize_names: true)[:wallet_id])
+      assert_match(/#{options[:wallet_id]}/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_sub_payments
     options = @options.merge(sub_payments: @sub_payments)
     options[:installments] = 4


### PR DESCRIPTION
Local:
6119 tests, 80836 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Decidir Unit:
46 tests, 223 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Decidir Remote:
29 tests, 99 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.1034% passed

Decidir Plus Unit:
20 tests, 84 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Decidir Plus Remote:
28 tests, 85 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
82.1429% passed