### PR TITLE
CyberSource: Void Acepts nil values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -141,6 +141,7 @@
 * Nuvei: Add addtional oct and aft user detail fields [yunnydang] #5433
 * CheckoutV2: Add support for partial authorization [yunnydang] #5441
 * Datatrans: Update the authorization for Capture responses [almalee24] #5437
+* CyberSource: Void Acepts nil values [gasb150] #5442
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -489,8 +489,11 @@ module ActiveMerchant # :nodoc:
       end
 
       def build_void_request(identification, options)
-        order_id, request_id, request_token, action, money, currency = identification.split(';')
+        order_id, request_id, request_token, action, money, currency = identification&.split(';')
         options[:order_id] = order_id
+
+        money ||= options[:amount]
+        currency ||= options[:currency]
 
         xml = Builder::XmlMarkup.new indent: 2
         case action
@@ -1038,7 +1041,7 @@ module ActiveMerchant # :nodoc:
 
       def add_auth_reversal_service(xml, request_id, request_token)
         xml.tag! 'ccAuthReversalService', { 'run' => 'true' } do
-          xml.tag! 'authRequestID', request_id
+          xml.tag! 'authRequestID', request_id unless request_id.nil?
           xml.tag! 'authRequestToken', request_token
         end
       end
@@ -1075,6 +1078,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_merchant_category_code(xml, options)
+        xml.tag! 'merchantTransactionIdentifier', options[:merchant_transaction_id] if options[:merchant_transaction_id]
         xml.tag! 'merchantCategoryCode', options[:merchant_category_code] if options[:merchant_category_code]
       end
 

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -412,6 +412,15 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_successful_response(void)
   end
 
+  def test_void_with_no_authorization_value
+    merchant_transaction_id = 'testTransaction131' + SecureRandom.hex(3)
+
+    @gateway.authorize(@amount, @credit_card, @options.merge(merchant_transaction_id:))
+
+    assert void = @gateway.void(nil, @options.merge({ merchant_transaction_id:, amount: @amount }))
+    assert_successful_response(void)
+  end
+
   def test_purchase_and_void_with_merchant_category_code
     assert purchase = @gateway.purchase(@amount, @credit_card, @options)
     assert_successful_response(purchase)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -952,7 +952,19 @@ class CyberSourceTest < Test::Unit::TestCase
       @gateway.void(authorization, @options)
     end.check_request do |_endpoint, data, _headers|
       assert_match(%r(<ccAuthReversalService run=\"true\"), data)
+      assert_match(%r(<authRequestID>), data)
     end.respond_with(successful_auth_reversal_response)
+  end
+
+  def test_successful_void_authorize_request_without_reference
+    previous_authorization = ''
+
+    stub_comms do
+      @gateway.void(previous_authorization, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(ccAuthReversalService run=\"true\"), data)
+      assert_no_match(%r(<authRequestID>), data)
+    end.respond_with(successful_void_response)
   end
 
   def test_successful_void_with_issuer_additional_data


### PR DESCRIPTION
 Summary
-------------------------
Improve void request to handle cases where we
don't receive an authorization, (timeOuts cases)

[SER-1636](https://spreedly.atlassian.net/browse/SER-1636)

Unit Tests
----------------
Finished in 3.532173 seconds.
167 tests, 981 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests
----------------
Finished in 127.168569 seconds.
143 tests, 730 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 97.9021% passed

Rubocop
----------------
808 files inspected, no offenses detected