### PR TITLE
CyberSource: Remove XID and CAVV

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -940,49 +940,42 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_auth_network_tokenization(xml, payment_method, options)
-        brand = card_brand(payment_method)
+        brand = card_brand(payment_method)&.to_sym
         return if payment_method.mobile_wallet? && brand == 'discover' && !options[:enable_cybs_discover_apple_pay]
 
         if payment_method.network_token?
           xml.tag!('networkTokenCryptogram', payment_method.payment_cryptogram)
           xml.tag!('commerceIndicator', stored_credential_commerce_indicator(options) || 'internet')
-        elsif send_only_commerce_indicator(payment_method, options)
-          commerce_indicator = if brand == 'discover'
+        elsif send_only_commerce_indicator(brand, payment_method, options)
+          commerce_indicator = if brand == :discover
                                  'dipb'
                                elsif subsequent_wallet_auth(payment_method, options)
                                  'internet'
                                else
-                                 ECI_BRAND_MAPPING[brand.to_sym]
+                                 ECI_BRAND_MAPPING[brand]
                                end
 
           xml.commerceIndicator(commerce_indicator)
         else
-          default_wallet_values(xml, payment_method)
+          default_wallet_values(xml, brand, payment_method)
         end
       end
 
-      def send_only_commerce_indicator(payment_method, options)
-        brand = card_brand(payment_method)
+      def send_only_commerce_indicator(brand, payment_method, options)
+        return false if brand == :american_express
 
-        return false if brand == 'american_express'
-
-        brand == 'master' || subsequent_wallet_auth(payment_method, options)
+        brand == :master || subsequent_wallet_auth(payment_method, options)
       end
 
-      def default_wallet_values(xml, payment_method)
-        brand = card_brand(payment_method).to_sym
+      def default_wallet_values(xml, brand, payment_method)
         commerce_indicator = brand == :discover ? 'dipb' : ECI_BRAND_MAPPING[brand]
-        cryptogram = brand == :american_express ? Base64.decode64(payment_method.payment_cryptogram) : payment_method.payment_cryptogram
-        cavv = xid = cryptogram
 
-        if brand == :american_express
-          cavv = Base64.encode64(cavv[0...20])
-          xid = xid.bytes.count > 20 ? Base64.encode64(xid[20...40]) : nil
-        end
+        network_token_cryptogram = brand == :american_express ? Base64.decode64(payment_method.payment_cryptogram) : payment_method.payment_cryptogram
 
-        xml.tag! 'cavv', cavv
+        network_token_cryptogram = Base64.encode64(network_token_cryptogram[0...20]) if brand == :american_express
+
+        xml.tag! 'networkTokenCryptogram', network_token_cryptogram
         xml.tag! 'commerceIndicator', commerce_indicator
-        xml.tag! 'xid', xid if xid
       end
 
       def add_mastercard_network_tokenization_ucaf_data(xml, payment_method, options)

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -568,10 +568,10 @@ class CyberSourceTest < Test::Unit::TestCase
 
   def test_successful_apple_pay_purchase_subsequent_auth_discover
     @gateway.expects(:ssl_post).with do |_host, request_body|
-      assert_match %r'<cavv>', request_body
+      assert_match %r'<networkTokenCryptogram>', request_body
       assert_match %r'<commerceIndicator>dipb</commerceIndicator>', request_body
       true
-    end.returns(successful_purchase_response)
+    end.returns(successful_apple_pay_purchase_response)
 
     options = @options.merge(enable_cybs_discover_apple_pay: true)
 
@@ -2036,9 +2036,7 @@ class CyberSourceTest < Test::Unit::TestCase
     end.check_request(skip_response: true) do |_endpoint, body, _headers|
       assert_xml_valid_to_xsd(body)
       first_half = Base64.encode64(Base64.decode64(long_cryptogram)[0...20])
-      second_half = Base64.encode64(Base64.decode64(long_cryptogram)[20...40])
-      assert_match %r{<cavv>#{first_half}</cavv>}, body
-      assert_match %r{<xid>#{second_half}</xid>}, body
+      assert_match %r{<networkTokenCryptogram>#{first_half}</networkTokenCryptogram>}, body
     end
   end
 
@@ -2049,7 +2047,7 @@ class CyberSourceTest < Test::Unit::TestCase
       @gateway.authorize(@amount, credit_card, @options)
     end.check_request(skip_response: true) do |_endpoint, body, _headers|
       assert_xml_valid_to_xsd(body)
-      assert_match %r{<cavv>#{credit_card.payment_cryptogram}\n</cavv>}, body
+      assert_match %r{<networkTokenCryptogram>#{credit_card.payment_cryptogram}\n</networkTokenCryptogram>}, body
       assert_not_match %r{<xid>}, body
     end
   end
@@ -2355,6 +2353,14 @@ class CyberSourceTest < Test::Unit::TestCase
     read 1572 bytes
     Conn close
     POST_SCRUBBED
+  end
+
+  def successful_apple_pay_purchase_response
+    <<~XML
+      <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+      <soap:Header>
+      <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><wsu:Timestamp wsu:Id="TS-0d8c7fab-dab5-4618-8d0f-2e422f1cb7d8"><wsu:Created>2025-05-22T20:22:35.397Z</wsu:Created></wsu:Timestamp></wsse:Security></soap:Header><soap:Body><c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.201"><c:merchantReferenceCode>da65765883e484aeb97ac49f591ebe64</c:merchantReferenceCode><c:requestID>7479453550786771804606</c:requestID><c:decision>ACCEPT</c:decision><c:reasonCode>100</c:reasonCode><c:requestToken>Axj//wSTlXZE8JjnneG+ABsOxcs2zhmxT35bQOnsBT35bQOnvSA+RQWhk0ky3SA7ek8MCcnKuyJ4THPO8N8AMUi0</c:requestToken><c:purchaseTotals><c:currency>USD</c:currency></c:purchaseTotals><c:ccAuthReply><c:reasonCode>100</c:reasonCode><c:amount>1.00</c:amount><c:authorizationCode>831000</c:authorizationCode><c:avsCode>Y</c:avsCode><c:avsCodeRaw>Y</c:avsCodeRaw><c:authorizedDateTime>2025-05-22T20:22:35Z</c:authorizedDateTime><c:processorResponse>00</c:processorResponse><c:reconciliationID>IOAW7AXL92Z9</c:reconciliationID><c:authRecord>0110322000000E1000020000000000000001000522202235007223494F41573741584C39325A393833313030303030000159004400223134573031363135303730333830323039344730363400103232415050524F56414C0006564943524320</c:authRecord><c:paymentNetworkTransactionID>016150703802094</c:paymentNetworkTransactionID></c:ccAuthReply><c:ccCaptureReply><c:reasonCode>100</c:reasonCode><c:requestDateTime>2025-05-22T20:22:35Z</c:requestDateTime><c:amount>1.00</c:amount><c:reconciliationID>1936831</c:reconciliationID></c:ccCaptureReply><c:card><c:cardType>001</c:cardType></c:card><c:acquirerMerchantNumber>000123456789012</c:acquirerMerchantNumber><c:pos><c:terminalID>01234567</c:terminalID></c:pos></c:replyMessage></soap:Body></soap:Envelope>
+    XML
   end
 
   def successful_authorization_certificate_response


### PR DESCRIPTION
Gateway: CyberSource

Spreedly reference: [OPPS-381](https://spreedly.atlassian.net/browse/OPPS-381)

Changes:
- Remove XID and CAVVand replace with networkTokenCryptogram field for all AP & GP to prevent any further errors.

Unit Tests:
Finished in 33.027328 seconds.
6286 tests, 81699 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
190.33 tests/s, 2473.68 assertions/s

Remote Tests:
Finished in 137.92934 seconds.
152 tests, 791 assertions, 3 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.0263% passed

RuboCop:
812 files inspected, no offenses detected