### PR TITLE
Credorax: Add Sender Birth Date for AFT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -156,6 +156,7 @@
 * Credorax: Add optional crypto currency type field [yunnydang] #5460
 * CommerceHub: Map ecommerce_indicator value based on three_d_secure.eci [mjdonga] #5461
 * StripePI: Add the optional kana and kanji descriptor suffix fields [yunnydang] #5466
+* Credorax: Add sender birth date for AFT [adarsh-spreedly] #5469
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/credorax.rb
+++ b/lib/active_merchant/billing/gateways/credorax.rb
@@ -366,7 +366,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_sender(post, options)
-        return unless options[:sender_ref_number] || options[:sender_fund_source] || options[:sender_country_code] || options[:sender_street_address] || options[:sender_city] || options[:sender_state] || options[:sender_first_name] || options[:sender_last_name]
+        return unless options[:sender_ref_number] || options[:sender_fund_source] || options[:sender_country_code] || options[:sender_street_address] || options[:sender_city] || options[:sender_state] || options[:sender_first_name] || options[:sender_last_name] || options[:sender_birth_date]
 
         sender_country_code = options[:sender_country_code]&.length == 3 ? options[:sender_country_code] : Country.find(options[:sender_country_code]).code(:alpha3).value if options[:sender_country_code]
         post[:s15] = sender_country_code
@@ -377,6 +377,7 @@ module ActiveMerchant # :nodoc:
         post[:s12] = options[:sender_street_address] if options[:sender_street_address]
         post[:s13] = options[:sender_city] if options[:sender_city]
         post[:s14] = options[:sender_state] if options[:sender_state]
+        post[:s19] = options[:sender_birth_date] if options[:sender_birth_date]
       end
 
       def add_recipient(post, options)

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -6,7 +6,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
 
     @amount = 100
     @adviser_amount = 1000001
-    @credit_card = credit_card('4012001038443335', verification_value: '512', month: '12')
+    @credit_card = credit_card('4018810000100036', verification_value: '123', month: '12', year: 2034)
     @fully_auth_card = credit_card('5223450000000007', brand: 'mastercard', verification_value: '090', month: '12')
     @declined_card = credit_card('4176661000001111', verification_value: '681', month: '12')
     @three_ds_card = credit_card('5455330200000016', verification_value: '737', month: '10', year: Time.now.year + 2)
@@ -726,6 +726,33 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert_success response
     assert_equal 'Succeeded', response.message
     assert_equal 'Echo Parameter', response.params['D2']
+  end
+
+  def test_successful_aft_purchase_with_sender_birth_date
+    aft_options = @options.merge(
+      aft: true,
+      sender_ref_number: 'test',
+      sender_fund_source: '01',
+      sender_country_code: 'USA',
+      sender_street_address: 'sender street',
+      sender_city: 'city',
+      sender_state: 'NY',
+      sender_first_name: 'george',
+      sender_last_name: 'smith',
+      sender_birth_date: '12121212',
+      recipient_street_address: 'street',
+      recipient_postal_code: '12345',
+      recipient_city: 'chicago',
+      recipient_province_code: '312',
+      recipient_country_code: 'USA',
+      recipient_first_name: 'logan',
+      recipient_last_name: 'bill'
+    )
+
+    response = @gateway.purchase(@amount, @credit_card, aft_options)
+    assert_success response
+    assert_equal '1', response.params['H9']
+    assert_equal 'Succeeded', response.message
   end
 
   # #########################################################################

--- a/test/unit/gateways/credorax_test.rb
+++ b/test/unit/gateways/credorax_test.rb
@@ -1169,6 +1169,51 @@ class CredoraxTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_purchase_adds_aft_fields_along_with_sender_birth_date
+    aft_options = @options.merge(
+      aft: true,
+      sender_ref_number: 'test',
+      sender_fund_source: '01',
+      sender_country_code: 'USA',
+      sender_street_address: 'sender street',
+      sender_city: 'city',
+      sender_state: 'NY',
+      sender_first_name: 'george',
+      sender_last_name: 'smith',
+      sender_birth_date: '12121212',
+      recipient_street_address: 'street',
+      recipient_city: 'chicago',
+      recipient_province_code: '312',
+      recipient_postal_code: '12345',
+      recipient_country_code: 'USA',
+      recipient_first_name: 'logan',
+      recipient_last_name: 'bill'
+    )
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, aft_options)
+    end.check_request do |_endpoint, data, _headers|
+      # recipient fields
+      assert_match(/j5=logan/, data)
+      assert_match(/j6=street/, data)
+      assert_match(/j7=chicago/, data)
+      assert_match(/j8=312/, data)
+      assert_match(/j9=USA/, data)
+      assert_match(/j13=bill/, data)
+      assert_match(/j12=12345/, data)
+      # sender fields
+      assert_match(/s10=george/, data)
+      assert_match(/s11=smith/, data)
+      assert_match(/s12=sender\+street/, data)
+      assert_match(/s13=city/, data)
+      assert_match(/s14=NY/, data)
+      assert_match(/s15=USA/, data)
+      assert_match(/s17=test/, data)
+      assert_match(/s18=01/, data)
+      assert_match(/s19=12121212/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def stored_credential_options(*args, id: nil)


### PR DESCRIPTION
Credorax: Add Sender Birth Date for AFT

Remote:
56 tests, 192 assertions, 9 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 
83.9286% passed

Unit
87 tests, 445 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed