### PR TITLE
Normalize API versions for Priority, Pin and Plexo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -184,6 +184,7 @@
 * Nuvei: Map order_id to clientUniqueId field on capture transactions [aaqibrashidmir] #5498
 * Ebanx: Added new GSF payment.taxes.iva_co [ritesh-spreedly] #5509
 * Litle: Remove 141 & 142 [almalee24] #5505
+* Normalize API Version for Plexo, Pin, Priority [adarsh-spreedly] #5517
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/pin.rb
+++ b/lib/active_merchant/billing/gateways/pin.rb
@@ -1,8 +1,10 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class PinGateway < Gateway
-      self.test_url = 'https://test-api.pinpayments.com/1'
-      self.live_url = 'https://api.pinpayments.com/1'
+      version '1'
+
+      self.test_url = "https://test-api.pinpayments.com/#{fetch_version}"
+      self.live_url = "https://api.pinpayments.com/#{fetch_version}"
 
       self.default_currency = 'AUD'
       self.money_format = :cents

--- a/lib/active_merchant/billing/gateways/plexo.rb
+++ b/lib/active_merchant/billing/gateways/plexo.rb
@@ -1,8 +1,10 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class PlexoGateway < Gateway
-      self.test_url = 'https://api.testing.plexo.com.uy/v1/payments'
-      self.live_url = 'https://api.plexo.com.uy/v1/payments'
+      version 'v1'
+
+      self.test_url = "https://api.testing.plexo.com.uy/#{fetch_version}/payments"
+      self.live_url = "https://api.plexo.com.uy/#{fetch_version}/payments"
 
       self.supported_countries = ['UY']
       self.default_currency = 'UYU'

--- a/lib/active_merchant/billing/gateways/priority.rb
+++ b/lib/active_merchant/billing/gateways/priority.rb
@@ -3,7 +3,6 @@ module ActiveMerchant # :nodoc:
     class PriorityGateway < Gateway
       version 'v3'
       version 'v1', :verify_card_api
-      version 'v3', :batch_status_api
       version 'v1', :jwt_api
 
       # Sandbox and Production
@@ -17,8 +16,8 @@ module ActiveMerchant # :nodoc:
       self.live_url_verify = "https://api2.mxmerchant.com/merchant/#{fetch_version(:verify_card_api)}/bin"
 
       # Sandbox and Production - check batch status
-      self.test_url_batch = "https://sandbox.api.mxmerchant.com/checkout/#{fetch_version(:batch_status_api)}/batch"
-      self.live_url_batch = "https://api.mxmerchant.com/checkout/#{fetch_version(:batch_status_api)}/batch"
+      self.test_url_batch = "https://sandbox.api.mxmerchant.com/checkout/#{fetch_version}/batch"
+      self.live_url_batch = "https://api.mxmerchant.com/checkout/#{fetch_version}/batch"
 
       # Sandbox and Production - generate jwt for verify card url
       self.test_url_jwt = "https://sandbox-api2.mxmerchant.com/security/#{fetch_version(:jwt_api)}/application/merchantId"

--- a/lib/active_merchant/billing/gateways/priority.rb
+++ b/lib/active_merchant/billing/gateways/priority.rb
@@ -1,23 +1,28 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class PriorityGateway < Gateway
+      version 'v3'
+      version 'v1', :verify_card_api
+      version 'v3', :batch_status_api
+      version 'v1', :jwt_api
+
       # Sandbox and Production
-      self.test_url = 'https://sandbox.api.mxmerchant.com/checkout/v3/payment'
-      self.live_url = 'https://api.mxmerchant.com/checkout/v3/payment'
+      self.test_url = "https://sandbox.api.mxmerchant.com/checkout/#{fetch_version}/payment"
+      self.live_url = "https://api.mxmerchant.com/checkout/#{fetch_version}/payment"
 
       class_attribute :test_url_verify, :live_url_verify, :test_auth, :live_auth, :test_env_verify, :live_env_verify, :test_url_batch, :live_url_batch, :test_url_jwt, :live_url_jwt, :merchant
 
       # Sandbox and Production - verify card
