### PR TITLE
Normalize API versions for paypal, paysafe, and payu_latam

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -183,6 +183,7 @@
 * Cecabank: Fix finRec field formatting for Cecabank Gateway [aaqibrashidmir] #5506
 * Nuvei: Map order_id to clientUniqueId field on capture transactions [aaqibrashidmir] #5498
 * Ebanx: Added new GSF payment.taxes.iva_co [ritesh-spreedly] #5509
+* Normalize API versions for paypal, paysafe, and payu_latam [mjdonga] #5515
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/paypal.rb
+++ b/lib/active_merchant/billing/gateways/paypal.rb
@@ -5,6 +5,8 @@ require 'active_merchant/billing/gateways/paypal_express'
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class PaypalGateway < Gateway
+      version '2.0'
+
       include PaypalCommonAPI
       include PaypalRecurringApi
 

--- a/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
+++ b/lib/active_merchant/billing/gateways/paypal/paypal_common_api.rb
@@ -7,13 +7,6 @@ module ActiveMerchant # :nodoc:
       API_VERSION = '124'
       API_VERSION_3DS2 = '214.0'
 
-      URLS = {
-        :test => { :certificate => 'https://api.sandbox.paypal.com/2.0/',
-                   :signature   => 'https://api-3t.sandbox.paypal.com/2.0/' },
-        :live => { :certificate => 'https://api.paypal.com/2.0/',
-                   :signature   => 'https://api-3t.paypal.com/2.0/' }
-      }
-
       PAYPAL_NAMESPACE = 'urn:ebay:api:PayPalAPI'
       EBAY_NAMESPACE = 'urn:ebay:apis:eBLBaseComponents'
 
@@ -59,8 +52,6 @@ module ActiveMerchant # :nodoc:
         base.default_currency = 'USD'
         base.cattr_accessor :pem_file
         base.cattr_accessor :signature
-        base.live_url = URLS[:live][:signature]
-        base.test_url = URLS[:test][:signature]
       end
 
       # The gateway must be configured with either your PayPal PEM file
@@ -94,6 +85,15 @@ module ActiveMerchant # :nodoc:
         end
 
         super(options)
+      end
+
+      def urls
+        {
+          :test => { :certificate => "https://api.sandbox.paypal.com/#{fetch_version}/",
+                    :signature   => "https://api-3t.sandbox.paypal.com/#{fetch_version}/" },
+          :live => { :certificate => "https://api.paypal.com/#{fetch_version}/",
+                    :signature   => "https://api-3t.paypal.com/#{fetch_version}/" }
+        }
       end
 
       def reauthorize(money, authorization, options = {})
@@ -661,7 +661,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def endpoint_url
-        URLS[test? ? :test : :live][@options[:signature].blank? ? :certificate : :signature]
+        urls[test? ? :test : :live][@options[:signature].blank? ? :certificate : :signature]
       end
 
       def commit(action, request)

--- a/lib/active_merchant/billing/gateways/paypal_express.rb
+++ b/lib/active_merchant/billing/gateways/paypal_express.rb
@@ -6,6 +6,8 @@ require 'active_merchant/billing/gateways/paypal_express_common'
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class PaypalExpressGateway < Gateway
+      version '2.0'
+
       include PaypalCommonAPI
       include PaypalExpressCommon
       include PaypalRecurringApi

--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -1,6 +1,8 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class PaysafeGateway < Gateway
+      version 'v1'
+
       self.test_url = 'https://api.test.paysafe.com'
       self.live_url = 'https://api.paysafe.com'
 
@@ -369,9 +371,9 @@ module ActiveMerchant # :nodoc:
         base_url = (test? ? test_url : live_url)
 
         if action.include? 'profiles'
-          "#{base_url}/customervault/v1/#{action}"
+          "#{base_url}/customervault/#{fetch_version}/#{action}"
         else
-          "#{base_url}/cardpayments/v1/accounts/#{@options[:account_id]}/#{action}"
+          "#{base_url}/cardpayments/#{fetch_version}/accounts/#{@options[:account_id]}/#{action}"
         end
       end
 

--- a/lib/active_merchant/billing/gateways/payu_latam.rb
+++ b/lib/active_merchant/billing/gateways/payu_latam.rb
@@ -3,11 +3,13 @@ require 'digest/md5'
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class PayuLatamGateway < Gateway
+      version '4.0'
+
       self.display_name = 'PayU Latam'
       self.homepage_url = 'http://www.payulatam.com'
 
-      self.test_url = 'https://sandbox.api.payulatam.com/payments-api/4.0/service.cgi'
-      self.live_url = 'https://api.payulatam.com/payments-api/4.0/service.cgi'
+      self.test_url = "https://sandbox.api.payulatam.com/payments-api/#{fetch_version}/service.cgi"
+      self.live_url = "https://api.payulatam.com/payments-api/#{fetch_version}/service.cgi"
 
       self.supported_countries = %w[AR BR CL CO MX PA PE]
       self.default_currency = 'USD'

--- a/test/unit/gateways/paypal_express_test.rb
+++ b/test/unit/gateways/paypal_express_test.rb
@@ -825,6 +825,10 @@ class PaypalExpressTest < Test::Unit::TestCase
     assert_equal 'idempotency_key', REXML::XPath.first(request, '//n2:DoExpressCheckoutPaymentRequestDetails/n2:MsgSubID').text
   end
 
+  def test_api_version
+    assert_equal '2.0', @gateway.fetch_version
+  end
+
   private
 
   def successful_create_billing_agreement_response

--- a/test/unit/gateways/paypal_test.rb
+++ b/test/unit/gateways/paypal_test.rb
@@ -294,7 +294,7 @@ class PaypalTest < Test::Unit::TestCase
       password: 'test',
       pem: 'PEM'
     )
-    assert_equal PaypalGateway::URLS[:test][:certificate], gateway.send(:endpoint_url)
+    assert_equal 'https://api.sandbox.paypal.com/2.0/', gateway.send(:endpoint_url)
   end
 
   def test_should_use_live_certificate_endpoint
@@ -305,7 +305,7 @@ class PaypalTest < Test::Unit::TestCase
     )
     gateway.expects(:test?).returns(false)
 
-    assert_equal PaypalGateway::URLS[:live][:certificate], gateway.send(:endpoint_url)
+    assert_equal 'https://api.paypal.com/2.0/', gateway.send(:endpoint_url)
   end
 
   def test_should_use_test_signature_endpoint
@@ -315,7 +315,7 @@ class PaypalTest < Test::Unit::TestCase
       signature: 'SIG'
     )
 
-    assert_equal PaypalGateway::URLS[:test][:signature], gateway.send(:endpoint_url)
+    assert_equal 'https://api-3t.sandbox.paypal.com/2.0/', gateway.send(:endpoint_url)
   end
 
   def test_should_use_live_signature_endpoint
@@ -326,7 +326,7 @@ class PaypalTest < Test::Unit::TestCase
     )
     gateway.expects(:test?).returns(false)
 
-    assert_equal PaypalGateway::URLS[:live][:signature], gateway.send(:endpoint_url)
+    assert_equal 'https://api-3t.paypal.com/2.0/', gateway.send(:endpoint_url)
   end
 
   def test_should_raise_argument_when_credentials_not_present
@@ -640,6 +640,10 @@ class PaypalTest < Test::Unit::TestCase
       assert_match %r{<ThreeDSVersion>2.1.0</ThreeDSVersion>}, data
       assert_match %r{<DSTransactionId>ds_transaction_id</DSTransactionId>}, data
     end.respond_with(successful_purchase_response)
+  end
+
+  def test_api_version
+    assert_equal '2.0', @gateway.fetch_version
   end
 
   private

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -321,6 +321,19 @@ class PaysafeTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_urls_for_test_and_live_mode
+    assert_equal 'https://api.test.paysafe.com/customervault/v1/profiles', @gateway.send(:url, 'profiles')
+    assert_equal 'https://api.test.paysafe.com/cardpayments/v1/accounts/account_id/auths', @gateway.send(:url, 'auths')
+
+    @gateway.expects(:test?).returns(false).twice
+    assert_equal 'https://api.paysafe.com/customervault/v1/profiles', @gateway.send(:url, 'profiles')
+    assert_equal 'https://api.paysafe.com/cardpayments/v1/accounts/account_id/auths', @gateway.send(:url, 'auths')
+  end
+
+  def test_api_version
+    assert_equal 'v1', @gateway.fetch_version
+  end
+
   private
 
   def pre_scrubbed

--- a/test/unit/gateways/payu_latam_test.rb
+++ b/test/unit/gateways/payu_latam_test.rb
@@ -486,6 +486,17 @@ class PayuLatamTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_urls_for_test_and_live_mode
+    assert_equal 'https://sandbox.api.payulatam.com/payments-api/4.0/service.cgi', @gateway.send(:url)
+
+    @gateway.expects(:test?).returns(false)
+    assert_equal 'https://api.payulatam.com/payments-api/4.0/service.cgi', @gateway.send(:url)
+  end
+
+  def test_api_version
+    assert_equal '4.0', @gateway.fetch_version
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Normalize API versions for paypal, paysafe, and payu_latam

**Remote test result**
Paysafe:
33 tests, 98 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.9697% passed

Paypal:
31 tests, 86 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
96.7742% passed

Payu Latam:
39 tests, 59 assertions, 26 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
33.3333% passed