### PR TITLE
credorax: fix spec for updated processor name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -171,6 +171,7 @@
 * Cenpos: Add purchase_order_number field [yunnydang] #5481
 * Rapyd: Fix error on billing address [jherrera] #5472
 * Nuvei: Map order_id to clientUniqueId field on refund/credit [jherrera] #5477
+* Credorax: Spec fix for updated processor name [adarsh-spreedly] #5492
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/test/remote/gateways/remote_credorax_test.rb
+++ b/test/remote/gateways/remote_credorax_test.rb
@@ -714,7 +714,7 @@ class RemoteCredoraxTest < Test::Unit::TestCase
     assert good_response = @gateway.purchase(@amount, @credit_card, @options.merge(processor: 'CREDORAX'))
     assert_success good_response
     assert_equal 'Succeeded', good_response.message
-    assert_equal 'CREDORAX', good_response.params['Z33']
+    assert_equal 'Shift4', good_response.params['Z33']
 
     # returns a failed response when an invalid processor parameter is sent
     assert bad_response = @gateway.purchase(@amount, @credit_card, @options.merge(processor: 'invalid'))


### PR DESCRIPTION
credorax: fix spec for updated processor name

Remote Test:
59 tests, 210 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
89.8305% passed