### PR TITLE
Normalize API version for CyberSourceRest, Datatrans, and FlexCharge.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -182,6 +182,7 @@
 * MultiPay: Add Base Gateway adapter [Heavblade] #5497
 * Cecabank: Fix finRec field formatting for Cecabank Gateway [aaqibrashidmir] #5506
 * Nuvei: Map order_id to clientUniqueId field on capture transactions [aaqibrashidmir] #5498
+* Normalize API Version for CyberSourceRest, Datatrans, and FlexCharge [aaqibrashidmir] #5489
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/cyber_source_rest.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source_rest.rb
@@ -5,6 +5,8 @@ module ActiveMerchant # :nodoc:
     class CyberSourceRestGateway < Gateway
       include ActiveMerchant::Billing::CyberSourceCommon
 
+      version 'v2'
+
       self.test_url = 'https://apitest.cybersource.com'
       self.live_url = 'https://api.cybersource.com'
 
@@ -386,7 +388,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def url(action)
-        "#{test? ? test_url : live_url}/pts/v2/#{action}"
+        "#{test? ? test_url : live_url}/pts/#{fetch_version}/#{action}"
       end
 
       def host
@@ -446,7 +448,7 @@ module ActiveMerchant # :nodoc:
         string_to_sign = {
           host:,
           date: gmtdatetime,
-          'request-target': "#{http_method} /pts/v2/#{resource}",
+          'request-target': "#{http_method} /pts/#{fetch_version}/#{resource}",
           digest:,
           'v-c-merchant-id': @options[:merchant_id]
         }.map { |k, v| "#{k}: #{v}" }.join("\n").force_encoding(Encoding::UTF_8)

--- a/lib/active_merchant/billing/gateways/datatrans.rb
+++ b/lib/active_merchant/billing/gateways/datatrans.rb
@@ -1,8 +1,10 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class DatatransGateway < Gateway
-      self.test_url = 'https://api.sandbox.datatrans.com/v1/'
-      self.live_url = 'https://api.datatrans.com/v1/'
+      version 'v1'
+
+      self.test_url = "https://api.sandbox.datatrans.com/#{fetch_version}/"
+      self.live_url = "https://api.datatrans.com/#{fetch_version}/"
 
       self.supported_countries = %w(CH GR US) # to confirm the countries supported.
       self.default_currency = 'CHF'

--- a/lib/active_merchant/billing/gateways/flex_charge.rb
+++ b/lib/active_merchant/billing/gateways/flex_charge.rb
@@ -1,8 +1,10 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class FlexChargeGateway < Gateway
-      self.test_url = 'https://api-sandbox.flex-charge.com/v1/'
-      self.live_url = 'https://api.flex-charge.com/v1/'
+      version 'v1'
+
+      self.test_url = "https://api-sandbox.flex-charge.com/#{fetch_version}/"
+      self.live_url = "https://api.flex-charge.com/#{fetch_version}/"
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'

--- a/test/unit/gateways/cyber_source_rest_test.rb
+++ b/test/unit/gateways/cyber_source_rest_test.rb
@@ -345,6 +345,23 @@ class CyberSourceRestTest < Test::Unit::TestCase
     assert_equal "#{@gateway.class.test_url}/pts/v2/action", @gateway.send(:url, 'action')
   end
 
+  def test_endpoint_with_version
+    version = 'v3'
+    @gateway.versions = { default_api: version }
+    assert_equal "#{@gateway.class.test_url}/pts/#{version}/payments", @gateway.send(:url, 'payments')
+  end
+
+  def test_http_signature_with_custom_version
+    version = 'v3'
+    @gateway.versions = { default_api: version }
+    signature = @gateway.send :get_http_signature, 'payments', @digest, 'post', @gmt_time
+
+    parsed = parse_signature(signature)
+    assert_equal 'def345', parsed['keyid']
+    assert_equal 'HmacSHA256', parsed['algorithm']
+    assert_equal 'host date request-target digest v-c-merchant-id', parsed['headers']
+  end
+
   def test_stored_credential_cit_initial
     @options[:stored_credential] = stored_credential(:cardholder, :internet, :initial)
     response = stub_comms do

--- a/test/unit/gateways/datatrans_test.rb
+++ b/test/unit/gateways/datatrans_test.rb
@@ -342,6 +342,17 @@ class DatatransTest < Test::Unit::TestCase
                     ['Invalid JSON response received from Datatrans. Please contact them for support if you continue to receive this message.  (The raw response returned by the API was "{\\"transactionId\\":\\"240418170233899207\\",acquirerAuthorizationCode\\":\\"170233\\"}")'] }
   end
 
+  def test_base_urls_include_version
+    assert_includes @gateway.test_url, '/v1/'
+    assert_includes @gateway.live_url, '/v1/'
+  end
+
+  def test_default_version_in_endpoint_url
+    action = :authorize
+    url = @gateway.send(:url, action)
+    assert_match(%r{/v1/transactions/authorize\z}, url)
+  end
+
   private
 
   def successful_authorize_response

--- a/test/unit/gateways/flex_charge_test.rb
+++ b/test/unit/gateways/flex_charge_test.rb
@@ -378,6 +378,17 @@ class FlexChargeTest < Test::Unit::TestCase
     assert_equal 5, post[:idempotencyKey].split('-').size
   end
 
+  def test_base_urls_include_version
+    assert_includes @gateway.test_url, '/v1/'
+    assert_includes @gateway.live_url, '/v1/'
+  end
+
+  def test_default_version_in_endpoint_url
+    action = :purchase
+    url = @gateway.send(:url, action)
+    assert_match(%r{/v1/evaluate\z}, url)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Normalizes API version handling across three payment gateways .This change enables runtime API version overrides and standardizes version management.

Tests:
Datatrans: 47 tests ✅ (100% pass)
CyberSource REST: 46 tests ✅ (100% pass)
FlexCharge: 36 tests ✅ (100% pass)