### PR TITLE
Stripe PI: add the request_extended_authorization field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -134,6 +134,7 @@
 * Stripe: Update tokenization method for google pay [yunnydang] #5414
 * StripePI: Add AFT fields [yunnydang] #5418
 * CheckoutV2: Improve payout handling with blank sender data [jcreiff] #5423
+* StripePI: Add the request_extended_authorization field [yunnydang] #5417
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -56,6 +56,7 @@ module ActiveMerchant # :nodoc:
             add_card_brand(post, options)
             add_aft_recipient_details(post, options)
             add_aft_sender_details(post, options)
+            add_request_extended_authorization(post, options)
             post[:expand] = ['charges.data.balance_transaction']
 
             CREATE_INTENT_ATTRIBUTES.each do |attribute|
@@ -381,6 +382,14 @@ module ActiveMerchant # :nodoc:
         post[:payment_method_options] ||= {}
         post[:payment_method_options][:card] ||= {}
         post[:payment_method_options][:card][:network] = options[:card_brand] if options[:card_brand]
+      end
+
+      def add_request_extended_authorization(post, options)
+        return unless options[:request_extended_authorization]
+
+        post[:payment_method_options] ||= {}
+        post[:payment_method_options][:card] ||= {}
+        post[:payment_method_options][:card][:request_extended_authorization] = options[:request_extended_authorization] if options[:request_extended_authorization]
       end
 
       def add_level_three(post, options = {})

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -612,6 +612,19 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     refute authorization.params.dig('charges', 'data')[0]['captured']
   end
 
+  def test_successful_authorize_with_extended_authorization
+    options = {
+      request_extended_authorization: 'if_available'
+    }
+
+    assert authorize = @gateway.authorize(@amount, @visa_payment_method, options)
+    assert_equal 'requires_capture', authorize.params['status']
+
+    card_details = authorize.params['charges']['data'][0]['payment_method_details']['card']
+    assert_equal 'disabled', card_details['extended_authorization']['status']
+    assert_not_nil card_details['capture_before']
+  end
+
   def test_create_payment_intent_manual_capture_method
     options = {
       currency: 'USD',

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -722,6 +722,18 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
     end.respond_with(successful_create_intent_response_with_apple_pay_and_billing_address)
   end
 
+  def test_authorize_with_with_request_extended_authorization
+    options = {
+      request_extended_authorization: 'if_available'
+    }
+    stub_comms(@gateway, :ssl_request) do
+      @gateway.authorize(@amount, @visa_token, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match('payment_method_options[card][request_extended_authorization]=if_available', data)
+      assert_match('capture_method=manual', data)
+    end.respond_with(successful_create_intent_response)
+  end
+
   def test_stored_credentials_does_not_override_ntid_field
     sc_network_transaction_id = '1078784111114777'
     options = @options.merge(


### PR DESCRIPTION
adds the optional request_extended_authorization field for authorization requests

local:
6206 tests, 81265 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
70 tests, 367 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
101 tests, 451 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.0297% passed

A note about tests: I had tried to write a remote test for this and it fails due to account related issues. Here is the error message: "This account is not eligible for the requested card features. See https://stripe.com/docs/payments/flexible-payments for more details."

Given the error message, I do think stripe is acknowledging that this field is valid, but its just that our test account is not set up for it. I tried poking around in the dashboard but havent made progress.