### PR TITLE
FlexCharge: Fixing bug on session_expire

### DIFF
--- a/lib/active_merchant/billing/gateways/flex_charge.rb
+++ b/lib/active_merchant/billing/gateways/flex_charge.rb
@@ -240,7 +240,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def access_token_valid?
-        @options[:access_token].present? && @options.fetch(:token_expires, 0) > DateTime.now.strftime('%Q').to_i
+        @options[:access_token].present? && @options.fetch(:token_expires, 0).to_i > DateTime.now.strftime('%Q').to_i
       end
 
       def fetch_access_token

--- a/test/unit/gateways/flex_charge_test.rb
+++ b/test/unit/gateways/flex_charge_test.rb
@@ -63,6 +63,38 @@ class FlexChargeTest < Test::Unit::TestCase
     }.merge(@options)
   end
 
+  def test_access_token_valid_when_token_present_and_not_expired
+    @gateway.instance_variable_set(:@options, {
+      access_token: 'valid_token',
+      token_expires: (DateTime.now + 10.minutes).strftime('%Q').to_i
+    })
+    assert @gateway.send(:access_token_valid?)
+  end
+
+  def test_access_token_valid_when_token_present_but_expired
+    @gateway.instance_variable_set(:@options, {
+      access_token: 'expired_token',
+      token_expires: (DateTime.now - 10.minutes).strftime('%Q').to_i
+    })
+    refute @gateway.send(:access_token_valid?)
+  end
+
+  def test_access_token_valid_when_token_not_present
+    @gateway.instance_variable_set(:@options, {
+      access_token: nil,
+      token_expires: (DateTime.now + 10.minutes).strftime('%Q').to_i
+    })
+    refute @gateway.send(:access_token_valid?)
+  end
+
+  def test_access_token_valid_when_token_is_an_string
+    @gateway.instance_variable_set(:@options, {
+      access_token:  'valid_token',
+      token_expires: (DateTime.now + 10.minutes).strftime('%Q')
+    })
+    assert @gateway.send(:access_token_valid?)
+  end
+
   def test_valid_homepage_url
     assert @gateway.homepage_url.present?
     assert_equal 'https://www.flexfactor.io/', @gateway.homepage_url


### PR DESCRIPTION
## Summary:


Fixing issue that happend when `token_expires` is store like an string on core:

[UBI-276](https://spreedly.atlassian.net/browse/UBI-276)

## Tests

### Remote Test:
Finished in 118.763803 seconds.
21 tests, 64 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
0.18 tests/s, 0.54 assertions/s

### Unit Tests:
Finished in 60.312398 seconds.
6199 tests, 81237 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### RuboCop:
808 files inspected, no offenses detected