### PR TITLE
Worldpay: Add AFT support to Authorize and Purchase transaction types

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -63,7 +63,11 @@ module ActiveMerchant # :nodoc:
       def authorize(money, payment_method, options = {})
         requires!(options, :order_id)
         payment_details = payment_details(payment_method, options)
-        authorize_request(money, payment_method, payment_details.merge(options))
+        if options[:account_funding_transaction]
+          aft_request(money, payment_method, payment_details.merge(**options))
+        else
+          authorize_request(money, payment_method, payment_details.merge(options))
+        end
       end
 
       def capture(money, authorization, options = {})

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -1056,6 +1056,38 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal '20', credit.error_code
   end
 
+  def test_successful_authorize_visa_account_funding_transfer
+    auth = @gateway.authorize(@amount, @credit_card, @options.merge(@aft_options))
+    assert_success auth
+    assert_equal 'funding_transfer_transaction', auth.params['action']
+    assert_equal 'SUCCESS', auth.message
+  end
+
+  def test_successful_authorize_visa_account_funding_transfer_via_token
+    assert store = @gateway.store(@credit_card, @store_options)
+    assert_success store
+
+    auth = @gateway.authorize(@amount, store.authorization, @options.merge(@aft_options))
+    assert_success auth
+    assert_equal 'funding_transfer_transaction', auth.params['action']
+    assert_equal 'SUCCESS', auth.message
+  end
+
+  def test_failed_authorize_visa_account_funding_transfer
+    auth = @gateway.authorize(@amount, credit_card('4111111111111111', name: 'REFUSED'), @options.merge(@aft_options))
+    assert_failure auth
+    assert_equal 'funding_transfer_transaction', auth.params['action']
+    assert_equal 'REFUSED', auth.message
+  end
+
+  def test_failed_authorize_visa_account_funding_transfer_acquirer_error
+    auth = @gateway.authorize(@amount, credit_card('4111111111111111', name: 'ACQERROR'), @options.merge(@aft_options))
+    assert_failure auth
+    assert_equal 'ACQUIRER ERROR', auth.message
+    assert_equal 'funding_transfer_transaction', auth.params['action']
+    assert_equal '20', auth.error_code
+  end
+
   def test_successful_fast_fund_credit_on_cft_gateway
     options = @options.merge({ fast_fund_credit: true })
 

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -898,6 +898,16 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal '3d4187536044bd39ad6a289c4339c41c', response.authorization
   end
 
+  def test_successful_authorize_visa_account_funding_transaction
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options.merge(@aft_options))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<fundingTransfer type="A" category="PULL_FROM_CARD">/, data)
+    end.respond_with(successful_visa_credit_response)
+    assert_success response
+    assert_equal '3d4187536044bd39ad6a289c4339c41c', response.authorization
+  end
+
   def test_description
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)


### PR DESCRIPTION
Adds AFT fields to auth and purchase.

CER-2069

Unit Tests
140 tests, 771 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests
122 tests, 490 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 90.9836% passed
*11 tests also failing on master