### PR TITLE
Worldpay: AFT middle name address2 bugfix

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -440,12 +440,12 @@ module ActiveMerchant # :nodoc:
             xml.accountReference options[:aft_sender_account_reference], 'accountType' => options[:aft_sender_account_type]
             xml.fullName do
               xml.first options.dig(:aft_sender_full_name, :first)
-              xml.middle options.dig(:aft_sender_full_name, :middle)
+              xml.middle options.dig(:aft_sender_full_name, :middle) if options.dig(:aft_sender_full_name, :middle)
               xml.last options.dig(:aft_sender_full_name, :last)
             end
             xml.fundingAddress do
               xml.address1 options.dig(:aft_sender_funding_address, :address1)
-              xml.address2 options.dig(:aft_sender_funding_address, :address2)
+              xml.address2 options.dig(:aft_sender_funding_address, :address2) if options.dig(:aft_sender_funding_address, :address2)
               xml.postalCode options.dig(:aft_sender_funding_address, :postal_code)
               xml.city options.dig(:aft_sender_funding_address, :city)
               xml.state options.dig(:aft_sender_funding_address, :state)
@@ -456,12 +456,12 @@ module ActiveMerchant # :nodoc:
             xml.accountReference options[:aft_recipient_account_reference], 'accountType' => options[:aft_recipient_account_type]
             xml.fullName do
               xml.first options.dig(:aft_recipient_full_name, :first)
-              xml.middle options.dig(:aft_recipient_full_name, :middle)
+              xml.middle options.dig(:aft_recipient_full_name, :middle) if options.dig(:aft_recipient_full_name, :middle)
               xml.last options.dig(:aft_recipient_full_name, :last)
             end
             xml.fundingAddress do
               xml.address1 options.dig(:aft_recipient_funding_address, :address1)
-              xml.address2 options.dig(:aft_recipient_funding_address, :address2)
+              xml.address2 options.dig(:aft_recipient_funding_address, :address2) if options.dig(:aft_recipient_funding_address, :address2)
               xml.postalCode options.dig(:aft_recipient_funding_address, :postal_code)
               xml.city options.dig(:aft_recipient_funding_address, :city)
               xml.state options.dig(:aft_recipient_funding_address, :state)

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -193,6 +193,46 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         }
       }
     }
+
+    @aft_less_options = {
+      account_funding_transaction: true,
+      aft_type: 'A',
+      aft_payment_purpose: '01',
+      aft_sender_account_type: '02',
+      aft_sender_account_reference: '4111111111111112',
+      aft_sender_full_name: {
+        first: 'First',
+        last: 'Sender'
+      },
+      aft_sender_funding_address: {
+        address1: '123 Sender St',
+        postal_code: '12345',
+        city: 'Senderville',
+        state: 'NC',
+        country_code: 'US'
+      },
+      aft_recipient_account_type: '03',
+      aft_recipient_account_reference: '4111111111111111',
+      aft_recipient_full_name: {
+        first: 'First',
+        last: 'Recipient'
+      },
+      aft_recipient_funding_address: {
+        address1: '123 Recipient St',
+        postal_code: '12345',
+        city: 'Recipientville',
+        state: 'NC',
+        country_code: 'US'
+      },
+      aft_recipient_funding_data: {
+        telephone_number: '123456789',
+        birth_date: {
+          day_of_month: '01',
+          month: '01',
+          year: '1980'
+        }
+      }
+    }
   end
 
   def test_successful_purchase
@@ -1086,6 +1126,13 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'ACQUIRER ERROR', auth.message
     assert_equal 'funding_transfer_transaction', auth.params['action']
     assert_equal '20', auth.error_code
+  end
+
+  def test_successful_authorize_visa_account_funding_transfer_with_no_middle_name_address2
+    auth = @gateway.authorize(@amount, @credit_card, @options.merge(@aft_less_options))
+    assert_success auth
+    assert_equal 'funding_transfer_transaction', auth.params['action']
+    assert_equal 'SUCCESS', auth.message
   end
 
   def test_successful_fast_fund_credit_on_cft_gateway


### PR DESCRIPTION
CER-2099

Prevents sending middle name and address2 in request if no values are present. Fields are optional but should not be sent empty.

Unit Tests
141 tests, 778 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests
123 tests, 497 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 90.9836% passed
*11 tests also failing on master