### PR TITLE
Shift4: Add interface_name field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -130,6 +130,7 @@
 * Credit Card Sol: Update tarjeta sol support for Decidir and Decidir plus gateways [javierpedrozaing] #5405
 * Routex Bin: Update routex bin range to include 18 digits [yunnydang] #5410
 * Nuvei: Fix isRebilling flag for Stored credentials [javierpedrozaing] #5408
+* Shift4: Add interface_name field [almalee24] #5395
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/shift4.rb
+++ b/lib/active_merchant/billing/gateways/shift4.rb
@@ -323,7 +323,7 @@ module ActiveMerchant # :nodoc:
         headers['AccessToken'] = @access_token
         headers['Invoice'] = options[:invoice] if action != 'capture' && options[:invoice].present?
         headers['InterfaceVersion'] = '1'
-        headers['InterfaceName'] = 'Spreedly'
+        headers['InterfaceName'] = options[:interface_name]
         headers['CompanyName'] = 'Spreedly'
         headers
       end

--- a/test/unit/gateways/shift4_test.rb
+++ b/test/unit/gateways/shift4_test.rb
@@ -6,7 +6,9 @@ class Shift4Test < Test::Unit::TestCase
     @gateway = Shift4Gateway.new(client_guid: '123456', auth_token: 'abcder123')
     @credit_card = credit_card('4000100011112224', verification_value: '333', first_name: 'John', last_name: 'Doe')
     @amount = 5
-    @options = {}
+    @options = {
+      interface_name: 'Interface Name'
+    }
     @extra_options = {
       clerk_id: '1576',
       notes: 'test notes',
@@ -392,7 +394,7 @@ class Shift4Test < Test::Unit::TestCase
     end.check_request do |_endpoint, _data, headers|
       assert_equal headers['CompanyName'], 'Spreedly'
       assert_equal headers['InterfaceVersion'], '1'
-      assert_equal headers['InterfaceName'], 'Spreedly'
+      assert_equal headers['InterfaceName'], 'Interface Name'
     end.respond_with(successful_purchase_response)
   end
 


### PR DESCRIPTION
Add a interface_name field which will be used
to populate interfaceName.

Remote
29 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed