### PR TITLE
Cardstream: Accept custom API URL

### DIFF
--- a/lib/active_merchant/billing/gateways/card_stream.rb
+++ b/lib/active_merchant/billing/gateways/card_stream.rb
@@ -334,7 +334,8 @@ module ActiveMerchant # :nodoc:
         # adds a signature to the post hash/array
         add_hmac(parameters)
 
-        response = parse(ssl_post(self.live_url, post_data(action, parameters)))
+        api_url = @options[:custom_api_url] || self.live_url
+        response = parse(ssl_post(api_url, post_data(action, parameters)))
 
         Response.new(
           response[:responseCode] == '0',

--- a/test/unit/gateways/card_stream_test.rb
+++ b/test/unit/gateways/card_stream_test.rb
@@ -363,6 +363,21 @@ class CardStreamTest < Test::Unit::TestCase
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end
 
+  def test_custom_api_url_usage
+    custom_url = 'https://custom.gateway.url/direct/'
+    @gateway = CardStreamGateway.new(
+      login: 'login',
+      shared_secret: 'secret',
+      custom_api_url: custom_url
+    )
+
+    stub_comms do
+      @gateway.purchase(142, @visacreditcard, @visacredit_options)
+    end.check_request do |endpoint, _data, _headers|
+      assert_equal custom_url, endpoint
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def successful_authorization_response


### PR DESCRIPTION
Cardstream: Accept custom API URL

Description
-------------------------
[OPPS-305](https://spreedly.atlassian.net/browse/OPPS-305)

Allow customers to pass customer API URL to use in their transactions

Unit test
-------------------------
Finished in 0.013669 seconds.
31 tests, 159 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
2267.91 tests/s, 11632.16 assertions/s

Rubocop
-------------------------
809 files inspected, no offenses detected