### PR TITLE
Nuvei: add addtional oct and aft user_details fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -138,6 +138,7 @@
 * Plexo: Add Transaction sync support for Plexo Gateway [javierpedrozaing] #5416
 * CheckoutV2: Add account name inquiry [jcreiff] #5427
 * Adyen: Update shopperInteraction [almalee24] #5430
+* Nuvei: Add addtional oct and aft user detail fields [yunnydang] #5433
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/nuvei.rb
+++ b/lib/active_merchant/billing/gateways/nuvei.rb
@@ -111,6 +111,7 @@ module ActiveMerchant
         add_payment_method(post, payment, payment_key, options)
         add_customer_ip(post, options)
         url_details(post, options)
+        add_user_details(post, options)
         commit(:general_credit, post.compact)
       end
 
@@ -171,6 +172,34 @@ module ActiveMerchant
         post[:billingAddress] ||= {}
         post[:billingAddress].merge!(address_details)
         post[:recipientDetails] = recipient_details unless recipient_details.empty?
+        add_user_details(post, options)
+      end
+
+      def add_user_details(post, options)
+        return unless options[:user_details]&.is_a?(Hash)
+
+        user_details = options[:user_details]
+        post[:userDetails] = {}
+        post[:userDetails][:firstName] = user_details[:first_name] if user_details[:first_name]
+        post[:userDetails][:lastName] = user_details[:last_name] if user_details[:last_name]
+        post[:userDetails][:address] = user_details[:address] if user_details[:address]
+        post[:userDetails][:streetNumber] = user_details[:street_number] if user_details[:street_number]
+        post[:userDetails][:phone] = user_details[:phone] if user_details[:phone]
+        post[:userDetails][:zip] = user_details[:zip] if user_details[:zip]
+        post[:userDetails][:city] = user_details[:city] if user_details[:city]
+        post[:userDetails][:country] = user_details[:country] if user_details[:country]
+        post[:userDetails][:state] = user_details[:state] if user_details[:state]
+        post[:userDetails][:email] = user_details[:email] if user_details[:email]
+        post[:userDetails][:county] = user_details[:county] if user_details[:county]
+        post[:userDetails][:language] = user_details[:language] if user_details[:language]
+        post[:userDetails][:identification] = user_details[:identification] if user_details[:identification]
+
+        # special case depending on AFT or Payout transactions
+        if user_details[:date_of_birth] && options[:is_aft]
+          post[:userDetails][:dateOfBirth] = user_details[:date_of_birth]
+        elsif user_details[:birth_date] && options[:is_payout]
+          post[:userDetails][:birthdate] = user_details[:birth_date]
+        end
       end
 
       def set_reason_type(post, options)

--- a/test/remote/gateways/remote_nuvei_test.rb
+++ b/test/remote/gateways/remote_nuvei_test.rb
@@ -20,6 +20,24 @@ class RemoteNuveiTest < Test::Unit::TestCase
       order_id: '123456'
     }
 
+    @user_details_options = @options.merge({
+      user_details: {
+        first_name: 'first',
+        last_name: 'last',
+        street_number: '1234',
+        address: '123 address',
+        phone: '123456789',
+        zip: '12345',
+        city: 'city',
+        country: 'US',
+        state: 'CA',
+        email: 'test@test.com',
+        county: 'county',
+        language: 'US',
+        identification: '12345667'
+      }
+    })
+
     @three_ds_options = {
       execute_threed: true,
       redirect_url: 'http://www.example.com/redirect',
@@ -275,6 +293,17 @@ class RemoteNuveiTest < Test::Unit::TestCase
     assert_match 'APPROVED', payout_response.message
   end
 
+  def test_successful_payout_with_oct_user_details
+    @user_details_options[:user_details][:birth_date] = '1990-09-01'
+    @user_details_options[:user_details].delete(:language)
+    @user_details_options[:user_details].delete(:county)
+    @user_details_options[:user_details].delete(:street_number)
+    payout_response = @gateway.credit(@amount, @credit_card, @user_details_options.merge(user_token_id: '12345678', is_payout: true))
+    assert_success payout_response
+    assert_match 'SUCCESS', payout_response.params['status']
+    assert_match 'APPROVED', payout_response.message
+  end
+
   def test_successful_payout_with_google_pay
     purchase_response = @gateway.purchase(@amount, @credit_card, @options.merge(user_token_id: '12345678'))
     assert_success purchase_response
@@ -444,6 +473,13 @@ class RemoteNuveiTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options.merge(is_aft: true, aft_recipient_first_name: 'John', aft_recipient_last_name: 'Doe'))
     assert_success response
     assert_equal 'APPROVED', response.message
+  end
+
+  def test_successful_authorize_with_aft_user_details
+    @user_details_options[:user_details][:date_of_birth] = '1990-09-01'
+    response = @gateway.authorize(@amount, @credit_card, @user_details_options.merge(is_aft: true, aft_recipient_first_name: 'John', aft_recipient_last_name: 'Doe'))
+    assert_success response
+    assert_match 'APPROVED', response.message
   end
 
   def test_refund_account_funding_transaction


### PR DESCRIPTION
According to visa mandate we will need to send the DOB on both payout and aft transactions. This change adds and opens up the user_details object to allow for additional optional fields for both endpoints. Payouts and AFT transactions have the same field names, though /Payout does not have the language, county, and streetNumber fields. Nuvei expects 'birthdate' for payout transactions and 'dateOfBirth' for the purchase/auth endpoint.

You will have to follow the convention of also sending 'is_aft' or 'is_payout' as well as the correct corresponding 'user_details' fields.

Note: I know that the add_user_details is well guarded but for some extra measures, I wanted to ensure that if you were to initiate an AFT transaction, but sent the 'birthdate' instead, it will not add it in the if clause. If vice versa with OCT transactions, the same condition will take place. If this is deemed unnecessary I can remove the '...&& options[:is_aft]" and '...&& options[:is_payout]"

Local:
6229 tests, 81428 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
38 tests, 224 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
47 tests, 154 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.8723% passed

[/payment doc](https://docs.nuvei.com/api/main/indexMain_v1_0.html?json#payment)
[/payout doc](https://docs.nuvei.com/api/main/indexMain_v1_0.html?json#payout)
