### PR TITLE
Hi Pay: Don't add 3ds when :three_ds_2 is missing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,7 +103,7 @@
 * Braintree: Account for BraintreeError [almalee24] #5346
 * Worldpay: Fix stored credentials unscheduled reason type [Buitragox] #5352
 * Worldpay: Worldpay: Idempotency key fix [jherreraa] #5359
-
+* Hi Pay: Don't add 3ds when :three_ds_2 is missing [Buitragox] #5355
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/hi_pay.rb
+++ b/lib/active_merchant/billing/gateways/hi_pay.rb
@@ -144,7 +144,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_3ds(post, options)
-        return unless options.has_key?(:execute_threed)
+        return unless options[:execute_threed] && options[:three_ds_2]
 
         browser_info_3ds = options[:three_ds_2][:browser_info]
 


### PR DESCRIPTION
Description
-------------------------
When `:execute_threed` was present but `:three_ds_2` wasn't, it would cause an error. This fix makes it return early when `:three_ds_2` is missing.

Relevant docs:
- https://support.hipay.com/hc/en-us/articles/213882649-How-can-I-test-payment-methods
- https://developer.hipay.com/api-explorer/api-online-payments#/payments/requestNewOrder

Unit tests
-------------------------
6120 tests, 80841 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote tests
-------------------------
20 tests, 85 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Rubocop
-------------------------
803 files inspected, no offenses detected