### PR TITLE
PaySafe: Added Google and apple pay support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -202,6 +202,7 @@
 * Normalize API Version for Plexo, Pin, Priority [adarsh-spreedly] #5517
 * Stripe PI: Update API version [almalee24] #5360
 * Airwallex: Add optional products array field [yunnydang] #5530
+* PaySafe: Added Google and apple pay support [mjdonga] #5503
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/credit_card_formatting.rb
+++ b/lib/active_merchant/billing/credit_card_formatting.rb
@@ -16,6 +16,13 @@ module ActiveMerchant # :nodoc:
         format(year, :four_digits) + format(month, :two_digits) + format(last_day, :two_digits)
       end
 
+      def strftime_yymmdd_last_day(credit_card)
+        year = credit_card.year.to_i
+        month = credit_card.month.to_i
+        last_day = Date.civil(year, month, -1).day
+        format(year, :two_digits) + format(month, :two_digits) + format(last_day, :two_digits)
+      end
+
       # This method is used to format numerical information pertaining to credit cards.
       #
       #   format(2005, :two_digits)  # => "05"


### PR DESCRIPTION
PaySafe: Added Google and apple pay support. Integrated single-use token API to support AP & GP

Remote test case result
42 tests, 131 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit test case result
26 tests, 137 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed