### PR TITLE
Adyen: Update shopperInteraction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -137,6 +137,7 @@
 * StripePI: Add the request_extended_authorization field [yunnydang] #5417
 * Plexo: Add Transaction sync support for Plexo Gateway [javierpedrozaing] #5416
 * CheckoutV2: Add account name inquiry [jcreiff] #5427
+* Adyen: Update shopperInteraction [almalee24] #5430
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/adyen.rb
+++ b/lib/active_merchant/billing/gateways/adyen.rb
@@ -1033,8 +1033,16 @@ module ActiveMerchant # :nodoc:
         return true if payment.is_a?(NetworkTokenizationCreditCard) && options.dig(:stored_credential, :initiator) != 'merchant'
         return true unless (stored_credential = options[:stored_credential])
 
-        stored_credential[:initiator] == 'cardholder' ||
+        cardholder_shopper_interaction?(stored_credential) ||
           (payment.respond_to?(:verification_value) && payment.verification_value && stored_credential[:initial_transaction])
+      end
+
+      def cardholder_shopper_interaction?(stored_credential)
+        if stored_credential[:reason_type] == 'unscheduled'
+          stored_credential[:initial_transaction] && stored_credential[:initiator] == 'cardholder'
+        else
+          stored_credential[:initiator] == 'cardholder'
+        end
       end
     end
   end

--- a/test/unit/gateways/adyen_test.rb
+++ b/test/unit/gateways/adyen_test.rb
@@ -810,7 +810,7 @@ class AdyenTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, options)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/"shopperInteraction":"Ecommerce"/, data)
+      assert_match(/"shopperInteraction":"ContAuth"/, data)
       assert_match(/"recurringProcessingModel":"CardOnFile"/, data)
     end.respond_with(successful_authorize_response)
 


### PR DESCRIPTION
If stored_credential[:reason_type] is unschedule we should only be setting shopperInteraction as Ecommerce if initial_transaction is true and stored_credential[:initiator] is cardholder.

Remote
152 tests, 481 assertions, 12 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.1053% passed

Unit
138 tests, 731 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed