### PR TITLE
Decidir/Decidir Plus: Add the discover payment method ID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -145,6 +145,7 @@
 * Ebanx: Handle special characters in email [ankurspreedly] #5444
 * Orbital: Add support for more currencies [ankurspreedly] #5438
 * Datatrans: Include additional scrub on store call [naashton] #5447
+* Decidir and DecicirPlus: Add the discover payment method ID [yunnydang] #5448
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/decidir.rb
+++ b/lib/active_merchant/billing/gateways/decidir.rb
@@ -7,7 +7,7 @@ module ActiveMerchant # :nodoc:
       self.supported_countries = ['AR']
       self.money_format = :cents
       self.default_currency = 'ARS'
-      self.supported_cardtypes = %i[visa master american_express diners_club naranja cabal tuya patagonia_365 tarjeta_sol]
+      self.supported_cardtypes = %i[visa master american_express diners_club naranja cabal tuya patagonia_365 tarjeta_sol discover]
 
       self.homepage_url = 'http://www.decidir.com'
       self.display_name = 'Decidir'
@@ -149,7 +149,8 @@ module ActiveMerchant # :nodoc:
           'diners_club' => 8,
           'naranja' => 24,
           'patagonia_365' => 55,
-          'tarjeta_sol' => 64
+          'tarjeta_sol' => 64,
+          'discover' => 139
         }
 
         payment_method_ids.fetch(card_brand, 1)

--- a/lib/active_merchant/billing/gateways/decidir_plus.rb
+++ b/lib/active_merchant/billing/gateways/decidir_plus.rb
@@ -6,7 +6,7 @@ module ActiveMerchant # :nodoc:
 
       self.supported_countries = ['AR']
       self.default_currency = 'ARS'
-      self.supported_cardtypes = %i[visa master american_express discover diners_club naranja cabal patagonia_365 tarjeta_sol]
+      self.supported_cardtypes = %i[visa master american_express discover diners_club naranja cabal patagonia_365 tarjeta_sol discover]
 
       self.homepage_url = 'http://decidir.com.ar/home'
       self.display_name = 'Decidir Plus'
@@ -196,7 +196,8 @@ module ActiveMerchant # :nodoc:
           'american_express_prisma' => 111,
           'diners_club' => 8,
           'patagonia_365' => 55,
-          'tarjeta_sol' => 64
+          'tarjeta_sol' => 64,
+          'discover' => 139
         }
 
         payment_method_ids.fetch(card_brand, debit ? 31 : 1)

--- a/test/unit/gateways/decidir_plus_test.rb
+++ b/test/unit/gateways/decidir_plus_test.rb
@@ -40,7 +40,7 @@ class DecidirPlusTest < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal DecidirPlusGateway.supported_cardtypes, %i[visa master american_express discover diners_club naranja cabal patagonia_365 tarjeta_sol]
+    assert_equal DecidirPlusGateway.supported_cardtypes, %i[visa master american_express discover diners_club naranja cabal patagonia_365 tarjeta_sol discover]
   end
 
   def test_successful_purchase
@@ -61,6 +61,19 @@ class DecidirPlusTest < Test::Unit::TestCase
     end.check_request do |_action, _endpoint, data, _headers|
       data = JSON.parse(data)
       assert_equal(64, data['payment_method_id'])
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
+  def test_successful_purchase_with_discover
+    options = @options.merge(card_brand: 'discover')
+
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @payment_reference, options)
+    end.check_request do |_action, _endpoint, data, _headers|
+      data = JSON.parse(data)
+      assert_equal(139, data['payment_method_id'])
     end.respond_with(successful_purchase_response)
 
     assert_success response

--- a/test/unit/gateways/decidir_test.rb
+++ b/test/unit/gateways/decidir_test.rb
@@ -50,7 +50,7 @@ class DecidirTest < Test::Unit::TestCase
   end
 
   def test_supported_card_types
-    assert_equal DecidirGateway.supported_cardtypes, %i[visa master american_express diners_club naranja cabal tuya patagonia_365 tarjeta_sol]
+    assert_equal DecidirGateway.supported_cardtypes, %i[visa master american_express diners_club naranja cabal tuya patagonia_365 tarjeta_sol discover]
   end
 
   def test_successful_purchase
@@ -100,6 +100,21 @@ class DecidirTest < Test::Unit::TestCase
       @gateway_for_purchase.purchase(@amount, tarjeta_sol_card, @options)
     end.check_request do |_method, _endpoint, data, _headers|
       assert_match(/"payment_method_id":64/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert_equal 7719132, response.authorization
+    assert_equal 'approved', response.message
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_discover
+    discover_card = credit_card('6011000993026909')
+
+    response = stub_comms(@gateway_for_purchase, :ssl_request) do
+      @gateway_for_purchase.purchase(@amount, discover_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"payment_method_id":139/, data)
     end.respond_with(successful_purchase_response)
 
     assert_success response


### PR DESCRIPTION
This adds the discover PM ID to decidir and decidir plus. @naashton I tagged you on here with a hopefully simple question. I noticed you had done a similar thing for patagonia_365 in this [PR](https://github.com/activemerchant/active_merchant/pull/5324) and said your remote test was not passing until the other PR was merged (which i think it was). However the remote test you wrote still failed for me, did you ever get it to work? I tried writing one for my changes and it gives me the same failure/error as yours, thanks!

Local:
6241 tests, 81487 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Decidir Unit:
48 tests, 237 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Decidir Remote:
29 tests, 99 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.1034% passed

Decidir Plus Unit:
22 tests, 92 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Decidir Plus Remote:
28 tests, 91 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92.8571% passed