### PR TITLE
Fat Zebra: Add support for purchase with wallet

### DIFF
--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -25,7 +25,7 @@ module ActiveMerchant # :nodoc:
         post = {}
 
         add_amount(post, money, options)
-        add_creditcard(post, creditcard, options)
+        add_creditcard(post, creditcard, options) unless creditcard.nil?
         add_extra_options(post, options)
         add_order_id(post, options)
         add_ip(post, options)

--- a/lib/active_merchant/billing/gateways/fat_zebra.rb
+++ b/lib/active_merchant/billing/gateways/fat_zebra.rb
@@ -31,6 +31,7 @@ module ActiveMerchant # :nodoc:
         add_ip(post, options)
         add_metadata(post, options)
         add_three_ds(post, options)
+        add_wallet(post, options)
 
         commit(:post, 'purchases', post)
       end
@@ -154,6 +155,15 @@ module ActiveMerchant # :nodoc:
           ver: formatted_enrollment(three_d_secure[:enrolled]),
           threeds_version: three_d_secure[:version],
           directory_server_txn_id: three_d_secure[:ds_transaction_id]
+        }.compact
+      end
+
+      def add_wallet(post, options)
+        return unless wallet = options[:wallet]
+
+        post[:wallet] = {
+          type: wallet[:type],
+          token: wallet[:token],
         }.compact
       end
 

--- a/test/remote/gateways/remote_fat_zebra_test.rb
+++ b/test/remote/gateways/remote_fat_zebra_test.rb
@@ -257,4 +257,18 @@ class RemoteFatZebraTest < Test::Unit::TestCase
     assert_failure response
     assert_match(/version is not valid/, response.message)
   end
+
+  def test_failed_purchase_with_wallet_apple_pay
+    @options[:wallet] = {
+      "type":"APPLE",
+      "token": {
+        "paymentData": {
+           "test": "value"
+        }
+      }
+    }
+    assert response = @gateway.purchase(@amount, nil, @options)
+    assert_failure response
+    assert_match( /Unable to load credit card data from Wallet details/, response.message)
+  end
 end

--- a/test/unit/gateways/fat_zebra_test.rb
+++ b/test/unit/gateways/fat_zebra_test.rb
@@ -109,6 +109,26 @@ class FatZebraTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_wallet_apple_pay
+    @gateway.expects(:ssl_request).returns(successful_apple_pay_purchase_response)
+
+    @options[:wallet] = {
+      "type":"APPLE",
+      "token": {
+        "paymentData": {
+           "test": "value"
+        }
+      }
+    }
+
+    assert response = @gateway.purchase(@amount, nil, @options)
+    assert_success response
+
+    assert_equal '85230-P-4QXDYKWJ|purchases', response.authorization
+    assert response.params["response"]["wallet"].include? "card_source_reference"
+    assert response.test?
+  end
+
   def test_successful_authorization
     @gateway.expects(:ssl_request).with { |_method, _url, body, _headers|
       body.match '"capture":false'
@@ -400,6 +420,51 @@ class FatZebraTest < Test::Unit::TestCase
       errors: []
     }.to_json
   end
+
+  def successful_apple_pay_purchase_response
+    {
+      "successful": true,
+      "response": {
+        "authorization": "678533",
+        "id": "85230-P-4QXDYKWJ",
+        card_number: 'XXXXXXXXXXXX1111',
+        card_holder: 'John Smith',
+        card_expiry: '2011-10-31',
+        "card_token": "lsfnwgtq0krqq9iw9frq",
+        "card_type": "VISA",
+        "card_category": "Charge Card",
+        "card_subcategory": "Standard",
+        "amount": 9100,
+        "decimal_amount": 91,
+        "successful": true,
+        "message": "Approved",
+        "reference": "ABC123",
+        "currency": "AUD",
+        "transaction_id": "85230-P-4QXDYKWJ",
+        "settlement_date": "2025-11-27",
+        "transaction_date": "2025-11-27T17:16:05+11:00",
+        "response_code": "00",
+        "captured": true,
+        "captured_amount": 9100,
+        "rrn": "85230P4QXDYK",
+        "cvv_match": "M",
+        "metadata": {
+          "authorization_tracking_id": "",
+          "card_sequence_number": "",
+          "sca_exemption": "",
+          "least_cost_routed": "false",
+          "original_transaction_reference": ""
+        },
+        "addendum_data": {},
+        "wallet": {
+          "card_source_reference": "29081975d8d2809fd460fe89d6ed06b8b33504e340563248fccef5bf41f6bfe2"
+        }
+      },
+      "errors": [],
+      "test": true
+    }.to_json
+  end
+
 
   def declined_purchase_response
     {


### PR DESCRIPTION
May be Apple Pay or Google Pay, as per https://docs.fatzebra.com/reference/create-a-purchase-with-wallet

~~Can't test fully here because it requires a valid current token from the Apple SDK (for example) which requires Apple device.~~
I've since found that a recorded test token does seem to work; let me know if you think it would be worth adding a remote test with that, and if I should add the token (a json blob) to the `test/fixtures.yml` file.

I'll add a changelog comment after first review, to avoid conflicts with longrunning PRs.

```
ruby -Itest test/unit/gateways/fat_zebra_test.rb -n test_successful_purchase_with_wallet_apple_pay
1 tests, 7 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

ruby -Itest test/remote/gateways/remote_fat_zebra_test.rb -n test_failed_purchase_with_wallet_apple_pay
1 tests, 3 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```