### PR TITLE
Ebanx: Fix NoMethodError for address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -176,6 +176,7 @@
 * Credorax: Fixed request signature [mjdonga] #5486
 * Nuvei/Reach/Shift4: Normalize API_VERSION usage [sumit-sharmas] #5493
 * Xpay/Sumup/Quickbooks: Normalize API_VERSION usage [aaqibrashidmir] #5495
+* Ebanx: Fix NoMethodError for address [almalee24] #5500
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/ebanx.rb
+++ b/lib/active_merchant/billing/gateways/ebanx.rb
@@ -201,8 +201,10 @@ module ActiveMerchant # :nodoc:
 
       def add_address(post, options)
         if address = options[:billing_address] || options[:address]
-          post[:payment][:address] = address[:address1].split[1..-1].join(' ') if address[:address1]
-          post[:payment][:street_number] = address[:address1].split.first if address[:address1]
+          if address[:address1].present?
+            post[:payment][:address] = address[:address1].split[1..-1].join(' ')
+            post[:payment][:street_number] = address[:address1].split.first
+          end
           post[:payment][:city] = address[:city]
           post[:payment][:state] = address[:state]
           post[:payment][:zipcode] = address[:zip]

--- a/test/remote/gateways/remote_ebanx_test.rb
+++ b/test/remote/gateways/remote_ebanx_test.rb
@@ -47,6 +47,17 @@ class RemoteEbanxTest < Test::Unit::TestCase
     assert_equal 'Accepted', response.message
   end
 
+  def test_successful_purchase_with_nil_address
+    @options[:billing_address][:address1] = ''
+    @options[:billing_address][:city] = ''
+    @options[:billing_address][:state] = ''
+    @options[:billing_address][:zip] = ''
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Field payment.zipcode is required', response.message
+  end
+
   def test_successful_purchase_hipercard
     response = @gateway.purchase(@amount, @hiper_card, @options)
     assert_success response

--- a/test/unit/gateways/ebanx_test.rb
+++ b/test/unit/gateways/ebanx_test.rb
@@ -44,6 +44,25 @@ class EbanxTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_nil_address1
+    @options[:billing_address][:address1] = ''
+    @options[:billing_address][:city] = ''
+    @options[:billing_address][:state] = ''
+    @options[:billing_address][:zip] = ''
+
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options.merge(processing_type: 'local'))
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match %r{"zipcode\":\"\"}, data
+      assert_match %r{"city\":\"\"}, data
+      assert_match %r{"state\":\"\"}, data
+      assert_not_match %r{"address\":\"\"}, data
+      assert_not_match %r{"street_number\":\"\"}, data
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_soft_descriptor
     response = stub_comms(@gateway, :ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options.merge(soft_descriptor: 'ActiveMerchant'))


### PR DESCRIPTION
If address is "" then it causes a NoMethodError so this changes to only send address if it's present.

47 tests, 115 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed