### PR TITLE
Worldpay: fix the refund reference field to correctly be added

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -367,7 +367,7 @@ module ActiveMerchant # :nodoc:
             # Worldpay docs claim amount must be passed. This causes an error.
             xml.cancelOrRefund # { add_amount(xml, money, options.merge(debit_credit_indicator: 'credit')) }
           elsif options[:refund_reference]
-            xml.refund(reference: options[:refund_reference]) do
+            xml.refund 'reference' => options[:refund_reference] do
               add_amount(xml, money, options.merge(debit_credit_indicator: 'credit'))
             end
           else


### PR DESCRIPTION
Apparently from testing this, im not sure if the way i implemented the field is working correctly. I think this method is better suited though both method should be the same

Local:
6355 tests, 81959 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
148 tests, 806 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
128 tests, 549 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed 