### PR TITLE
Update clean_emoji_emoticons_and_accent method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -171,6 +171,7 @@
 * Cenpos: Add purchase_order_number field [yunnydang] #5481
 * Rapyd: Fix error on billing address [jherrera] #5472
 * Nuvei: Map order_id to clientUniqueId field on refund/credit [jherrera] #5477
+* Update clean_emoji_emoticons_and_accent method [almalee24] #5485
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -316,14 +316,14 @@ module ActiveMerchant # :nodoc:
         [first_name, last_name]
       end
 
-      def clean_emoji_emoticons_and_accent(str = '')
+      def format_name(str = '')
         return nil unless str.respond_to?(:force_encoding)
 
         str = str.force_encoding('utf-8').encode
         emoji_regex = /[\u{1f600}-\u{1f64f}\u{2702}-\u{27b0}\u{1f680}-\u{1f6ff}\u{24C2}-\u{1F251}\u{1f300}-\u{1f5ff}]/
         emoticon_regex = /[:;=8xX]-?[)(DPpO3]/
         str = str.gsub(emoji_regex, '').gsub(emoticon_regex, '').strip
-        I18n.transliterate(str)
+        I18n.transliterate(str).gsub(/[^\w\s]/, '')
       end
 
       def split_address(full_address)

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -86,7 +86,7 @@ module ActiveMerchant # :nodoc:
         post[:expiration_month] = payment.month
         post[:expiration_year] = payment.year
         post[:cardholder] = {
-          name: clean_emoji_emoticons_and_accent(payment.name),
+          name: format_name(payment.name),
           identification: {
             type: options[:cardholder_identification_type],
             number: options[:cardholder_identification_number]
@@ -151,8 +151,8 @@ module ActiveMerchant # :nodoc:
       def add_customer_data(post, payment, options)
         post[:payer] = {
           email: options[:email],
-          first_name: clean_emoji_emoticons_and_accent(payment.first_name),
-          last_name: clean_emoji_emoticons_and_accent(payment.last_name)
+          first_name: format_name(payment.first_name),
+          last_name: format_name(payment.last_name)
         }.merge(options[:payer] || {})
       end
 

--- a/lib/active_merchant/billing/gateways/orbital.rb
+++ b/lib/active_merchant/billing/gateways/orbital.rb
@@ -542,7 +542,7 @@ module ActiveMerchant # :nodoc:
           elsif options[:billing_address] && options[:billing_address][:name].present?
             options[:billing_address][:name]
           end
-        name ? clean_emoji_emoticons_and_accent(name)[0..29] : nil
+        name ? format_name(name)[0..29] : nil
       end
 
       def avs_supported?(address)
@@ -582,7 +582,7 @@ module ActiveMerchant # :nodoc:
         add_bank_account_type(xml, check)
         xml.tag! :ECPAuthMethod, options[:auth_method] if options[:auth_method]
         xml.tag! :BankPmtDelv, options[:payment_delivery] || 'B'
-        xml.tag! :AVSname, (check&.name ? clean_emoji_emoticons_and_accent(check.name)[0..29] : nil) if get_address(options).blank?
+        xml.tag! :AVSname, (check&.name ? format_name(check.name)[0..29] : nil) if get_address(options).blank?
       end
 
       def add_credit_card(xml, credit_card, options)

--- a/test/unit/gateways/gateway_test.rb
+++ b/test/unit/gateways/gateway_test.rb
@@ -169,19 +169,19 @@ class GatewayTest < Test::Unit::TestCase
     assert_false post.key?(:do_not_add)
   end
 
-  def test_clean_emoji_emoticons_and_accent
+  def test_format_name
     input = 'Hello😊 World! :D'
-    expected_output = 'Hello World!'
-    assert_equal expected_output, @gateway.send(:clean_emoji_emoticons_and_accent, input)
+    expected_output = 'Hello World'
+    assert_equal expected_output, @gateway.send(:format_name, input)
 
     input_with_accent = 'Café 😊'
     expected_output_with_accent = 'Cafe'
-    assert_equal expected_output_with_accent, @gateway.send(:clean_emoji_emoticons_and_accent, input_with_accent)
+    assert_equal expected_output_with_accent, @gateway.send(:format_name, input_with_accent)
   end
 
-  def test_clean_emoji_emoticons_and_accent_with_nil_input
+  def test_format_name_with_nil_input
     input = nil
     expected_output = nil
-    assert_equal expected_output, @gateway.send(:clean_emoji_emoticons_and_accent, input)
+    assert_equal expected_output, @gateway.send(:format_name, input)
   end
 end

--- a/test/unit/gateways/orbital_test.rb
+++ b/test/unit/gateways/orbital_test.rb
@@ -142,7 +142,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(50, card, order_id: 1, billing_address: address)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/Jose Garcia-Lopez de la Santa/, data)
+      assert_match(/Jose GarciaLopez de la Santa/, data)
       assert_no_match(/José/, data)
       assert_no_match(/García/, data)
     end.respond_with(successful_purchase_response)
@@ -160,7 +160,7 @@ class OrbitalGatewayTest < Test::Unit::TestCase
     response = stub_comms do
       @gateway.purchase(50, check, order_id: 1, billing_address: address)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/Jose Garcia-Lopez de la Santa/, data)
+      assert_match(/Jose GarciaLopez de la Santa/, data)
       assert_no_match(/José/, data)
       assert_no_match(/García/, data)
     end.respond_with(successful_purchase_response)


### PR DESCRIPTION
Update clean_emoji_emoticons_and_accent used in MercadoPago & Orbital to remove any non-word characters. Rename method to be format_name.

Remote Tests
Orbital:
140 tests, 563 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

MercadoPago:
45 tests, 131 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 95.5556% passed