### PR TITLE
CommerceHub: Pass order_id for Verify

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -164,6 +164,7 @@
 * Pin Payments: Add support for Apple and Google payment method types [naashton] #5462
 * Pin Payments: Scrub sensitive data from transcript [naashton] #5473
 * CheckoutV2: Send payment type as Regular instead of unscheduled if initiator is cardholder [adarsh-spreedly] #5471
+* CommerceHub: Pass order_id for Verify [almalee24] #5475
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -101,6 +101,7 @@ module ActiveMerchant # :nodoc:
         post = {}
         add_payment(post, credit_card, options)
         add_billing_address(post, credit_card, options)
+        add_transaction_details(post, options, 'verify')
 
         commit('verify', post, options)
       end
@@ -155,7 +156,7 @@ module ActiveMerchant # :nodoc:
           physicalGoodsIndicator: [true, 'true'].include?(options[:physical_goods_indicator])
         }
 
-        if action == 'sale'
+        if %w(sale verify).include?(action)
           details[:merchantOrderId] = options[:order_id]
           details[:merchantTransactionId] = rand.to_s[2..13]
         end

--- a/test/unit/gateways/commerce_hub_test.rb
+++ b/test/unit/gateways/commerce_hub_test.rb
@@ -390,12 +390,16 @@ class CommerceHubTest < Test::Unit::TestCase
   end
 
   def test_successful_verify
+    @options[:order_id] = 'abc123'
+
     stub_comms do
       @gateway.verify(@credit_card, @options)
     end.check_request do |endpoint, data, _headers|
       request = JSON.parse(data)
       assert_match %r{verification}, endpoint
       assert_equal request['source']['sourceType'], 'PaymentCard'
+      assert_equal request['transactionDetails']['merchantOrderId'], @options[:order_id]
+      assert_equal request['transactionDetails']['merchantInvoiceNumber'], @options[:order_id]
     end.respond_with(successful_authorize_response)
   end
 


### PR DESCRIPTION
This updates now populates merchantOrderId & merchantInvoiceNumber with order_id for Verify.

Remote
37 tests, 100 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 91.8919% passed