### PR TITLE
TNS/TransFirstTransactionExpress/USA EPAY: Normalize the use of API_VERSION

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -198,6 +198,7 @@
 * PayArc/PayConex/HPS: Normalize API_VERSION usage [sumit-sharmas] #5521
 * VantivExpress: Add support of level 2 and 3 data [adarsh-spreedly] #5487
 * Normalize API versions for paypal, paysafe, and payu_latam [mjdonga] #5515
+* TNS/TransFirstTransactionExpress/USA EPAY: Normalize API_VERSION usage [sumit-sharmas] #5516
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/tns.rb
+++ b/lib/active_merchant/billing/gateways/tns.rb
@@ -5,13 +5,13 @@ module ActiveMerchant
 
       class_attribute :live_na_url, :live_ap_url, :live_eu_url, :test_na_url, :test_ap_url, :test_eu_url
 
-      VERSION = '52'
+      version '52'
 
-      self.live_na_url = "https://secure.na.tnspayments.com/api/rest/version/#{VERSION}/"
-      self.live_ap_url = "https://secure.ap.tnspayments.com/api/rest/version/#{VERSION}/"
-      self.live_eu_url = "https://secure.eu.tnspayments.com/api/rest/version/#{VERSION}/"
+      self.live_na_url = "https://secure.na.tnspayments.com/api/rest/version/#{fetch_version}/"
+      self.live_ap_url = "https://secure.ap.tnspayments.com/api/rest/version/#{fetch_version}/"
+      self.live_eu_url = "https://secure.eu.tnspayments.com/api/rest/version/#{fetch_version}/"
 
-      self.test_url = "https://secure.uat.tnspayments.com/api/rest/version/#{VERSION}/"
+      self.test_url = "https://secure.uat.tnspayments.com/api/rest/version/#{fetch_version}/"
 
       self.display_name = 'TNS'
       self.homepage_url = 'http://www.tnsi.com/'

--- a/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
+++ b/lib/active_merchant/billing/gateways/trans_first_transaction_express.rb
@@ -3,18 +3,20 @@ require 'nokogiri'
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class TransFirstTransactionExpressGateway < Gateway
+      version 'v1'
+
       self.display_name = 'TransFirst Transaction Express'
       self.homepage_url = 'http://transactionexpress.com/'
 
-      self.test_url = 'https://ws.cert.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1?wsdl'
-      self.live_url = 'https://ws.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1?wsdl'
+      self.test_url = "https://ws.cert.transactionexpress.com/portal/merchantframework/MerchantWebServices-#{fetch_version}?wsdl"
+      self.live_url = "https://ws.transactionexpress.com/portal/merchantframework/MerchantWebServices-#{fetch_version}?wsdl"
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'
       self.money_format = :cents
       self.supported_cardtypes = %i[visa master american_express discover diners_club]
 
-      V1_NAMESPACE = 'http://postilion/realtime/merchantframework/xsd/v1/'
+      V1_NAMESPACE = "http://postilion/realtime/merchantframework/xsd/#{fetch_version}/"
       SOAPENV_NAMESPACE = 'http://schemas.xmlsoap.org/soap/envelope/'
       AUTHORIZATION_FIELD_SEPARATOR = '|'
 

--- a/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
+++ b/lib/active_merchant/billing/gateways/usa_epay_advanced.rb
@@ -62,7 +62,7 @@ module ActiveMerchant # :nodoc:
     # * {USA ePay Developer Login}[https://www.usaepay.com/developer/login]
     #
     class UsaEpayAdvancedGateway < Gateway
-      API_VERSION = '1.4'
+      version '1.4'
 
       TEST_URL_BASE = 'https://sandbox.usaepay.com/soap/gate/' # :nodoc:
       LIVE_URL_BASE = 'https://www.usaepay.com/soap/gate/' # :nodoc:

--- a/test/unit/gateways/tns_test.rb
+++ b/test/unit/gateways/tns_test.rb
@@ -18,6 +18,10 @@ class TnsTest < Test::Unit::TestCase
     }
   end
 
+  def test_api_version
+    assert_equal '52', @gateway.fetch_version
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_request).twice.returns(successful_authorize_response).then.returns(successful_capture_response)
 
@@ -176,6 +180,13 @@ class TnsTest < Test::Unit::TestCase
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  def test_url
+    assert_equal 'https://secure.na.tnspayments.com/api/rest/version/52/', @gateway.live_na_url
+    assert_equal 'https://secure.ap.tnspayments.com/api/rest/version/52/', @gateway.live_ap_url
+    assert_equal 'https://secure.eu.tnspayments.com/api/rest/version/52/', @gateway.live_eu_url
+    assert_equal 'https://secure.uat.tnspayments.com/api/rest/version/52/', @gateway.test_url
   end
 
   private

--- a/test/unit/gateways/trans_first_transaction_express_test.rb
+++ b/test/unit/gateways/trans_first_transaction_express_test.rb
@@ -15,6 +15,10 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
     @declined_amount = 21
   end
 
+  def test_api_version
+    assert_equal 'v1', @gateway.fetch_version
+  end
+
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
@@ -272,6 +276,11 @@ class TransFirstTransactionExpressTest < Test::Unit::TestCase
 
   def test_account_number_scrubbing
     assert_equal post_scrubbed_account_number, @gateway.scrub(pre_scrubbed_account_number)
+  end
+
+  def test_url
+    assert_equal 'https://ws.cert.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1?wsdl', @gateway.test_url
+    assert_equal 'https://ws.transactionexpress.com/portal/merchantframework/MerchantWebServices-v1?wsdl', @gateway.live_url
   end
 
   private

--- a/test/unit/gateways/usa_epay_advanced_test.rb
+++ b/test/unit/gateways/usa_epay_advanced_test.rb
@@ -103,6 +103,10 @@ class UsaEpayAdvancedTest < Test::Unit::TestCase
 
   # Standard Gateway ==================================================
 
+  def test_api_version
+    assert_equal '1.4', @gateway.fetch_version
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert response = @gateway.purchase(1234, @credit_card, @options)


### PR DESCRIPTION
Normalize the use of API_VERSION for TNS, TransFirstTransactionExpress and USA EPAY gateways.

Remote Test Results:

TNS:
13 tests, 26 assertions, 9 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications 23.0769% passed

TransFirstTransactionExpress:
34 tests, 0 assertions, 0 failures, 34 errors, 0 pendings, 0 omissions, 0 notifications 0% passed

USA EPAY:
USA EPAY advanced:
40 tests, 0 assertions, 0 failures, 40 errors, 0 pendings, 0 omissions, 0 notifications 0% passed

USA EPAY transaction:
34 tests, 0 assertions, 0 failures, 34 errors, 0 pendings, 0 omissions, 0 notifications 0% passed