-      self.test_url_verify = 'https://sandbox-api2.mxmerchant.com/merchant/v1/bin'
-      self.live_url_verify = 'https://api2.mxmerchant.com/merchant/v1/bin'
+      self.test_url_verify = "https://sandbox-api2.mxmerchant.com/merchant/#{fetch_version(:verify_card_api)}/bin"
+      self.live_url_verify = "https://api2.mxmerchant.com/merchant/#{fetch_version(:verify_card_api)}/bin"
 
       # Sandbox and Production - check batch status
-      self.test_url_batch = 'https://sandbox.api.mxmerchant.com/checkout/v3/batch'
-      self.live_url_batch = 'https://api.mxmerchant.com/checkout/v3/batch'
+      self.test_url_batch = "https://sandbox.api.mxmerchant.com/checkout/#{fetch_version(:batch_status_api)}/batch"
+      self.live_url_batch = "https://api.mxmerchant.com/checkout/#{fetch_version(:batch_status_api)}/batch"
 
       # Sandbox and Production - generate jwt for verify card url
-      self.test_url_jwt = 'https://sandbox-api2.mxmerchant.com/security/v1/application/merchantId'
-      self.live_url_jwt = 'https://api2.mxmerchant.com/security/v1/application/merchantId'
+      self.test_url_jwt = "https://sandbox-api2.mxmerchant.com/security/#{fetch_version(:jwt_api)}/application/merchantId"
+      self.live_url_jwt = "https://api2.mxmerchant.com/security/#{fetch_version(:jwt_api)}/application/merchantId"
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'

--- a/test/unit/gateways/pin_test.rb
+++ b/test/unit/gateways/pin_test.rb
@@ -58,6 +58,11 @@ class PinTest < Test::Unit::TestCase
     }
   end
 
+  def test_endpoint
+    assert_equal 'https://test-api.pinpayments.com/1', @gateway.test_url
+    assert_equal 'https://api.pinpayments.com/1', @gateway.live_url
+  end
+
   def test_required_api_key_on_initialization
     assert_raises ArgumentError do
       PinGateway.new

--- a/test/unit/gateways/plexo_test.rb
+++ b/test/unit/gateways/plexo_test.rb
@@ -48,6 +48,11 @@ class PlexoTest < Test::Unit::TestCase
     }
   end
 
+  def test_endpoint
+    assert_equal 'https://api.testing.plexo.com.uy/v1/payments', @gateway.test_url
+    assert_equal 'https://api.plexo.com.uy/v1/payments', @gateway.live_url
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 

--- a/test/unit/gateways/priority_test.rb
+++ b/test/unit/gateways/priority_test.rb
@@ -46,6 +46,26 @@ class PriorityTest < Test::Unit::TestCase
     }
   end
 
+  def test_endpoint
+    assert_equal 'https://sandbox.api.mxmerchant.com/checkout/v3/payment', @gateway.test_url
+    assert_equal 'https://api.mxmerchant.com/checkout/v3/payment', @gateway.live_url
+  end
+
+  def test_verify_card_endpoint
+    assert_equal 'https://sandbox-api2.mxmerchant.com/merchant/v1/bin', @gateway.test_url_verify
+    assert_equal 'https://api2.mxmerchant.com/merchant/v1/bin', @gateway.live_url_verify
+  end
+
+  def test_batch_status_endpoint
+    assert_equal 'https://sandbox.api.mxmerchant.com/checkout/v3/batch', @gateway.test_url_batch
+    assert_equal 'https://api.mxmerchant.com/checkout/v3/batch', @gateway.live_url_batch
+  end
+
+  def test_jwt_endpoint
+    assert_equal 'https://sandbox-api2.mxmerchant.com/security/v1/application/merchantId', @gateway.test_url_jwt
+    assert_equal 'https://api2.mxmerchant.com/security/v1/application/merchantId', @gateway.live_url_jwt
+  end
+
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
Plexo:

> Remote:
>   34 tests, 70 assertions, 7 failures, 0 errors, 0 pendings, 3 omissions, 0 notifications
>   77.4194% passed
> Unit:
>   27 tests, 147 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
>   100% passed
> 

Pin:
    

> Remote:
>       25 tests, 74 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
>       96% passed
>     Unit:
>       49 tests, 164 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
>       100% passed

Priority:
    

> Remote:
>       31 tests, 84 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
>       80.6452% passed
>     Unit:
>       27 tests, 163 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
>       100% passed