### PR TITLE
Vantiv Express: Add support of level 2 and 3 data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -196,6 +196,7 @@
 * Normalize API for Rapyd, SafeCharge and SecureNet [ritesh-kapoor-spreedly] #5514
 * Normalize API Version for Orbital, OptimalPayment, NabTransact [adarsh-spreedly] #5523
 * PayArc/PayConex/HPS: Normalize API_VERSION usage [sumit-sharmas] #5521
+* VantivExpress: Add support of level 2 and 3 data [adarsh-spreedly] #5487
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).
@@ -888,7 +889,6 @@
 * Payflow Pro: Add `stored_credential` fields [ajawadmirza] #4277
 * Decidir Plus: Add `fraud_detection` fields [naashton] #4289
 * Elavon: Pass through ssl_email for verify transactions [ankurspreedly] #5502
-* Nuvei: Add address compoenents for all transactions [ankurspreedly] #5511
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -889,6 +889,7 @@
 * Payflow Pro: Add `stored_credential` fields [ajawadmirza] #4277
 * Decidir Plus: Add `fraud_detection` fields [naashton] #4289
 * Elavon: Pass through ssl_email for verify transactions [ankurspreedly] #5502
+* Nuvei: Add address compoenents for all transactions [ankurspreedly] #5511
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/vantiv_express.rb
+++ b/lib/active_merchant/billing/gateways/vantiv_express.rb
@@ -150,6 +150,24 @@ module ActiveMerchant # :nodoc:
         'ECommerce' => 6
       }
 
+      DISCOUNT_CODE = {
+        'NotSupported' => 0,
+        'AmountIsDiscounted' => 1,
+        'AmountIsNotDiscounted' => 2
+      }
+
+      NET_GROSS_CODE = {
+        'NotSupported' => 0,
+        'ItemAmountIncludesTaxAmount' => 1,
+        'ItemAmountDoesNotIncludeTaxAmount' => 2
+      }
+
+      DEBIT_CREDIT_CODE = {
+        'NotSupported' => 0,
+        'ExtendedItemAmountIsCredit' => 1,
+        'ExtendedItemAmountIsDebit' => 2
+      }
+
       def initialize(options = {})
         requires!(options, :account_id, :account_token, :application_id, :acceptor_id, :application_name, :application_version)
         super
@@ -199,6 +217,7 @@ module ActiveMerchant # :nodoc:
             add_credentials(xml)
             add_transaction(xml, money, options, eci)
             add_terminal(xml, options, eci)
+            add_level_3_data(xml, options)
           end
         end
 
@@ -344,6 +363,8 @@ module ActiveMerchant # :nodoc:
           xml.PaymentType PAYMENT_TYPE[options[:payment_type]] || options[:payment_type] if options[:payment_type]
           xml.SubmissionType SUBMISSION_TYPE[options[:submission_type]] || options[:submission_type] if options[:submission_type]
           xml.DuplicateCheckDisableFlag 1 if options[:duplicate_check_disable_flag].to_s == 'true' || options[:duplicate_override_flag].to_s == 'true'
+          xml.SalesTaxAmount options[:sales_tax_amount] if options[:sales_tax_amount]
+          xml.CommercialCardCustomerCode options[:commercial_card_customer_code] if options[:commercial_card_customer_code]
         end
       end
 
@@ -450,6 +471,7 @@ module ActiveMerchant # :nodoc:
               xml.BillingZipcode address[:zip] if address[:zip]
               xml.BillingEmail address[:email] if address[:email]
               xml.BillingPhone address[:phone_number] if address[:phone_number]
+              xml.BillingName address[:name] if address[:name]
             end
 
             if shipping_address
@@ -460,6 +482,65 @@ module ActiveMerchant # :nodoc:
               xml.ShippingZipcode shipping_address[:zip] if shipping_address[:zip]
               xml.ShippingEmail shipping_address[:email] if shipping_address[:email]
               xml.ShippingPhone shipping_address[:phone_number] if shipping_address[:phone_number]
+            end
+          end
+        end
+      end
+
+      # Add Enhanced Level III data to transaction requests
+      def add_level_3_data(xml, options)
+        return unless options[:level_3_data]
+
+        level_3 = options[:level_3_data]
+        xml.ExtendedParameters do
+          xml.EnhancedData do
+            # Header-level fields
+            xml.MerchantVATRegistrationNumber level_3[:merchant_vat_registration_number] if level_3[:merchant_vat_registration_number]
+            xml.CustomerVATRegistrationNumber level_3[:customer_vat_registration_number] if level_3[:customer_vat_registration_number]
+            xml.SummaryCommodityCode level_3[:summary_commodity_code] if level_3[:summary_commodity_code]
+            xml.DiscountAmount level_3[:discount_amount] if level_3[:discount_amount]
+            xml.FreightAmount level_3[:freight_amount] if level_3[:freight_amount]
+            xml.DutyAmount level_3[:duty_amount] if level_3[:duty_amount]
+            xml.DestinationZIPCode level_3[:destination_postal_code] if level_3[:destination_postal_code]
+            xml.ShipFromZIPCode level_3[:ship_from_postal_code] if level_3[:ship_from_postal_code]
+            xml.DestinationCountryCode level_3[:destination_country_code] if level_3[:destination_country_code]
+            xml.UniqueVATInvoiceReferenceNumber level_3[:unique_vat_invoice_reference_number] if level_3[:unique_vat_invoice_reference_number]
+            xml.OrderDate level_3[:order_date] if level_3[:order_date]
+            xml.VATAmount level_3[:vat_amount] if level_3[:vat_amount]
+            xml.VATRate level_3[:vat_rate] if level_3[:vat_rate]
+            xml.LineItemCount level_3[:line_items].size if level_3[:line_items]&.any?
+            xml.AlternateTaxAmount level_3[:alternate_tax_amount] if level_3[:alternate_tax_amount]
+            xml.NationalTaxAmount level_3[:national_tax_amount] if level_3[:national_tax_amount]
+
+            # Line item details
+            add_line_items(xml, level_3[:line_items]) if level_3[:line_items]&.any?
+          end
+        end
+      end
+
+      def add_line_items(xml, line_items)
+        return unless line_items
+
+        xml.LineItemDetail do
+          line_items.each do |item|
+            xml.LineItem do
+              xml.ItemCommodityCode item[:commodity_code] if item[:commodity_code]
+              xml.ItemDescription item[:description] if item[:description]
+              xml.ProductCode item[:product_code] if item[:product_code]
+              xml.Quantity item[:quantity] if item[:quantity]
+              xml.UnitOfMeasure item[:unit_measure] if item[:unit_measure]
+              xml.UnitCost item[:unit_price] if item[:unit_price]
+              xml.LineItemVATAmount item[:tax_amount] if item[:tax_amount]
+              xml.LineItemVATRate item[:tax_rate] if item[:tax_rate]
+              xml.LineItemDiscountAmount item[:discount_amount] if item[:discount_amount]
+              xml.LineItemTotalAmount item[:total_amount] if item[:total_amount]
+              xml.AlternateTaxIdentifier item[:alternate_tax_id] if item[:alternate_tax_id]
+              xml.VATType item[:vat_type] if item[:vat_type]
+              xml.DiscountCode DISCOUNT_CODE[item[:discount_code]] || item[:discount_code] if item[:discount_code]
+              xml.NetGrossCode NET_GROSS_CODE[item[:net_gross_code]] || item[:net_gross_code] if item[:net_gross_code]
+              xml.ExtendedItemAmount item[:extended_item_amount] if item[:extended_item_amount]
+              xml.DebitCreditCode DEBIT_CREDIT_CODE[item[:debit_credit_code]] || item[:debit_credit_code] if item[:debit_credit_code]
+              xml.ItemDiscountRate item[:item_discount_rate] if item[:item_discount_rate]
             end
           end
         end

