### PR TITLE
Tarjeta Sol: Update tarjeta_sol support for Decidir and Decidir plus

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -127,6 +127,7 @@
 * Airwallex: Update authorization_from method to include payment intent ID on refunds [yunnydang] #5400
 * New Credit Card Sol: Add new bin set for Sol credit card [javierpedrozaing] #5380
 * Credit Card Sol: Update card name to `tarjeta_sol` instead of `sol` [javierpedrozaing] #5404
+* Credit Card Sol: Update tarjeta sol support for Decidir and Decidir plus gateways [javierpedrozaing] #5405
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -135,33 +135,24 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_payment_method_id(credit_card, options)
-        if options[:payment_method_id]
-          options[:payment_method_id].to_i
-        elsif options[:debit]
-          if CreditCard.brand?(credit_card.number) == 'visa'
-            31
-          elsif CreditCard.brand?(credit_card.number) == 'master'
-            105
-          elsif CreditCard.brand?(credit_card.number) == 'maestro'
-            106
-          elsif CreditCard.brand?(credit_card.number) == 'cabal'
-            108
-          end
-        elsif CreditCard.brand?(credit_card.number) == 'master'
-          104
-        elsif CreditCard.brand?(credit_card.number) == 'american_express'
-          65
-        elsif CreditCard.brand?(credit_card.number) == 'diners_club'
-          8
-        elsif CreditCard.brand?(credit_card.number) == 'cabal'
-          63
-        elsif CreditCard.brand?(credit_card.number) == 'naranja'
-          24
-        elsif CreditCard.brand?(credit_card.number) == 'patagonia_365'
-          55
-        else
-          1
-        end
+        return options[:payment_method_id].to_i if options[:payment_method_id]
+
+        card_brand = CreditCard.brand?(credit_card.number)
+        debit = options[:debit]
+
+        payment_method_ids = {
+          'visa' => debit ? 31 : 1,
+          'master' => debit ? 105 : 104,
+          'maestro' => 106,
+          'cabal' => debit ? 108 : 63,
+          'american_express' => 65,
+          'diners_club' => 8,
+          'naranja' => 24,
+          'patagonia_365' => 55,
+          'tarjeta_sol' => 64
+        }
+
+        payment_method_ids.fetch(card_brand, 1)
       end
 
       def add_invoice(post, money, options)

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -184,39 +184,22 @@ module ActiveMerchant # :nodoc:
       def add_payment_method_id(options)
         return options[:payment_method_id].to_i if options[:payment_method_id]
 
-        if options[:debit]
-          case options[:card_brand]
-          when 'visa'
-            31
-          when 'master'
-            105
-          when 'maestro'
-            106
-          when 'cabal'
-            108
-          else
-            31
-          end
-        else
-          case options[:card_brand]
-          when 'visa'
-            1
-          when 'master'
-            104
-          when 'american_express'
-            65
-          when 'american_express_prisma'
-            111
-          when 'cabal'
-            63
-          when 'diners_club'
-            8
-          when 'patagonia_365'
-            55
-          else
-            1
-          end
-        end
+        card_brand = options[:card_brand]
+        debit = options[:debit]
+
+        payment_method_ids = {
+          'visa' => debit ? 31 : 1,
+          'master' => debit ? 105 : 104,
+          'maestro' => 106,
+          'cabal' => debit ? 108 : 63,
+          'american_express' => 65,
+          'american_express_prisma' => 111,
+          'diners_club' => 8,
+          'patagonia_365' => 55,
+          'tarjeta_sol' => 64
+        }
+
+        payment_method_ids.fetch(card_brand, debit ? 31 : 1)
       end
 
       def add_fraud_detection(post, options)

--- a/test/unit/gateways/decidir_plus_test.rb
+++ b/test/unit/gateways/decidir_plus_test.rb
@@ -53,6 +53,19 @@ class DecidirPlusTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_tarjeta_sol
+    options = @options.merge(card_brand: 'tarjeta_sol')
+
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @payment_reference, options)
+    end.check_request do |_action, _endpoint, data, _headers|
+      data = JSON.parse(data)
+      assert_equal(64, data['payment_method_id'])
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_failed_purchase
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -93,6 +93,21 @@ class DecidirTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_tarjeta_sol
+    tarjeta_sol_card = credit_card('5046391746825544')
+
+    response = stub_comms(@gateway_for_purchase, :ssl_request) do
+      @gateway_for_purchase.purchase(@amount, tarjeta_sol_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"payment_method_id":64/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal 7719132, response.authorization
+    assert_equal 'approved', response.message
+    assert response.test?
+  end
+
   def test_successful_purchase_with_aggregate_data
     options = {
       aggregate_data: {


### PR DESCRIPTION
Description
-------------------------
[SER-1607](https://spreedly.atlassian.net/browse/SER-1607)

This commit handles the card type specific values for Tarjeta Sol in Decidir and Decidir Plus gateways.

Unit test
-------------------------

Decidir
-------------
Finished in 0.0462 seconds.

47 tests, 230 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

1017.32 tests/s, 4978.35 assertions/s

Decidir Plus
--------------
Finished in 0.020998 seconds.

21 tests, 88 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

1000.10 tests/s, 4190.88 assertions/s

Remote test
-------------------------

Decidir
-------------
Finished in 53.9379 seconds.

29 tests, 99 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 93.1034% passed

0.54 tests/s, 1.84 assertions/s

Decidir Plus
-------------
Finished in 171.923859 seconds.

28 tests, 85 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 82.1429% passed

0.16 tests/s, 0.49 assertions/s

Rubocop
-------------------------
808 files inspected, no offenses detected