### PR TITLE
CommerceHub: Update merchantInvoiceNumber & merchantTransactionId

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -107,6 +107,7 @@
 * SecurePayAU: Send order ID for payments with stored card [dacook] #3979
 * Orbital: Add XSD version testing to unit test [almalee24] #5375
 * Priority: fix for bin lookup [Buitragox] #5366
+* CommerceHub: Update merchantInvoiceNumber & merchantTransactionId [almalee24] #5374
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -154,16 +154,12 @@ module ActiveMerchant # :nodoc:
           physicalGoodsIndicator: [true, 'true'].include?(options[:physical_goods_indicator])
         }
 
-        if options[:order_id].present? && action == 'sale'
+        if action == 'sale'
           details[:merchantOrderId] = options[:order_id]
-          details[:merchantTransactionId] = options[:order_id]
+          details[:merchantTransactionId] = rand.to_s[2..13]
         end
 
-        if action != 'capture'
-          details[:merchantInvoiceNumber] = options[:merchant_invoice_number] || rand.to_s[2..13]
-          details[:primaryTransactionType] = options[:primary_transaction_type]
-          details[:accountVerification] = options[:account_verification]
-        end
+        details[:merchantInvoiceNumber] = options[:order_id] if action != 'capture'
 
         post[:transactionDetails] = details.compact
       end

--- a/test/remote/gateways/remote_commerce_hub_test.rb
+++ b/test/remote/gateways/remote_commerce_hub_test.rb
@@ -174,7 +174,7 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
     assert_equal 'X', response.cvv_result['code']
     assert_equal 'CVV check not supported for card', response.cvv_result['message']
-    assert_nil response.avs_result['code']
+    assert_equal 'Y', response.avs_result['code']
   end
 
   def test_successful_purchase_with_billing_and_shipping


### PR DESCRIPTION
Update merchantTransactionId to be a random number and merchantInvoiceNumber to be the order_id. Remove account_verification, primary_transaction_type and merchant_invoice_number since they are not in use.

Remote 36 tests, 97 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.2222% passed