### PR TITLE
Adyen: Add support for localized shopper statement

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -75,6 +75,7 @@ module ActiveMerchant # :nodoc:
         add_recurring_detail_reference(post, options)
         add_fund_source(post, options)
         add_fund_destination(post, options)
+        post[:localizedShopperStatement] = options[:localized_shopper_statement] if options[:localized_shopper_statement]
         commit('authorise', post, options)
       end
 
@@ -94,6 +95,7 @@ module ActiveMerchant # :nodoc:
         add_reference(post, authorization, options)
         add_splits(post, options)
         add_network_transaction_reference(post, options)
+        add_shopper_statement(post, options)
         commit('refund', post, options)
       end
 
@@ -427,11 +429,9 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_shopper_statement(post, options)
-        return unless options[:shopper_statement]
-
-        post[:additionalData] = {
-          shopperStatement: options[:shopper_statement]
-        }
+        post[:additionalData] ||= {}
+        post[:additionalData][:shopperStatement] = options[:shopper_statement] if options[:shopper_statement]
+        post[:additionalData][:localizedShopperStatement] = options[:localized_shopper_statement] if options[:localized_shopper_statement]
       end
 
       def add_merchant_data(post, options)

--- a/test/remote/gateways/remote_adyen_test.rb
+++ b/test/remote/gateways/remote_adyen_test.rb
@@ -1471,6 +1471,22 @@ class RemoteAdyenTest < Test::Unit::TestCase
     assert_success capture
   end
 
+  def test_successful_capture_with_localized_shopper_statement
+    auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success auth
+
+    assert capture = @gateway.capture(@amount, auth.authorization, @options.merge(localized_shopper_statement: { 'ja-Kana' => 'ADYEN - セラーA' }))
+    assert_success capture
+  end
+
+  def test_successful_refund_with_localized_shopper_statement
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization, @options.merge(localized_shopper_statement: { 'ja-Kana' => 'ADYEN - セラーA' }))
+    assert_success refund
+  end
+
   def test_purchase_with_skip_mpi_data
     options = {
       reference: '345123',
@@ -1816,6 +1832,11 @@ class RemoteAdyenTest < Test::Unit::TestCase
 
     @options[:billing_address][:country] = 'QZ'
     response = @gateway.authorize(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_authorize_with_localized_shopper_statement
+    response = @gateway.authorize(@amount, @credit_card, @options.merge(localized_shopper_statement: { 'ja-Kana' => 'ADYEN - セラーA' }))
     assert_success response
   end
 

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -232,6 +232,14 @@ class AdyenTest < Test::Unit::TestCase
     end.respond_with(successful_authorize_response)
   end
 
+  def test_successful_authorize_with_localized_shopper_statement
+    stub_comms do
+      @gateway.authorize(100, @credit_card, @options.merge(localized_shopper_statement: { 'ja-Kana' => 'ADYEN - セラーA' }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'ADYEN - セラーA', JSON.parse(data)['localizedShopperStatement']['ja-Kana']
+    end.respond_with(successful_authorize_response)
+  end
+
   def test_adds_3ds1_standalone_fields
     eci = '05'
     cavv = '3q2+78r+ur7erb7vyv66vv\/\/\/\/8='
@@ -440,6 +448,22 @@ class AdyenTest < Test::Unit::TestCase
       @gateway.capture(@amount, '7914775043909934', @options.merge(shopper_statement: 'test1234'))
     end.check_request do |_endpoint, data, _headers|
       assert_equal 'test1234', JSON.parse(data)['additionalData']['shopperStatement']
+    end.respond_with(successful_capture_response)
+  end
+
+  def test_successful_capture_with_localized_shopper_statement
+    stub_comms do
+      @gateway.capture(@amount, '7914775043909934', @options.merge(localized_shopper_statement: { 'ja-Kana' => 'ADYEN - セラーA' }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'ADYEN - セラーA', JSON.parse(data)['additionalData']['localizedShopperStatement']['ja-Kana']
+    end.respond_with(successful_capture_response)
+  end
+
+  def test_successful_refund_with_localized_shopper_statement
+    stub_comms do
+      @gateway.refund(@amount, '7914775043909934', @options.merge(localized_shopper_statement: { 'ja-Kana' => 'ADYEN - セラーA' }))
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal 'ADYEN - セラーA', JSON.parse(data)['additionalData']['localizedShopperStatement']['ja-Kana']
     end.respond_with(successful_capture_response)
   end
 


### PR DESCRIPTION
CER-2023

This field is an object that expects data specific to Japanese branded cards and the ja-Kana character set. If localized shopper statement is not provided it will default to shopper statement in authorize transaction types.

For refund and capture, it is sent through as part of additional data and will likely not display on credit card statements for that reason.

Unit Tests
138 tests, 731 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests
152 tests, 481 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.1053% passed
*12 tests also failing on master