### PR TITLE
Tarjeta sol: Rename card type name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -126,6 +126,7 @@
 * Cybersource: Update 3DS fields [almalee24] #5396
 * Airwallex: Update authorization_from method to include payment intent ID on refunds [yunnydang] #5400
 * New Credit Card Sol: Add new bin set for Sol credit card [javierpedrozaing] #5380
+* Credit Card Sol: Update card name to `tarjeta_sol` instead of `sol` [javierpedrozaing] #5404
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -43,7 +43,7 @@ module ActiveMerchant # :nodoc:
     # * Tuya
     # * UATP
     # * Patagonia365
-    # * Sol
+    # * Tarjeta Sol
     #
     # For testing purposes, use the 'bogus' credit card brand. This skips the vast majority of
     # validations, allowing you to focus on your core concerns until you're ready to be more concerned
@@ -141,7 +141,7 @@ module ActiveMerchant # :nodoc:
       # * +'tuya'+
       # * +'uatp'+
       # * +'patagonia_365'+
-      # * +'sol'+
+      # * +'tarjeta_sol'+
       #
       # Or, if you wish to test your implementation, +'bogus'+.
       #

--- a/lib/active_merchant/billing/credit_card_methods.rb
+++ b/lib/active_merchant/billing/credit_card_methods.rb
@@ -56,7 +56,7 @@ module ActiveMerchant # :nodoc:
         'tuya' => ->(num) { num =~ /^588800\d{10}$/ },
         'uatp' => ->(num) { num =~ /^(1175|1290)\d{11}$/ },
         'patagonia_365' => ->(num) { num =~ /^504656\d{10}$/ },
-        'sol' => ->(num) { num =~ /^504639\d{10}$/ }
+        'tarjeta_sol' => ->(num) { num =~ /^504639\d{10}$/ }
       }
 
       SODEXO_NO_LUHN = ->(num) { num =~ /^(505864|505865)\d{10}$/ }

--- a/test/unit/credit_card_methods_test.rb
+++ b/test/unit/credit_card_methods_test.rb
@@ -606,7 +606,7 @@ class CreditCardMethodsTest < Test::Unit::TestCase
   end
 
   def test_should_detect_sol_cards
-    assert_equal 'sol', CreditCard.brand?('5046391746825544')
+    assert_equal 'tarjeta_sol', CreditCard.brand?('5046391746825544')
   end
 
   def test_should_validate_sol_card


### PR DESCRIPTION
Description
-------------------------
[SER-1604](https://spreedly.atlassian.net/browse/SER-1604)

This commit rename the card type for tarjeta sol
to 'tarjeta_sol' instead 'sol'

Unit test
-------------------------
Finished in 0.155089 seconds.

76 tests, 672 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

490.04 tests/s, 4333.00 assertions/s

Rubocop
-------------------------
808 files inspected, no offenses detected