### PR TITLE
Normalize API Versions for Barclay card Smart pay, Fat Zebra and Forte

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -184,6 +184,7 @@
 * Nuvei: Map order_id to clientUniqueId field on capture transactions [aaqibrashidmir] #5498
 * Ebanx: Added new GSF payment.taxes.iva_co [ritesh-spreedly] #5509
 * Litle: Remove 141 & 142 [almalee24] #5505
+* Normalize API Versions for Barclay card Smart pay, Fat Zebra and Forte gateways [mjdonga] #5519
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
+++ b/lib/active_merchant/billing/gateways/barclaycard_smartpay.rb
@@ -1,6 +1,8 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class BarclaycardSmartpayGateway < Gateway
+      version 'v40'
+
       self.test_url = 'https://pal-test.barclaycardsmartpay.com/pal/servlet'
       self.live_url = 'https://pal-live.barclaycardsmartpay.com/pal/servlet'
 
@@ -13,8 +15,6 @@ module ActiveMerchant # :nodoc:
 
       self.homepage_url = 'https://www.barclaycardsmartpay.com/'
       self.display_name = 'Barclaycard Smartpay'
-
-      API_VERSION = 'v40'
 
       def initialize(options = {})
         requires!(options, :company, :merchant, :password)
@@ -257,13 +257,13 @@ module ActiveMerchant # :nodoc:
       def build_url(action)
         case action
         when 'store'
-          "#{test? ? self.test_url : self.live_url}/Recurring/#{API_VERSION}/storeToken"
+          "#{test? ? self.test_url : self.live_url}/Recurring/#{fetch_version}/storeToken"
         when 'finalize3ds'
-          "#{test? ? self.test_url : self.live_url}/Payment/#{API_VERSION}/authorise3d"
+          "#{test? ? self.test_url : self.live_url}/Payment/#{fetch_version}/authorise3d"
         when 'storeDetailAndSubmitThirdParty', 'confirmThirdParty'
-          "#{test? ? self.test_url : self.live_url}/Payout/#{API_VERSION}/#{action}"
+          "#{test? ? self.test_url : self.live_url}/Payout/#{fetch_version}/#{action}"
         else
-          "#{test? ? self.test_url : self.live_url}/Payment/#{API_VERSION}/#{action}"
+          "#{test? ? self.test_url : self.live_url}/Payment/#{fetch_version}/#{action}"
         end
       end
 

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -3,8 +3,10 @@ require 'json'
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class FatZebraGateway < Gateway
-      self.live_url = 'https://gateway.fatzebra.com.au/v1.0'
-      self.test_url = 'https://gateway.sandbox.fatzebra.com.au/v1.0'
+      version 'v1.0'
+
+      self.live_url = "https://gateway.fatzebra.com.au/#{fetch_version}"
+      self.test_url = "https://gateway.sandbox.fatzebra.com.au/#{fetch_version}"
 
       self.supported_countries = ['AU']
       self.default_currency = 'AUD'

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -5,8 +5,10 @@ module ActiveMerchant # :nodoc:
     class ForteGateway < Gateway
       include Empty
 
-      self.test_url = 'https://sandbox.forte.net/api/v2'
-      self.live_url = 'https://api.forte.net/v2'
+      version 'v2'
+
+      self.test_url = "https://sandbox.forte.net/api/#{fetch_version}"
+      self.live_url = "https://api.forte.net/#{fetch_version}"
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'

--- a/test/unit/gateways/barclaycard_smartpay_test.rb
+++ b/test/unit/gateways/barclaycard_smartpay_test.rb
@@ -485,6 +485,21 @@ class BarclaycardSmartpayTest < Test::Unit::TestCase
     assert_equal('702: Internal error', message2)
   end
 
+  def test_api_version
+    assert_equal 'v40', @gateway.fetch_version
+  end
+
+  def test_urls_for_test_and_live_mode
+    assert_equal 'https://pal-test.barclaycardsmartpay.com/pal/servlet/Recurring/v40/storeToken', @gateway.send(:build_url, 'store')
+    assert_equal 'https://pal-test.barclaycardsmartpay.com/pal/servlet/Payment/v40/authorise', @gateway.send(:build_url, 'authorise')
+    assert_equal 'https://pal-test.barclaycardsmartpay.com/pal/servlet/Payment/v40/capture', @gateway.send(:build_url, 'capture')
+
+    @gateway.expects(:test?).returns(false).times(3)
+    assert_equal 'https://pal-live.barclaycardsmartpay.com/pal/servlet/Recurring/v40/storeToken', @gateway.send(:build_url, 'store')
+    assert_equal 'https://pal-live.barclaycardsmartpay.com/pal/servlet/Payment/v40/authorise', @gateway.send(:build_url, 'authorise')
+    assert_equal 'https://pal-live.barclaycardsmartpay.com/pal/servlet/Payment/v40/capture', @gateway.send(:build_url, 'capture')
+  end
+
   private
 
   def successful_authorize_response

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -268,6 +268,15 @@ class FatZebraTest < Test::Unit::TestCase
     assert_equal 'U', @gateway.send('formatted_enrollment', 'U')
   end
 
+  def test_api_version
+    assert_equal 'v1.0', @gateway.fetch_version
+  end
+
+  def test_urls_for_test_and_live_mode
+    assert_equal 'https://gateway.sandbox.fatzebra.com.au/v1.0', @gateway.test_url
+    assert_equal 'https://gateway.fatzebra.com.au/v1.0', @gateway.live_url
+  end
+
   private
 
   def pre_scrubbed

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -188,6 +188,15 @@ class ForteTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_api_version
+    assert_equal 'v2', @gateway.fetch_version
+  end
+
+  def test_urls_for_test_and_live_mode
+    assert_equal 'https://sandbox.forte.net/api/v2', @gateway.test_url
+    assert_equal 'https://api.forte.net/v2', @gateway.live_url
+  end
+
   private
 
   class MockedResponse


### PR DESCRIPTION
Normalize API Versions for Barclay card Smart pay, Fat Zebra and Forte gateways

**Remote**
Forte Gateway
24 tests, 74 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Fat Zebra
30 tests, 104 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.3333% passed

Barclaycard Smartpay
38 tests, 0 assertions, 0 failures, 37 errors, 0 pendings, 0 omissions, 0 notifications
2.63158% passed