### PR TITLE
Normalize the use of API_VERSION for Vpos, VisanetPeru and QuickPay 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -201,6 +201,7 @@
 * StripePI: Add support for multicapture [mjdonga] #5491
 * Normalize API Version for Plexo, Pin, Priority [adarsh-spreedly] #5517
 * Stripe PI: Update API version [almalee24] #5360
+* Vpos/VisanetPeru/QuickPay: Normalize the use of API_VERSION [aaqibrashidmir] #5520
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -9,11 +9,14 @@ module ActiveMerchant # :nodoc:
     class QuickpayGateway < Gateway
       self.abstract_class = true
 
+      DEFAULT_API_VERSION = QuickpayV10Gateway::API_VERSION
+      version DEFAULT_API_VERSION
+
       def self.new(options = {})
         options.fetch(:login) { raise ArgumentError.new('Missing required parameter: login') }
 
-        version = options[:login].to_i < 10000000 ? 10 : 7
-        if version <= 7
+        version = options[:login].to_i < 10000000 ? QuickpayV10Gateway::API_VERSION : QuickpayV4to7Gateway::API_VERSION
+        if version <= QuickpayV4to7Gateway::API_VERSION
           QuickpayV4to7Gateway.new(options)
         else
           QuickpayV10Gateway.new(options)

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v10.rb
@@ -5,7 +5,9 @@ module ActiveMerchant
   module Billing
     class QuickpayV10Gateway < Gateway
       include QuickpayCommon
+
       API_VERSION = 10
+      version API_VERSION
 
       self.live_url = self.test_url = 'https://api.quickpay.net'
 
@@ -200,8 +202,8 @@ module ActiveMerchant
       end
 
       def add_additional_params(action, post, options = {})
-        MD5_CHECK_FIELDS[API_VERSION][action].each do |key|
-          key       = key.to_sym
+        MD5_CHECK_FIELDS[fetch_version][action].each do |key|
+          key = key.to_sym
           post[key] = options[key] if options[key]
         end
       end
@@ -273,9 +275,9 @@ module ActiveMerchant
         auth = Base64.strict_encode64(":#{@options[:api_key]}")
         {
           'Authorization'  => 'Basic ' + auth,
-          'User-Agent'     => "Quickpay-v#{API_VERSION} ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+          'User-Agent'     => "Quickpay-v#{fetch_version} ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           'Accept'         => 'application/json',
-          'Accept-Version' => "v#{API_VERSION}",
+          'Accept-Version' => "v#{fetch_version}",
           'Content-Type'   => 'application/json'
         }
       end

--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
@@ -6,6 +6,10 @@ module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class QuickpayV4to7Gateway < Gateway
       include QuickpayCommon
+
+      API_VERSION = 7
+      version API_VERSION
+
       self.live_url = self.test_url = 'https://secure.quickpay.dk/api'
       APPROVED = '000'
 
@@ -14,8 +18,8 @@ module ActiveMerchant # :nodoc:
       # To use the API-key from the Quickpay manager, specify :api-key
       # Using the API-key, requires that you use version 4+. Specify :version => 4/5/6/7 in options.
       def initialize(options = {})
+        @protocol = options.delete(:version) || API_VERSION
         requires!(options, :login, :password)
-        @protocol = options.delete(:version) || 7 # default to protocol version 7
         super
       end
 

--- a/lib/active_merchant/billing/gateways/visanet_peru.rb
+++ b/lib/active_merchant/billing/gateways/visanet_peru.rb
@@ -2,11 +2,12 @@ module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class VisanetPeruGateway < Gateway
       include Empty
+      version 'v2'
       self.display_name = 'VisaNet Peru Gateway'
       self.homepage_url = 'http://www.visanet.com.pe'
 
-      self.test_url = 'https://devapi.vnforapps.com/api.tokenization/api/v2/merchant'
-      self.live_url = 'https://api.vnforapps.com/api.tokenization/api/v2/merchant'
+      self.test_url = "https://devapi.vnforapps.com/api.tokenization/api/#{fetch_version}/merchant"
+      self.live_url = "https://api.vnforapps.com/api.tokenization/api/#{fetch_version}/merchant"
 
       self.supported_countries = %w[US PE]
       self.default_currency = 'PEN'

--- a/lib/active_merchant/billing/gateways/vpos.rb
+++ b/lib/active_merchant/billing/gateways/vpos.rb
@@ -4,6 +4,7 @@ require 'jwe'
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class VposGateway < Gateway
+      version '0.3'
       self.test_url = 'https://vpos.infonet.com.py:8888'
       self.live_url = 'https://vpos.infonet.com.py'
 
@@ -17,11 +18,11 @@ module ActiveMerchant # :nodoc:
       self.money_format = :dollars
 
       ENDPOINTS = {
-        pci_encryption_key: '/vpos/api/0.3/application/encryption-key',
-        pay_pci_buy_encrypted: '/vpos/api/0.3/pci/encrypted',
-        pci_buy_rollback: '/vpos/api/0.3/pci_buy/rollback',
-        refund: '/vpos/api/0.3/refunds',
-        inquire: '/vpos/api/0.3/pci_buy/confirmations'
+        pci_encryption_key: "/vpos/api/#{fetch_version}/application/encryption-key",
+        pay_pci_buy_encrypted: "/vpos/api/#{fetch_version}/pci/encrypted",
+        pci_buy_rollback: "/vpos/api/#{fetch_version}/pci_buy/rollback",
+        refund: "/vpos/api/#{fetch_version}/refunds",
+        inquire: "/vpos/api/#{fetch_version}/pci_buy/confirmations"
       }
 
       def initialize(options = {})

