### PR TITLE
Adyen: Update shopperInteraction

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -1033,7 +1033,7 @@ module ActiveMerchant # :nodoc:
         return true if payment.is_a?(NetworkTokenizationCreditCard) && options.dig(:stored_credential, :initiator) != 'merchant'
         return true unless (stored_credential = options[:stored_credential])
 
-        (stored_credential[:initial_transaction] && stored_credential[:initiator] == 'cardholder') ||
+        stored_credential[:initiator] == 'cardholder' ||
           (payment.respond_to?(:verification_value) && payment.verification_value && stored_credential[:initial_transaction])
       end
     end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -736,7 +736,7 @@ class AdyenTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/"shopperInteraction":"ContAuth"/, data)
+      assert_match(/"shopperInteraction":"Ecommerce"/, data)
       assert_match(/"recurringProcessingModel":"Subscription"/, data)
     end.respond_with(successful_authorize_response)
 
@@ -786,7 +786,7 @@ class AdyenTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/"shopperInteraction":"ContAuth"/, data)
+      assert_match(/"shopperInteraction":"Ecommerce"/, data)
       assert_match(/"recurringProcessingModel":"CardOnFile"/, data)
     end.respond_with(successful_authorize_response)
 


### PR DESCRIPTION
shopperInteraction should be Ecommerce if
shopper_interaction is in options and
initiator is cardholder.

Remote:
149 tests, 474 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 91.9463% passed