### PR TITLE
StripePI: add the optional kana_and_kanji_descriptor_suffix fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -155,6 +155,7 @@
 * Credorax: Support zero dollar verify [yunnydang] #5457
 * Credorax: Add optional crypto currency type field [yunnydang] #5460
 * CommerceHub: Map ecommerce_indicator value based on three_d_secure.eci [mjdonga] #5461
+* StripePI: Add the optional kana and kanji descriptor suffix fields [yunnydang] #5466
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -57,6 +57,7 @@ module ActiveMerchant # :nodoc:
             add_aft_recipient_details(post, options)
             add_aft_sender_details(post, options)
             add_request_extended_authorization(post, options)
+            add_statement_descriptor_suffix_kanji_kana(post, options)
             post[:expand] = ['charges.data.balance_transaction']
 
             CREATE_INTENT_ATTRIBUTES.each do |attribute|
@@ -155,6 +156,7 @@ module ActiveMerchant # :nodoc:
         add_shipping_address(post, options)
         add_connected_account(post, options)
         add_fulfillment_date(post, options)
+        add_statement_descriptor_suffix_kanji_kana(post, options)
 
         UPDATE_INTENT_ATTRIBUTES.each do |attribute|
           add_whitelisted_attribute(post, options, attribute)
@@ -390,6 +392,15 @@ module ActiveMerchant # :nodoc:
         post[:payment_method_options] ||= {}
         post[:payment_method_options][:card] ||= {}
         post[:payment_method_options][:card][:request_extended_authorization] = options[:request_extended_authorization] if options[:request_extended_authorization]
+      end
+
+      def add_statement_descriptor_suffix_kanji_kana(post, options)
+        return unless options[:statement_descriptor_suffix_kanji] || options[:statement_descriptor_suffix_kana]
+
+        post[:payment_method_options] ||= {}
+        post[:payment_method_options][:card] ||= {}
+        post[:payment_method_options][:card][:statement_descriptor_suffix_kanji] = options[:statement_descriptor_suffix_kanji] if options[:statement_descriptor_suffix_kanji]
+        post[:payment_method_options][:card][:statement_descriptor_suffix_kana] = options[:statement_descriptor_suffix_kana] if options[:statement_descriptor_suffix_kana]
       end
 
       def add_level_three(post, options = {})


### PR DESCRIPTION
Adds optional fields to enable compliant card statement descriptors for merchants operating in Japan.[ Stripe PI documentation](https://docs.stripe.com/get-started/account/statement-descriptors#set-japanese-statement-descriptors)

Local:
6244 tests, 81499 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
72 tests, 399 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
104 tests, 465 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.1154% passed