### PR TITLE
Adding and configure VCR to be used on remote tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,10 +29,18 @@ task test: 'test:units'
 
 RuboCop::RakeTask.new
 
+## Find all files under test/remote that include the VCRRemote module
+def find_vcr_files
+  Dir['test/remote/**/*_test.rb'].select do |file|
+    File.read(file).include?('VCRRemote')
+  end
+end
+
 namespace :test do
   Rake::TestTask.new(:units) do |t|
     ENV['RUNNING_UNIT_TESTS'] = 'true'
     t.pattern = 'test/unit/**/*_test.rb'
+    t.test_files = find_vcr_files
     t.libs << 'test'
     t.verbose = false
   end

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')
   s.add_development_dependency('thor')
+  s.add_development_dependency('vcr')
+  s.add_development_dependency('webmock')
 end

--- a/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
+++ b/lib/active_merchant/billing/gateways/braintree/braintree_common.rb
@@ -25,6 +25,7 @@ module BraintreeCommon
       gsub(%r((<value>)[^<]{100,}(</value>)), '\1[FILTERED]\2').
       gsub(%r((<token>)[^<]+(</token>)), '\1[FILTERED]\2').
       gsub(%r((<cryptogram>)[^<]+(</cryptogram>)), '\1[FILTERED]\2').
-      gsub(%r((<number>)[^<]+(</number>)), '\1[FILTERED]\2')
+      gsub(%r((<number>)[^<]+(</number>)), '\1[FILTERED]\2').
+      gsub(%r((tokenusbankacct_bc)\w*), '\1[FILTERED]')
   end
 end

--- a/test/remote/gateways/remote_braintree_token_nonce_test.rb
+++ b/test/remote/gateways/remote_braintree_token_nonce_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class RemoteBraintreeTokenNonceTest < Test::Unit::TestCase
+  prepend VCRRemote
+
   def setup
     @gateway = BraintreeGateway.new(fixtures(:braintree_blue))
     @braintree_backend = @gateway.instance_eval { @braintree_gateway }

