### PR TITLE
Worldpay: Update passing 3DS data for NT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -119,6 +119,7 @@
 * Ebanx: Update list of supported countries [jcreiff] #5387
 * Add alternate spelling for Vietnam [jcreiff] #5386
 * Checkout v2: add l2/l3 [gasb150] #5385
+* Worldpay: Update passing 3DS data for NT [almalee24] #5389
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -678,6 +678,7 @@ module ActiveMerchant # :nodoc:
           end
           add_stored_credential_options(xml, options)
           add_shopper_id(xml, options, false)
+          add_three_d_secure(xml, options)
         end
       end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -871,6 +871,24 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert response.params['last_event'] || response.params['ok']
   end
 
+  def test_3ds_version_2_parameters_for_nt
+    options = @options.merge(
+      {
+        three_d_secure: {
+          version: '2.1.0',
+          ds_transaction_id: 'c5b808e7-1de1-4069-a17b-f70d3b3b1645',
+          cavv: 'MAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+          eci: '05'
+        }
+      }
+    )
+
+    assert response = @gateway.authorize(@amount, @nt_credit_card, @options.merge(options))
+    assert response.test?
+    assert response.success?
+    assert response.params['last_event'] || response.params['ok']
+  end
+
   def test_failed_capture
     assert response = @gateway.capture(@amount, 'bogus')
     assert_failure response

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -28,11 +28,6 @@ class WorldpayTest < Test::Unit::TestCase
       source: :network_token,
       payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
     )
-    @nt_credit_card_without_eci = network_tokenization_credit_card(
-      '4895370015293175',
-      source: :network_token,
-      payment_cryptogram: 'EHuWW9PiBkWvqE5juRwDzAUFBAk='
-    )
     @credit_card_with_two_digits_year = credit_card(
       '4514 1600 0000 0008',
       month: 10,
@@ -1408,6 +1403,19 @@ class WorldpayTest < Test::Unit::TestCase
       assert_match %r{<cavv>cavv</cavv>}, data
       assert_match %r{<dsTransactionId>ds_transaction_id</dsTransactionId>}, data
       assert_match %r{<threeDSVersion>2.1.0</threeDSVersion>}, data
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_3ds_version_2_request_nt
+    stub_comms do
+      @gateway.authorize(@amount, @nt_credit_card, @options.merge(three_d_secure_option(version: '2.1.0', ds_transaction_id: 'ds_transaction_id')))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r{<paymentService version="1.4" merchantCode="testlogin">}, data
+      assert_match %r{<eci>eci</eci>}, data
+      assert_match %r{<cavv>cavv</cavv>}, data
+      assert_match %r{<dsTransactionId>ds_transaction_id</dsTransactionId>}, data
+      assert_match %r{<threeDSVersion>2.1.0</threeDSVersion>}, data
+      assert_match %r(<EMVCO_TOKEN-SSL type="NETWORKTOKEN">), data
     end.respond_with(successful_authorize_response)
   end
 


### PR DESCRIPTION
Remote
118 tests, 504 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed