### PR TITLE
Ebanx: Add the merchant_payment_code override

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -120,6 +120,7 @@
 * Add alternate spelling for Vietnam [jcreiff] #5386
 * Checkout v2: add l2/l3 [gasb150] #5385
 * Worldpay: Update passing 3DS data for NT [almalee24] #5389
+* Ebanx: Add the merchant_payment_code override [yunnydang] #5394
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -213,7 +213,7 @@ module ActiveMerchant # :nodoc:
       def add_invoice(post, money, options)
         post[:payment][:amount_total] = amount(money)
         post[:payment][:currency_code] = (options[:currency] || currency(money))
-        post[:payment][:merchant_payment_code] = Digest::MD5.hexdigest(options[:order_id])
+        post[:payment][:merchant_payment_code] = Digest::MD5.hexdigest(order_id_override(options))
         post[:payment][:instalments] = options[:instalments] || 1
         post[:payment][:order_number] = options[:order_id][0..39] if options[:order_id]
       end
@@ -249,11 +249,16 @@ module ActiveMerchant # :nodoc:
         end
       end
 
+      # we will prefer the merchant_payment_code if both fields are provided
+      def order_id_override(options)
+        options[:merchant_payment_code] || options[:order_id]
+      end
+
       def add_additional_data(post, options)
         post[:device_id] = options[:device_id] if options[:device_id]
         post[:metadata] = options[:metadata] if options[:metadata]
         post[:metadata] = {} if post[:metadata].nil?
-        post[:metadata][:merchant_payment_code] = options[:order_id] if options[:order_id]
+        post[:metadata][:merchant_payment_code] = order_id_override(options)
         post[:payment][:tags] = TAGS
         post[:notification_url] = options[:notification_url] if options[:notification_url]
       end

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -362,6 +362,14 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_equal 'Accepted', response.message
   end
 
+  def test_successful_purchase_with_supplied_payment_merchant_code
+    options = @options.merge(merchant_payment_code: SecureRandom.hex(40))
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Accepted', response.message
+  end
+
   def test_successful_purchase_with_stored_credentials_cardholder_recurring
     options = @options.merge!({
       stored_credential: {

--- a/test/unit/gateways/ebanx_test.rb
+++ b/test/unit/gateways/ebanx_test.rb
@@ -54,6 +54,32 @@ class EbanxTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_without_merchant_payment_code
+    # hexdigest of 1 is c4ca4238a0b923820dcc509a6f75849b
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match %r{"merchant_payment_code\":\"1\"}, data
+      assert_match %r{"merchant_payment_code\":\"c4ca4238a0b923820dcc509a6f75849b\"}, data
+      assert_match %r{"order_number\":\"1\"}, data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_successful_purchase_with_merchant_payment_code
+    # hexdigest of 2 is c81e728d9d4c2f636f067f89cc14862c
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge(merchant_payment_code: '2'))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match %r{"merchant_payment_code\":\"2\"}, data
+      assert_match %r{"merchant_payment_code\":\"c81e728d9d4c2f636f067f89cc14862c\"}, data
+      assert_match %r{"order_number\":\"1\"}, data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_notification_url
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge(notification_url: 'https://notify.example.com/'))


### PR DESCRIPTION
Adds the optional merchant_payment_code override

Local:
6178 tests, 81154 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
33 tests, 163 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
45 tests, 102 assertions, 7 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
84.4444% passed
