### PR TITLE
Credorax: Add optional crypto currency type field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -153,6 +153,7 @@
 * Payeezy: Update authorization when extra space [almalee24] #5446
 * Worldpay: Update inquire success_criteria [almalee24] #5445
 * Credorax: Support zero dollar verify [yunnydang] #5457
+* Credorax: Add optional crypto currency type field [yunnydang] #5460
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -150,6 +150,7 @@ module ActiveMerchant # :nodoc:
         add_submerchant_id(post, options)
         add_stored_credential(post, options)
         add_processor(post, options)
+        add_crypto_currency_type(post, options)
 
         if options[:aft]
           add_recipient(post, options)
@@ -173,6 +174,7 @@ module ActiveMerchant # :nodoc:
         add_account_name_inquiry(post, options)
         add_processor(post, options)
         add_authorization_details(post, options)
+        add_crypto_currency_type(post, options)
 
         if options[:aft]
           add_recipient(post, options)
@@ -190,6 +192,8 @@ module ActiveMerchant # :nodoc:
         add_echo(post, options)
         add_submerchant_id(post, options)
         add_processor(post, options)
+        add_crypto_currency_type(post, options)
+        add_transaction_type(post, options)
 
         commit(:capture, post)
       end
@@ -202,6 +206,8 @@ module ActiveMerchant # :nodoc:
         add_submerchant_id(post, options)
         post[:a1] = generate_unique_id
         add_processor(post, options)
+        add_crypto_currency_type(post, options)
+        add_transaction_type(post, options)
 
         commit(:void, post, reference_action)
       end
@@ -216,6 +222,8 @@ module ActiveMerchant # :nodoc:
         add_processor(post, options)
         add_email(post, options)
         add_recipient(post, options)
+        add_crypto_currency_type(post, options)
+        add_transaction_type(post, options)
 
         if options[:referral_cft]
           add_customer_name(post, options)
@@ -236,6 +244,7 @@ module ActiveMerchant # :nodoc:
         add_transaction_type(post, options)
         add_processor(post, options)
         add_customer_name(post, options)
+        add_crypto_currency_type(post, options)
 
         commit(:credit, post)
       end
@@ -492,6 +501,10 @@ module ActiveMerchant # :nodoc:
       def add_authorization_details(post, options)
         post[:a10] = options[:authorization_type] if options[:authorization_type]
         post[:a11] = options[:multiple_capture_count] if options[:multiple_capture_count]
+      end
+
+      def add_crypto_currency_type(post, options)
+        post[:crypto_currency_type] = options[:crypto_currency_type] if options[:crypto_currency_type]
       end
 
       ACTIONS = {

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -349,6 +349,15 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_authorize_with_crypto_currency_type
+    options_with_auth_details = @options.merge({ crypto_currency_type: '7', transaction_type: '6' })
+    response = @gateway.authorize(@amount, @credit_card, options_with_auth_details)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal '6', response.params['A9']
+    assert response.authorization
+  end
+
   def test_successful_zero_authorize_with_name_inquiry_match
     extra_options = @options.merge({ account_name_inquiry: true, first_name: 'Art', last_name: 'Vandelay' })
     response = @gateway.authorize(0, @inquiry_match_card, extra_options)

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -631,6 +631,16 @@ class CredoraxTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_purchase_adds_crypto_currency_type
+    options_with_crypto_details = @options.merge({ crypto_currency_type: '7', transaction_type: '6' })
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options_with_crypto_details)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/crypto_currency_type=7/, data)
+      assert_match(/a9=6/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_adds_moto_a2_field
     @options[:metadata] = { manual_entry: true }
     stub_comms do


### PR DESCRIPTION
Adds the optional cryto_currency_field. 

The remote tests are failing as usual but a different PR (once merged) will address this.

Local:
6244 tests, 81497 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
85 tests, 421 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed