### PR TITLE
Cenpos: Add purchase_order_number field

### DIFF
--- a/lib/active_merchant/billing/gateways/cenpos.rb
+++ b/lib/active_merchant/billing/gateways/cenpos.rb
@@ -99,6 +99,7 @@ module ActiveMerchant # :nodoc:
         post[:CurrencyCode] = options[:currency] || currency(money)
         post[:InvoiceDetail] = options[:invoice_detail] if options[:invoice_detail]
         post[:CustomerCode] = options[:customer_code] if options[:customer_code]
+        post[:PurchaseOrderNumber] = options[:purchase_order_number] if options[:purchase_order_number]
         add_order_id(post, options)
         add_tax(post, options)
       end

--- a/test/remote/gateways/remote_cenpos_test.rb
+++ b/test/remote/gateways/remote_cenpos_test.rb
@@ -54,6 +54,12 @@ class RemoteCenposTest < Test::Unit::TestCase
     assert_equal 'Succeeded', response.message
   end
 
+  def test_successful_purchase_with_purchase_order_number
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(purchase_order_number: 'abcde12345'))
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
   def test_successful_purchase_with_customer_code
     response = @gateway.purchase(@amount, @credit_card, @options.merge(customer_code: '3214'))
     assert_success response

--- a/test/unit/gateways/cenpos_test.rb
+++ b/test/unit/gateways/cenpos_test.rb
@@ -25,6 +25,19 @@ class CenposTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_purchase_order_number
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, { purchase_order_number: 'abcede12345' })
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<acr1:PurchaseOrderNumber>abcede12345<\/acr1:PurchaseOrderNumber>/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal '1609995363|4242|1.00', response.authorization
+    assert response.test?
+  end
+
   def test_successful_purchase_cvv_result
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)


### PR DESCRIPTION
Adds the optional purchase_order_number field for level 3 data

The remote tests requires new fixtures, so many of the general test are failing including the one I wrote.

Local:

Unit:
24 tests, 104 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed