### PR TITLE
Normalize api versions for wepay, wompi and commerce hub

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -172,6 +172,7 @@
 * Rapyd: Fix error on billing address [jherrera] #5472
 * Nuvei: Map order_id to clientUniqueId field on refund/credit [jherrera] #5477
 * Update clean_emoji_emoticons_and_accent method [almalee24] #5485
+* Wepay/Wompi/CommerceHub: Normalize API_VERSION usage [sumit-sharmas] #5490
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/commerce_hub.rb
+++ b/lib/active_merchant/billing/gateways/commerce_hub.rb
@@ -1,6 +1,8 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class CommerceHubGateway < Gateway
+      version 'v1'
+
       self.test_url = 'https://connect-cert.fiservapps.com/ch'
       self.live_url = 'https://connect.fiservapis.com/ch'
 
@@ -15,11 +17,11 @@ module ActiveMerchant # :nodoc:
 
       SCHEDULED_REASON_TYPES = %w(recurring installment)
       ENDPOINTS = {
-        'sale' => '/payments/v1/charges',
-        'void' => '/payments/v1/cancels',
-        'refund' => '/payments/v1/refunds',
-        'vault' => '/payments-vas/v1/tokens',
-        'verify' => '/payments-vas/v1/accounts/verification'
+        'sale' => "/payments/#{fetch_version}/charges",
+        'void' => "/payments/#{fetch_version}/cancels",
+        'refund' => "/payments/#{fetch_version}/refunds",
+        'vault' => "/payments-vas/#{fetch_version}/tokens",
+        'verify' => "/payments-vas/#{fetch_version}/accounts/verification"
       }
 
       def initialize(options = {})

--- a/lib/active_merchant/billing/gateways/wepay.rb
+++ b/lib/active_merchant/billing/gateways/wepay.rb
@@ -1,8 +1,10 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class WepayGateway < Gateway
-      self.test_url = 'https://stage.wepayapi.com/v2'
-      self.live_url = 'https://wepayapi.com/v2'
+      version 'v2'
+
+      self.test_url = "https://stage.wepayapi.com/#{fetch_version}"
+      self.live_url = "https://wepayapi.com/#{fetch_version}"
 
       self.supported_countries = %w[US CA]
       self.supported_cardtypes = %i[visa master american_express discover]

--- a/lib/active_merchant/billing/gateways/wompi.rb
+++ b/lib/active_merchant/billing/gateways/wompi.rb
@@ -1,8 +1,10 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class WompiGateway < Gateway
-      self.test_url = 'https://sync.sandbox.wompi.co/v1'
-      self.live_url = 'https://sync.production.wompi.co/v1'
+      version 'v1'
+
+      self.test_url = "https://sync.sandbox.wompi.co/#{fetch_version}"
+      self.live_url = "https://sync.production.wompi.co/#{fetch_version}"
 
       self.supported_countries = ['CO']
       self.default_currency = 'COP'

--- a/test/unit/gateways/commerce_hub_test.rb
+++ b/test/unit/gateways/commerce_hub_test.rb
@@ -65,6 +65,10 @@ class CommerceHubTest < Test::Unit::TestCase
     @post = {}
   end
 
+  def test_api_version
+    assert_equal 'v1', @gateway.fetch_version
+  end
+
   def test_successful_authorize_with_full_headers
     @options.merge!(
       headers_identifiers: {
@@ -522,6 +526,14 @@ class CommerceHubTest < Test::Unit::TestCase
       uuid_v4_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
       assert_match uuid_v4_regex, client_request_id, 'Client-Request-Id is not a valid UUIDv4'
     end.respond_with(successful_purchase_response)
+  end
+
+  def test_endpoints
+    assert_equal '/payments/v1/charges', CommerceHubGateway::ENDPOINTS['sale']
+    assert_equal '/payments/v1/cancels', CommerceHubGateway::ENDPOINTS['void']
+    assert_equal '/payments/v1/refunds', CommerceHubGateway::ENDPOINTS['refund']
+    assert_equal '/payments-vas/v1/tokens', CommerceHubGateway::ENDPOINTS['vault']
+    assert_equal '/payments-vas/v1/accounts/verification', CommerceHubGateway::ENDPOINTS['verify']
   end
 
   private

--- a/test/unit/gateways/wepay_test.rb
+++ b/test/unit/gateways/wepay_test.rb
@@ -18,6 +18,10 @@ class WepayTest < Test::Unit::TestCase
     }
   end
 
+  def test_api_version
+    assert_equal 'v2', @gateway.fetch_version
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).at_most(3).returns(successful_capture_response)
 
@@ -176,6 +180,11 @@ class WepayTest < Test::Unit::TestCase
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  def test_url
+    assert_equal 'https://wepayapi.com/v2', @gateway.live_url
+    assert_equal 'https://stage.wepayapi.com/v2', @gateway.test_url
   end
 
   private

--- a/test/unit/gateways/wompi_test.rb
+++ b/test/unit/gateways/wompi_test.rb
@@ -17,6 +17,10 @@ class WompiTest < Test::Unit::TestCase
     }
   end
 
+  def test_api_version
+    assert_equal 'v1', @gateway.fetch_version
+  end
+
   def test_ambidextrous_gateway_behaves_accordingly
     response = stub_comms(@ambidextrous_gateway) do
       @ambidextrous_gateway.purchase(@amount, @credit_card)
@@ -165,6 +169,11 @@ class WompiTest < Test::Unit::TestCase
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  def test_url
+    assert_equal 'https://sync.production.wompi.co/v1', @gateway.live_url
+    assert_equal 'https://sync.sandbox.wompi.co/v1', @gateway.test_url
   end
 
   private


### PR DESCRIPTION
Normalizes API version handling across three payment gateways .This change enables runtime API version overrides and standardizes version management.

Remote Test Results:

wepay
27 tests, 45 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.2963% passed

wompi
14 tests, 27 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
71.4286% passed

commerce_hub
37 tests, 100 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
94.5946% passed