### PR TITLE
Add AFT fields for credorax

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -121,6 +121,7 @@
 * Checkout v2: add l2/l3 [gasb150] #5385
 * Worldpay: Update passing 3DS data for NT [almalee24] #5389
 * Ebanx: Add the merchant_payment_code override [yunnydang] #5394
+* Credorax: Add AFT fields [yunnydang] #5390
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -151,6 +151,11 @@ module ActiveMerchant # :nodoc:
         add_stored_credential(post, options)
         add_processor(post, options)
 
+        if options[:aft]
+          add_recipient(post, options)
+          add_sender(post, options)
+        end
+
         commit(:purchase, post)
       end
 
@@ -168,6 +173,11 @@ module ActiveMerchant # :nodoc:
         add_account_name_inquiry(post, options)
         add_processor(post, options)
         add_authorization_details(post, options)
+
+        if options[:aft]
+          add_recipient(post, options)
+          add_sender(post, options)
+        end
 
         commit(:authorize, post)
       end
@@ -341,14 +351,34 @@ module ActiveMerchant # :nodoc:
         post[:c3] = options[:email] || 'unspecified@example.com'
       end
 
+      def add_sender(post, options)
+        return unless options[:sender_ref_number] || options[:sender_fund_source] || options[:sender_country_code] || options[:sender_address] || options[:sender_street_address] || options[:sender_city] || options[:sender_state] || options[:sender_first_name] || options[:sender_last_name]
+
+        sender_country_code = options[:sender_country_code]&.length == 3 ? options[:sender_country_code] : Country.find(options[:sender_country_code]).code(:alpha3).value if options[:sender_country_code]
+        post[:s15] = sender_country_code
+        post[:s17] = options[:sender_ref_number] if options[:sender_ref_number]
+        post[:s18] = options[:sender_fund_source] if options[:sender_fund_source]
+        post[:s10] = options[:sender_first_name] if options[:sender_first_name]
+        post[:s11] = options[:sender_last_name] if options[:sender_last_name]
+        post[:s12] = options[:sender_street_address] if options[:sender_street_address]
+        post[:s13] = options[:sender_city] if options[:sender_city]
+        post[:s14] = options[:sender_state] if options[:sender_state]
+      end
+
       def add_recipient(post, options)
-        return unless options[:recipient_street_address] || options[:recipient_city] || options[:recipient_province_code] || options[:recipient_country_code]
+        return unless options[:recipient_street_address] || options[:recipient_city] || options[:recipient_province_code] || options[:recipient_country_code] || options[:recipient_first_name] || options[:recipient_last_name] || options[:recipient_postal_code]
 
         recipient_country_code = options[:recipient_country_code]&.length == 3 ? options[:recipient_country_code] : Country.find(options[:recipient_country_code]).code(:alpha3).value if options[:recipient_country_code]
         post[:j6] = options[:recipient_street_address] if options[:recipient_street_address]
         post[:j7] = options[:recipient_city] if options[:recipient_city]
         post[:j8] = options[:recipient_province_code] if options[:recipient_province_code]
+        post[:j12] = options[:recipient_postal_code] if options[:recipient_postal_code]
         post[:j9] = recipient_country_code
+
+        if options[:aft]
+          post[:j5] = options[:recipient_first_name] if options[:recipient_first_name]
+          post[:j13] = options[:recipient_last_name] if options[:recipient_last_name]
+        end
       end
 
       def add_customer_name(post, options)

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -154,6 +154,32 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_aft_fields
+    aft_options = @options.merge(
+      aft: true,
+      sender_ref_number: 'test',
+      sender_fund_source: '01',
+      sender_country_code: 'USA',
+      sender_street_address: 'sender street',
+      sender_city: 'city',
+      sender_state: 'NY',
+      sender_first_name: 'george',
+      sender_last_name: 'smith',
+      recipient_street_address: 'street',
+      recipient_postal_code: '12345',
+      recipient_city: 'chicago',
+      recipient_province_code: '312',
+      recipient_country_code: 'USA',
+      recipient_first_name: 'logan',
+      recipient_last_name: 'bill'
+    )
+
+    response = @gateway.purchase(@amount, @credit_card, aft_options)
+    assert_success response
+    assert_equal '1', response.params['H9']
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_auth_data_via_3ds1_fields
     options = @options.merge(
       eci: '02',

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -540,6 +540,49 @@ class CredoraxTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_purchase_adds_aft_fields
+    aft_options = @options.merge(
+      aft: true,
+      sender_ref_number: 'test',
+      sender_fund_source: '01',
+      sender_country_code: 'USA',
+      sender_street_address: 'sender street',
+      sender_city: 'city',
+      sender_state: 'NY',
+      sender_first_name: 'george',
+      sender_last_name: 'smith',
+      recipient_street_address: 'street',
+      recipient_city: 'chicago',
+      recipient_province_code: '312',
+      recipient_postal_code: '12345',
+      recipient_country_code: 'USA',
+      recipient_first_name: 'logan',
+      recipient_last_name: 'bill'
+    )
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, aft_options)
+    end.check_request do |_endpoint, data, _headers|
+      # recipient fields
+      assert_match(/j5=logan/, data)
+      assert_match(/j6=street/, data)
+      assert_match(/j7=chicago/, data)
+      assert_match(/j8=312/, data)
+      assert_match(/j9=USA/, data)
+      assert_match(/j13=bill/, data)
+      assert_match(/j12=12345/, data)
+      # sender fields
+      assert_match(/s10=george/, data)
+      assert_match(/s11=smith/, data)
+      assert_match(/s12=sender\+street/, data)
+      assert_match(/s13=city/, data)
+      assert_match(/s14=NY/, data)
+      assert_match(/s15=USA/, data)
+      assert_match(/s17=test/, data)
+      assert_match(/s18=01/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_authorize_adds_a9_field
     options_with_3ds = @options.merge({ transaction_type: '8' })
     stub_comms do


### PR DESCRIPTION
Adds the s( sender) field for aft transactions while also re-using the j (recipient)fields for purchase and authorize.

Local:
6168 tests, 81069 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
84 tests, 417 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
55 tests, 195 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
89.0909% passed

The failing tests are 3ds related. I dont believe its due to my changes.