### PR TITLE
Fix Cecabank ApplePay Eci Error

### DIFF
--- a/test/unit/gateways/cecabank_rest_json_test.rb
+++ b/test/unit/gateways/cecabank_rest_json_test.rb
@@ -186,6 +186,19 @@ class CecabankJsonTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_format_eci
+    one_digit = @no_encrypted_gateway.send(:eci_padding, '5')
+    two_digits = @no_encrypted_gateway.send(:eci_padding, '12')
+    non_eci = @no_encrypted_gateway.send(:eci_padding, nil)
+    empty_eci = @no_encrypted_gateway.send(:eci_padding, '')
+    # Modify the eci only if it's 1 length.
+    assert_equal one_digit, '05'
+    # Return the same eci value if no modification is required
+    assert_equal two_digits, '12'
+    assert_equal non_eci, nil
+    assert_equal empty_eci, ''
+  end
+
   def test_successful_purchase_with_google_pay
     stub_comms(@no_encrypted_gateway, :ssl_post) do
       @no_encrypted_gateway.purchase(@amount, @google_pay_network_token, @options.merge(xid: 'some_xid'))


### PR DESCRIPTION
 Summary
-------------------------
    
 This format the ECI value to return 0#{number} in the case
 the number is only 1 digit.
    
 [SER-1619](https://spreedly.atlassian.net/browse/SER-1619)
    
 Unit Tests
 ----------------
 Finished in 0.032173 seconds.
 21 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
 100% passed
    
 Remote Tests
 ----------------
 Finished in 0.168569 seconds.
 21 tests, 111 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    
 Rubocop
 ----------------
 808 files inspected, no offenses detected