### PR TITLE
checkout-v2-source-token-structure

### DIFF
--- a/lib/active_merchant/billing/gateways/checkout_v2.rb
+++ b/lib/active_merchant/billing/gateways/checkout_v2.rb
@@ -329,8 +329,8 @@ module ActiveMerchant # :nodoc:
         end
         if payment_method.is_a?(String)
           if /tok/.match?(payment_method)
-            post[:type] = 'token'
-            post[:token] = payment_method
+            post[key][:type] = 'token'
+            post[key][:token] = payment_method
           elsif /src/.match?(payment_method)
             post[key][:type] = 'id'
             post[key][:id] = payment_method


### PR DESCRIPTION
I work at Dubizzle Labs, where we use the ActiveMerchant gem in one of our products that I am leading. While migrating our Checkout.com payment gateway implementation from a custom service to ActiveMerchant, I encountered an issue with how token-based payments were structured in the request payload.

This PR aligns the Checkout V2 gateway payload with the [Checkout.com API specification](https://api-reference.checkout.com/#operation/requestAPaymentOrPayout) for token-based payments.

Previously, type and token were being added at the top level of the request which did not align with Checkout V2’s expected payload structure.

All tests were run locally, and no new test failures occurred after this change.