### PR TITLE
Change Braintree gem requirement to >= 4.11.0

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -2,13 +2,12 @@ require 'active_merchant/billing/gateways/braintree/braintree_common'
 require 'active_merchant/billing/gateways/braintree/token_nonce'
 require 'active_support/core_ext/array/extract_options'
 
+gem 'braintree', '>= 4.11.0'
 begin
   require 'braintree'
 rescue LoadError
   raise 'Could not load the braintree gem.  Use `gem install braintree` to install it.'
 end
-
-raise 'Need braintree gem >= 2.0.0.' unless Braintree::Version::Major >= 2 && Braintree::Version::Minor >= 0
 
 module ActiveMerchant # :nodoc:
   module Billing # :nodoc:


### PR DESCRIPTION
Updated the Braintree gem requirement to version 4.11.0 or higher. Version 4.11.0 introduced availability of the network_token_details API that is required by this gateway. Version 2 is not nearly enough to work with this gateway.