--- a/test/support/vcr_module.rb
+++ b/test/support/vcr_module.rb
@@ -1,0 +1,38 @@
+# Given the state of remote tests, the VCR gem will initially be disabled and
+# will only be available in test classes that enable the VCRModule.
+# To do this, simply add VCRModule with the prepend keyword.
+
+module VCRRemote
+  def setup
+    class_name = self.name.match(/\((\w*)\)/)[1]
+
+    unless config_already_defined?
+      VCR.configure do |conf|
+        conf.before_record do |interaction|
+          if @gateway.supports_scrubbing
+            interaction.request.body = @gateway.scrub(interaction.request.body)
+            interaction.response.body = @gateway.scrub(interaction.response.body)
+          end
+        end
+      end
+    end
+
+    VCR.turn_on!
+    VCR.insert_cassette([class_name, method_name].compact.join('/').underscore)
+    super
+  end
+
+  def teardown
+    VCR.eject_cassette
+    VCR.turn_off!
+    super
+  end
+
+  private
+
+  def config_already_defined?
+    VCR.configuration.hooks[:before_record].any? do |hook|
+      hook.hook.source_location.first =~ /vcr_module/
+    end
+  end
+end

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_client_token_generation.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_client_token_generation.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/X/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.22.0 (ActiveMerchant 1.137.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:14 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1537'
+      Connection:
+      - keep-alive
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - f609632933124
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=GHGnwWanaAcTp8iK9O.EtCLUK6m1SW4CTg9k.6174Vc-1742402054-1.0.1.1-xQYGmxxVopXKiVgVKHqLnPDg9gkM_YLvYskBBrMlLUnWhYCasEDJ9i3HN1iZS1Z7Pi55ieNhtsWrLzpsTj_50b5mnYHb76jRM3mbE05LFZ8;
+        path=/; expires=Wed, 19-Mar-25 17:04:14 GMT; domain=.sandbox.braintreegateway.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e604639dc31f8-MIA
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKVWW5ObRhN996/wm5/yhcuiz1StnYp2YcRYoGiAGZg3hmGXywzC1gXBr0+jtWOnskmlKg8qlYae7tPnnG50/8tVq7eX6suxOfQf3pn/M969rfryIJv++cO7NPF/ev/ul49v7kvVVP3pp9Ohq/qPb96+vb8U6lx9rCZs8QzPBXPPQXuYtg+4lhk5CBsPlfaN5ZxodeYWncoNHkS/b3YNVlV6GDmt10XqDnF3YiH1h8SLPhUIb3JL/VakA6LZgMPUGeIswiIjI+siHHXqc5zJiCJpJx3BYWemLCNt2HGTdfKT1PTxFs+uq9xWS/ypeFx3sYdXidXdSaXyfb8ORecccm3GBQtmblMuuuGQ09IMUXSi+lqEXT4yVXcFoknEhiZs1wNX3pln6pNANNgzwNil8w2D53p8Xu+o788xM8cQ+UmccFyobk5SWYjU+cxRHVIzvSZs4NJzvHz2d1XiHxKDdEV3zVhWFxQd56Qfoio1VxAfpYaCfM4upGpY8gHmKWGAOXU8ph1VdM4qN8proYATpsK9MYz5HEU3TrXbxT62c3u4yG6cSC/rdKYrBj0WpjrtEhKKdHAYlUfJSBBDz9QiB+5JFpoqL4CTsFUG5LULhjPaKx7qGjhzCOQ/l5ZqY58PeSePhXqeBDrhQrtDPuO5osMmTtY7wfZWkkQ7aeEs0Qpw3fopBHAskKloqz4zWn8qzOcpbmkeKnxk2kQhw0EK/AoKmnT1TiCeSKgHmp7ztI4r8ECJMBbAH2iIhBrYLsGc+Xzm4CHuXR/jfljw20yBZ5R04i5qRcpHwB8DvowmnIk0v0J+UtB6yd+ERjCCBxzJIgf4VuHsOdue1qFJGpGQfdJKa5+pOO3lRNAwERoZzDM5z6gJ2uyJceq3qbOLen8QHp6jxJvKDse54SKykXu68R95gps9dbcMjVOh5NNekZr16ymefbxPaZtMJgmasckt98y16mmGjzBXTbEhRrkJV9vJrUvUAf/+mSN8qR6cptRQrycTZ7TPM6Kk5TtbHV1EcjCix/AiGJ1yq64hZt7a0ZdQkyZ65H3VRnOJzDZvg0tuXQfOHCOz/LGIXSuM3VZYji6YNMuvc7zg4jaG+jVJHoIVzD48G5d5PsgNGcv5cNna67piprrV6qNaQC1hP5/zHtcF5C81VVu21HAgv3H5mu8qHoJjoEktUQr5gil89O62ya8mfO5udTWt5YZOPAubnTo2ErlfAC/sGPqU21hxpAB7VJeazIEyXdhDrUBqwbEukaJ/wXnr05lz5nS5du+2Gk85U2e5gVxMAg5q51l3Bh1Ou3ZvhJN7gj3XFsiHmPBSWseJo8CItFyFdjQKFjVh436r+ZRn6+GGmzlWkeGL0Asnt933R83l+Q/aYA6cBv2r+jTLXi1tcPImeq2XubSoUU7/4IV44dc3Japfuw/nz2fYnWfB3v87by35eq6gr8viT2Fx/eJb6AVd4VyqcgpWzDQgjhwW3YkfqdwGDVN6zhk+cgZ8QG7J0gUbnF0diVS73HvVW5Y7gR8H0ZjgK/9YZWTI7fB0w/vwN1rG5m1eFh3/xvvNUzw2JfId+BwJc+pcX9WiBdw3+Q/Pgnb4f6DhHYauA/S35ovvvnr9tXt/1p7shOGAfvJS6mOz07wWm0iBrqYAHqFHxT1TlTo6QB8G1NLAx7zkge+jsGWw8ADnRtnT5V5XZOA7wJZo/8Rj8I6KxoVnjq7OixYvMx2zm+/WqZmPhJ1CavkNTwcdJXUXzlKnqU8q5quq5VPaKpRap4Gl3CTedU4tw0mZm+wtPxFM3TEdbaiil6rt7iqmHmSntpU2HdqdFPXUZ2rK38qb18CvFv0vXn2JM+kklrnQtSE363nXvIddVavcOl1ktj9/0+b7PTIAB630fqivHVOgEZ5R8LiaYK+d+I3jF9/CzJ75C+bvvkmjY8Eg3lPdLY75M+yE6Run4bTEf9drz+D9Yn+PL+310lcnNt0yu63MMPx22gregcKILvy25zBNjX3zlBkf7n9++T/15v7nP//T+h3hyVtBoAkAAA==
+  recorded_at: Wed, 19 Mar 2025 16:34:14 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_client_token_generation_with_a_new_mid.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_client_token_generation_with_a_new_mid.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/X/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <merchant-account-id>5678</merchant-account-id>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.22.0 (ActiveMerchant 1.137.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:15 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1591'
+      Connection:
+      - keep-alive
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      - accept-encoding
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - '075801d5f6d94'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=CjlNe.2S4ecXwrk_cp41aICXz217RIL1.MbWEAncbhE-1742402055-1.0.1.1-FB1lLFZhoxhdDLg32M8lI2SS5caSCwxVptFfgK5uLvKVaIwXSx2ChpiNL2qzdmNlXlyOMpeHv8J4qD83QWPKreFbyoxoPKnpGPAf_Oo7E6M;
+        path=/; expires=Wed, 19-Mar-25 17:04:15 GMT; domain=.sandbox.braintreegateway.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e604c5ebdcc72-TPA
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1Wy5ajOBLd11fUrlY9DbjwFOdkVZ9xJsJWJnKah4S0k5AreUiYbj8wfH0HzpmqfmTN6QUbiMeNGzciuPvlas37y/63Y33oPn9w/+V8eL/vyoOuu5fPH/IM/fTpwy9f3t2Vpt53p59Oh3bffXn3/v3dRZrz/st+xJ4o8CRZcN40h/HpHle6SA5qgfu9Rc78PrHmLDw6lmvcq25Xb2ts9vlhELRayTzo0/bEYor6LCSPMsJr7plnmfcRLXoc536fFgSrIhlYSzBpza9poQmN9CJrExy3bs6KpIlb4bJWP2pLH2727LrkCzPbn+TDqk1DvMy89qM2hu+6Vaxa/8Ctm0q2mcSCCtX2B05LN47IidqrjFs+MFO1MqIZYX0dN6temPAsCvOoIrrZMcDY5tMNQxiEYlptKaJTytwhjlCWZgLLtr1mUIN2+3We0ZhGRyejSaNDP5QL85xP6JA5GsX5Nc8zIigKB2b7RxW6uVxokjsG4vnbmJp+jgeYx4wB5twPmfWNbP0ld8qrNMAJM/HO6Qc+EXLj1AZtivCCL/qLbocx6XSVT3TJoEbpmtM2S2KV9z6j+qhZskmhZuolBxFqFruGS+AkbowDcReS4YJ2RsS2As78BOKfS880KRI9b/VRmpdRRScsbdDzCU972q/TbLVVbOdlGdlqDxeZNYDrVo9UwLGKXEMb8yuj1aN0X8a0oTw2+MisG8UMb3LgV1HoSVttVSQyDfmgp2eeV+keNFBGGKsMzT2MlOnZNsOCITEJ0JAIrw9p18/4F8yAZoz205Y0KhcD4E8BX0EzwVTOrxA/kbSa49exsxlAA75mxAe+QaO9Axp4lBatk462SWMOLMNbbZOCZCse2+tvKesv0I+cZeR55xz8WSNJjp/nHmQuWctF9bhf9+ukRfU+rCh1RZG3vVVuMsQPSc86ZNLaPehFNeS0egbuR+JUK53hJsmvXBgMM/jpyt0Kyabaidp90iGetEVf9xQ1JatwScMa5q5Rnm8l07S0wzxjB71OhnI6XJ48NMjUnzjzW26Dj08Wj5yZs15jI5iudEQXvGjP3AtO22bnxGNwgpluZITAJr6U3nEU0cYhVi/jBRkUI3VcB42KjFFd8pUXq/5pwa9PHrkoK3qYp5EXSa+8jzOu77FC1EAOF3ywuN8sN03ukelltulKCxgRijdN/+9NR0c1f7eVo9eraVt/upQR8hWjMx7QHjqLCF/2934NfrBTklGw/HTDYQFDGrzGW6Pjph5qESFHpHO+zRBnL6f4IYfnlteCaBxdYFOOmyUbsaO8k1HWLAUNmtLSVhZQn4dGsY7ronCOG0uOcsYRQnz6d5w3DB2plE1qtXg58w5XkvkOxDLCAxyFrvapD71yluRhNz15riktOfDZZgwmOeGWNztPLA5TuViduLcZgdfXnCioyqidcQPvoi9tcL5xMmP4nvMvnJsW9nL9dg83UA+aSo86pftWLWQSRTL9P73M/PKCOhK95Q/v731PMP+kxn+mvzke7HCo69Os4Yuw/KZtqOUIe3e+IxNoRBUp2EUV9J2GuUebuYcJ8ytur2bWFsR2BdhAzkqtDdwhMv1IW/OtEp45PzF05uzq68g05eje8P6ol2A7z9Tcxx/MBw4A98ALM0BMpCyqAT/0onfKDvy/fYNZ7Y41twbqgzvpoG6O/6p18pbfn3sf+pfMUkd7wShBw8KiY+nlR6jzrOf34JsxmEevqm631wrgg8xxKhVdL9qZefgPYEhGzcDPJj3o7gjYtpy5ZtZOvljNPLdq3b7umde5f53hFmW0WSHpXAvOsEktd7fRbiKeSHYU+ZzRJelwus1FJj0jYI+G2ZpkKjOJcskDp+Qki0pyRzPKguU2q3yZYy/NT0tVGJZ6NIcdC0oKrjetgV7Fm3P3T7X6akcLfJxrk+vEKdfx8mkMQGO0kbCf9L3/v9588xORAQ6Is/tDftXRo7qHb8z3ZIFh97nmv/83oFsBM+ubW84/6GbnXXuwh7t6s4OdRZx5Vl853U2zvfrWr2TFYafq7/ZTeasrOe7TeXaJW3agBwv3qiCXnRe0tz1naJbc4+Dr7vPnu59f/9Pe3f385z+43wGAxeIa+AkAAA==
+  recorded_at: Wed, 19 Mar 2025 16:34:15 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_client_token_generation_with_mid.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_client_token_generation_with_mid.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/X/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <merchant-account-id>1234</merchant-account-id>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.22.0 (ActiveMerchant 1.137.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:16 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1589'
+      Connection:
+      - keep-alive
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      - accept-encoding
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 4d7dd2322d2f4
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=skoQ6hY5L9wMxjuMOfNdp7kOZ05dnTAVnUreQgo3EtA-1742402056-1.0.1.1-Du5lXxqJ2yt1V__n3Z1Hb.v04.XDRy4NsB7VAklpNGfZCI6WXBu8Q0rUvzGqZY9dKjhyDDZUaXzm5zt3yELaF4i_k2xw2J3VzCUTsuSp1oE;
+        path=/; expires=Wed, 19-Mar-25 17:04:16 GMT; domain=.sandbox.braintreegateway.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e60528be9cc76-TPA
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI1WXZebOBJ9z6/IW55mB3DwhnM6mTPuBmy1kQcQEtKbBJ7GIGEy+At+/Zbcu8nMbmfPPPAC9XHr1q0qHn65Gf3+sv9jPBz7zx/cfzgf3u/76lgf+pfPHwoS/fTpwy9f3j1U+rDvTz+djt2+//Lu/fuHi9Tn/Zf9hDxRolmy4Lxpj9P2ETV1mR3VAg17Ezn2fWb0WXh0qtZoUH162B2Q3hfHq6DNShbBkHcnltBoICF+ljFac0//JoshpuWAksIf8hIjVWZX1mGEO/01L2tM43pBugwlnVuwMmuTTrisq59rQ5/u9uy25Att7U/yadXlIVoSr/tYa83TfpWozj9y4+aSbWaxoEJ1w5HTyk1ifKLmJpOOX5luOhlTgtlwSNrVIHR4FqV+VjHdpAwwdsV8xxAGoZhXOxrpOWfuNYkjkhOBpMkG4mZ437mnglAoUYyEZrgO/TUhkSjmXx34PsriVqj4tJNaHIkZpAr9rynBv6WOjefvEqoHGw8wT4QB5sIPmfG17Pwld6qb1MAJ00nqDFc+Y3zn1ARdHqEFXwyXurtOWV83xUyXDGqUrj7tSJaoYvAZrceaZZscaqZedhRhzRJXcwmcJK12IO5CMlTSXovENMCZn0H8c+XpNo/EwLt6lPplAvxQbzDwGc17OqxzstoplnqE4F3toZIYDbju9UgFHKvY1bTVXxltnqX7MuUt5YlGIzNunDC0KYBfRaEnXbNTsSA15IOennnR5HvQQBUjpEhkexgrPbAdQYJFYhagIRHenvJ+sPgXTINmdO3nHW5VIa6APwd8JSWCqYLfIH4maWPjHxJncwUN+DXDPvANGh0c0MCzNNE662mXtfrICNrVJisxWfHE3P7I2XCRhVvk5bBLnaNvNUK7iKR6OArv9pz0GU6hVMyimbriUdCsKUJdki5Y5FG2KLpmVAzjws3CrBBZHrt+VjTdLhaaO1FJiMB5FCyxg+N9hwtB8Qo0v5Vt4lZ0SFl3dRMaHmDuWuX5RrKaVuZqZ+xYr7NrNR8vWy+6ytyfOfM7boKPW4MmzvS5XiMtWN3UMV3wsjtzLzjt2tRJpuAEM93KOAKb5FJ54yTijYNNvUwW+Ap4D8khaFWsteqz33m5GrYLftt6+KKMGGCeJl5mg/I+WlzfY4VRCzlc8EHicbPctOGUzKm16SsDGKMo2bTDPzc9nZT9bhqnXq/m3eHTpYojXzFq8YD2orOI0WX/6B/AD3ZKNglWnO44DGDIg9d462jcHK4HEUeOyG2+zTUhL6fkqYDnxeY1IBqnLpGups2STchR3kkro5eCBm1laCdLqM+LJrFODmXpjBuDR2lxhBCf/i/OO4YeN8pkB7V4OfMeNZL5DsTSwgMcZd3scx965SzxUzpvPVdXBh+5tZmCWc6o423qicVxrharE/c2E/D6mjMKmiruLG7gXQyVCc53TiyG7zn/i3PdwV4+vN3DDdQTzZVHncp9qxY8izKb/59eLL+8pI6M3vKH94++J5h/UtPf05+NBzsc6vpkNXwRht+1DbWMsHftHZlBI6rMwS5uoO80LDza2h5mzG+4uWmrLYjtCrCBnI1aa7hDeP6RtuytEp4+b1l05uzm17Fuq8m94/1RL8HWzpTt4w/mAwWA+8pLfYWYkTLRAfBDLwan6sH/2zeY1X48cKOhPriTTtTb+K9ax2/5/bX3oX8hhjq1F0wSNCxMNFZeMUKd59q+B1/CYB69prnfXiOAD2zjNCq+XWrH8vArYMimmoEf3CzQ3QjYdpy52mqnWKwsz51ad6975nXuX2cYdh1tV5F0biVnSOeGu7s4nbEnspRGPmd0iXuU7wpBpKcF7NGQrDFRRGfKxU+c4pMsG8mdmlEWLHek8WWBvLw4LVWpWe7RAnYsKCm43bUGehVvzt3f1eqrHS3RaGuT68yp1slyOwWgMdpK2E/1o/+f3nzzE7EGDrCT/im/6umoHuEb8z1ZIth9rv73/w3oVsDM+vqe80+6Sb3bAPZwV+92sLOwY2f1ldN0tvbqW7+yFYedWn+3n6t7Xdm4z+3sYrfqQQ8G7lWJL6kXdPc9pynJHlHwe/r588PPr/9p7x5+/usf3L8AlVrCafgJAAA=
+  recorded_at: Wed, 19 Mar 2025 16:34:16 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_successfully_create_token_nonce_for_bank_account.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_successfully_create_token_nonce_for_bank_account.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/X/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.22.0 (ActiveMerchant 1.137.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:17 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1533'
+      Connection:
+      - keep-alive
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      - accept-encoding
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 89aa95db55494
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=3bhW8CQnVCJzss2FhHQuTXVwuk3iF8GUy3dvVf8LYUk-1742402057-1.0.1.1-arIjD5lsHE2rz6VsKXi_hVE9ubvP8fnVmfOup27CSDIe0iDfarhoN7_wD.T1nfR8VhJPvV8WF3e47.nM2kbYDZbKNiCqGsRQqki0mxhyIWI;
+        path=/; expires=Wed, 19-Mar-25 17:04:17 GMT; domain=.sandbox.braintreegateway.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e60578bcea4e6-MIA
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKVWXZObOhJ9z6/IW57uXj6G2VA1ya31DGCIkWM+JKQ3hMgAkjCJPzD8+tswySa3du7WVu2Dy2XR6j59zunGD3/ctHp7rb+d2mP/4Z35D+Pd27qvjqLtnz+8yzP/t/fv/vj45qFSbd2ffzsfZd1/fPP27cO1VJf6Yz1FFiuiuSTuJeyO0+4xakSRHLkdDbX2jeU80erCLDxV22jg/aHdt5Gq8+PIcLMpc3dI5ZnE2B8yD30qg2hLLfW5zIcAF0MU586QFijiRTISiSIk1de0EAgHws5kEsXSzEmRdLFkJpHik9D4aY0nt3tqqyX+XD5tZOpF95kl74RS9NBvYi6dI9VmWpJwZjZmXA5HiiszDtAZ61sZSzoS1cgywBkiQxt3m4Ep78IK9YkHODwQwCjzecXguR6bN3scoDkl5hgHfpZmLOI5+0qwgOfGlGQ+tBidiR6w8ByPBwPKZ+iZDB3ybnlaNCyWzolAzwgPORC/r3MF+Zx9jNWw5pPOlBHAnDse0Y4qpXNPjepWKuCEqPhgDCOdEVo51a5M/cim9nAVcpySXjT5jO8J9Fia6rzPkpjngwP4ToIkYQo9Yys5Mk+Q2FS0BE7iThmQ1y5JVOBesVg3wJmTQP5LZaku9dlApTiV6nniwTkqtTvQOZprPGzTbLPn5GBlGdoLKyoyrQDX2k/JgWMemAp3CvhpPpXm85R2mMYqOhFtBjGJwhz45Rg0kc2eBywTUA80vdC8SWvwQBVEEc/8RcOAq4Hss4gRn80MPMS821PaDwt+myjwjBJOKlEHeoyAPwV8Bc4Y4Tm9Qf6kxM2Sv42NcAQPOIIgB/hW8ew5O0Wd0kt2RKnPe+84ch2bh15tEoOBD1yJcbJLAvUt9xufGswHLxmiNY8JaTwimX2wWFaZzYQJehK+oMhwHSw95wCMYuUjpA8Ol41HDVzs8OaumoUdtmNLLffCtOpxEZ1grtpymxjVNr7fTW5TBRL49y8siK71o9NW2oe5SiZGcE+LRAnLd3YaXXl2NNBTfOUET9RqGoiZdzb6FuukRU+srzs0V4HZ0S68Uus2MOIYheWPZepacep23HJ0SYRZfZ/jBRezI6jfJNljeA+zD8/GZZ6PYpuM1Xy87uxNUxNTrbV61HCoxe3nC+2jpoT8lcZqR5YaDuQ3rt/z3fhjeAp10oggh3zhFD95d7vsXyZ87ta6GjdiiydWxO1enVoRuN8AL+wY/IXakWKBAuyoqXQyh8p0YQ91PFALjk0VKPwfONc+nZkSR1Lt3u10NFGiLmILuYgAHNimhbyADud9dzDiyT3DnuvKwIeY+FpZp4kFoYG0uI9tNHKC2rh1f9T8QovNsOImjlUW0ZXrhZN19/275vL8F20iBpyG/av6tMterWxw8ha91stcWdiopv/ihXTh1zdF0Lx2H86fL7A7L5y8/9+8teTrmYK+ros/ucX0i2+hl+AG50JVU3hPTAPikuOie+IjRW3QMMcXSqITI8AH5BYkX7DB2c0RgeqWe696y3In8OPAWxN85Z/qIhmoHZ9XvI9/o2VqrvOy6Pg33m+/pGNbBb4Dn1NCnIbqm1q0gPsm++VZ2A3/DDW8w4LbAP1t2OK7715/7d5ftU/23HBAP3Gt9Knda9bwLVKgq8mBR+hRMc9UlUZH6MOAWhr4mJc88H3itggXHuDcqGBzwD1ZFuA7wJZp/8xS8I5C48IzC27OixYvM52S1Xeb3KRjQs4xtvyW5YNGWSPjWeg895Oa+Kru2JR3Ksit80ByZibebc4tw8mJmx0sP+NE3RGNtljha93Ju5qoRyHVrtYm7LSzwp76ik3xuVq9Bn618P/j1Zc4E098mQvdGGK7mffte9hVjaLW+SqKw+WHNj/vJQNw0Anvl/raMXkwwjMMHlcT7LUzWzl+8S3M7IW9YP7pmxydSgLxnpJrHPFn2AnTD07jaYn/qdeBwPvF/hlf2ZulL8m3cpndThQR/Ha65Z3ODXRl656LcG4c2i+F8eHh95f/U28efv/rP60/AQhBdbGgCQAA
+  recorded_at: Wed, 19 Mar 2025 16:34:17 GMT
+- request:
+    method: post
+    uri: https://payments.sandbox.braintree-api.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"clientSdkMetadata":{"platform":"web","source":"client","integration":"custom","sessionId":"c7e5f0b0-8caa-4bba-a445-0f1be45484d8","version":"3.83.0"},"query":"        mutation
+        TokenizeUsBankAccount($input: TokenizeUsBankAccountInput!) {\n          tokenizeUsBankAccount(input:
+        $input) {\n            paymentMethod {\n              id\n              details
+        {\n                ... on UsBankAccountDetails {\n                  last4\n                }\n              }\n            }\n          }\n        }\n","variables":{"input":{"usBankAccount":{"achMandate":"By
+        clicking [\"Checkout\"], I authorize Braintree, a service of PayPal, on behalf
+        of My Company (i) to verify my bank account information using bank information
+        and consumer reports and (ii) to debit my bank account.","routingNumber":"011000015","accountNumber":"4012000033330125","accountType":"CHECKING","billingAddress":{"streetAddress":"96706
+        Onie Plains","extendedAddress":"01897 Alysa Lock","city":"Miami","state":"FL","zipCode":"32191"},"individualOwner":{"firstName":"Jim","lastName":"Smith"}}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <AUTH_DATA>
+      Braintree-Version:
+      - '2018-05-10'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Accept-Encoding
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - f85bb9639b034
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=SgRy.RACLRBKv7UdRx7ovJPT7omPT7pzdf3EdUfSV24-1742402057-1.0.1.1-WRDzE0zzWBGujCcQ9ysa0vBR67KNG5Q.r8mtnZDJHrnKMm4s2lMNYUCPTi9.1GcuN74UKJoHE473DUI.Yjf4KF5J1Qk7XCR2uXa1jePqLuQ;
+        path=/; expires=Wed, 19-Mar-25 17:04:17 GMT; domain=.sandbox.braintree-api.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e605b7f05746d-MIA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"tokenizeUsBankAccount":{"paymentMethod":{"id":"tokenusbankacct_bd_6qb6z2_prph35_ny73qn_67ss5k_ct4","details":{"last4":"0125"}}}},"extensions":{"requestId":"d125f99f-cd28-4f76-96bb-571efd5bbfdc"}}'
+  recorded_at: Wed, 19 Mar 2025 16:34:17 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_successfully_create_token_nonce_for_credit_card.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_successfully_create_token_nonce_for_credit_card.yml
@@ -1,0 +1,143 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/X/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.22.0 (ActiveMerchant 1.137.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:18 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1533'
+      Connection:
+      - keep-alive
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      - accept-encoding
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 288795aa62e34
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=kzaHQCH5yCfT1pJPLFwla8YW.ZwzMhRPNwmnII6wdqA-1742402058-1.0.1.1-3bbHJMTNVJYxcBp9wb8zxO1PQuLhwSd.PPPq1pbQEjwmJWMtJcvFUj6NSDrkVrC176nm01OVoTEQ2taX0Vmq1qoLCxnKmAJsmUjNhX07nnU;
+        path=/; expires=Wed, 19-Mar-25 17:04:18 GMT; domain=.sandbox.braintreegateway.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e605d794d7bfa-MIA
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKVWXZObuBJ9z6/IW572Lh/D3Lhqkq31DGAUC68FkkBvCJHhQ8Ik/sDw67fxJDfZurNbt+o+uFwWre7T55xu/PDb1ei3l+rrsTn0H97Z/7Leva368qCa/vnDO5oGv7x/99vHNw+lbqr+9Mvp0FX9xzdv3z5cCn2uPlYTckSG5oKvzlF7mLaPqFYZOUgXDZUJrOWcGH0WDpvKDRpkv292DdIVPYyC1euCroakO3HMgiH1409FiDa5o/8o6BCybECYekOSxUhmZORdjOJOf0kyFbNQuWlHEO5syjPS4k7YvFOflGFPt3h+vc9dvcSfiqd1l/joPnW6O6V1vu/XWHbeITd2UvBoFi4TshsOOSttHMYnZq4F7vKR67orQpbGfGhwux6E9s8i059kyKI9B4wdnW8Y/JUv5vUOMM0Jt0ccBmmSClQYPHNNSBUMfhHW0CI68hQR5XsbmukdnaFnrQS2rlSEg8Adu+fZkBTUpvlMREU15PN2mOlhyQeYp5QDZur53Hi66Lz73CqvhQZOuMZ7axjzOY5vnJpVlwTIzd3horpxIr2q6Qz5ocfC1qddSrCkg8eZOipOogR6Zg45CF9xbOu8AE5wqy3I6xYcZazXApsaOPMI5D+Xjm6TQAx5p46Ffp5keIJ+V0M+o7liwyZJ1zvJ906axjvloCw1GnDd+ikkcCxDW7NWf+Gs/lTYz1PSshxr4MfYIeYoosCvZKBJV+9kKFIF9UDTc07rpAIPlCFCMg0WDUOpB75LkeCBmAV4SPjXp6QfFvwu1+AZrbyki1tJxQj4E8CXsVRwSfMr5CcFq5f8DbaiETzgKR57wLfGs+9tzWrGLTJqsv2Ca59ytC0bG+/bmlArt6WuM2nXPU+sOQm70zZFR0oJJzz4omb1tczWTFks3rtxU3WHWTmey/xhHSf2uOcxTWjdqI7cK6bviMZeydk6asYmd1ZnYXTPMnSEuWqKDbHKDb7fTqu6DDvgPziLEF2qR68pTQBzRSbBWZ9nRCsnANzxRaYHK37CF8nZlDt1DTHz1o2/YkOa+En0VRvPZWi3eRtdcuc6CO5ZmROMRbJycLJqpeOZgiu7/DbHCy7hIqhfk/QxuofZh2fjMs8HtSFjOR8uW3ddV9zWt1p9XEuoJd3nc96juoD8pWF6y5caHuS3Lt/yXeVjdIwMqVVIIV804Sf/bpv+bsPn7lbXsFpt2CQy3Oz0sVHh6ivghR3DPucu0iLUgD2uS0PmSNsr2EOtDPWCY12Gmv0Xzluf3pxzr8vN6m5r0JRzfVYbyMUV4GBunnVn0OG0a/cWnlYn2HNtEQYQgy+lc5xEGFmxUffYjUfJ4wY3q+81P+fZerjh5p5TZOgizcLJbff9p+by/CdtkABOo/5VfZplr5YuOHkTv9bLXDrMKqd/8EKy8BvYKqxfuw/nz2fYnWfJ3/9v3lry9UJDX5fFn9IR5sW30Et4hXOlyym657YFceSw6E6CWOcuaEjZOefoKDjwAbkVpws2OLt6KtTtcu9VbzmrCfw4yMYGXwXHKiND7uLTDe/j32iZ2Ld5WXT8G+83n5OxKcPAg8+RcK/OzVUvWsB9W/z0LGqHf0cG3mHhdYD+1mLx3Tevv3bvr9qTnbQ80E9dSnNsdkbUchNr0NWWwCP0qIVv69LEB+jDgloG+JiXPPB9lK6KFh7g3Cp7ttzrigx8B9hSE5xEAt7R8bjwLMKr96LFy0wn/Oa7NbXzkfATZk7QCDqYOK07PCtDaUAqHuiqFRNtdUid08CpsIl/naljeZSv0r0TpJLrO27iDdPsUrXdXcX1o+r0tjK2x7qTZr7+wmz1R3nzGvjVYf+PV1/ibDbJZS5MbanNet4172FX1Tp3TheV7c/ftflxjwzAQav8n+obz5bhCM8YeFxPsNdO4sbxi29hZs/iBfMP39D4WHCI93V3i+PBDDth+s4pnpb4H3rBLm+l+yO+dNdLX53cdMvstipD8Ntrl3e6tOKLuO05xKi1bz5n1oeHX1/+T715+PWv/7T+BK+kfkWgCQAA
+  recorded_at: Wed, 19 Mar 2025 16:34:18 GMT
+- request:
+    method: post
+    uri: https://payments.sandbox.braintree-api.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"clientSdkMetadata":{"platform":"web","source":"client","integration":"custom","sessionId":"16d2570a-4ec3-4450-a4e2-4773762da688","version":"3.83.0"},"query":"        mutation
+        TokenizeCreditCard($input: TokenizeCreditCardInput!) {\n          tokenizeCreditCard(input:
+        $input) {\n            paymentMethod {\n              id\n              details
+        {\n                ... on CreditCardDetails {\n                  last4\n                }\n              }\n            }\n          }\n        }\n","variables":{"input":{"creditCard":{"number":"4111111111111111","expirationYear":"2026","expirationMonth":"09","cvv":"123","cardholderName":"Longbob
+        Longsen","billingAddress":{"streetAddress":"96706 Onie Plains","extendedAddress":"01897
+        Alysa Lock","locality":"Miami","region":"FL","postalCode":"32191"}}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <AUTH_DATA>
+      Braintree-Version:
+      - '2018-05-10'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:18 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Accept-Encoding
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - f4d8dd42d6fe4
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=7oZSRej_ERbHKHsuec3xwLe5NLCDh7TIbfbsCjMMPu8-1742402058-1.0.1.1-OeKZCwuT38IB9cL7RKLoVWrMPKhysCrm6s3DLfRblZVgB154k7mRVZFzSA1kP_Kv6BubPmgc.cSDDongsLJzFF8Ok1BwT4AaPN9L0Wz7p2U;
+        path=/; expires=Wed, 19-Mar-25 17:04:18 GMT; domain=.sandbox.braintree-api.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e6062fbd821c7-MIA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"tokenizeCreditCard":{"paymentMethod":{"id":"tokencc_bc_4dgt3b_chrrb3_zwvhj3_y2qmtk_8n3","details":{"last4":"1111"}}}},"extensions":{"requestId":"1b681be7-389d-4d05-9854-230056d4fd16"}}'
+  recorded_at: Wed, 19 Mar 2025 16:34:18 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_unsucesfull_create_token_with_invalid_state.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_unsucesfull_create_token_with_invalid_state.yml
@@ -1,0 +1,146 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/X/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.22.0 (ActiveMerchant 1.137.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:19 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1538'
+      Connection:
+      - keep-alive
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      - accept-encoding
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - cf48204858e84
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=oNp4qouNlavIvhZMZ0sKGEmaiaJQjur8MPPxWGyy8cE-1742402059-1.0.1.1-X1vHsgMjZc0i03vrKsN0Ka.At_Pw_ohbDPR4xZMGRv5IYonNKDaq2wQrmtfglrYUb.GmuTa7UPJ8064bzKvJzNlbVES4u1aovoCwhhkwfHs;
+        path=/; expires=Wed, 19-Mar-25 17:04:19 GMT; domain=.sandbox.braintreegateway.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e6064b811ae3f-MIA
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKVWW5ObuBJ+z6/IW572LJdhTqiaZCseg4zGyGsuEugNITJcJExifIFfv40n2WTrzJ7aqn1wuSxa3V9/39eNH367avX2XH09Nof+wzvzP8a7t1VfHmTTP394lyb+L+/f/fbxzUOpmqoffxkPXdV/fPP27cO5UKfqYzVhi2d4Lph7CtrDtH3Etcyig7DxUGnfWM4jrU7colO5wYPo982uwapKDxdO61WRukPcjSyk/pB45KlAeJNb6vciHRDNBhymzhBnBIssurCOYNKpL3EmCUXSTroIh52Zsixqw46brJNPUtP1LZ5d73NbLfFjsV51sYfvE6u7k0rl+34Vis455NqMCxbM3KZcdMMhp6UZIjJSfS3CLr8wVXcFoglhQxO2q4Er78Qz9SQQDfYMMHbpfMPguR6fVzuKxjlm5iVEfhInHMPza2JGPvFML9EqpCicEiNqped4HA27KvlkAOa4MK4ZzepdARgYjWgFPRVoKPaGgnzOLqRqWPIB5ilhgDl1PKYdVXTOfW6U10IBJ0yFe2O45DMhN06128U+tnN7OMvuMkW9rNOZ3jPosTDVuEuiUKSDw6g8ShYFMfRMrejAPclCU+UFcBK2yoC8dsFwRnvFQ10DZ04E+U+lpdrY50PeyWOhnieBRlxod8hnPFd02MTJaifY3koSspMWzqB/wHXrpxDAsUCmoq36wmj9VJjPU9zSPFT4yLSJQoaDFPgVFDTp6p1APJFQDzQ95WkdV+CBEmEsEn/REAk1sF2COfP5zMFD3Luu435Y8NtMgWeUdOKOtCLlF8AfA76MJpyJNL9C/qig9ZK/CY3gAh5wJCMO8K3C2XO2akVZInc0Jbu0G53IkAY13jvRmuy3dPgqrOOd8MlTzmpVGCTbmzQRhmtxNqRQb12tJa7W3pibdRh7vC6Y30adm6TZp1GYdOTU7UvELzQ9mOkaP5WMREFzaXLLPXGteprhI8xVU2wio9yE99vJrUvUAf/+iSN8rh6dptQ+zFU0cUb7PIuUtHxnq8lZJAeDrMOzYHTKrbqGmHlrk6+hjhqy5n3VkrlEZpu3wTm3rgNnjpFZ/qWIXSuM3VZYji6YNMtvc7zg4jaG+nWUPAb3MPvw7LLM80Fuoks5H85be1VXzFS3Wj2pBdQS9vMp7zH07hilpmrLlhoO5DfO3/JdxWNwDHRUS5RCvmAK197dNvlkwufuVlfTWm7oxLOw2aljI5H7FfDCjqGfcxsrjhRgJ3WpozlQpgt7qBVILThWJVL0f3De+nTmnDldrt27rcZTztRJbiAXk4CD2nnWnUCHcdfujXByR9hzbYF8iAnPpXWcOAoMouV9aJOLYKQJG/d7zc95thpuuJljFRk+C71wctt9f9Zcnv+kDebAadC/qk+z7NXSBidvyGu9zKVFjXL6P16IF359U6L6tftw/nyC3XkS7P0/89aSr+cK+jov/hQW1y++hV7QFc6lKqfgnpkGxEWHRXfYhCq3QcOUnnKGj5wBH5BbsnTBBmdXRyLVLvde9ZblTuDHQTQm+Mo/Vlk05HY43vA+/o2WsXmbl0XHv/F+8zm+NCXyHfgcI+bUub6qRQu4b/KfngXt8N9AwzsMXQfob8UX333z+mv3/qp9tBOGA/rJc6mPzU7zWmyIAl1NATxCj4p7pio1OUAfBtTSwMe85IHvo7BlsPAA50bZ0+VeV2TgO8CWaH/kMXhHkcvCM0dX50WLl5mO2c13q9TMLxEbQ2r5DU8HTZK6C2ep09SPKuarquVT2iqUWuPAUm5G3nVOLcNJmZvsLT8RTN0xTTZU0XPVdncVU4+yU9tKmw7tRkU99YWa8vfy5jXwq0X/jVdf4kw6iWUudG3IzWreNe9hV9Uqt8azzPan79r8uBcNwAG8Y3+qrx1ToAs8o+BxNcFeG/mN4xffwsye+AvmH75JybFgEO+p7hbH/Bl2wvSd03Ba4n/otWfwfrF/xJf2aumrE5tumd1WZhh+O20F70BhkDO/7TlMU2PffM6MDw+/vvyfevPw61//af0BgC3qYqAJAAA=
+  recorded_at: Wed, 19 Mar 2025 16:34:19 GMT
+- request:
+    method: post
+    uri: https://payments.sandbox.braintree-api.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"clientSdkMetadata":{"platform":"web","source":"client","integration":"custom","sessionId":"6cd84276-2fac-4860-bbb5-86e6b4e363fd","version":"3.83.0"},"query":"        mutation
+        TokenizeUsBankAccount($input: TokenizeUsBankAccountInput!) {\n          tokenizeUsBankAccount(input:
+        $input) {\n            paymentMethod {\n              id\n              details
+        {\n                ... on UsBankAccountDetails {\n                  last4\n                }\n              }\n            }\n          }\n        }\n","variables":{"input":{"usBankAccount":{"achMandate":"By
+        clicking [\"Checkout\"], I authorize Braintree, a service of PayPal, on behalf
+        of My Company (i) to verify my bank account information using bank information
+        and consumer reports and (ii) to debit my bank account.","routingNumber":"011000015","accountNumber":"4012000033330125","accountType":"CHECKING","billingAddress":{"streetAddress":"96706
+        Onie Plains","extendedAddress":"01897 Alysa Lock","city":"Miami","zipCode":"32191"},"individualOwner":{"firstName":"Jim","lastName":"Smith"}}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <AUTH_DATA>
+      Braintree-Version:
+      - '2018-05-10'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:19 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Accept-Encoding
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 2e06d9185fe04
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=HbTAgIuq16kIbRuvpJeWnWcWyN3y_h4KSiYkoSQxtwc-1742402059-1.0.1.1-.wR.NkJoIbYxnpCr52baXCPUtkHMo4HX3zk9AYDewhCdHKHjihVqMncOu3iY_4aJCHISGiW2eUHtv.0NLjhEVHK2BhEsIwHRs6D3hAJUMf0;
+        path=/; expires=Wed, 19-Mar-25 17:04:19 GMT; domain=.sandbox.braintree-api.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e60692a3dcc79-TPA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"message":"Variable ''input'' has an invalid value: Field
+        ''state'' has coerced Null value for NonNull type ''UsStateCode!''","locations":[{"line":1,"column":40}]}],"extensions":{"requestId":"179662fa-84d3-4479-94ce-23a6f4e3efc0"}}'
+  recorded_at: Wed, 19 Mar 2025 16:34:19 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/remote_braintree_token_nonce_test/test_unsucesfull_create_token_with_invalid_zip_code.yml
+++ b/test/vcr_cassettes/remote_braintree_token_nonce_test/test_unsucesfull_create_token_with_invalid_zip_code.yml
@@ -1,0 +1,146 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/X/client_token
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <client-token>
+          <version type="integer">2</version>
+        </client-token>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.22.0 (ActiveMerchant 1.137.0)
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic <AUTH_DATA>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:20 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1535'
+      Connection:
+      - keep-alive
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Braintree-Version
+      - accept-encoding
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 377aa09cf1544
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=aHX5MzkGmPOu.NbTiZ5HzaYHldNSJqVE8fyjQ82WMJA-1742402060-1.0.1.1-3_51srb.KYwg4NeP3HbE4lZEiIsbQ8FPkrTB6mx024XsHYqLILBMmcBNJCTngpjMa3sQEu1UicgJTTzzwcrJZdV0rBSEpBgwKPE0a3xGazk;
+        path=/; expires=Wed, 19-Mar-25 17:04:20 GMT; domain=.sandbox.braintreegateway.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e606adcc8745d-MIA
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKVWXZObuBJ9z6/IW572Lh/D3Lhqkq31DGCIwWuBJKQ3hMgAkjCJPzD8+tt4kpts7ezWrboPLpdFq/v0OacbP/x2Nfrtpf56bA/9h3f2v6x3b+u+Osi2f/7wDufBL+/f/fbxzUOl27o//XI6qLr/+Obt24dLqc/1x3qKHV7Ec0lX56g7TNvHuJEFOgg3HmoTWMs5MvrMHTJVm3gQ/b7dtbGu8WHkpFmXeDVk6kQTEgy5n34qw3jDHP1HiYeQFEOcYG/IijQWBRqpSuNU6S9ZIVMSSjdXKE6UjWmBukRxmyr5SRrydIun13vm6iX+VD6tVebH97mj7qTWbN+vE6G8AzN2VtJo5i7hQg0HRio7CdMTMdcyUWykulFlSPKUDm3SrQeu/TMv9CcRkmhPAaPC8w2Dv/L5vN6VKpgzao9JGORZzmNB+DHHkpbBgHGOEuIHC2YkfQ/ig7TOg0OuUVn61wLla14qNeYYpXWgJlrI3d7SkM/bJUQPt3zKm3IKmLHnU+PpUnn3zKqupQZOqE721jCyOU1vnJqVyoLYZe5wkWqcUC8bPJN7Cj2Wtj7tAI/Ag0eJPEqKogx6Jg46cF/SxNasBE6STluQ1y1pXJBe88Q0wJmHIP+5cnSXBXxgSh5L/TyJ8BSXZjWwOZ5rMmyyfL0TdO/kebqTTlzkRgOuWz+lAI5FaGvS6S+UNJ9K+3nKOsISHR+pscOExhEGfgUBTVSzEyHPJdQDTc8MN1kNHqjCOBbAH2gYCj3QXR5zGvCZg4e4f33K+mHB71INntHSy1TaCcxHwJ8BvoLknArMrpAflaRZ8reJFY3gAU/S1AO+dTL73lZz8DahMid74Ltllvc17fAofbvb62CHdVogeopIFyDkkiZxg05obEms97Xx6J6eLJH/7iBN7sEDCvVsTmwZVBs0MfP+mofA+VOKEld7aMOHyuUoaseWOaszN7onRXyEuWrLDbKqTXK/nVZNFSrgPzjzML7Uj15bmQDmCk2ckp4VSEsn8LYmvYj8YKVPyUVQMjGnaSBm3rrp18SgNn3ifd2lcxXaHeuiC3OuA6eeVTjBWGYrJ8lWnXA8U1JpV9/meMHF3RjqNyh/jO5h9uHZuMzzQW7QWM2Hy9ZdNzW19a1WnzYCagn3+cz6uCkhf2WI3tKlhgf5rcu3fFfxGB0jgxoZYsgXTcmTf7fNf7fhc3era0gjN2TiRdLu9LGV4eor4IUdQz4zN9Y81IA9bSqD5kjbK9hDnQj1gmNdhZr8BeetT29m1FPMrO62Jp4Y1We5gVxUAg7iskKdQYfTrttbybQ6wZ7ryjCAmORSOceJh5GVGnmfuOkoaNom7ep7zc+sWA833NRzyiK+CLNwctt9/625PP9Jm5gDp1H/qj7tslcrF5y8SV/rZa4cYlXTP3ghW/gNbBk2r92H8+cz7M6zoO//N28t+Xquoa/L4k/hcPPiW+glvMK51NUU3VPbgjh0WHRHQaqZCxpicmY0PnIKfEBuSfGCDc6ungx1t9x71VvOagI/DqK1wVfBsS7QwNzkdMP7+DdaZvZtXhYd/8b77edsbKsw8OBzRNRrmLnqRQu4b/OfnkXd8O/IwDssvA7Q35ovvvvm9dfu/Vl7tBOWB/rJS2WO7c7wRmxSDbraAniEHjX3bV2Z9AB9WFDLAB/zkge+j8KV0cIDnFtVT5Z7qizAd4AtN8GJZ+AdnY4Lzzy8ei9avMx0Rm++W2ObjbCrEuIELceDSfNGJbM0GAeopoGuOz7hTofYOQ0Ucxv51xk7lofpKt87QS6ovqMm3RBNLnWn7mqqH6XS29rYHlEnTXz9hdjyj+rmNfCrQ/4fr77E2WQSy1yYxpKb9bxr38OuajRzThdZ7M/ftflxDw3AQSf9n+obzxbhCM8IeFxPsNdO/Mbxi29hZs/8BfMP3+D0CHv/LH2tbnE0mGEnTN85TaYl/odeewrvF/dHfOWul76U2KhldjtZxPDb62p4BworvfDbnosJtvbt58L68PDry/+pNw+//vmf1n8AmzE6SaAJAAA=
+  recorded_at: Wed, 19 Mar 2025 16:34:20 GMT
+- request:
+    method: post
+    uri: https://payments.sandbox.braintree-api.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"clientSdkMetadata":{"platform":"web","source":"client","integration":"custom","sessionId":"9e73d059-a550-4690-bc10-38b2e94cc603","version":"3.83.0"},"query":"        mutation
+        TokenizeUsBankAccount($input: TokenizeUsBankAccountInput!) {\n          tokenizeUsBankAccount(input:
+        $input) {\n            paymentMethod {\n              id\n              details
+        {\n                ... on UsBankAccountDetails {\n                  last4\n                }\n              }\n            }\n          }\n        }\n","variables":{"input":{"usBankAccount":{"achMandate":"By
+        clicking [\"Checkout\"], I authorize Braintree, a service of PayPal, on behalf
+        of My Company (i) to verify my bank account information using bank information
+        and consumer reports and (ii) to debit my bank account.","routingNumber":"011000015","accountNumber":"4012000033330125","accountType":"CHECKING","billingAddress":{"streetAddress":"96706
+        Onie Plains","extendedAddress":"01897 Alysa Lock","city":"Miami","state":"FL"},"individualOwner":{"firstName":"Jim","lastName":"Smith"}}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <AUTH_DATA>
+      Braintree-Version:
+      - '2018-05-10'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Mar 2025 16:34:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Braintree-Version:
+      - '2016-10-07'
+      Vary:
+      - Accept-Encoding
+      - Braintree-Version
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Paypal-Debug-Id:
+      - 4f84807ea83b4
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=49dEQF.DyOke3XZ9QhY0dIYQWIxntsbAMiPlABZxDOs-1742402060-1.0.1.1-A61.dd7Vs02IX3o95fvMBfVOgRV8rwdabsNdLCEhFCoYPpIm_yhPPkaZORodAv5zZ5vjuSS7pSYdL9Yc4MY3Hr.hiRkDw2_vFY2yf_tEo0s;
+        path=/; expires=Wed, 19-Mar-25 17:04:20 GMT; domain=.sandbox.braintree-api.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 922e606dee4ce9f3-MIA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"message":"Variable ''input'' has an invalid value: Field
+        ''zipCode'' has coerced Null value for NonNull type ''UsZipCode!''","locations":[{"line":1,"column":40}]}],"extensions":{"requestId":"32d64678-5cfa-4efa-b47a-8fa09b143f4c"}}'
+  recorded_at: Wed, 19 Mar 2025 16:34:20 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Description

This PR Adds the VCR gem to record and stub the remote tests.

## Why?
We need to be able to run remote tests as part of the integration tests suite so we can:

- Ensure that changes don't have side effects on the requests.
- BeAbilityo make changes/improvements to base classes like CreditCard, Gateway, and Check without side effects.
- To Have more confidence in upgrading Ruby versions and gem dependencies.
- Explore different HTTP clients to implement retry calls
- etc.

## How?
To make the implementation less intrusive, a small module (the VCR module) was introduced. This module hooks into the test life cycle and stores a cassette for each test.

**Note:** This PR adds the VCRmodule for the Braintree token remote tests as an implementation example.

Test Suite
---

**Unit Tests:**
Finished in 31.581706 seconds.
5112 tests, 75300 assertions, 0 failures, 2 errors,
0 pendings, 0 omissions, 0 notifications.
100% passed

**Remote Tests:**
bundle exec ruby -Itest
test/remote/gateways/remote_braintree_token_nonce_test.rb

Finished in 0.343357 seconds.
5 tests, 10 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100 passed

**Rubocop**
737 files inspected, no offenses detected