### PR TITLE
CyberSource: Add the optional merchant reference number for capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -146,6 +146,7 @@
 * Orbital: Add support for more currencies [ankurspreedly] #5438
 * Datatrans: Include additional scrub on store call [naashton] #5447
 * Decidir and DecicirPlus: Add the discover payment method ID [yunnydang] #5448
+* CyberSource: Add the optional merchant reference code on capture [yunnydang] #5453
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -427,7 +427,7 @@ module ActiveMerchant # :nodoc:
 
       def build_capture_request(money, authorization, options)
         order_id, request_id, request_token = authorization.split(';')
-        options[:order_id] = order_id
+        options[:order_id] = options[:merchant_reference_code] || order_id
 
         xml = Builder::XmlMarkup.new indent: 2
         add_purchase_data(xml, money, true, options)

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -753,6 +753,27 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert !response.authorization.blank?
   end
 
+  def test_successful_capture_with_merchant_reference_code_override
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+
+    assert response = @gateway.capture(@amount, auth.authorization, @capture_options.merge(merchant_reference_code: '1234566778'))
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+    assert_equal '1234566778', response.params['merchantReferenceCode']
+  end
+
+  def test_successful_capture_without_merchant_reference_code_override
+    assert auth = @gateway.authorize(@amount, @credit_card, @options)
+    assert_successful_response(auth)
+    order_id = auth.authorization.split(';').first
+
+    assert response = @gateway.capture(@amount, auth.authorization, @capture_options)
+    assert_successful_response(response)
+    assert !response.authorization.blank?
+    assert_equal order_id, response.params['merchantReferenceCode']
+  end
+
   def test_successful_capture_with_merchant_category_code
     assert auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_successful_response(auth)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -756,6 +756,22 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
   end
 
+  def test_successful_capture_with_merchant_reference_code_override
+    stub_comms do
+      @gateway.capture(100, '1846925324700976124593', @options.merge!(merchant_reference_code: '1234566778'))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<merchantReferenceCode>1234566778<\/merchantReferenceCode>/, data)
+    end.respond_with(successful_capture_response)
+  end
+
+  def test_successful_capture_without_merchant_reference_code_override
+    stub_comms do
+      @gateway.capture(100, '1846925324700976124593', @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<merchantReferenceCode>1846925324700976124593<\/merchantReferenceCode>/, data)
+    end.respond_with(successful_capture_response)
+  end
+
   def test_successful_credit_card_purchase_request
     @gateway.stubs(:ssl_post).returns(successful_capture_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
Adds the optional merchant reference number override on the capture endpoint.

Note: Im having issues running the remote tests for this since the introduction of line number 9 in the remote spec file:

    @gateway_certificate = CyberSourceGateway.new({ nexus: 'NC' }.merge(fixtures(:cyber_source_certificate)))

Though hen i comment it out my remote spec will pass. I checked that the fixture is properly in place but still run into an argument error.