### PR TITLE
OPPS-482: Elavon: Verify - support for ssl_email

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -866,6 +866,7 @@
 * CyberSource: Add `line_items` for purchase [ajawadmirza] #4282
 * Payflow Pro: Add `stored_credential` fields [ajawadmirza] #4277
 * Decidir Plus: Add `fraud_detection` fields [naashton] #4289
+* Elavon: Pass through ssl_email for verify transactions [ankurspreedly] #5502
 
 == Version 1.124.0 (October 28th, 2021)
 * Worldpay: Add Support for Submerchant Data on Worldpay [almalee24] #4147

--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -148,6 +148,7 @@ module ActiveMerchant # :nodoc:
           xml.ssl_transaction_type  self.actions[:verify]
           add_creditcard(xml, credit_card, options)
           add_address(xml, options)
+          add_customer_email(xml, options)
           add_test_mode(xml, options)
           add_ip(xml, options)
         end

--- a/test/unit/gateways/elavon_test.rb
+++ b/test/unit/gateways/elavon_test.rb
@@ -289,6 +289,15 @@ class ElavonTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_verify_with_ssl_email
+    response = stub_comms do
+                 @gateway.verify(@credit_card, @options.merge(email: 'abc@example.com'))
+               end.check_request do |_endpoint, data, _headers|
+      assert_match(/<ssl_email>abc%40example.com<\/ssl_email>/, data)
+    end.respond_with(successful_authorization_response)
+    assert_success response
+  end
+
   def test_unsuccessful_verify
     response = stub_comms do
       @gateway.verify(@credit_card, @options)


### PR DESCRIPTION
Pass through ssl_email for verify transactions.

Elavon Unit Test
61 tests, 358 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications