### PR TITLE
CheckoutV2: Send payment type as Regular instead of unscheduled if initiator is cardholder

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -163,6 +163,7 @@
 * Normalize API versions for Payeezy, Paymentez, and Paymill [mjdonga] #5451
 * Pin Payments: Add support for Apple and Google payment method types [naashton] #5462
 * Pin Payments: Scrub sensitive data from transcript [naashton] #5473
+* CheckoutV2: Send payment type as Regular instead of unscheduled if initiator is cardholder [adarsh-spreedly] #5471
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -415,6 +415,7 @@ module ActiveMerchant # :nodoc:
         return unless options[:stored_credential]
 
         post[:payment_type] = options[:stored_credential][:reason_type]&.capitalize
+        post[:payment_type] = 'Regular' if options[:stored_credential][:initiator] == 'cardholder' && post[:payment_type] == 'Unscheduled'
 
         if options[:merchant_initiated_transaction_id]
           merchant_initiated_override(post, options)

--- a/test/remote/gateways/remote_checkout_v2_test.rb
+++ b/test/remote/gateways/remote_checkout_v2_test.rb
@@ -1276,4 +1276,16 @@ class RemoteCheckoutV2Test < Test::Unit::TestCase
     response = @gateway.purchase(1500, @credit_card, options)
     assert_success response
   end
+
+  def test_successful_purchase_with_stored_credentials_payment_type_as_unscheduled_and_initiator_as_cardholder
+    stored_options = @options.merge(
+      stored_credential: {
+        initiator: 'cardholder',
+        reason_type: 'unscheduled'
+      }
+    )
+    response = @gateway.purchase(@amount, @credit_card, stored_options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
 end

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -1328,6 +1328,34 @@ class CheckoutV2Test < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_payment_type_is_regular_when_reason_type_is_unscheduled_and_initiator_is_cardholder
+    stub_comms(@gateway, :ssl_request) do
+      initial_options = {
+        stored_credential: {
+          initiator: 'cardholder',
+          reason_type: 'unscheduled'
+        }
+      }
+      @gateway.purchase(@amount, @credit_card, initial_options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(%r{"payment_type":"Regular"}, data)
+    end.respond_with(successful_purchase_initial_stored_credential_response)
+  end
+
+  def test_payment_type_is_not_changed_when_reason_type_is_unscheduled_and_initiator_is_merchant
+    stub_comms(@gateway, :ssl_request) do
+      initial_options = {
+        stored_credential: {
+          initiator: 'merchant',
+          reason_type: 'unscheduled'
+        }
+      }
+      @gateway.purchase(@amount, @credit_card, initial_options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(%r{"payment_type":"Unscheduled"}, data)
+    end.respond_with(successful_purchase_initial_stored_credential_response)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
CheckoutV2: Send payment type as Regular instead of unscheduled if initiator is cardholder

Remote:
120 tests, 293 assertions, 9 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications

Unit:
77 tests, 517 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed