### PR TITLE
Credorax: support zero dollar verify

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -152,6 +152,7 @@
 * CheckoutV2: Update Authorization from Basic to Bearer [sinourain] #5381
 * Payeezy: Update authorization when extra space [almalee24] #5446
 * Worldpay: Update inquire success_criteria [almalee24] #5445
+* Credorax: Support zero dollar verify [yunnydang] #5457
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -289,6 +289,17 @@ class CredoraxTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_verify_with_0_auth
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options.merge(zero_dollar_auth: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/a9=5/, data)
+      assert_match(/a4=0/, data)
+    end.respond_with(successful_authorize_response)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_failed_verify
     response = stub_comms do
       @gateway.verify(@credit_card)


### PR DESCRIPTION
This supports the optional zero dollar verify for the credorax gateway. Per documentation when doing a zero $0 verify, we should be sending the a9 field set to the value 5, while skipping the subsequent void request. This change will also require the additional optional field of zero_dollar_auth to trigger said verify request. Also updated the remote test file to fix a handful of the failing tests

Local:
6244 tests, 81498 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
85 tests, 422 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
56 tests, 197 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
89.2857% passed

The 6 failing remote tests are 3ds related and the error message is "Format error". Not sure whats causing it.