### PR TITLE
StripePI: validate capture reference

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -213,16 +213,22 @@ module ActiveMerchant # :nodoc:
       end
 
       def capture(money, intent_id, options = {})
-        post = {}
-        currency = options[:currency] || currency(money)
-        post[:amount_to_capture] = localized_amount(money, currency)
-        if options[:transfer_amount]
-          post[:transfer_data] = {}
-          post[:transfer_data][:amount] = options[:transfer_amount]
+        if intent_id.include?('pi_')
+          post = {}
+          currency = options[:currency] || currency(money)
+          post[:amount_to_capture] = localized_amount(money, currency)
+          if options[:transfer_amount]
+            post[:transfer_data] = {}
+            post[:transfer_data][:amount] = options[:transfer_amount]
+          end
+          post[:application_fee_amount] = options[:application_fee] if options[:application_fee]
+          options = format_idempotency_key(options, 'capture')
+          commit(:post, "payment_intents/#{intent_id}/capture", post, options)
+        else
+          error_message = "No associated charge for #{intent_id}"
+          error_message << '; payment_intent reference is not valid for capture'
+          return Response.new(false, error_message)
         end
-        post[:application_fee_amount] = options[:application_fee] if options[:application_fee]
-        options = format_idempotency_key(options, 'capture')
-        commit(:post, "payment_intents/#{intent_id}/capture", post, options)
       end
 
       def void(intent_id, options = {})

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -1311,6 +1311,21 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert_equal 'Payment complete.', capture_response.params.dig('charges', 'data')[0].dig('outcome', 'seller_message')
   end
 
+  def test_manual_capture_with_invalid_intent
+    options = {
+      currency: 'GBP',
+      customer: @customer,
+      confirmation_method: 'manual',
+      capture_method: 'manual',
+      confirm: true
+    }
+
+    intent_id = 'seti_3RRZi6AWOtgoysog1kgqnyV7'
+    assert capture_response = @gateway.capture(@amount, intent_id, options)
+    assert_failure capture_response
+    assert_match 'payment_intent reference is not valid for capture', capture_response.message
+  end
+
   def test_create_a_payment_intent_and_manually_capture_with_network_token
     options = {
       currency: 'GBP',


### PR DESCRIPTION
[OPPS-254](https://spreedly.atlassian.net/browse/OPPS-254)

## Summary:

Validate that the reference used for Captures starts with ‘pi_‘

Unit Tests:
---
Finished in 0.076833 seconds.
74 tests, 409 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
963.13 tests/s, 5323.23 assertions/s

Remote Tests:
---
Finished in 831.599938 seconds.
110 tests, 508 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
99.0909% passed
0.13 tests/s, 0.61 assertions/s
