### PR TITLE
Change Client-Request-Id from rand number to UUIDv4

### DIFF
--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -342,7 +342,7 @@ module ActiveMerchant # :nodoc:
 
       def headers(request, options)
         time = DateTime.now.strftime('%Q').to_s
-        client_request_id = options[:client_request_id] || rand.to_s[2..8]
+        client_request_id = options[:client_request_id] || SecureRandom.uuid
         raw_signature = @options[:api_key] + client_request_id.to_s + time + request
         hmac = OpenSSL::HMAC.digest('sha256', @options[:api_secret], raw_signature)
         signature = Base64.strict_encode64(hmac.to_s).to_s

--- a/test/remote/gateways/remote_commerce_hub_test.rb
+++ b/test/remote/gateways/remote_commerce_hub_test.rb
@@ -404,4 +404,11 @@ class RemoteCommerceHubTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Approved', response.message
   end
+
+  def test_client_request_id_is_uuidv4
+    client_request_id = SecureRandom.uuid
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(client_request_id:))
+    assert_match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i, response.params['gatewayResponse']['transactionProcessingDetails']['clientRequestId'])
+    assert_match(client_request_id, response.params['gatewayResponse']['transactionProcessingDetails']['clientRequestId'])
+  end
 end

--- a/test/unit/gateways/commerce_hub_test.rb
+++ b/test/unit/gateways/commerce_hub_test.rb
@@ -499,6 +499,17 @@ class CommerceHubTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_client_request_id_is_uuidv4
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, _data, headers|
+      client_request_id = headers['Client-Request-Id']
+      assert_not_nil client_request_id, 'Client-Request-Id header is missing'
+      uuid_v4_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      assert_match uuid_v4_regex, client_request_id, 'Client-Request-Id is not a valid UUIDv4'
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def successful_purchase_response


### PR DESCRIPTION
Spreedly reference: [OPPS-372](https://spreedly.atlassian.net/browse/OPPS-372)

Remote tests
Finished in 70.933066 seconds.
36 tests, 97 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.2222% passed
0.51 tests/s, 1.37 assertions/s

Unit tests
Finished in 50.661584 seconds.
6228 tests, 81395 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
122.93 tests/s, 1606.64 assertions/s

Rubocop
808 files inspected, no offenses detected
