### PR TITLE
Orbital: Pass override_exp_date if provided

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -165,6 +165,7 @@
 * Pin Payments: Scrub sensitive data from transcript [naashton] #5473
 * CheckoutV2: Send payment type as Regular instead of unscheduled if initiator is cardholder [adarsh-spreedly] #5471
 * CommerceHub: Pass order_id for Verify [almalee24] #5475
+* Orbital: Pass override_exp_date if provided [almalee24] #5476
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -587,7 +587,7 @@ module ActiveMerchant # :nodoc:
 
       def add_credit_card(xml, credit_card, options)
         xml.tag! :AccountNum, credit_card.number if credit_card.is_a?(CreditCard)
-        xml.tag! :Exp, expiry_date(credit_card) if credit_card.is_a?(CreditCard)
+        xml.tag! :Exp, options[:override_exp_date] || expiry_date(credit_card) if credit_card.is_a?(CreditCard)
         add_currency_fields(xml, options[:currency])
         add_verification_value(xml, credit_card) if credit_card.is_a?(CreditCard)
       end

--- a/test/remote/gateways/remote_orbital_test.rb
+++ b/test/remote/gateways/remote_orbital_test.rb
@@ -137,6 +137,12 @@ class RemoteOrbitalGatewayTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
+  def test_successful_purchase_with_override
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(override_exp_date: '0429'))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
   def test_successful_purchase_with_soft_descriptor_hash
     options = @options.merge(
       soft_descriptors: {


### PR DESCRIPTION
If override_exp_data is in options pass it for Exp instead of the CreditCard expiration date.

Remote:
139 tests, 557 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 1 notifications 99.2806% passed