### PR TITLE
LoanPaymentPro: Adding ACH support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -198,6 +198,7 @@
 * Stripe and Stripe PI: Add header fields to response body [yunnydang] #5185
 * Nuvei: Add support for Stored Credentials [javierpedrozaing] #5186
 * Addition of shopper ip address when a network token transaction occurs [rubenmarindev] #5262
+* LoanPaymentPro: Add new gateway adapter for the Loanpaymentpro gateway [heavyblade] #5470
 
 == Version 1.136.0 (June 3, 2024)
 * Shift4V2: Add new gateway based on SecurionPay adapter [heavyblade] #4860

--- a/lib/active_merchant/billing/gateways/loan_payment_pro.rb
+++ b/lib/active_merchant/billing/gateways/loan_payment_pro.rb
@@ -59,6 +59,8 @@ module ActiveMerchant # :nodoc:
       end
 
       def purchase(money, payment, options = {})
+        return delegate_to_ach(:purchase, money, payment, options) if use_ach_gateway?(payment)
+
         post = {}
 
         add_invoice(post, money, options)
@@ -69,6 +71,8 @@ module ActiveMerchant # :nodoc:
       end
 
       def authorize(money, payment, options = {})
+        return delegate_to_ach(:authorize, money, payment, options) if use_ach_gateway?(payment)
+
         options[:action] = :authorize
         purchase(money, payment, options)
       end
@@ -78,6 +82,8 @@ module ActiveMerchant # :nodoc:
       end
 
       def refund(money, authorization, options = {})
+        return delegate_to_ach(:refund, money, authorization, options) if use_ach_gateway?(authorization)
+
         transaction_id, invoice_id = authorization.split('|')
         post = { Amount: amount(money), InvoiceId: invoice_id }
 
@@ -85,6 +91,8 @@ module ActiveMerchant # :nodoc:
       end
 
       def void(authorization, options = {})
+        return delegate_to_ach(:void, authorization, options) if use_ach_gateway?(authorization)
+
         commit(path(:void, authorization), {})
       end
 
@@ -241,6 +249,18 @@ module ActiveMerchant # :nodoc:
 
       def error_code_from(response)
         RESPONSE_CODE_MAPPING[response[:ResponseCode].to_i] unless success_from(response)
+      end
+
+      def ach_gateway
+        @ach_gateway ||= LoanPaymentProAchGateway.new(@options)
+      end
+
+      def use_ach_gateway?(payment_or_auth)
+        payment_or_auth.is_a?(Check) || (payment_or_auth.is_a?(String) && payment_or_auth.include?('|ach'))
+      end
+
+      def delegate_to_ach(method, *args)
+        ach_gateway.public_send(method, *args)
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/loan_payment_pro_ach.rb
+++ b/lib/active_merchant/billing/gateways/loan_payment_pro_ach.rb
@@ -1,0 +1,94 @@
+module ActiveMerchant # :nodoc:
+  module Billing # :nodoc:
+    class LoanPaymentProAchGateway < LoanPaymentProGateway
+      self.live_url = 'https://www.checkcommerce.com/EpnPublic/ACH.aspx'
+      self.test_url = 'https://sandbox.checkcommerce.com/EpnPublic/ACH.aspx'
+
+      API_VERSION = '1.4.2.35'.freeze
+
+      def initialize(options = {})
+        requires!(options, :login, :password)
+        super
+      end
+
+      def purchase(money, bank_account, options = {})
+        post = {
+          Method: options.delete(:method) || :Debit,
+          ReferenceNumber: options[:order_id] || SecureRandom.uuid,
+          Name: bank_account.name,
+          Amount: amount(money),
+          RoutingNumber: bank_account.routing_number,
+          AccountNumber: bank_account.account_number
+        }
+
+        commit(post)
+      end
+
+      def authorize(money, bank_account, options = {})
+        purchase(money, bank_account, options.merge(method: :Authorize))
+      end
+
+      def void(authorization, options = {})
+        post = {
+          Method: :Cancel,
+          TransactionId: authorization.to_s.split('|').first
+        }
+        commit(post)
+      end
+
+      def refund(money, authorization, options = {})
+        post = {
+          Method: :Refund,
+          TransactionId: authorization.to_s.split('|').first,
+          Amount: amount(money)
+        }
+        commit(post)
+      end
+
+      private
+
+      def add_credentials_and_version(post)
+        post.merge!({
+          Login: @options[:login],
+          Password: @options[:password],
+          Version: API_VERSION,
+          Test: test? ? 'True' : 'False'
+        })
+      end
+
+      def url
+        test? ? test_url : live_url
+      end
+
+      def commit(post = {}, method = :post, options = {})
+        add_credentials_and_version(post)
+        response = parse(ssl_request(method, url, post_data(post), {}))
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def parse(response_body)
+        URI.decode_www_form(response_body.gsub(/\r\n/, '&')).to_h.with_indifferent_access
+      end
+
+      def success_from(response)
+        response[:Success].to_s.downcase == 'true'
+      end
+
+      def message_from(response)
+        response[:Message]
+      end
+
+      def authorization_from(response = {})
+        "#{response[:TransactionID]}|ach"
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -581,6 +581,8 @@ litle:
 
 loan_payment_pro:
   transaction_key: SOMECREDENTIAL
+  login: demo
+  password: demo
 
 # Working test credentials, no need to replace
 maxipago:


### PR DESCRIPTION
## Summary:
This PR introduces functionality that allows LLP gateway users to make payments with bank accounts. For this purpose, a new Gateway class was introduced to act as a complementary gateway so that LLP can provide this functionality.

## Tests

### Remote Test:
18 tests, 44 assertions, 0 failures, 0 errors, 0 pendings,
1 omissions, 0 notifications
100% passed

### Unit Tests:
6288 tests, 81708 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100% passed

### RuboCop:
813 files inspected, no offenses detected