### PR TITLE
Braintree: Update gem to 4.26.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -148,6 +148,7 @@
 * Decidir and DecicirPlus: Add the discover payment method ID [yunnydang] #5448
 * CyberSource: Add the optional merchant reference code on capture [yunnydang] #5453
 * Orbital: Update authorization string [almalee24] #5458
+* Braintree: Update gem to 4.26.0 [almalee24] #5440
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rubocop', '~> 1.26.0', require: false
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 4.14.0'
+  gem 'braintree', '>= 4.26.0'
   gem 'concurrent-ruby', '1.3.4'
   gem 'jose', '~> 1.2.0'
   gem 'jwe'


### PR DESCRIPTION
Remote
103 tests, 550 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed