### PR TITLE
Stripe: update tokenization method for google pay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -131,6 +131,7 @@
 * Routex Bin: Update routex bin range to include 18 digits [yunnydang] #5410
 * Nuvei: Fix isRebilling flag for Stored credentials [javierpedrozaing] #5408
 * Shift4: Add interface_name field [almalee24] #5395
+* Stripe: Update tokenization method for google pay [yunnydang] #5414
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -475,9 +475,10 @@ module ActiveMerchant # :nodoc:
           end
 
           if creditcard.is_a?(NetworkTokenizationCreditCard)
+            tokenization_method = creditcard.source == :google_pay ? :android_pay : creditcard.source
             card[:cryptogram] = creditcard.payment_cryptogram
             card[:eci] = creditcard.eci.rjust(2, '0') if creditcard.eci =~ /^[0-9]+$/
-            card[:tokenization_method] = creditcard.source.to_s
+            card[:tokenization_method] = tokenization_method.to_s
           end
           post[:card] = card
 

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -10,6 +10,28 @@ class RemoteStripeTest < Test::Unit::TestCase
     @new_credit_card = credit_card('5105105105105100')
     @debit_card = credit_card('4000056655665556')
 
+    @google_pay = network_tokenization_credit_card(
+      '4242424242424242',
+      payment_cryptogram: 'dGVzdGNyeXB0b2dyYW1YWFhYWFhYWFhYWFg9PQ==',
+      source: :google_pay,
+      brand: 'visa',
+      eci: '05',
+      month: '09',
+      year: '2030'
+    )
+
+    @apple_pay = network_tokenization_credit_card(
+      '4242424242424242',
+      payment_cryptogram: 'dGVzdGNyeXB0b2dyYW1YWFhYWFhYWFhYWFg9PQ==',
+      source: :apple_pay,
+      brand: 'visa',
+      eci: '05',
+      month: '09',
+      year: '2030',
+      first_name: 'Longbob',
+      last_name: 'Longsen'
+    )
+
     @check = check({
       bank_name: 'STRIPE TEST BANK',
       account_number: '000123456789',
@@ -85,6 +107,18 @@ class RemoteStripeTest < Test::Unit::TestCase
     assert response.params['paid']
     assert_equal 'ActiveMerchant Test Purchase', response.params['description']
     assert_equal 'wow@example.com', response.params['metadata']['email']
+  end
+
+  def test_successful_purchase_with_google_pay_tokenization
+    purchase = @gateway.purchase(@amount, @google_pay, @options)
+    assert_success purchase
+    assert_match('android_pay', purchase.params['source']['tokenization_method'])
+  end
+
+  def test_successful_purchase_with_non_google_pay_tokenization
+    purchase = @gateway.purchase(@amount, @apple_pay, @options)
+    assert_success purchase
+    assert_match('apple_pay', purchase.params['source']['tokenization_method'])
   end
 
   def test_successful_purchase_with_destination_and_amount

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -847,6 +847,38 @@ class StripeTest < Test::Unit::TestCase
     assert_equal '07', post[:card][:eci]
   end
 
+  def test_add_creditcard_with_android_pay
+    post = {}
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: '111111111100cryptogram',
+      source: :google_pay,
+      transaction_id: '1234567890'
+    )
+
+    @gateway.send(:add_creditcard, post, credit_card, {})
+
+    assert_equal 'android_pay', post[:card][:tokenization_method]
+  end
+
+  def test_add_creditcard_with_other_tokenization_method
+    post = {}
+    credit_card = network_tokenization_credit_card(
+      '4111111111111111',
+      brand: 'visa',
+      eci: '05',
+      payment_cryptogram: '111111111100cryptogram',
+      source: :apple_pay,
+      transaction_id: '1234567890'
+    )
+
+    @gateway.send(:add_creditcard, post, credit_card, {})
+
+    assert_equal 'apple_pay', post[:card][:tokenization_method]
+  end
+
   def test_application_fee_is_submitted_for_purchase
     stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge({ application_fee: 144 }))


### PR DESCRIPTION
Adds a quick fix to the tokenization method for google pay cards

Local:
6201 tests, 81246 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
138 tests, 683 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
79 tests, 343 assertions, 10 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
87.3418% passed