### PR TITLE
Update authorization_from method so that refunds will have the payment_intent_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -124,6 +124,7 @@
 * Credorax: Add AFT fields [yunnydang] #5390
 * Cashnet: Update max_retries to 1 [almalee24] #5393
 * Cybersource: Update 3DS fields [almalee24] #5396
+* Airwallex: Update authorization_from method to include payment intent ID on refunds [yunnydang] #5400
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/airwallex.rb
+++ b/lib/active_merchant/billing/gateways/airwallex.rb
@@ -373,7 +373,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def authorization_from(response)
-        response.dig('latest_payment_attempt', 'payment_intent_id')
+        response.dig('latest_payment_attempt', 'payment_intent_id') || response.dig('payment_intent_id')
       end
 
       def error_code_from(response)

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -352,7 +352,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_sender(post, options)
-        return unless options[:sender_ref_number] || options[:sender_fund_source] || options[:sender_country_code] || options[:sender_address] || options[:sender_street_address] || options[:sender_city] || options[:sender_state] || options[:sender_first_name] || options[:sender_last_name]
+        return unless options[:sender_ref_number] || options[:sender_fund_source] || options[:sender_country_code] || options[:sender_street_address] || options[:sender_city] || options[:sender_state] || options[:sender_first_name] || options[:sender_last_name]
 
         sender_country_code = options[:sender_country_code]&.length == 3 ? options[:sender_country_code] : Country.find(options[:sender_country_code]).code(:alpha3).value if options[:sender_country_code]
         post[:s15] = sender_country_code

--- a/test/remote/gateways/remote_airwallex_test.rb
+++ b/test/remote/gateways/remote_airwallex_test.rb
@@ -25,6 +25,7 @@ class RemoteAirwallexTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'AUTHORIZED', response.message
+    assert_not_nil response.authorization
   end
 
   def test_successful_purchase_with_shipping_address
@@ -103,6 +104,7 @@ class RemoteAirwallexTest < Test::Unit::TestCase
     assert refund = @gateway.refund(@amount, purchase.authorization, @options)
     assert_success refund
     assert_equal 'RECEIVED', refund.message
+    assert_not_nil refund.authorization
   end
 
   def test_partial_refund

--- a/test/unit/gateways/airwallex_test.rb
+++ b/test/unit/gateways/airwallex_test.rb
@@ -204,6 +204,7 @@ class AirwallexTest < Test::Unit::TestCase
     assert_success response
 
     assert_equal 'RECEIVED', response.message
+    assert_equal response.authorization, 'int_hkdmb6rw6g79o82v60s'
     assert response.test?
   end
 


### PR DESCRIPTION
Local:
6189 tests, 81209 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
36 tests, 196 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
29 tests, 67 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.1034% passed