### PR TITLE
Stripe add amount details line items

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -449,8 +449,8 @@ module ActiveMerchant # :nodoc:
         post[:payment_method_options][:card][:request_multicapture] = request_multicapture
       end
 
-      # stripe's newer API is depracting the level3 field. It still works now but
-      # we will open up the new amount_details field for level 3 data as well
+      # stripe's newer API is depracting the level3 field. It still works now but we will open
+      # up the new amount_details field for level 3 data as well if an override is included.
       def add_level_three(post, options = {})
         level_three = {}
 

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -663,7 +663,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert authorize = @gateway.authorize(@amount, @visa_payment_method, options)
     assert_equal 'requires_capture', authorize.params['status']
 
-    card_details = authorize.params['charges']['data'][0]['payment_method_details']['card']
+    card_details = authorize.params['latest_charge']['payment_method_details']['card']
     assert_equal 'disabled', card_details['extended_authorization']['status']
     assert_not_nil card_details['capture_before']
   end

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -204,6 +204,50 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
     assert response.params.dig('latest_charge')['captured']
   end
 
+  def test_successful_purchase_with_new_level_3_and_api_version
+    options = {
+      currency: 'USD',
+      customer: @customer,
+      version: '2025-04-30.preview',
+      return_url: 'https://example.com',
+      customer_reference: 456,
+      order_reference: 123345,
+      level_3_shipping: {
+        'from_postal_code' => 1234,
+        'to_postal_code' => 4321,
+        'amount' => 5
+      },
+      line_items: [
+        {
+          'product_code' => 1234,
+          'product_name' => 'An item',
+          'unit_cost' => 15,
+          'quantity' => 2,
+          'discount_amount' => 1,
+          'tax' => {
+            'total_tax_amount' => 0
+          },
+          'unit_of_measure' => 'feet'
+        },
+        {
+          'product_code' => 999,
+          'product_name' => 'A totes different item',
+          'discount_amount' => 1,
+          'quantity' => 1,
+          'tax' => {
+            'total_tax_amount' => 0
+          },
+          'unit_cost' => 50,
+          'unit_of_measure' => 'feet'
+        }
+      ]
+    }
+
+    assert response = @gateway.purchase(83, @visa_card, options)
+    assert_success response
+    assert_equal 'succeeded', response.params['status']
+  end
+
   def test_unsuccessful_purchase_google_pay_with_invalid_card_number
     options = {
       currency: 'GBP',


### PR DESCRIPTION
Adds the new optional payment line item fields when a version override is also present

Local:
6388 tests, 82129 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Unit:
82 tests, 447 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote:
113 tests, 496 assertions, 5 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
95.5752% passed