--- a/test/unit/gateways/vantiv_express_test.rb
+++ b/test/unit/gateways/vantiv_express_test.rb
@@ -480,6 +480,68 @@ class VantivExpressTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_successful_purchase_with_level_2_data_fields
+    level_ii_options = {
+      sales_tax_amount: 850,
+      commercial_card_customer_code: 'PO123456',
+      ticket_number: 'INV789'
+    }
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(level_ii_options))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match "<SalesTaxAmount>#{level_ii_options[:sales_tax_amount]}</SalesTaxAmount>", data
+      assert_match "<CommercialCardCustomerCode>#{level_ii_options[:commercial_card_customer_code]}</CommercialCardCustomerCode>", data
+      assert_match "<TicketNumber>#{level_ii_options[:ticket_number]}</TicketNumber>", data
+      assert_match "<BillingName>#{@options[:billing_address][:name]}", data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_successful_capture_with_level_3_data_fields
+    stub_comms do
+      @gateway.capture(@amount, 'trans-id', @options.merge(level_3_data: level_3_data_fields))
+    end.check_request do |_endpoint, data, _headers|
+      # Header-level fields
+      assert_match "<MerchantVATRegistrationNumber>#{level_3_data_fields[:merchant_vat_registration_number]}</MerchantVATRegistrationNumber>", data
+      assert_match "<CustomerVATRegistrationNumber>#{level_3_data_fields[:customer_vat_registration_number]}</CustomerVATRegistrationNumber>", data
+      assert_match "<SummaryCommodityCode>#{level_3_data_fields[:summary_commodity_code]}</SummaryCommodityCode>", data
+      assert_match "<DiscountAmount>#{level_3_data_fields[:discount_amount]}</DiscountAmount>", data
+      assert_match "<FreightAmount>#{level_3_data_fields[:freight_amount]}</FreightAmount>", data
+      assert_match "<DutyAmount>#{level_3_data_fields[:duty_amount]}</DutyAmount>", data
+      assert_match "<DestinationZIPCode>#{level_3_data_fields[:destination_postal_code]}</DestinationZIPCode>", data
+      assert_match "<ShipFromZIPCode>#{level_3_data_fields[:ship_from_postal_code]}</ShipFromZIPCode>", data
+      assert_match "<DestinationCountryCode>#{level_3_data_fields[:destination_country_code]}</DestinationCountryCode>", data
+      assert_match "<UniqueVATInvoiceReferenceNumber>#{level_3_data_fields[:unique_vat_invoice_reference_number]}</UniqueVATInvoiceReferenceNumber>", data
+      assert_match "<OrderDate>#{level_3_data_fields[:order_date]}</OrderDate>", data
+      assert_match "<VATAmount>#{level_3_data_fields[:vat_amount]}</VATAmount>", data
+      assert_match "<VATRate>#{level_3_data_fields[:vat_rate]}</VATRate>", data
+      assert_match "<LineItemCount>#{level_3_data_fields[:line_items].size}</LineItemCount>", data
+      assert_match "<AlternateTaxAmount>#{level_3_data_fields[:alternate_tax_amount]}</AlternateTaxAmount>", data
+      assert_match "<NationalTaxAmount>#{level_3_data_fields[:national_tax_amount]}</NationalTaxAmount>", data
+
+      # Line item fields
+      level_3_data_fields[:line_items].each do |item|
+        assert_match "<ItemCommodityCode>#{item[:commodity_code]}</ItemCommodityCode>", data
+        assert_match "<ItemDescription>#{item[:description]}</ItemDescription>", data
+        assert_match "<ProductCode>#{item[:product_code]}</ProductCode>", data
+        assert_match "<Quantity>#{item[:quantity]}</Quantity>", data
+        assert_match "<UnitOfMeasure>#{item[:unit_measure]}</UnitOfMeasure>", data
+        assert_match "<UnitCost>#{item[:unit_price]}</UnitCost>", data
+        assert_match "<LineItemVATAmount>#{item[:tax_amount]}</LineItemVATAmount>", data
+        assert_match "<LineItemVATRate>#{item[:tax_rate]}</LineItemVATRate>", data
+        assert_match "<LineItemDiscountAmount>#{item[:discount_amount]}</LineItemDiscountAmount>", data
+        assert_match "<LineItemTotalAmount>#{item[:total_amount]}</LineItemTotalAmount>", data
+        assert_match "<AlternateTaxIdentifier>#{item[:alternate_tax_id]}</AlternateTaxIdentifier>", data
+        assert_match "<VATType>#{item[:vat_type]}</VATType>", data
+        assert_match '<DiscountCode>0</DiscountCode>', data
+        assert_match '<NetGrossCode>1</NetGrossCode>', data
+        assert_match '<DebitCreditCode>2</DebitCreditCode>', data
+        assert_match "<ExtendedItemAmount>#{item[:extended_item_amount]}</ExtendedItemAmount>", data
+        assert_match "<ItemDiscountRate>#{item[:item_discount_rate]}</ItemDiscountRate>", data
+      end
+    end.respond_with(successful_capture_response)
+  end
+
   private
 
   def lodging_fields
@@ -506,6 +568,47 @@ class VantivExpressTest < Test::Unit::TestCase
       prestigious_property_code: 1,
       special_program_code: 3,
       charge_type: 1
+    }
+  end
+
+  def level_3_data_fields
+    {
+      merchant_vat_registration_number: '12345678',
+      customer_vat_registration_number: '0987654',
+      summary_commodity_code: '1234',
+      discount_amount: '12',
+      freight_amount: 500, # $5.00 shipping
+      duty_amount: 0,
+      destination_postal_code: '12345',
+      ship_from_postal_code: '54321',
+      destination_country_code: 'US',
+      unique_vat_invoice_reference_number: '098765345',
+      order_date: 20250910,
+      vat_amount: '12',
+      vat_rate: '12',
+      alternate_tax_amount: '234',
+      national_tax_amount: 850,
+      line_items: [
+        {
+          commodity_code: '1234567890',
+          product_code: 'WIDGET001',
+          description: 'Widget A',
+          quantity: 2,
+          unit_price: 4000,
+          unit_measure: '2',
+          total_amount: 8000,
+          tax_amount: 640,
+          tax_rate: '2',
+          discount_amount: '6',
+          alternate_tax_id: '1123',
+          vat_type: '1',
+          discount_code: 'NotSupported',
+          net_gross_code: 'ItemAmountIncludesTaxAmount',
+          extended_item_amount: '8',
+          debit_credit_code: 'ExtendedItemAmountIsDebit',
+          item_discount_rate: '1'
+        }
+      ]
     }
   end
 


### PR DESCRIPTION
Vantiv Express: Add support of level 2 and 3 data

reference link - https://docs.worldpay.com/apis/express/features/level-2-data

Remote Tests:
35 tests, 91 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 88.5714% passed

Note - For now the the level 3 data is supported by capture only we can implement `CreditCardAdjustment` as well.