### PR TITLE
Ebanx: add the optional notification_url field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -114,6 +114,7 @@
 * Normalize API versions for Adyen, Braintree & GlobalCollect [Buitragox] #5371
 * SafeCharge: Add Australia & Canada as supported countries [almalee24] #5377
 * RedsysRest: Improve authorization from in Redsys [gasb150] #5372
+* Ebanx: Add the notification_url field [yunnydang] #5388
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -255,6 +255,7 @@ module ActiveMerchant # :nodoc:
         post[:metadata] = {} if post[:metadata].nil?
         post[:metadata][:merchant_payment_code] = options[:order_id] if options[:order_id]
         post[:payment][:tags] = TAGS
+        post[:notification_url] = options[:notification_url] if options[:notification_url]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -79,6 +79,12 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_equal 'Accepted', response.message
   end
 
+  def test_successful_purchase_with_notification_url
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(notification_url: 'https://notify.example.com/'))
+    assert_success response
+    assert_equal 'Accepted', response.message
+  end
+
   def test_successful_purchase_passing_processing_type_in_header
     response = @gateway.purchase(@amount, @credit_card, @options.merge({ processing_type: 'local' }))
 

--- a/test/unit/gateways/ebanx_test.rb
+++ b/test/unit/gateways/ebanx_test.rb
@@ -54,6 +54,16 @@ class EbanxTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_notification_url
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge(notification_url: 'https://notify.example.com/'))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match %r{"notification_url\":\"https://notify.example.com/\"}, data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_stored_credentials_cardholder_recurring
     options = @options.merge!({
       stored_credential: {


### PR DESCRIPTION
This change adds the notification_url field to the add_addtional_data helper method for purchase and authorization

local:
6169 tests, 81065 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
29 tests, 148 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

remote:
44 tests, 100 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
84.0909% passed

Seems like the tests that failed remotely had to do with card types, here are the messages: "Payment type not enabled in full mode for merchant:"