### PR TITLE
worldpay: add refund reference field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -190,6 +190,7 @@
 * DLocal: Add issuer_identification_number as bin in Card object [adarsh-spreedly] #5499
 * Normalize API Versions for litle, mercado_pago and mundipagg [mjdonga] #5518
 * Normalize API Versions for Barclay card Smart pay, Fat Zebra and Forte gateways [mjdonga] #5519
+* Worldpay: Add refund reference field [yunnydang] #5531
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -366,6 +366,10 @@ module ActiveMerchant # :nodoc:
           if options[:cancel_or_refund]
             # Worldpay docs claim amount must be passed. This causes an error.
             xml.cancelOrRefund # { add_amount(xml, money, options.merge(debit_credit_indicator: 'credit')) }
+          elsif options[:refund_reference]
+            xml.refund(reference: options[:refund_reference]) do
+              add_amount(xml, money, options.merge(debit_credit_indicator: 'credit'))
+            end
           else
             xml.refund do
               add_amount(xml, money, options.merge(debit_credit_indicator: 'credit'))

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -820,6 +820,16 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal '924e810350efc21a989e0ac7727ce43b', response.params['cancel_received_order_code']
   end
 
+  def test_successful_refund_with_refund_reference_field
+    response = stub_comms do
+      @gateway.refund(@amount, @options[:order_id], @options.merge(refund_reference: 12233, authorization_validated: true))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<refund reference=\"12233\">/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success response
+  end
+
   def test_successful_refund_for_captured_payment
     response = stub_comms do
       @gateway.refund(@amount, @options[:order_id], @options)


### PR DESCRIPTION
Adds the optional refund reference field.

Local:
6326 tests, 81841 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
147 tests, 802 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
128 tests, 550 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed