### PR TITLE
OPPS-414 - Mapped ecommerce_indicator value

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -154,7 +154,7 @@
 * Worldpay: Update inquire success_criteria [almalee24] #5445
 * Credorax: Support zero dollar verify [yunnydang] #5457
 * Credorax: Add optional crypto currency type field [yunnydang] #5460
-* Map ecommerce_indicator value from additionalData3DS to CommerceHub eciIndicator [mjdonga] #5461
+* CommerceHub: Map ecommerce_indicator value based on three_d_secure.eci [mjdonga] #5461
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -154,6 +154,7 @@
 * Worldpay: Update inquire success_criteria [almalee24] #5445
 * Credorax: Support zero dollar verify [yunnydang] #5457
 * Credorax: Add optional crypto currency type field [yunnydang] #5460
+* Map ecommerce_indicator value from additionalData3DS to CommerceHub eciIndicator [mjdonga] #5461
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -141,7 +141,7 @@ module ActiveMerchant # :nodoc:
       def add_transaction_interaction(post, options)
         post[:transactionInteraction] = {}
         post[:transactionInteraction][:origin] = options[:origin] || 'ECOM'
-        post[:transactionInteraction][:eciIndicator] = options[:eci_indicator] || 'CHANNEL_ENCRYPTED'
+        post[:transactionInteraction][:eciIndicator] = map_ecommerce_indicator(options)
         post[:transactionInteraction][:posConditionCode] = options[:pos_condition_code] || 'CARD_NOT_PRESENT_ECOM'
         post[:transactionInteraction][:posEntryMode] = (options[:pos_entry_mode] || 'MANUAL') unless options[:encryption_data].present?
         post[:transactionInteraction][:additionalPosInformation] = {}
@@ -429,6 +429,20 @@ module ActiveMerchant # :nodoc:
 
       def error_code_from(response, action)
         response.dig('error', 0, 'code') unless success_from(response, action)
+      end
+
+      def map_ecommerce_indicator(options)
+        return options[:eci_indicator] if options[:eci_indicator]
+        return 'CHANNEL_ENCRYPTED'     unless options[:three_d_secure]
+
+        case options[:three_d_secure][:eci]
+        when '2', '02', '5', '05'
+          'SECURE_ECOM'
+        when '01', '1', '06', '6'
+          'NON_AUTH_ECOM'
+        else
+          'CHANNEL_ENCRYPTED'
+        end
       end
     end
   end

--- a/test/unit/gateways/commerce_hub_test.rb
+++ b/test/unit/gateways/commerce_hub_test.rb
@@ -310,12 +310,17 @@ class CommerceHubTest < Test::Unit::TestCase
     options[:data_entry_source] = 'MOBILE_WEB'
     options[:pos_entry_mode] = 'MANUAL'
     options[:pos_condition_code] = 'CARD_PRESENT'
+    options[:three_d_secure] = {
+      cavv: '12345678901234567890',
+      xid: '12345678901234567890',
+      eci: '05'
+    }
     response = stub_comms do
       @gateway.purchase(@amount, 'authorization123', options)
     end.check_request do |_endpoint, data, _headers|
       request = JSON.parse(data)
       assert_equal request['transactionInteraction']['origin'], 'ECOM'
-      assert_equal request['transactionInteraction']['eciIndicator'], 'CHANNEL_ENCRYPTED'
+      assert_equal request['transactionInteraction']['eciIndicator'], 'SECURE_ECOM'
       assert_equal request['transactionInteraction']['posConditionCode'], 'CARD_PRESENT'
       assert_equal request['transactionInteraction']['posEntryMode'], 'MANUAL'
       assert_equal request['transactionInteraction']['additionalPosInformation']['dataEntrySource'], 'MOBILE_WEB'
@@ -328,6 +333,11 @@ class CommerceHubTest < Test::Unit::TestCase
     options[:origin] = 'POS'
     options[:pos_entry_mode] = 'MANUAL'
     options[:data_entry_source] = 'MOBILE_WEB'
+    options[:three_d_secure] = {
+      cavv: '12345678901234567890',
+      xid: '12345678901234567890',
+      eci: '07'
+    }
     response = stub_comms do
       @gateway.purchase(@amount, 'authorization123', options)
     end.check_request do |_endpoint, data, _headers|


### PR DESCRIPTION
### Summary
Map ecommerce_indicator value from additionalData3DS to CommerceHub eciIndicator

[OPPS-414](https://spreedly.atlassian.net/browse/OPPS-414)

### Unit Tests
30 tests, 209 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

### Remote Tests
37 tests, 100 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
91.8919% passed

### Rubocop
809 files inspected, no offenses detected
