### PR TITLE
Include additional scrub on store call

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -144,6 +144,7 @@
 * CyberSource: Void Acepts nil values [gasb150] #5442
 * Ebanx: Handle special characters in email [ankurspreedly] #5444
 * Orbital: Add support for more currencies [ankurspreedly] #5438
+* Datatrans: Include additional scrub on store call [naashton] #5447
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/datatrans.rb
+++ b/lib/active_merchant/billing/gateways/datatrans.rb
@@ -102,7 +102,8 @@ module ActiveMerchant # :nodoc:
         transcript.
           gsub(%r((Authorization: Basic )[\w =]+), '\1[FILTERED]').
           gsub(%r((\"number\\":\\")\d+), '\1[FILTERED]\2').
-          gsub(%r((\"cvv\\":\\")\d+), '\1[FILTERED]\2')
+          gsub(%r((\"cvv\\":\\")\d+), '\1[FILTERED]\2').
+          gsub(%r((\"pan\\":\\")\d+), '\1[FILTERED]\2')
       end
 
       private

--- a/test/remote/gateways/remote_datatrans_test.rb
+++ b/test/remote/gateways/remote_datatrans_test.rb
@@ -258,6 +258,16 @@ class RemoteDatatransTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.verification_value, transcript)
   end
 
+  def test_transcript_scrubbing_store
+    transcript = capture_transcript(@gateway) do
+      @gateway.store(@credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+  end
+
   def test_successful_purchase_with_billing_address
     response = @gateway.purchase(@amount, @credit_card, @options.merge({ billing_address: @billing_address }))
 


### PR DESCRIPTION
This adds an additional scrub for `pan` when the transaction is a `store`