### PR TITLE
Nuvei: Fix stored credentials hash

### DIFF
--- a/lib/active_merchant/billing/gateways/nuvei.rb
+++ b/lib/active_merchant/billing/gateways/nuvei.rb
@@ -132,12 +132,19 @@ module ActiveMerchant
       end
 
       def set_initiator_type(post, payment, options)
-        is_initial_transaction = options[:stored_credential][:initial_transaction]
+        stored_credential = options[:stored_credential]
+        return unless stored_credential
+
+        is_initial_transaction = stored_credential[:initial_transaction]
         stored_credentials_mode = is_initial_transaction ? '0' : '1'
 
-        post[:storedCredentials] = {
-          storedCredentialsMode: stored_credentials_mode
-        }
+        if payment.is_a?(CreditCard)
+          post[:paymentOption] ||= {}
+          post[:paymentOption][:card] ||= {}
+          post[:paymentOption][:card][:storedCredentials] ||= {}
+          post[:paymentOption][:card][:storedCredentials][:storedCredentialsMode] = stored_credentials_mode
+        end
+
         post[:isRebilling] = stored_credentials_mode
       end
 

--- a/test/remote/gateways/remote_nuvei_test.rb
+++ b/test/remote/gateways/remote_nuvei_test.rb
@@ -351,6 +351,17 @@ class RemoteNuveiTest < Test::Unit::TestCase
     assert_match 'SUCCESS', recurring_response.params['status']
   end
 
+  def test_purchase_subsequent_mit
+    initial_options = @options.merge(user_token_id: '12345678', stored_credential: stored_credential(:merchant, :unscheduled, :initial))
+    initial_response = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success initial_response
+
+    subsequent_options = @options.merge(user_token_id: '12345678', stored_credential: stored_credential(:merchant, :recurring, network_transaction_id: initial_response.authorization))
+    subsequent_response = @gateway.purchase(@amount, @credit_card, subsequent_options)
+    assert_success subsequent_response
+    assert_match 'SUCCESS', subsequent_response.params['status']
+  end
+
   def test_successful_partial_approval
     response = @gateway.authorize(55, @credit_card, @options.merge(is_partial_approval: true))
     assert_success response

--- a/test/unit/gateways/nuvei_test.rb
+++ b/test/unit/gateways/nuvei_test.rb
@@ -297,6 +297,8 @@ class NuveiTest < Test::Unit::TestCase
     end.check_request do |_method, endpoint, data, _headers|
       if /payment/.match?(endpoint)
         json_data = JSON.parse(data)
+        assert_equal('0', json_data['isRebilling'])
+        assert_equal('0', json_data['paymentOption']['card']['storedCredentials']['storedCredentialsMode'])
         assert_match(/ADDCARD/, json_data['authenticationOnlyType'])
       end
     end.respond_with(successful_purchase_response)
@@ -308,6 +310,8 @@ class NuveiTest < Test::Unit::TestCase
     end.check_request do |_method, endpoint, data, _headers|
       if /payment/.match?(endpoint)
         json_data = JSON.parse(data)
+        assert_equal('1', json_data['isRebilling'])
+        assert_equal('1', json_data['paymentOption']['card']['storedCredentials']['storedCredentialsMode'])
         assert_match(/abc123/, json_data['relatedTransactionId'])
         assert_match(/RECURRING/, json_data['authenticationOnlyType'])
       end


### PR DESCRIPTION
Description
-------------------------
[SER-1545](https://spreedly.atlassian.net/browse/SER-1545)

This commit fixes the storedCredentials hash in order to send it under the card object

Unit test
-------------------------
Finished in 1.340614 seconds.

28 tests, 147 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

20.89 tests/s, 109.65 assertions/s

Remote test
-------------------------

Finished in 124.620111 seconds.

43 tests, 139 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

0.35 tests/s, 1.12 assertions/s

Rubocop
-------------------------
806 files inspected, no offenses detected