### PR TITLE
DLocal: Add issuer_identification_number as bin in Card object.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -174,6 +174,7 @@
 * Update clean_emoji_emoticons_and_accent method [almalee24] #5485
 * Payflow: Send CAVV as xid if xid is not present [adarsh-spreedly] #5496
 * Credorax: Fixed request signature [mjdonga] #5486
+* DLocal: Add issuer_identification_number as bin in Card object [adarsh-spreedly] #5499
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/d_local.rb
+++ b/lib/active_merchant/billing/gateways/d_local.rb
@@ -171,6 +171,7 @@ module ActiveMerchant # :nodoc:
           post[:card][:network_token] = card.number
           post[:card][:cryptogram] = card.payment_cryptogram
           post[:card][:eci] = card.eci
+          post[:card][:bin] = options[:issuer_identification_number] if options[:issuer_identification_number]
         else
           post[:card][:number] = card.number
           post[:card][:cvv] = card.verification_value

--- a/test/remote/gateways/remote_d_local_test.rb
+++ b/test/remote/gateways/remote_d_local_test.rb
@@ -362,7 +362,7 @@ class RemoteDLocalTest < Test::Unit::TestCase
 
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
-    assert_match %r{Invalid parameter}, response.message
+    assert_match %r{non valid values}, response.message
   end
 
   def test_transcript_scrubbing
@@ -402,5 +402,15 @@ class RemoteDLocalTest < Test::Unit::TestCase
     auth = @gateway.authorize(@amount, @credit_card, @options)
     assert_success auth
     assert_match 'The payment was authorized', auth.message
+  end
+
+  def test_passes_issuer_identification_number_in_card_object
+    issuer_identification_number = 424242
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    @options[:issuer_identification_number] = issuer_identification_number
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, credit_card, @options)
+    end
+    assert_match %r{bin.*#{issuer_identification_number}}, transcript
   end
 end

--- a/test/unit/gateways/d_local_test.rb
+++ b/test/unit/gateways/d_local_test.rb
@@ -523,6 +523,17 @@ class DLocalTest < Test::Unit::TestCase
     assert_equal 'U', @gateway.send('formatted_enrollment', 'U')
   end
 
+  def test_passes_issuer_identification_number_in_card_object
+    issuer_identification_number = 424242
+    credit_card = network_tokenization_credit_card('4242424242424242', payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=')
+    @options[:issuer_identification_number] = issuer_identification_number
+    stub_comms do
+      @gateway.purchase(@amount, credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_equal issuer_identification_number, JSON.parse(data)['card']['bin']
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
DLocal: Add issuer_identification_number as bin in Card object.

Remote Tests:
43 tests, 119 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 
100% passed