### PR TITLE
Datatrans: Update the authorization for Capture responses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -140,6 +140,7 @@
 * Adyen: Update shopperInteraction [almalee24] #5430
 * Nuvei: Add addtional oct and aft user detail fields [yunnydang] #5433
 * CheckoutV2: Add support for partial authorization [yunnydang] #5441
+* Datatrans: Update the authorization for Capture responses [almalee24] #5437
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/datatrans.rb
+++ b/lib/active_merchant/billing/gateways/datatrans.rb
@@ -253,6 +253,8 @@ module ActiveMerchant # :nodoc:
         token_array = [response.dig('responses', 0, 'alias'), options[:expiry_month], options[:expiry_year]].join('|') if action == 'tokenize'
 
         auth = [response['transactionId'], response['acquirerAuthorizationCode'], token_array].join('|')
+        auth = options[:transaction_id] if action == 'settle'
+
         return auth unless auth == '||'
       end
 

--- a/test/remote/gateways/remote_datatrans_test.rb
+++ b/test/remote/gateways/remote_datatrans_test.rb
@@ -5,7 +5,7 @@ class RemoteDatatransTest < Test::Unit::TestCase
     @gateway = DatatransGateway.new(fixtures(:datatrans))
 
     @amount = 756
-    @credit_card = credit_card('4242424242424242', verification_value: '123', first_name: 'John', last_name: 'Smith', month: 6, year: Time.now.year + 1)
+    @credit_card = credit_card('4242424242424242', verification_value: '123', first_name: 'John', last_name: 'Smith', month: 6, year: Time.now.year)
     @bad_amount = 100000 # anything grather than 500 EUR
     @credit_card_frictionless = credit_card('4000001000000018', verification_value: '123', first_name: 'John', last_name: 'Smith', month: 6, year: 2025)
 
@@ -94,7 +94,7 @@ class RemoteDatatransTest < Test::Unit::TestCase
 
     response = @gateway.capture(@amount, authorize_response.authorization, @options)
     assert_success response
-    assert_equal response.authorization, nil
+    assert_equal response.authorization, authorize_response.authorization.split('|').first
   end
 
   def test_successful_refund
@@ -113,7 +113,7 @@ class RemoteDatatransTest < Test::Unit::TestCase
     capture_response = @gateway.capture(@amount - 100, authorize_response.authorization, @options)
     assert_success capture_response
 
-    response = @gateway.refund(@amount - 200, authorize_response.authorization, @options)
+    response = @gateway.refund(@amount - 200, capture_response.authorization, @options)
     assert_success response
   end
 
@@ -137,7 +137,7 @@ class RemoteDatatransTest < Test::Unit::TestCase
     capture_response = @gateway.capture(100, authorize_response.authorization, @options)
     assert_success capture_response
 
-    response = @gateway.refund(200, authorize_response.authorization, @options)
+    response = @gateway.refund(200, capture_response.authorization, @options)
     assert_failure response
     assert_equal response.error_code, 'INVALID_PROPERTY'
     assert_equal response.message, 'credit.amount'


### PR DESCRIPTION
Populate the authorization in the capture response by the transaction_id used in the request.

Remote
27 tests, 76 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications 100% passed