### PR TITLE
Ebanx: fix field nesting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -178,6 +178,7 @@
 * Xpay/Sumup/Quickbooks: Normalize API_VERSION usage [aaqibrashidmir] #5495
 * Ebanx: Fix NoMethodError for address [almalee24] #5500
 * Vpos: Check for response under refund.response_code [almalee24] #5501
+* Ebanx: Fix field nesting cof_info, device_id, and notification_url [yunnydang] #5494
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -180,7 +180,7 @@ module ActiveMerchant # :nodoc:
       def add_stored_credentials(post, options)
         return unless (stored_creds = options[:stored_credential])
 
-        post[:cof_info] = {
+        post[:payment][:cof_info] = {
           cof_type: stored_creds[:initial_transaction] ? 'initial' : 'stored',
           initiator: stored_creds[:initiator] == 'cardholder' ? 'CIT' : 'MIT',
           trans_type: add_trans_type(stored_creds),
@@ -258,12 +258,12 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_additional_data(post, options)
-        post[:device_id] = options[:device_id] if options[:device_id]
+        post[:payment][:device_id] = options[:device_id] if options[:device_id]
         post[:metadata] = options[:metadata] if options[:metadata]
         post[:metadata] = {} if post[:metadata].nil?
         post[:metadata][:merchant_payment_code] = order_id_override(options)
         post[:payment][:tags] = TAGS
-        post[:notification_url] = options[:notification_url] if options[:notification_url]
+        post[:payment][:notification_url] = options[:notification_url] if options[:notification_url]
       end
 
       def parse(body)


### PR DESCRIPTION
This change fixes the proper field nesting for a handful of optional fields. Currently they're being ignored and this will correct  that.

Local:
6298 tests, 81751 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
35 tests, 172 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
46 tests, 113 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed