### PR TITLE
Checkout: Bug fix for AFT date_of_birth

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -245,11 +245,13 @@ module ActiveMerchant # :nodoc:
 
         sender = options[:sender]
 
+        birthdate = sender[:dob] || sender[:date_of_birth]
+
         post[:sender] = {}
         post[:sender][:type] = sender[:type] if sender[:type]
         post[:sender][:first_name] = sender[:first_name] if sender[:first_name]
         post[:sender][:last_name] = sender[:last_name] if sender[:last_name]
-        post[:sender][:dob] = sender[:dob] if sender[:dob]
+        post[:sender][:date_of_birth] = birthdate if birthdate
         post[:sender][:reference] = sender[:reference] if sender[:reference]
         post[:sender][:company_name] = sender[:company_name] if sender[:company_name]
 

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -649,7 +649,7 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     options = @options.merge(
       sender: {
         type: 'individual',
-        dob: '1985-05-15',
+        date_of_birth: '1985-05-15',
         first_name: 'Jane',
         last_name: 'Doe',
         address: {

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -445,7 +445,7 @@ class CheckoutV2Test < Test::Unit::TestCase
       @gateway.purchase(@amount, @credit_card, {
         sender: {
           type: 'individual',
-          dob: '1985-05-15',
+          date_of_birth: '1985-05-15',
           first_name: 'Jane',
           last_name: 'Doe',
           address: {
@@ -469,7 +469,7 @@ class CheckoutV2Test < Test::Unit::TestCase
       assert_equal request['first_name'], 'Jane'
       assert_equal request['last_name'], 'Doe'
       assert_equal request['type'], 'individual'
-      assert_equal request['dob'], '1985-05-15'
+      assert_equal request['date_of_birth'], '1985-05-15'
       assert_equal request['reference'], '8285282045818'
       assert_equal request['address']['address_line1'], '123 High St.'
       assert_equal request['address']['address_line2'], 'Flat 456'


### PR DESCRIPTION
Update field in sender object for AFT transactions to date_of_birth. This is what is now stated in their docs.

Unit Tests
75 tests, 510 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests
Hot Mess Express
Credentials issues, working to fix. The remote test I updated passes.