### PR TITLE
Paysafe: Add support for lodging fields

### DIFF
--- a/lib/active_merchant/billing/gateways/paysafe.rb
+++ b/lib/active_merchant/billing/gateways/paysafe.rb
@@ -21,6 +21,7 @@ module ActiveMerchant # :nodoc:
         post = {}
         add_auth_purchase_params(post, money, payment, options)
         add_airline_travel_details(post, options)
+        add_lodging_details(post, options)
         add_split_pay_details(post, options)
         post[:settleWithAuth] = true
 
@@ -290,6 +291,22 @@ module ActiveMerchant # :nodoc:
         details[:flight] = {}
         details[:flight][:carrierCode] = leg[:flight][:carrier_code] if leg[:flight][:carrier_code]
         details[:flight][:flightNumber] = leg[:flight][:flight_number] if leg[:flight][:flight_number]
+      end
+
+      def add_lodging_details(post, options)
+        return unless options[:lodging_details]
+
+        post[:lodgingDetails] = {}
+        post[:lodgingDetails][:hotelFolioNumber] = options[:lodging_details][:hotel_folio_number] if options[:lodging_details][:hotel_folio_number]
+        post[:lodgingDetails][:checkInDate] = options[:lodging_details][:check_in_date] if options[:lodging_details][:check_in_date]
+        post[:lodgingDetails][:checkOutDate] = options[:lodging_details][:check_out_date] if options[:lodging_details][:check_out_date]
+        post[:lodgingDetails][:customerServicePhone] = options[:lodging_details][:customer_service_phone] if options[:lodging_details][:customer_service_phone]
+        post[:lodgingDetails][:propertyLocalPhone] = options[:lodging_details][:property_local_phone] if options[:lodging_details][:property_local_phone]
+        post[:lodgingDetails][:extraCharges] = options[:lodging_details][:extra_charges] if options[:lodging_details][:extra_charges]
+        post[:lodgingDetails][:roomRate] = options[:lodging_details][:room_rate].to_i if options[:lodging_details][:room_rate]
+        post[:lodgingDetails][:programCode] = options[:lodging_details][:program_code] if options[:lodging_details][:program_code]
+        post[:lodgingDetails][:numberOfNights] = options[:lodging_details][:number_of_nights].to_i if options[:lodging_details][:number_of_nights]
+        post[:lodgingDetails][:isFireSafetyActCompliant] = options[:lodging_details][:is_fire_safety_act_compliant] if options[:lodging_details][:is_fire_safety_act_compliant]
       end
 
       def add_split_pay_details(post, options)

--- a/test/remote/gateways/remote_paysafe_test.rb
+++ b/test/remote/gateways/remote_paysafe_test.rb
@@ -104,6 +104,27 @@ class RemotePaysafeTest < Test::Unit::TestCase
         }
       }
     }
+    @lodging_options = {
+      lodging_details: {
+        hotel_folio_number: 'Customer Folio Number',
+        check_in_date: '2026-11-30',
+        check_out_date: '2026-12-01',
+        customer_service_phone: '9998887777',
+        property_local_phone: '9998887777',
+        extra_charges: %w[
+          RESTAURANT
+          GIFT_SHOP
+          MINI_BAR
+          TELEPHONE
+          LAUNDRY
+          OTHER
+        ],
+        room_rate: 100,
+        program_code: 'LODGING',
+        number_of_nights: 1,
+        is_fire_safety_act_compliant: true
+      }
+    }
   end
 
   def test_successful_purchase
@@ -148,6 +169,12 @@ class RemotePaysafeTest < Test::Unit::TestCase
     assert_equal 'COMPLETED', response.message
     assert_equal 'LH', response.params['airlineTravelDetails']['tripLegs']['leg1']['flight']['carrierCode']
     assert_equal 'F', response.params['airlineTravelDetails']['tripLegs']['leg2']['serviceClass']
+  end
+
+  def test_successful_purchase_with_lodging_details
+    response = @gateway.purchase(@amount, @credit_card, @options.merge(@lodging_options))
+    assert_success response
+    assert_equal 'COMPLETED', response.message
   end
 
   def test_successful_purchase_with_truncated_address

--- a/test/unit/gateways/paysafe_test.rb
+++ b/test/unit/gateways/paysafe_test.rb
@@ -97,6 +97,47 @@ class PaysafeTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_lodging_details
+    lodging_options = {
+      lodging_details: {
+        hotel_folio_number: 'Customer Folio Number',
+        check_in_date: '2026-11-30',
+        check_out_date: '2026-12-01',
+        customer_service_phone: '9998887777',
+        property_local_phone: '9998887777',
+        extra_charges: %w[
+          RESTAURANT
+          GIFT_SHOP
+          MINI_BAR
+          TELEPHONE
+          LAUNDRY
+          OTHER
+        ],
+        room_rate: 100,
+        program_code: 'LODGING',
+        number_of_nights: 1,
+        is_fire_safety_act_compliant: true
+      }
+    }
+    response = stub_comms(@gateway, :ssl_request) do
+      @gateway.purchase(@amount, @credit_card, lodging_options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      assert_match(/"lodgingDetails"/, data)
+      assert_match(/"hotelFolioNumber":"Customer Folio Number"/, data)
+      assert_match(/"checkInDate":"2026-11-30"/, data)
+      assert_match(/"checkOutDate":"2026-12-01"/, data)
+      assert_match(/"customerServicePhone":"9998887777"/, data)
+      assert_match(/"propertyLocalPhone":"9998887777"/, data)
+      assert_match(/"extraCharges":\["RESTAURANT","GIFT_SHOP","MINI_BAR","TELEPHONE","LAUNDRY","OTHER"\]/, data)
+      assert_match(/"roomRate":100/, data)
+      assert_match(/"programCode":"LODGING"/, data)
+      assert_match(/"numberOfNights":1/, data)
+      assert_match(/"isFireSafetyActCompliant":true/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+  end
+
   def test_successful_purchase_with_stored_credentials
     stored_credential_options = {
       stored_credential: {


### PR DESCRIPTION
CER-2412

These fields can only be used by Lodging Merchants (must be enabled at gateway).

Unit Tests:
25 tests, 139 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Remote Tests:
37 tests, 109 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed

Local Tests:
6387 tests, 82115 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications 100% passed