### PR TITLE
Payeezy: Update authorization when extra space

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -150,6 +150,7 @@
 * Orbital: Update authorization string [almalee24] #5458
 * Braintree: Update gem to 4.26.0 [almalee24] #5440
 * CheckoutV2: Update Authorization from Basic to Bearer [sinourain] #5381
+* Payeezy: Update authorization when extra space [almalee24] #5446
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/payeezy.rb
+++ b/lib/active_merchant/billing/gateways/payeezy.rb
@@ -366,7 +366,7 @@ module ActiveMerchant
       def commit(params, options)
         url = base_url(options) + endpoint(params)
 
-        if transaction_id = params.delete(:transaction_id)
+        if transaction_id = params.delete(:transaction_id)&.delete(' ')
           url = "#{url}/#{transaction_id}"
         end
 
@@ -498,7 +498,7 @@ module ActiveMerchant
           end
         else
           [
-            response['transaction_id'],
+            response['transaction_id']&.delete(' '),
             response['transaction_tag'],
             params[:method],
             response['amount']&.to_i


### PR DESCRIPTION
If transaction_id in response has a extra space then use delete will be used to remove the spaces. This will prevent issues such as URI::InvalidURIError.