### PR TITLE
Add the fundingDestination field and fundingSource to authorize call

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -72,6 +72,8 @@ module ActiveMerchant # :nodoc:
         add_data_lodging(post, options)
         add_metadata(post, options)
         add_recurring_detail_reference(post, options)
+        add_fund_source(post, options)
+        add_fund_destination(post, options)
         commit('authorise', post, options)
       end
 
@@ -787,6 +789,7 @@ module ActiveMerchant # :nodoc:
 
         post[:fundSource] = {}
         post[:fundSource][:additionalData] = fund_source[:additional_data] if fund_source[:additional_data]
+        post[:fundSource][:shopperEmail] = fund_source[:shopper_email] if fund_source[:shopper_email]
 
         if fund_source[:first_name] && fund_source[:last_name]
           post[:fundSource][:shopperName] = {}
@@ -797,6 +800,13 @@ module ActiveMerchant # :nodoc:
         if (address = fund_source[:billing_address])
           add_billing_address(post[:fundSource], options, address)
         end
+      end
+
+      def add_fund_destination(post, options)
+        return unless fund_destination = options[:fund_destination]
+
+        post[:fundDestination] = {}
+        post[:fundDestination][:additionalData] = fund_destination[:additional_data] if fund_destination[:additional_data]
       end
 
       def add_metadata(post, options = {})

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -440,6 +440,25 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_equal 'Authorised', response.message
   end
 
+  def test_successful_authorize_with_fund_source_and_fund_destination
+    fund_options = {
+      fund_source: {
+        additional_data: { fundingSource: 'Debit' },
+        first_name: 'Payer',
+        last_name: 'Name',
+        billing_address: @us_address,
+        shopper_email: 'john.smith@test.com'
+      },
+      fund_destination: {
+        additional_data: { walletIdentifier: '12345' }
+      }
+    }
+
+    response = @gateway.authorize(@amount, @credit_card, @options.merge!(fund_options))
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
   def test_successful_authorize_with_credit_card_no_name
     credit_card_no_name = ActiveMerchant::Billing::CreditCard.new({
       number: '4111111111111111',

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -661,6 +661,33 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_fund_source_and_fund_destination_sent
+    fund_options = {
+      fund_source: {
+        additional_data: { fundingSource: 'Debit' },
+        first_name: 'Payer',
+        last_name: 'Name',
+        billing_address: @us_address,
+        shopper_email: 'john.smith@test.com'
+      },
+      fund_destination: {
+        additional_data: { walletIdentifier: '12345' }
+      }
+    }
+
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(fund_options))
+    end.check_request do |_endpoint, data, _headers|
+      fund_source = JSON.parse(data)['fundSource']
+      fund_destination = JSON.parse(data)['fundDestination']
+      assert_equal 'john.smith@test.com', fund_source['shopperEmail']
+      assert_equal 'Payer', fund_source['shopperName']['firstName']
+      assert_equal 'Name', fund_source['shopperName']['lastName']
+      assert_equal 'Debit', fund_source['additionalData']['fundingSource']
+      assert_equal '12345', fund_destination['additionalData']['walletIdentifier']
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_manual_capture_sent
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(manual_capture: 'true'))


### PR DESCRIPTION
This adds the shopperEmail to fundingSource object and adds the fundingDestination destination field. Previously, we only used fundingSource for payouts but I've added these 2 fields to the authorize endpoint for AFT related transactions

Local:
6145 tests, 80954 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
134 tests, 717 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
149 tests, 474 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.9463% passed