### PR TITLE
Cashnet: Update max_retries to 1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -122,6 +122,7 @@
 * Worldpay: Update passing 3DS data for NT [almalee24] #5389
 * Ebanx: Add the merchant_payment_code override [yunnydang] #5394
 * Credorax: Add AFT fields [yunnydang] #5390
+* Cashnet: Update max_retries to 1 [almalee24] #5393
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/cashnet.rb
+++ b/lib/active_merchant/billing/gateways/cashnet.rb
@@ -11,7 +11,7 @@ module ActiveMerchant # :nodoc:
       self.homepage_url        = 'https://transactcampus.com'
       self.display_name        = 'Cashnet'
       self.money_format        = :dollars
-      self.max_retries         = 0
+      self.max_retries         = 1
 
       # Creates a new CashnetGateway
       #

--- a/test/unit/gateways/cashnet_test.rb
+++ b/test/unit/gateways/cashnet_test.rb
@@ -175,6 +175,15 @@ class Cashnet < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_preventing_retries
+    Net::HTTP.any_instance.
+      expects(:request).
+      raises(Errno::ECONNREFUSED)
+
+    error = assert_raises(ActiveMerchant::ConnectionError) { @gateway.purchase(@amount, @credit_card) }
+    assert_equal 'The remote server refused the connection', error.message
+  end
+
   private
 
   def expected_expiration_date


### PR DESCRIPTION
Updating maxx_retries to 1 ensures that retries are not attempt which was the original purpose of setting max_retries in this gateway

Remote
8 tests, 36 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 75% passed