### PR TITLE
Litle: Remove customBilling element from echeck and capture transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -200,6 +200,7 @@
 * Normalize API versions for paypal, paysafe, and payu_latam [mjdonga] #5515
 * StripePI: Add support for multicapture [mjdonga] #5491
 * Normalize API Version for Plexo, Pin, Priority [adarsh-spreedly] #5517
+* Litle: Remove customBilling element from echeck and capture transactions [sumit-sharmas] #5512
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -152,7 +152,6 @@ module ActiveMerchant # :nodoc:
 
         request = build_xml_request do |doc|
           add_authentication(doc)
-          add_descriptor(doc, options)
           doc.capture_(transaction_attributes(options)) do
             doc.litleTxnId(transaction_id)
             doc.amount(money) if money
@@ -170,7 +169,7 @@ module ActiveMerchant # :nodoc:
       def refund(money, payment, options = {})
         request = build_xml_request do |doc|
           add_authentication(doc)
-          add_descriptor(doc, options)
+          add_descriptor(doc, options) unless refund_type(payment) == :echeckCredit
           doc.send(refund_type(payment), transaction_attributes(options)) do
             if payment.is_a?(String)
               transaction_id, = split_authorization(payment)
@@ -360,7 +359,6 @@ module ActiveMerchant # :nodoc:
         add_order_source(doc, payment_method, options)
         add_billing_address(doc, payment_method, options)
         add_payment_method(doc, payment_method, options)
-        add_descriptor(doc, options)
       end
 
       def add_descriptor(doc, options)


### PR DESCRIPTION
This update removes the customBilling element from echeckCredit, echeckSale, 
echeckVerification, and capture transaction types while maintaining it for 
credit card transactions. 

Remote Test Results:

Litle
60 tests, 207 assertions, 21 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 65% passed