### PR TITLE
FlexCharge: Include CVV in transactions

### DIFF
--- a/lib/active_merchant/billing/gateways/flex_charge.rb
+++ b/lib/active_merchant/billing/gateways/flex_charge.rb
@@ -109,7 +109,8 @@ module ActiveMerchant # :nodoc:
           gsub(%r(("environment\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
           gsub(%r(("number\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
           gsub(%r(("cardNumber\\?"\s*:\s*\\?")[^"]*)i, '\1[FILTERED]').
-          gsub(%r(("verification_value\\?":\\?")\d+), '\1[FILTERED]')
+          gsub(%r(("verification_value\\?":\\?")\d+), '\1[FILTERED]').
+          gsub(%r(("verificationValue\\?":\\?")\d+), '\1[FILTERED]')
       end
 
       def inquire(authorization, options = {})
@@ -219,6 +220,7 @@ module ActiveMerchant # :nodoc:
                                cardBinNumber: credit_card.number[0..5],
                                cardLast4Digits: credit_card.number[-4..-1],
                                cardNumber: credit_card.number,
+                               verificationValue: credit_card.verification_value,
                                Token: false
                              }
                            else

--- a/test/remote/gateways/remote_flex_charge_test.rb
+++ b/test/remote/gateways/remote_flex_charge_test.rb
@@ -102,6 +102,14 @@ class RemoteFlexChargeTest < Test::Unit::TestCase
     assert_equal '', response.params['access_token']
   end
 
+  def test_successful_purchase_without_cvv
+    set_credentials!
+    @credit_card_cit.verification_value = nil
+    response = @gateway.purchase(@amount, @credit_card_cit, @cit_options)
+    assert_success response
+    assert_equal 'CHALLENGE', response.message
+  end
+
   def test_successful_purchase_cit_challenge_purchase
     set_credentials!
     response = @gateway.purchase(@amount, @credit_card_cit, @cit_options)
@@ -175,6 +183,7 @@ class RemoteFlexChargeTest < Test::Unit::TestCase
 
   def test_failed_cit_declined_purchase
     set_credentials!
+    @credit_card_cit.verification_value = nil
     response = @gateway.purchase(@amount, @credit_card_cit, @cit_options.except(:phone))
     assert_failure response
     assert_equal 'DECLINED', response.error_code

--- a/test/unit/gateways/flex_charge_test.rb
+++ b/test/unit/gateways/flex_charge_test.rb
@@ -160,6 +160,8 @@ class FlexChargeTest < Test::Unit::TestCase
         assert_equal request['payer']['email'], @options[:email]
         assert_equal request['description'], @options[:description]
 
+        assert_equal request['paymentMethod']['verificationValue'], @credit_card.verification_value
+
         assert_equal request['billingInformation']['firstName'], 'Cure'
         assert_equal request['billingInformation']['country'], 'CA'
         assert_equal request['shippingInformation']['firstName'], 'Jhon'


### PR DESCRIPTION
Adding `verificationValue` to `purchase` transaction