--- a/test/unit/gateways/quickpay_test.rb
+++ b/test/unit/gateways/quickpay_test.rb
@@ -16,4 +16,18 @@ class QuickpayTest < Test::Unit::TestCase
     gateway = QuickpayGateway.new(login: 100, api_key: 'APIKEY')
     assert_instance_of QuickpayV10Gateway, gateway
   end
+
+  def test_factory_returns_v4to7_gateway_with_correct_url_and_version
+    gateway = QuickpayGateway.new(login: 50000000, password: 'secret')
+    assert_instance_of ActiveMerchant::Billing::QuickpayV4to7Gateway, gateway
+    assert_equal 'https://secure.quickpay.dk/api', gateway.class.test_url
+    assert_equal 7, gateway.class.fetch_version  # Expect integer version
+  end
+
+  def test_factory_returns_v10_gateway_with_correct_url_and_version
+    gateway = QuickpayGateway.new(login: 100, api_key: 'APIKEY')
+    assert_instance_of ActiveMerchant::Billing::QuickpayV10Gateway, gateway
+    assert_equal 'https://api.quickpay.net', gateway.class.test_url
+    assert_equal 10, gateway.class.fetch_version  # Expect integer version
+  end
 end

--- a/test/unit/gateways/quickpay_v10_test.rb
+++ b/test/unit/gateways/quickpay_v10_test.rb
@@ -166,6 +166,21 @@ class QuickpayV10Test < Test::Unit::TestCase
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end
 
+  def test_test_url_and_version
+    stub_comms do
+      response = @gateway.purchase(@amount, @credit_card, @options)
+      assert_success response
+    end.check_request do |_endpoint, _data, headers|
+      assert_equal 'https://api.quickpay.net', @gateway.class.test_url
+      assert_equal 'v10', headers['Accept-Version']
+    end.respond_with(successful_payment_response, successful_authorization_response)
+  end
+
+  def test_api_normalization_v10
+    assert_equal 'https://api.quickpay.net', @gateway.class.test_url
+    assert_instance_of ActiveMerchant::Billing::QuickpayV10Gateway, @gateway
+  end
+
   private
 
   def successful_payment_response

--- a/test/unit/gateways/quickpay_v4to7_test.rb
+++ b/test/unit/gateways/quickpay_v4to7_test.rb
@@ -160,6 +160,22 @@ class QuickpayV4to7Test < Test::Unit::TestCase
     end.respond_with(successful_capture_response)
   end
 
+  def test_class_level_version_and_test_url
+    klass = @gateway.class
+    assert_equal 7, klass.fetch_version, 'Default class version should be 7'
+    assert_equal 'https://secure.quickpay.dk/api', klass.test_url, 'test_url should match expected endpoint'
+  end
+
+  def test_instance_protocol_matches_version_option
+    gateway = QuickpayGateway.new(login: merchant_id, password: 'PASSWORD', version: 6)
+    assert_equal 6, gateway.instance_variable_get(:@protocol), 'Protocol should match version option'
+  end
+
+  def test_instance_protocol_defaults_to_class_version
+    gateway = QuickpayGateway.new(login: merchant_id, password: 'PASSWORD')
+    assert_equal 7, gateway.instance_variable_get(:@protocol), 'Protocol should default to class version (7)'
+  end
+
   private
 
   def error_response

--- a/test/unit/gateways/vpos_test.rb
+++ b/test/unit/gateways/vpos_test.rb
@@ -95,6 +95,13 @@ class VposTest < Test::Unit::TestCase
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
   end
 
+  def test_api_version_in_test_and_live_url
+    test_gateway = VposGateway.new(public_key: 'test_key', private_key: 'test_private_key', test: true)
+    live_gateway = VposGateway.new(public_key: 'live_key', private_key: 'live_private_key', test: false)
+    assert_match %r{^https://vpos\.infonet\.com\.py:8888/vpos/api/0\.3/}, test_gateway.send(:build_request_url, :pci_encryption_key)
+    assert_match %r{^https://vpos\.infonet\.com\.py/vpos/api/0\.3/}, live_gateway.send(:build_request_url, :pci_encryption_key)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
Normalize the use of API_VERSION for Vpos, VisanetPeru and QuickPay 

Remote Test Results:

Vpos:
13 tests, 46 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 92.3077% passed

VisnetPeru:
18 tests, 25 assertions, 15 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications 11.1111% passed

QuickPay:
29 tests, 64 assertions, 27 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 6.89655% passed

QuickPayV4:
29 tests, 64 assertions, 27 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 6.89655% passed

QuickPayV10:
29 tests, 64 assertions, 27 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 6.89655% passed