### PR TITLE
Nuvei: Fix isRebilling flag for Stored credentials

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -128,6 +128,7 @@
 * New Credit Card Sol: Add new bin set for Sol credit card [javierpedrozaing] #5380
 * Credit Card Sol: Update card name to `tarjeta_sol` instead of `sol` [javierpedrozaing] #5404
 * Routex Bin: Update routex bin range to include 18 digits [yunnydang] #5410
+* Nuvei: Fix isRebilling flag for Stored credentials [javierpedrozaing] #5408
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/nuvei.rb
+++ b/lib/active_merchant/billing/gateways/nuvei.rb
@@ -144,8 +144,11 @@ module ActiveMerchant
           post[:paymentOption][:card][:storedCredentials] ||= {}
           post[:paymentOption][:card][:storedCredentials][:storedCredentialsMode] = stored_credentials_mode
         end
+        post[:isRebilling] = options[:is_rebilling] ? '1' : '0' if mit?(options[:stored_credential])
+      end
 
-        post[:isRebilling] = stored_credentials_mode
+      def mit?(stored_credential)
+        stored_credential[:reason_type] != 'unscheduled' && stored_credential[:initial_transaction] == false
       end
 
       def add_account_funding_transaction(post, payment, options = {})

--- a/test/remote/gateways/remote_nuvei_test.rb
+++ b/test/remote/gateways/remote_nuvei_test.rb
@@ -365,13 +365,24 @@ class RemoteNuveiTest < Test::Unit::TestCase
     assert_match 'SUCCESS', recurring_response.params['status']
   end
 
-  def test_purchase_subsequent_mit
+  def test_purchase_subsequent_init_mit
     initial_options = @options.merge(user_token_id: '12345678', stored_credential: stored_credential(:merchant, :unscheduled, :initial))
     initial_response = @gateway.purchase(@amount, @credit_card, initial_options)
     assert_success initial_response
 
     subsequent_options = @options.merge(user_token_id: '12345678', stored_credential: stored_credential(:merchant, :recurring, network_transaction_id: initial_response.authorization))
     subsequent_response = @gateway.purchase(@amount, @credit_card, subsequent_options)
+    assert_success subsequent_response
+    assert_match 'SUCCESS', subsequent_response.params['status']
+  end
+
+  def test_successful_purchase_subsequent_mit
+    initial_options = @options.merge(user_token_id: '12345678', stored_credential: stored_credential(:merchant, :unscheduled, :initial))
+    initial_response = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success initial_response
+
+    subsequent_options = @options.merge(user_token_id: '12345678', stored_credential: stored_credential(:merchant, :recurring, network_transaction_id: initial_response.authorization))
+    subsequent_response = @gateway.purchase(@amount, @credit_card, subsequent_options.merge(is_rebilling: true))
     assert_success subsequent_response
     assert_match 'SUCCESS', subsequent_response.params['status']
   end


### PR DESCRIPTION
Description
-------------------------
[SER-1617](https://spreedly.atlassian.net/browse/SER-1617)

This commit sends `ísRebilling`  field only for MIT transactions, 
set "0" when is init MIT or "1" for subsequent MIT

Unit test
-------------------------
Finished in 1.482941 seconds.

34 tests, 180 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

22.93 tests/s, 121.38 assertions/s

Remote test
-------------------------
Finished in 601.986719 seconds.

45 tests, 150 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

0.07 tests/s, 0.25 assertions/s

Rubocop
-------------------------
808 files inspected, no offenses detected