### PR TITLE
 Normalize API  for Rapyd, SafeCharge and SecureNet

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -193,6 +193,7 @@
 * Worldpay: Add refund reference field [yunnydang] #5531
 * Paysafe: Save cards to exisiting profiles [almalee24] #5504
 * Credorax: Spec fix for updated processor name [adarsh-spreedly] #5492
+* Normalize API for Rapyd, SafeCharge and SecureNet [ritesh-kapoor-spreedly] #5514
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/rapyd.rb
+++ b/lib/active_merchant/billing/gateways/rapyd.rb
@@ -3,11 +3,13 @@ module ActiveMerchant # :nodoc:
     class RapydGateway < Gateway
       class_attribute :payment_redirect_test, :payment_redirect_live
 
-      self.test_url = 'https://sandboxapi.rapyd.net/v1/'
-      self.live_url = 'https://api.rapyd.net/v1/'
+      version 'v1'
 
-      self.payment_redirect_test = 'https://sandboxpayment-redirect.rapyd.net/v1/'
-      self.payment_redirect_live = 'https://payment-redirect.rapyd.net/v1/'
+      self.test_url = "https://sandboxapi.rapyd.net/#{fetch_version}/"
+      self.live_url = "https://api.rapyd.net/#{fetch_version}/"
+
+      self.payment_redirect_test = "https://sandboxpayment-redirect.rapyd.net/#{fetch_version}/"
+      self.payment_redirect_live = "https://payment-redirect.rapyd.net/#{fetch_version}/"
 
       self.supported_countries = %w(CA CL CO DO SV PE PT VI AU HK IN ID JP MY NZ PH SG KR TW TH VN AD AT BE BA BG HR CY CZ DK EE FI FR GE DE GI GR GL HU IS IE IL IT LV LI LT LU MK MT MD MC ME NL GB NO PL RO RU SM SK SI ZA ES SE CH TR VA)
       self.default_currency = 'USD'
@@ -335,7 +337,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def commit(method, action, parameters)
-        rel_path = "#{method}/v1/#{action}"
+        rel_path = "#{method}/#{fetch_version}/#{action}"
         response = api_request(method, url(action, @options[:url_override]), rel_path, parameters)
 
         Response.new(

--- a/lib/active_merchant/billing/gateways/safe_charge.rb
+++ b/lib/active_merchant/billing/gateways/safe_charge.rb
@@ -13,7 +13,8 @@ module ActiveMerchant # :nodoc:
       self.homepage_url = 'https://www.safecharge.com'
       self.display_name = 'SafeCharge'
 
-      VERSION = '4.1.0'
+      # Define the API version using the Versionable module
+      version '4.1.0'
 
       def initialize(options = {})
         requires!(options, :client_login_id, :client_password)
@@ -133,7 +134,7 @@ module ActiveMerchant # :nodoc:
         post[:sg_ClientLoginID] = @options[:client_login_id]
         post[:sg_ClientPassword] = @options[:client_password]
         post[:sg_ResponseFormat] = '4'
-        post[:sg_Version] = VERSION
+        post[:sg_Version] = fetch_version
         post[:sg_ClientUniqueID] = options[:order_id] if options[:order_id]
         post[:sg_UserID] = options[:user_id] if options[:user_id]
         post[:sg_AuthType] = options[:auth_type] if options[:auth_type]

--- a/lib/active_merchant/billing/gateways/secure_net.rb
+++ b/lib/active_merchant/billing/gateways/secure_net.rb
@@ -1,7 +1,7 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class SecureNetGateway < Gateway
-      API_VERSION = '4.0'
+      version '4.0'
 
       TRANSACTIONS = {
         auth_only:            '0000',

--- a/test/remote/gateways/remote_rapyd_test.rb
+++ b/test/remote/gateways/remote_rapyd_test.rb
@@ -196,7 +196,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   def test_failed_purchase
     response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'The request attempted an operation that requires a card number, but the number was not recognized. The request was rejected. Corrective action: Use the card number of a valid card.', response.message
+    assert_equal 'Do Not Honor', response.message
   end
 
   def test_successful_authorize_and_capture
@@ -211,7 +211,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   def test_failed_authorize
     response = @gateway.authorize(@amount, @declined_card, @options)
     assert_failure response
-    assert_equal 'The request attempted an operation that requires a card number, but the number was not recognized. The request was rejected. Corrective action: Use the card number of a valid card.', response.message
+    assert_equal 'Do Not Honor', response.message
   end
 
   def test_partial_capture
@@ -309,7 +309,7 @@ class RemoteRapydTest < Test::Unit::TestCase
   def test_failed_verify
     response = @gateway.verify(@declined_card, @options)
     assert_failure response
-    assert_equal 'The request attempted an operation that requires a card number, but the number was not recognized. The request was rejected. Corrective action: Use the card number of a valid card.', response.message
+    assert_equal 'Do Not Honor', response.message
   end
 
   def test_successful_store_and_purchase
@@ -527,5 +527,18 @@ class RemoteRapydTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal 'SUCCESS', response.message
+  end
+
+  def test_api_version_in_request_path
+    # Make a simple API call that will show the version in the response
+    response = @gateway.verify(@credit_card, @options)
+
+    # Verify the response is successful
+    assert_success response
+
+    # Check that the base URLs contain the correct version
+    assert_equal 'v1', @gateway.fetch_version
+    assert_match %r{/v1/$}, @gateway.test_url
+    assert_match %r{/v1/$}, @gateway.payment_redirect_test
   end
 end

--- a/test/unit/gateways/safe_charge_test.rb
+++ b/test/unit/gateways/safe_charge_test.rb
@@ -420,6 +420,29 @@ class SafeChargeTest < Test::Unit::TestCase
     assert_equal 'APPROVED', purchase.params['status']
   end
 
+  def test_version_functionality
+    # Test that version is set correctly
+    assert_equal '4.1.0', @gateway.fetch_version
+
+    # Test that version is included in transaction data
+    purchase = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/sg_Version=4\.1\.0/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success purchase
+
+    # Test that version is also included in other transaction types
+    authorize = stub_comms do
+      @gateway.authorize(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/sg_Version=4\.1\.0/, data)
+    end.respond_with(successful_authorize_response)
+
+    assert_success authorize
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
 Normalize API  for Rapyd, SafeCharge and SecureNet


Ticket : https://spreedly.atlassian.net/browse/OPPS-244

