### PR TITLE
EBANX: add optional payment_type_code override

### DIFF
--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -103,7 +103,7 @@ module ActiveMerchant # :nodoc:
         post = {}
         add_integration_key(post)
         customer_country(post, options)
-        add_payment_type(post)
+        add_payment_type(post, options)
         post[:creditcard] = payment_details(credit_card)
 
         commit(:store, post, options)
@@ -112,7 +112,7 @@ module ActiveMerchant # :nodoc:
       def verify(credit_card, options = {})
         post = {}
         add_integration_key(post)
-        add_payment_type(post)
+        add_payment_type(post, options)
         customer_country(post, options)
         post[:card] = payment_details(credit_card)
         post[:device_id] = options[:device_id] if options[:device_id]
@@ -220,13 +220,13 @@ module ActiveMerchant # :nodoc:
 
       def add_card_or_token(post, payment, options)
         payment = payment.split('|')[0] if payment.is_a?(String)
-        add_payment_type(post[:payment])
+        add_payment_type(post[:payment], options)
         post[:payment][:creditcard] = payment_details(payment)
         post[:payment][:creditcard][:soft_descriptor] = options[:soft_descriptor] if options[:soft_descriptor]
       end
 
-      def add_payment_type(post)
-        post[:payment_type_code] = 'creditcard'
+      def add_payment_type(post, options)
+        post[:payment_type_code] = options[:payment_type_code] || 'creditcard'
       end
 
       def payment_details(payment)

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -71,7 +71,8 @@ class RemoteEbanxTest < Test::Unit::TestCase
       ip: '127.0.0.1',
       email: 'joe@example.com',
       birth_date: '10/11/1980',
-      person_type: 'personal'
+      person_type: 'personal',
+      payment_type_code: 'visa'
     })
 
     response = @gateway.purchase(@amount, @credit_card, options)

--- a/test/unit/gateways/ebanx_test.rb
+++ b/test/unit/gateways/ebanx_test.rb
@@ -54,6 +54,26 @@ class EbanxTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_default_payment_type_code
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match %r{"payment_type_code\":\"creditcard\"}, data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_successful_purchase_with_payment_type_code_override
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge({ payment_type_code: 'visa' }))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match %r{"payment_type_code\":\"visa\"}, data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_stored_credentials_cardholder_recurring
     options = @options.merge!({
       stored_credential: {


### PR DESCRIPTION
LOCAL
6146 tests, 80950 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

UNIT
30 tests, 152 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

REMOTE
43 tests, 98 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 83.7209% passed

^these remote test failures also exist on the master branch

CER-1907