### PR TITLE
CyberSourceRest: support TMS store/unstore, and void of captures/refunds

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -421,7 +421,7 @@ module ActiveMerchant # :nodoc:
           authorization_options[:authorizationOptions][:initiator][:merchantInitiatedTransaction][:originalAuthorizedAmount] = post.dig(:orderInformation, :amountDetails, :totalAmount) if card_brand(payment) == 'discover'
         end
         authorization_options[:authorizationOptions][:initiator][:merchantInitiatedTransaction][:reason] = options[:reason_code] if options[:reason_code]
-        post[:processingInformation].merge!(authorization_options)
+        post[:processingInformation].deep_merge!(authorization_options)
       end
 
       def network_transaction_id_from(response)

--- a/lib/active_merchant/posts_data.rb
+++ b/lib/active_merchant/posts_data.rb
@@ -34,12 +34,24 @@ module ActiveMerchant # :nodoc:
       base.class_attribute :proxy_password
     end
 
+    def ssl_action(http_method, endpoint, data = {}, headers = {})
+      if http_method == 'post'
+        ssl_post(endpoint, data, headers)
+      else
+        send("ssl_#{http_method}", endpoint, headers)
+      end
+    end
+
     def ssl_get(endpoint, headers = {})
       ssl_request(:get, endpoint, nil, headers)
     end
 
     def ssl_post(endpoint, data, headers = {})
       ssl_request(:post, endpoint, data, headers)
+    end
+
+    def ssl_delete(endpoint, headers = {})
+      ssl_request(:delete, endpoint, nil, headers)
     end
 
     def ssl_request(method, endpoint, data, headers)

--- a/test/remote/gateways/remote_cyber_source_rest_test.rb
+++ b/test/remote/gateways/remote_cyber_source_rest_test.rb
@@ -673,4 +673,30 @@ class RemoteCyberSourceRestTest < Test::Unit::TestCase
     assert_equal 'AUTHORIZED', response.message
     assert_nil response.params['_links']['capture']
   end
+
+  def test_void_of_purchase
+    purchase_response = @gateway.purchase(@amount, @visa_card, @options)
+    response = @gateway.void([purchase_response.authorization, 'captures'].join('|'), @options)
+    assert_success response
+    assert response.params['id'].present?
+    assert_equal 'VOIDED', response.message
+    assert_nil response.params['_links']['capture']
+  end
+
+  def test_store_with_purchase
+    response = @gateway.store(@amount, @visa_card, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    assert_nil response.params['_links']['capture']
+  end
+
+  def test_store_without_purchase
+    response = @gateway.store(0, @visa_card, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'AUTHORIZED', response.message
+    refute_empty response.params['_links']['capture']
+    assert_equal '0.00', response.params['orderInformation']['amountDetails']['authorizedAmount']
+  end
 end


### PR DESCRIPTION
### Description
This pull request enhances the `CyberSourceRest` gateway to support Token Management Service (TMS) token creation and unstoring, providing closer parity with the `CyberSource` gateway SOAP API implementation.  This requires expanding the API url path to support not only the `pts/` (payments) API, but also the `tms/` (token) API as well.  This also requires extending the `commit` method to support not only HTTP `POST` but also other HTTP verbs, like `DELETE`, which is the verb used for unstoring.

The `void` method is also extended to support voiding of not just authorizations, but also captures, payments, and refunds.

### Unit Tests
```
6149 tests, 80957 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

### Remote Tests
```
61 tests, 210 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

### Rubocop
```
806 files inspected, no offenses detected
```