### PR TITLE
Braintree OffsiteSynchronous Transactions: update additional_processor_response appropriately

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -183,6 +183,7 @@
 * Cecabank: Fix finRec field formatting for Cecabank Gateway [aaqibrashidmir] #5506
 * Nuvei: Map order_id to clientUniqueId field on capture transactions [aaqibrashidmir] #5498
 * Ebanx: Added new GSF payment.taxes.iva_co [ritesh-spreedly] #5509
+* Braintree OffsiteSynchronous Transactions: update additional_processor_response appropriately [aaqibrashidmir] #5508
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -637,8 +637,7 @@ module ActiveMerchant # :nodoc:
 
         transaction = result.transaction
         if transaction.vault_customer
-          vault_customer = {
-          }
+          vault_customer = {}
           vault_customer['credit_cards'] = transaction.vault_customer.credit_cards.map do |cc|
             {
               'bin' => cc.bin
@@ -724,6 +723,7 @@ module ActiveMerchant # :nodoc:
           'risk_data'                    => risk_data,
           'network_transaction_id'       => transaction.network_transaction_id || nil,
           'processor_response_code'      => response_code_from_result(result),
+          'additional_processor_response' => nil,
           'processor_authorization_code' => transaction.processor_authorization_code,
           'recurring'                    => transaction.recurring,
           'payment_receipt'              => payment_receipt,

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -1519,6 +1519,18 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'must be personal or business', response.message[:account_holder_type].first
   end
 
+  def test_successful_purchase_has_nil_additional_processor_response
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_nil response.params['braintree_transaction']['additional_processor_response']
+  end
+
+  def test_failed_purchase_includes_additional_processor_response
+    assert response = @gateway.purchase(204700, @credit_card)
+    assert_failure response
+    assert_equal '2047 : Call Issuer. Pick Up Card.', response.params['braintree_transaction']['additional_processor_response']
+  end
+
   private
 
   def stored_credential_options(*args, id: nil)


### PR DESCRIPTION

Update additional-processor-response properly or remove if new complete response doesn’t have additional-processor-response


Remote Tests:

127 tests, 618 assertions, 5 failures, 5 errors, 0 pendings, 0 omissions, 0 notifications 92.126% passed