### PR TITLE
Datatrans: Mapping fix 3ds values

### DIFF
--- a/lib/active_merchant/billing/gateways/datatrans.rb
+++ b/lib/active_merchant/billing/gateways/datatrans.rb
@@ -145,8 +145,8 @@ module ActiveMerchant # :nodoc:
             '3D':
               {
                 eci: three_d_secure[:eci],
-                xid: three_d_secure[:xid],
-                threeDSTransactionId: three_d_secure[:ds_transaction_id],
+                xid: three_d_secure[:ds_transaction_id],
+                threeDSTransactionId: three_d_secure[:three_ds_server_trans_id],
                 cavv: three_d_secure[:cavv],
                 threeDSVersion: three_d_secure[:version],
                 cavvAlgorithm: three_d_secure[:cavv_algorithm],

--- a/test/remote/gateways/remote_datatrans_test.rb
+++ b/test/remote/gateways/remote_datatrans_test.rb
@@ -20,12 +20,12 @@ class RemoteDatatransTest < Test::Unit::TestCase
         eci: '05',
         cavv: '3q2+78r+ur7erb7vyv66vv8=',
         cavv_algorithm: '1',
-        xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
+        ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
         enrolled: 'Y',
         authentication_response_status: 'Y',
         directory_response_status: 'Y',
         version: '2',
-        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC'
+        three_ds_server_trans_id: '97267598-FAE6-48F2-8083-C23433990FBC'
       }
     }
 

--- a/test/unit/gateways/datatrans_test.rb
+++ b/test/unit/gateways/datatrans_test.rb
@@ -18,12 +18,12 @@ class DatatransTest < Test::Unit::TestCase
         eci: '05',
         cavv: '3q2+78r+ur7erb7vyv66vv8=',
         cavv_algorithm: '1',
-        xid: 'ODUzNTYzOTcwODU5NzY3Qw==',
+        ds_transaction_id: 'ODUzNTYzOTcwODU5NzY3Qw==',
         enrolled: 'Y',
         authentication_response_status: 'Y',
         directory_response_status: 'Y',
         version: '2',
-        ds_transaction_id: '97267598-FAE6-48F2-8083-C23433990FBC'
+        three_ds_server_trans_id: '97267598-FAE6-48F2-8083-C23433990FBC'
       }
     })
 
@@ -168,8 +168,8 @@ class DatatransTest < Test::Unit::TestCase
       parsed_3d = parsed_data['card']['3D']
 
       assert_equal('05', parsed_3d['eci'])
-      assert_equal(three_d_secure[:xid], parsed_3d['xid'])
-      assert_equal(three_d_secure[:ds_transaction_id], parsed_3d['threeDSTransactionId'])
+      assert_equal(three_d_secure[:ds_transaction_id], parsed_3d['xid'])
+      assert_equal(three_d_secure[:three_ds_server_trans_id], parsed_3d['threeDSTransactionId'])
       assert_equal(three_d_secure[:cavv], parsed_3d['cavv'])
       assert_equal('2', parsed_3d['threeDSVersion'])
       assert_equal(three_d_secure[:cavv_algorithm], parsed_3d['cavvAlgorithm'])


### PR DESCRIPTION
Description
-------------------------
[SER-1629](https://spreedly.atlassian.net/browse/SER-1629)

This commit add a mapping fix for the 3ds values
`ds_transaction_id`  and `three_ds_server_trans_id`

Unit test
-------------------------
29 tests, 165 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote test
-------------------------
27 tests, 42 assertions, 15 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications 42.3077% passed

Rubocop
-------------------------
808 files inspected, no offenses detected