### PR TITLE
Paysafe: Save cards to exisiting profiles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -191,6 +191,7 @@
 * Normalize API Versions for litle, mercado_pago and mundipagg [mjdonga] #5518
 * Normalize API Versions for Barclay card Smart pay, Fat Zebra and Forte gateways [mjdonga] #5519
 * Worldpay: Add refund reference field [yunnydang] #5531
+* Paysafe: Save cards to exisiting profiles [almalee24] #5504
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -77,12 +77,28 @@ module ActiveMerchant # :nodoc:
 
       def store(payment, options = {})
         post = {}
-        add_payment(post, payment)
-        add_address_for_vaulting(post, options)
-        add_profile_data(post, payment, options)
-        add_store_data(post, payment, options)
 
-        commit(:post, 'profiles', post, options)
+        if options[:profile_id]
+          post[:cardNum] = payment.number
+          post[:cardExpiry] = {
+            month: payment.month,
+            year: payment.year
+          }
+          post[:accountId] = options[:account_id] if options[:account_id]
+          post[:nickName] = options[:nickname] if options[:nickname]
+          post[:holderName] = payment.name
+          post[:billingAddressId] = options[:billing_address_id] if options[:billing_address_id]
+          post[:defaultCardIndicator] = normalize(options[:default_card_indicator]) if options[:default_card_indicator]
+        else
+          add_payment(post, payment)
+          add_address_for_vaulting(post, options)
+          add_profile_data(post, payment, options)
+          add_store_data(post, payment, options)
+        end
+
+        endpoint = options[:profile_id] ? "profiles/#{options[:profile_id]}/cards" : 'profiles'
+
+        commit(:post, endpoint, post, options)
       end
 
       def unstore(pm_profile_id)
@@ -389,7 +405,7 @@ module ActiveMerchant # :nodoc:
 
       def authorization_from(action, response)
         if action == 'profiles'
-          pm = response['cards'].first['paymentToken']
+          pm = response['cards']&.first&.dig('paymentToken')
           "#{pm}|#{response['id']}"
         else
           response['id']

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -263,6 +263,28 @@ class PaysafeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_store_with_customer_id
+    options = {
+      profile_id: '123456',
+      account_id: 'account_id',
+      nickname: 'nickname',
+      billing_address_id: '3456',
+      default_card_indicator: 'true'
+    }
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.store(@credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"cardNum":"#{@credit_card.number}"/, data)
+      assert_match(/"accountId":"#{options[:account_id]}"/, data)
+      assert_match(/"nickName":"#{options[:nickname]}"/, data)
+      assert_match(/"holderName":"#{@credit_card.name}"/, data)
+      assert_match(/"billingAddressId":"#{options[:billing_address_id]}"/, data)
+      assert_match(/"defaultCardIndicator":#{options[:default_card_indicator]}/, data)
+    end.respond_with(successful_store_response)
+
+    assert_success response
+  end
+
   def test_successful_credit
     stub_comms(@gateway, :ssl_request) do
       @gateway.credit(100, @credit_card, @options.merge({ email: 'profile@memail.com', customer_id: SecureRandom.hex(16) }))


### PR DESCRIPTION
If profile_id is provided in options then save the card to that exisiting profile.

Remote Tests:
36 tests, 107 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed