### PR TITLE
CheckoutV2: Add partial authorization field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -139,6 +139,7 @@
 * CheckoutV2: Add account name inquiry [jcreiff] #5427
 * Adyen: Update shopperInteraction [almalee24] #5430
 * Nuvei: Add addtional oct and aft user detail fields [yunnydang] #5433
+* CheckoutV2: Add support for partial authorization [yunnydang] #5441
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -155,6 +155,7 @@ module ActiveMerchant # :nodoc:
         add_risk_data(post, options)
         add_level_two_three_data(post, options)
         truncate_amex_reference_id(post, options, payment_method)
+        add_partial_authorization(post, options)
       end
 
       def add_invoice(post, money, options)
@@ -216,6 +217,13 @@ module ActiveMerchant # :nodoc:
         return unless options[:processing].is_a?(Hash)
 
         post[:processing] = options[:processing]
+      end
+
+      def add_partial_authorization(post, options)
+        return unless options[:partial_authorization]
+
+        post[:partial_authorization] = {}
+        post[:partial_authorization][:enabled] = options[:partial_authorization] if options[:partial_authorization]
       end
 
       def add_risk_data(post, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -17,6 +17,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     @amex_card = credit_card('341829238058580', brand: 'american_express', verification_value: '1234', month: '6', year: Time.now.year + 1)
     @threeds_card = credit_card('4485040371536584', verification_value: '100', month: '12', year: Time.now.year + 1)
     @mada_card = credit_card('5043000000000000', brand: 'mada')
+    @partial_auth_card = credit_card('5518207720770101', verification_value: '153', month: '12', year: Time.now.year + 1)
 
     @vts_network_token = network_tokenization_credit_card(
       '4242424242424242',
@@ -816,6 +817,24 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
 
     assert capture = @gateway.capture(nil, auth.authorization)
     assert_success capture
+  end
+
+  def test_successful_authorize_with_partial_authorization
+    options = {
+      order_id: '1',
+      billing_address: address,
+      shipping_address: address,
+      description: 'Purchase',
+      email: 'longbob.longsen@example.com',
+      processing_channel_id: 'pc_aaco6s3z7jbepo7dzdpmdcnfcy',
+      partial_authorization: true
+    }
+    response = @gateway_oauth.authorize(10000, @partial_auth_card, options)
+
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal '10010', response.params['response_code']
+    assert_equal 'Partial Value Approved', response.params['response_summary']
   end
 
   def test_successful_authorize_and_capture_with_3ds

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -641,6 +641,22 @@ class CheckoutV2Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_successful_purchase_with_partial_authorization
+    stub_comms(@gateway, :ssl_request) do
+      options = {
+        phone_country_code: '1',
+        billing_address: address,
+        processing_channel_id: 'pc_aaco6s3z7jbepo7dzdpmdcnfcy',
+        partial_authorization: true
+      }
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      request = JSON.parse(data)
+      assert_equal request['partial_authorization']['enabled'], true
+      assert_equal request['processing_channel_id'], 'pc_aaco6s3z7jbepo7dzdpmdcnfcy'
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_no_customer_name_included_in_token_purchase
     stub_comms(@gateway, :ssl_request) do
       options = {


### PR DESCRIPTION
Adds the optional partial_authorization field

Local:
6228 tests, 81395 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
75 tests, 510 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
119 tests, 198 assertions, 68 failures, 4 errors, 0 pendings, 0 omissions, 0 notifications
39.4958% passed

Note: A lot of remote tests are failing and that’s kind of the expected and known behavior prior to approval of account fix. I was able to successfully get write a passing remote test for my change after using a UK processing ID to get the expected related response back for partial authorization.