### PR TITLE
Checkout.com - MIT should not send the IP address to checkout.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -201,6 +201,7 @@
 * StripePI: Add support for multicapture [mjdonga] #5491
 * Normalize API Version for Plexo, Pin, Priority [adarsh-spreedly] #5517
 * Stripe PI: Update API version [almalee24] #5360
+* CheckoutV2 : MIT should not send the IP address to checkout [aaqibrashidmir] #5529
 
 == Version 1.137.0 (August 2, 2024)
 * Unlock dependency on `rexml` to allow fixing a CVE (#5181).

--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -352,7 +352,7 @@ module ActiveMerchant # :nodoc:
       def add_customer_data(post, options)
         post[:customer] = {}
         post[:customer][:email] = options[:email] || nil
-        post[:payment_ip] = options[:ip] if options[:ip]
+        post[:payment_ip] = options[:ip] if options[:ip] && options.dig(:stored_credential, :initiator) != 'merchant'
         address = options[:billing_address]
         if address && post[:source]
           post[:source][:billing_address] = {}

--- a/test/unit/gateways/checkout_v2_test.rb
+++ b/test/unit/gateways/checkout_v2_test.rb
@@ -1389,6 +1389,23 @@ class CheckoutV2Test < Test::Unit::TestCase
     end.respond_with(successful_purchase_initial_stored_credential_response)
   end
 
+  def test_merchant_initiated_transaction_does_not_send_ip
+    stub_comms(@gateway, :ssl_request) do
+      options = {
+        ip: '203.0.113.1',
+        stored_credential: {
+          initiator: 'merchant',
+          initial_transaction: false,
+          reason_type: 'recurring',
+          network_transaction_id: 'pay_12345'
+        }
+      }
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_method, _endpoint, data, _headers|
+      refute_match(/payment_ip/, data, 'payment_ip should not be present for merchant initiated transaction')
+    end.respond_with(successful_purchase_using_stored_credential_response)
+  end
+
   private
 
   def pre_scrubbed


### PR DESCRIPTION
CKO recommends not sending an IP address for merchant-initiated transactions, as it may affect risk scoring. This update ensures we omit the IP when stored_credential_initiator = merchant.