### PR TITLE
Litle: Remove 141 & 142

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -179,6 +179,7 @@
 * Ebanx: Fix NoMethodError for address [almalee24] #5500
 * Vpos: Check for response under refund.response_code [almalee24] #5501
 * Ebanx: Fix field nesting cof_info, device_id, and notification_url [yunnydang] #5494
+* Litle: Remove 141 & 142 [almalee24] #5505
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -561,7 +561,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def success_from(kind, parsed)
-        return %w(000 001 010 136 141 142 470 473).any?(parsed[:response]) unless kind == :registerToken
+        return %w(000 001 010 136 470 473).any?(parsed[:response]) unless kind == :registerToken
 
         %w(000 801 802).include?(parsed[:response])
       end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -107,26 +107,6 @@ class LitleTest < Test::Unit::TestCase
     assert response.test?
   end
 
-  def test_successful_purchase_prepaid_card_141
-    response = stub_comms do
-      @gateway.purchase(@amount, @credit_card)
-    end.respond_with(successful_purchase_for_prepaid_cards_141)
-
-    assert_success response
-    assert_equal 'Consumer non-reloadable prepaid card, Approved', response.message
-    assert_equal '141', response.params['response']
-  end
-
-  def test_successful_purchase_prepaid_card_142
-    response = stub_comms do
-      @gateway.purchase(@amount, @credit_card)
-    end.respond_with(successful_purchase_for_prepaid_cards_142)
-
-    assert_success response
-    assert_equal 'Consumer single-use virtual card number, Approved', response.message
-    assert_equal '142', response.params['response']
-  end
-
   def test_successful_purchase_with_010_response
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)


### PR DESCRIPTION
Remove 141 & 141 from the successful codes since
Worldpay moved this back to 000.