### PR TITLE
Nuvei: Fix 3ds transaction

### DIFF
--- a/lib/active_merchant/billing/gateways/nuvei.rb
+++ b/lib/active_merchant/billing/gateways/nuvei.rb
@@ -374,6 +374,8 @@ module ActiveMerchant
       end
 
       def add_3ds_data(post, options = {})
+        return unless options[:three_ds_2]
+
         three_d_secure = options[:three_ds_2]
         # 01 => Challenge requested, 02 => Exemption requested, 03 or not sending parameter => No preference
         challenge_preference = if [true, 'true'].include?(options[:force_3d_secure])

--- a/test/remote/gateways/remote_nuvei_test.rb
+++ b/test/remote/gateways/remote_nuvei_test.rb
@@ -107,7 +107,7 @@ class RemoteNuveiTest < Test::Unit::TestCase
     response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
 
-    capture_response = @gateway.capture(@amount, response.authorization)
+    capture_response = @gateway.capture(round_down(@amount).to_i, response.authorization)
 
     assert_success capture_response
     assert_match 'APPROVED', capture_response.message
@@ -306,7 +306,7 @@ class RemoteNuveiTest < Test::Unit::TestCase
     assert response = @gateway.authorize(@amount, @credit_card, options)
     assert_success response
 
-    assert capture = @gateway.capture(@amount, response.authorization, @options)
+    assert capture = @gateway.capture(round_down(@amount).to_i, response.authorization, @options)
     assert_success capture
 
     options_stored_credentials = @options.merge!(stored_credential: stored_credential(:cardholder, :recurring, id: response.network_transaction_id))
@@ -366,7 +366,7 @@ class RemoteNuveiTest < Test::Unit::TestCase
     response = @gateway.authorize(55, @credit_card, @options.merge(is_partial_approval: true))
     assert_success response
     assert_equal '55', response.params['partialApproval']['requestedAmount']
-    assert_equal '55', response.params['partialApproval']['processedAmount']
+    assert_equal round_down(55), response.params['partialApproval']['processedAmount']
     assert_match 'APPROVED', response.message
   end
 
@@ -434,5 +434,11 @@ class RemoteNuveiTest < Test::Unit::TestCase
     response = @gateway.authorize(0, @credit_card, @options.merge({ perform_name_verification: true }))
     assert_success response
     assert_match 'APPROVED', response.message
+  end
+
+  def round_down(value, decimals = 1)
+    value = value.to_f / 2
+    factor = 10**decimals
+    ((value * factor).floor / factor.to_f).to_s
   end
 end


### PR DESCRIPTION
Description
-------------------------
[SER-1568](https://spreedly.atlassian.net/browse/SER-1568)

This commit fixes a 3DS transaction issue when three_ds_2 data is null. Additionally, some remote test were failing due some changes in the Nuvei Api, so this commit inlcude a round_down method to fix remote tests.

Unit test
-------------------------
Finished in 1.349927 seconds.

29 tests, 161 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

21.48 tests/s, 119.27 assertions/s

Remote test
-------------------------
Finished in 270.209319 seconds.

43 tests, 139 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

0.16 tests/s, 0.51 assertions/s

Rubocop
-------------------------
806 files inspected, no offenses detected