### PR TITLE
Opps 198 normalize api versions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -149,6 +149,7 @@
 * CyberSource: Add the optional merchant reference code on capture [yunnydang] #5453
 * Orbital: Update authorization string [almalee24] #5458
 * Braintree: Update gem to 4.26.0 [almalee24] #5440
+* Normalize the use of API_VERSION for some gateways (iVeri, JetypayV2 and Kushki) #5454
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/iveri.rb
+++ b/lib/active_merchant/billing/gateways/iveri.rb
@@ -4,6 +4,8 @@ module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class IveriGateway < Gateway
       class_attribute :iveri_url
+      # Define the API version using the Versionable module
+      version '2.0'
 
       self.live_url = self.test_url = 'https://portal.nedsecure.co.za/iVeriWebService/Service.asmx'
       self.iveri_url = 'https://portal.host.iveri.com/iVeriWebService/Service.asmx'
@@ -97,7 +99,7 @@ module ActiveMerchant # :nodoc:
               xml.Execute 'xmlns' => 'http://iveri.com/' do
                 xml.validateRequest('false')
                 xml.protocol 'V_XML'
-                xml.protocolVersion '2.0'
+                xml.protocolVersion fetch_version # Fetch the version dynamically
                 xml.request vxml
               end
             end
@@ -109,7 +111,7 @@ module ActiveMerchant # :nodoc:
 
       def build_vxml_request(action, options)
         builder = Nokogiri::XML::Builder.new do |xml|
-          xml.V_XML('Version' => '2.0', 'CertificateID' => @options[:cert_id], 'Direction' => 'Request') do
+          xml.V_XML('Version' => fetch_version, 'CertificateID' => @options[:cert_id], 'Direction' => 'Request') do
             xml.Transaction('ApplicationID' => @options[:app_id], 'Command' => action, 'Mode' => mode) do
               yield(xml)
             end

--- a/lib/active_merchant/billing/gateways/jetpay_v2.rb
+++ b/lib/active_merchant/billing/gateways/jetpay_v2.rb
@@ -12,7 +12,8 @@ module ActiveMerchant # :nodoc:
       self.homepage_url = 'http://www.jetpay.com'
       self.display_name = 'JetPay'
 
-      API_VERSION = '2.2'
+      # Define the API version using the Versionable module
+      version '2.2'
 
       ACTION_CODE_MESSAGES = {
         '000' =>  'Approved.',
@@ -203,7 +204,7 @@ module ActiveMerchant # :nodoc:
 
       def build_xml_request(transaction_type, options = {}, transaction_id = nil, &block)
         xml = Builder::XmlMarkup.new
-        xml.tag! 'JetPay', 'Version' => API_VERSION do
+        xml.tag! 'JetPay', 'Version' => fetch_version do # Use normalized version
           # Basic values needed for any request
           xml.tag! 'TerminalID', @options[:login]
           xml.tag! 'TransactionType', transaction_type

--- a/lib/active_merchant/billing/gateways/kushki.rb
+++ b/lib/active_merchant/billing/gateways/kushki.rb
@@ -12,6 +12,9 @@ module ActiveMerchant # :nodoc:
       self.money_format = :dollars
       self.supported_cardtypes = %i[visa master american_express discover diners_club alia]
 
+      # Define the API version using the Versionable module
+      version 'v1'
+
       def initialize(options = {})
         requires!(options, :public_merchant_id, :private_merchant_id)
         super
@@ -317,9 +320,9 @@ module ActiveMerchant # :nodoc:
         base_url = test? ? test_url : live_url
 
         if %w[void refund].include?(action)
-          base_url + 'v1/' + ENDPOINT[action] + '/' + params[:ticketNumber].to_s
+          base_url + "#{fetch_version}/" + ENDPOINT[action] + '/' + params[:ticketNumber].to_s
         else
-          base_url + 'card/v1/' + ENDPOINT[action]
+          base_url + "card/#{fetch_version}/" + ENDPOINT[action]
         end
       end
 

--- a/test/unit/gateways/kushki_test.rb
+++ b/test/unit/gateways/kushki_test.rb
@@ -9,6 +9,22 @@ class KushkiTest < Test::Unit::TestCase
     @credit_card = credit_card
   end
 
+  def test_successful_purchase_with_version_endpoint_header
+    # Set up expected version
+    expected_version = 'v1'
+
+    # Simulate versioning using the Versionable module
+    @gateway.class.version(expected_version)
+
+    # Stub communication to intercept and validate the request
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, {})
+    end.check_request do |endpoint, _data, _headers|
+      # Check that the endpoint includes the correct version
+      assert_match %r{/#{expected_version}/}, endpoint, 'Endpoint should include the correct version'
+    end.respond_with(successful_charge_response)
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_charge_response)
     @gateway.expects(:ssl_post).returns(successful_token_response)


### PR DESCRIPTION
Summary:
Normalize the use of API_VERSION for some gateways (iVeri, JetypayV2 and Kushki)

Remote Tests: 

Jetpay_v2
20 tests, 93 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

iveri (Don’t have credential )
22 tests, 31 assertions, 19 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
9.09091% passed

Kushki (Don’t have credential )
25 tests, 0 assertions, 0 failures, 25 errors, 0 pendings, 0 omissions, 0 notifications
Unit Tests:
6246 tests, 81490 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop:
808 files inspected, no offenses detected

