### PR TITLE
Map order_id to Nuvei clientUniqueId field on refund/credit transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -170,6 +170,7 @@
 * StripePI: validate capture reference [jherrera] #5479
 * Cenpos: Add purchase_order_number field [yunnydang] #5481
 * Rapyd: Fix error on billing address [jherrera] #5472
+* Nuvei: Map order_id to clientUniqueId field on refund/credit [jherrera] #5477
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/nuvei.rb
+++ b/lib/active_merchant/billing/gateways/nuvei.rb
@@ -74,7 +74,7 @@ module ActiveMerchant
       def refund(money, authorization, options = {})
         post = { relatedTransactionId: authorization }
 
-        build_post_data(post)
+        build_post_data(post, options)
         add_amount(post, money, options)
 
         commit(:refund, post)
@@ -102,7 +102,7 @@ module ActiveMerchant
       def credit(money, payment, options = {})
         post = { userTokenId: options[:user_token_id] }
         payment_key = payment.is_a?(NetworkTokenizationCreditCard) ? :userPaymentOption : :cardData
-        build_post_data(post)
+        build_post_data(post, options)
         add_amount(post, money, options)
         options[:is_payout] ? send_payout_transaction(payment_key, post, payment, options) : send_unreferenced_refund_transaction(post, payment, options)
       end

--- a/test/remote/gateways/remote_nuvei_test.rb
+++ b/test/remote/gateways/remote_nuvei_test.rb
@@ -245,6 +245,17 @@ class RemoteNuveiTest < Test::Unit::TestCase
     assert_match 'APPROVED', refund_response.message
   end
 
+  def test_successful_refund_with_order_id
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    refund_response = @gateway.refund(@amount, response.authorization, options = { order_id: response.params['clientUniqueId'] })
+    assert_success refund_response
+    assert_equal response.params['clientUniqueId'], options[:order_id]
+    assert_match 'SUCCESS', refund_response.params['status']
+    assert_match 'APPROVED', refund_response.message
+  end
+
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response


### PR DESCRIPTION
[OPPS-440](https://spreedly.atlassian.net/browse/OPPS-440)

## Summary:

Map order_id to Nuvei clientUniqueId field on refund/credit transactions

Unit Tests:
---
Finished in 2.793984 seconds.
38 tests, 225 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
13.60 tests/s, 80.53 assertions/s

Remote Tests:
---
Finished in 170.526509 seconds.
48 tests, 159 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 
97.9167% passed
0.28 tests/s, 0.93 assertions/s