### PR TITLE
Normalize API Versions for litle, mercado_pago and mundipagg

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -184,6 +184,7 @@
 * Nuvei: Map order_id to clientUniqueId field on capture transactions [aaqibrashidmir] #5498
 * Ebanx: Added new GSF payment.taxes.iva_co [ritesh-spreedly] #5509
 * Litle: Remove 141 & 142 [almalee24] #5505
+* Normalize API Versions for litle, mercado_pago and mundipagg [mjdonga] #5518
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -3,7 +3,7 @@ require 'nokogiri'
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class LitleGateway < Gateway
-      SCHEMA_VERSION = '9.14'
+      version '9.14'
 
       class_attribute :postlive_url, :prelive_url
 
@@ -598,7 +598,7 @@ module ActiveMerchant # :nodoc:
       def root_attributes
         {
           merchantId: @options[:merchant_id],
-          version: SCHEMA_VERSION,
+          version: fetch_version,
           xmlns: 'http://www.litle.com/schema'
         }
       end

--- a/lib/active_merchant/billing/gateways/mercado_pago.rb
+++ b/lib/active_merchant/billing/gateways/mercado_pago.rb
@@ -1,7 +1,9 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class MercadoPagoGateway < Gateway
-      self.live_url = self.test_url = 'https://api.mercadopago.com/v1'
+      version 'v1'
+
+      self.live_url = self.test_url = "https://api.mercadopago.com/#{fetch_version}"
 
       self.supported_countries = %w[AR BR CL CO MX PE UY]
       self.supported_cardtypes = %i[visa master american_express elo cabal naranja creditel patagonia_365 tarjeta_sol]

--- a/lib/active_merchant/billing/gateways/mundipagg.rb
+++ b/lib/active_merchant/billing/gateways/mundipagg.rb
@@ -1,7 +1,9 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class MundipaggGateway < Gateway
-      self.live_url = 'https://api.mundipagg.com/core/v1'
+      version 'v1'
+
+      self.live_url = "https://api.mundipagg.com/core/#{fetch_version}"
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -805,6 +805,18 @@ class LitleTest < Test::Unit::TestCase
     assert @gateway.supports_scrubbing?
   end
 
+  def test_schema_version
+    assert_equal '9.14', @gateway.fetch_version
+  end
+
+  def test_schema_version_in_xml_request
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, order_source: 'recurring')
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<litleOnlineRequest xmlns="http://www.litle.com/schema" merchantId="merchant_id" version="9.14">), data)
+    end.respond_with(successful_purchase_response)
+  end
+
   private
 
   def network_transaction_id

--- a/test/unit/gateways/mercado_pago_test.rb
+++ b/test/unit/gateways/mercado_pago_test.rb
@@ -555,6 +555,15 @@ class MercadoPagoTest < Test::Unit::TestCase
     end.respond_with(successful_purchase_response)
   end
 
+  def test_api_version
+    assert_equal 'v1', @gateway.fetch_version
+  end
+
+  def test_test_and_live_urls
+    assert_equal 'https://api.mercadopago.com/v1', @gateway.test_url
+    assert_equal 'https://api.mercadopago.com/v1', @gateway.live_url
+  end
+
   private
 
   def pre_scrubbed

--- a/test/unit/gateways/mundipagg_test.rb
+++ b/test/unit/gateways/mundipagg_test.rb
@@ -389,6 +389,14 @@ class MundipaggTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_api_version
+    assert_equal 'v1', @gateway.fetch_version
+  end
+
+  def test_url_for
+    assert_equal 'https://api.mundipagg.com/core/v1/charges/', @gateway.send(:url_for, 'sale')
+  end
+
   private
 
   def test_successful_purchase_with(card)


### PR DESCRIPTION
Normalize API Versions for litle, mercado_pago and mundipagg gateways

**Remote**
Mercado pago
45 tests, 71 assertions, 29 failures, 2 errors, 0 pendings, 0 omissions, 0 notifications
31.1111% passed

Mundipagg
41 tests, 55 assertions, 38 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
7.31707% passed

Litle
60 tests, 207 assertions, 21 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
65% passed