### PR TITLE
PayArc/PayConex/HPS: Normalize the use of API_VERSION for some gateways

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -195,6 +195,7 @@
 * Credorax: Spec fix for updated processor name [adarsh-spreedly] #5492
 * Normalize API for Rapyd, SafeCharge and SecureNet [ritesh-kapoor-spreedly] #5514
 * Normalize API Version for Orbital, OptimalPayment, NabTransact [adarsh-spreedly] #5523
+* PayArc/PayConex/HPS: Normalize API_VERSION usage [sumit-sharmas] #5521
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/hps.rb
+++ b/lib/active_merchant/billing/gateways/hps.rb
@@ -3,6 +3,8 @@ require 'nokogiri'
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class HpsGateway < Gateway
+      version '1.0'
+
       self.live_url = 'https://api2.heartlandportico.com/hps.exchange.posgateway/posgatewayservice.asmx'
       self.test_url = 'https://cert.api2.heartlandportico.com/Hps.Exchange.PosGateway/PosGatewayService.asmx'
 
@@ -321,7 +323,7 @@ module ActiveMerchant # :nodoc:
         } do
           xml.SOAP :Body do
             xml.hps :PosRequest do
-              xml.hps :'Ver1.0' do
+              xml.hps :"Ver#{fetch_version}" do
                 xml.hps :Header do
                   xml.hps :SecretAPIKey, @options[:secret_api_key]
                   xml.hps :DeveloperID, @options[:developer_id] if @options[:developer_id]

--- a/lib/active_merchant/billing/gateways/pay_arc.rb
+++ b/lib/active_merchant/billing/gateways/pay_arc.rb
@@ -1,8 +1,10 @@
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:
     class PayArcGateway < Gateway
-      self.test_url = 'https://testapi.payarc.net/v1'
-      self.live_url = 'https://api.payarc.net/v1'
+      version 'v1'
+
+      self.test_url = "https://testapi.payarc.net/#{fetch_version}"
+      self.live_url = "https://api.payarc.net/#{fetch_version}"
 
       self.supported_countries = ['US']
       self.default_currency = 'usd'

--- a/lib/active_merchant/billing/gateways/pay_conex.rb
+++ b/lib/active_merchant/billing/gateways/pay_conex.rb
@@ -3,8 +3,10 @@ module ActiveMerchant # :nodoc:
     class PayConexGateway < Gateway
       include Empty
 
-      self.test_url = 'https://cert.payconex.net/api/qsapi/3.8/'
-      self.live_url = 'https://secure.payconex.net/api/qsapi/3.8/'
+      version '3.8'
+
+      self.test_url = "https://cert.payconex.net/api/qsapi/#{fetch_version}/"
+      self.live_url = "https://secure.payconex.net/api/qsapi/#{fetch_version}/"
 
       self.supported_countries = %w(US CA)
       self.default_currency = 'USD'

--- a/test/unit/gateways/hps_test.rb
+++ b/test/unit/gateways/hps_test.rb
@@ -18,6 +18,20 @@ class HpsTest < Test::Unit::TestCase
     }
   end
 
+  def test_api_version
+    assert_equal '1.0', @gateway.fetch_version
+  end
+
+  def test_api_version_in_xml
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/<hps:Ver1.0>/, data)
+    end.respond_with(successful_charge_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_charge_response)
 

--- a/test/unit/gateways/pay_arc_test.rb
+++ b/test/unit/gateways/pay_arc_test.rb
@@ -28,6 +28,10 @@ class PayArcTest < Test::Unit::TestCase
     }
   end
 
+  def test_api_version
+    assert_equal 'v1', @gateway.fetch_version
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).times(2).returns(
       successful_token_response
@@ -152,6 +156,11 @@ class PayArcTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_equal transcript, post_scrubbed
+  end
+
+  def test_url
+    assert_equal 'https://api.payarc.net/v1', @gateway.live_url
+    assert_equal 'https://testapi.payarc.net/v1', @gateway.test_url
   end
 
   private

--- a/test/unit/gateways/pay_conex_test.rb
+++ b/test/unit/gateways/pay_conex_test.rb
@@ -17,6 +17,10 @@ class PayConexTest < Test::Unit::TestCase
     }
   end
 
+  def test_api_version
+    assert_equal '3.8', @gateway.fetch_version
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     response = @gateway.purchase(@amount, @credit_card, @options)
@@ -174,6 +178,11 @@ class PayConexTest < Test::Unit::TestCase
   def test_scrub_check
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed_check), post_scrubbed_check
+  end
+
+  def test_url
+    assert_equal 'https://cert.payconex.net/api/qsapi/3.8/', @gateway.test_url
+    assert_equal 'https://secure.payconex.net/api/qsapi/3.8/', @gateway.live_url
   end
 
   private


### PR DESCRIPTION
Normalized the use of API_VERSION across PayArc, PayConex, and HPS gateways in ActiveMerchant.

Remote Test Results:

PayArc
24 tests, 58 assertions, 11 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 54.1667% passed

PayConex
25 tests, 41 assertions, 16 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 36% passed

HPS
54 tests, 143 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 96.2963% passed